### PR TITLE
feat: Add WatchmakerAgent with self-evolving agent ecosystem

### DIFF
--- a/python/openrappter/agents/watchmaker_agent.py
+++ b/python/openrappter/agents/watchmaker_agent.py
@@ -1,0 +1,650 @@
+"""
+WatchmakerAgent - Self-evolving agent ecosystem manager.
+
+Evaluates agent capabilities, A/B tests competing versions, and promotes
+winners. Natural selection for software: external processes produce
+candidate mutations; the Watchmaker decides which survive.
+
+Actions:
+  register - Add an agent version to a slot
+  evaluate - Score an agent version with test cases
+  compare  - A/B test two versions
+  promote  - Swap a candidate into the active slot
+  cycle    - Full evolution loop
+  status   - Current state of a slot (or all slots)
+  history  - Evaluation and promotion history
+
+Flow (cycle action):
+  1. Evaluate all active agents with test cases
+  2. For each slot with candidates, compare active vs candidate
+  3. Auto-promote candidates that beat active
+  4. Return full CycleResult audit trail
+
+Mirrors TypeScript agents/WatchmakerAgent.ts
+"""
+
+import json
+import time
+from datetime import datetime
+
+from openrappter.agents.basic_agent import BasicAgent
+
+
+class WatchmakerAgent(BasicAgent):
+    def __init__(self):
+        self.name = 'Watchmaker'
+        self.metadata = {
+            "name": self.name,
+            "description": "Self-evolving agent ecosystem manager. Evaluates agent capabilities, A/B tests competing versions, and promotes winners.",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "action": {
+                        "type": "string",
+                        "description": "The action to perform.",
+                        "enum": ["evaluate", "compare", "register", "promote", "cycle", "status", "history"]
+                    },
+                    "agent": {
+                        "type": "string",
+                        "description": "Agent name (slot key)."
+                    },
+                    "version": {
+                        "type": "string",
+                        "description": "Version identifier."
+                    },
+                    "versionA": {
+                        "type": "string",
+                        "description": "Version A for comparison."
+                    },
+                    "versionB": {
+                        "type": "string",
+                        "description": "Version B for comparison."
+                    },
+                    "testCases": {
+                        "type": "array",
+                        "description": "Test inputs for evaluation.",
+                        "items": {"type": "object"}
+                    },
+                    "reason": {
+                        "type": "string",
+                        "description": "Promotion reason."
+                    }
+                },
+                "required": []
+            }
+        }
+        super().__init__(name=self.name, metadata=self.metadata)
+
+        self._slots = {}           # name -> AgentSlot dict
+        self._eval_history = {}    # name -> list of EvaluationResult dicts
+        self._cycle_history = []   # list of CycleResult dicts
+        self._default_test_cases = {}  # name -> list of TestCase dicts
+
+    def set_agents(self, agents):
+        """Inject agents for testing.
+
+        Args:
+            agents: list of dicts with keys: agent (BasicAgent), version (str),
+                    source (str, optional: 'manual'|'learnNew'|'mutation')
+        """
+        for entry in agents:
+            agent_instance = entry['agent']
+            name = agent_instance.name
+            version = entry['version']
+            source = entry.get('source', 'manual')
+
+            agent_version = {
+                'agent': agent_instance,
+                'version': version,
+                'registeredAt': datetime.now().isoformat(),
+                'source': source,
+            }
+
+            if name not in self._slots:
+                self._slots[name] = {
+                    'name': name,
+                    'active': agent_version,
+                    'candidates': [],
+                    'history': [],
+                }
+            else:
+                self._slots[name]['candidates'].append(agent_version)
+
+            if name not in self._eval_history:
+                self._eval_history[name] = []
+
+    def perform(self, **kwargs):
+        action = kwargs.get('action')
+
+        if not action:
+            return json.dumps({
+                "status": "error",
+                "message": "No action specified. Use: evaluate, compare, register, promote, cycle, status, or history"
+            })
+
+        try:
+            if action == 'register':
+                return self._register_agent(kwargs)
+            elif action == 'evaluate':
+                return self._evaluate_agent(kwargs)
+            elif action == 'compare':
+                return self._compare_agents(kwargs)
+            elif action == 'promote':
+                return self._promote_agent(kwargs)
+            elif action == 'cycle':
+                return self._run_cycle(kwargs)
+            elif action == 'status':
+                return self._get_status(kwargs)
+            elif action == 'history':
+                return self._get_history(kwargs)
+            else:
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Unknown action: {action}"
+                })
+        except Exception as e:
+            return json.dumps({
+                "status": "error",
+                "action": action,
+                "message": str(e)
+            })
+
+    # ── register ────────────────────────────────────────────────────
+
+    def _register_agent(self, kwargs):
+        agent_name = kwargs.get('agent')
+        version = kwargs.get('version')
+        agent_instance = kwargs.get('agentInstance')
+        source = kwargs.get('source', 'manual')
+
+        if not agent_name or not version or not agent_instance:
+            return json.dumps({
+                "status": "error",
+                "message": "agent, version, and agentInstance are required for register"
+            })
+
+        agent_version = {
+            'agent': agent_instance,
+            'version': version,
+            'registeredAt': datetime.now().isoformat(),
+            'source': source,
+        }
+
+        if agent_name not in self._eval_history:
+            self._eval_history[agent_name] = []
+
+        slot = self._slots.get(agent_name)
+        if not slot:
+            self._slots[agent_name] = {
+                'name': agent_name,
+                'active': agent_version,
+                'candidates': [],
+                'history': [],
+            }
+
+            data_slush = self.slush_out(
+                signals={'agent_name': agent_name, 'version': version, 'action': 'register'},
+                registered='active',
+            )
+
+            return json.dumps({
+                "status": "success",
+                "action": "register",
+                "agent": agent_name,
+                "version": version,
+                "role": "active",
+                "message": f"Registered {agent_name} v{version} as active",
+                "data_slush": data_slush,
+            })
+
+        # Check for duplicate version
+        all_versions = [slot['active']] + slot['candidates']
+        if any(v['version'] == version for v in all_versions):
+            return json.dumps({
+                "status": "error",
+                "message": f"Version {version} already registered for {agent_name}"
+            })
+
+        slot['candidates'].append(agent_version)
+
+        data_slush = self.slush_out(
+            signals={'agent_name': agent_name, 'version': version, 'action': 'register'},
+            registered='candidate',
+        )
+
+        return json.dumps({
+            "status": "success",
+            "action": "register",
+            "agent": agent_name,
+            "version": version,
+            "role": "candidate",
+            "message": f"Registered {agent_name} v{version} as candidate",
+            "data_slush": data_slush,
+        })
+
+    # ── evaluate ────────────────────────────────────────────────────
+
+    def _evaluate_agent(self, kwargs):
+        agent_name = kwargs.get('agent')
+        if not agent_name:
+            return json.dumps({
+                "status": "error",
+                "message": "agent name is required for evaluate"
+            })
+
+        slot = self._slots.get(agent_name)
+        if not slot:
+            return json.dumps({
+                "status": "error",
+                "message": f"Agent not found: {agent_name}"
+            })
+
+        target_version = kwargs.get('version')
+        if target_version:
+            all_versions = [slot['active']] + slot['candidates']
+            found = next((v for v in all_versions if v['version'] == target_version), None)
+            if not found:
+                return json.dumps({
+                    "status": "error",
+                    "message": f"Version {target_version} not found for {agent_name}"
+                })
+            agent_version = found
+        else:
+            agent_version = slot['active']
+
+        test_cases = kwargs.get('testCases') or \
+            self._default_test_cases.get(agent_name) or \
+            [{'input': {'query': 'health check'}}]
+
+        eval_result = self._run_evaluation(agent_name, agent_version, test_cases)
+        self._eval_history[agent_name].append(eval_result)
+
+        data_slush = self.slush_out(
+            signals={
+                'agent_name': agent_name,
+                'version': agent_version['version'],
+                'quality': eval_result['quality'],
+                'eval_status': eval_result['status'],
+            },
+        )
+
+        return json.dumps({
+            "status": "success",
+            "action": "evaluate",
+            "evaluation": eval_result,
+            "data_slush": data_slush,
+        })
+
+    # ── compare ─────────────────────────────────────────────────────
+
+    def _compare_agents(self, kwargs):
+        agent_name = kwargs.get('agent')
+        version_a = kwargs.get('versionA')
+        version_b = kwargs.get('versionB')
+
+        if not agent_name or not version_a or not version_b:
+            return json.dumps({
+                "status": "error",
+                "message": "agent, versionA, and versionB are required for compare"
+            })
+
+        slot = self._slots.get(agent_name)
+        if not slot:
+            return json.dumps({
+                "status": "error",
+                "message": f"Agent not found: {agent_name}"
+            })
+
+        all_versions = [slot['active']] + slot['candidates']
+        found_a = next((v for v in all_versions if v['version'] == version_a), None)
+        found_b = next((v for v in all_versions if v['version'] == version_b), None)
+
+        if not found_a or not found_b:
+            return json.dumps({
+                "status": "error",
+                "message": f"One or both versions not found: {version_a}, {version_b}"
+            })
+
+        test_cases = kwargs.get('testCases') or \
+            self._default_test_cases.get(agent_name) or \
+            [{'input': {'query': 'health check'}}]
+
+        result_a = self._run_evaluation(agent_name, found_a, test_cases)
+        result_b = self._run_evaluation(agent_name, found_b, test_cases)
+
+        comparison = self._build_comparison(agent_name, result_a, result_b)
+
+        return json.dumps({
+            "status": "success",
+            "action": "compare",
+            "comparison": comparison,
+        })
+
+    # ── promote ─────────────────────────────────────────────────────
+
+    def _promote_agent(self, kwargs):
+        agent_name = kwargs.get('agent')
+        version = kwargs.get('version')
+        reason = kwargs.get('reason', 'manual promotion')
+
+        if not agent_name or not version:
+            return json.dumps({
+                "status": "error",
+                "message": "agent and version are required for promote"
+            })
+
+        slot = self._slots.get(agent_name)
+        if not slot:
+            return json.dumps({
+                "status": "error",
+                "message": f"Agent not found: {agent_name}"
+            })
+
+        candidate_index = None
+        for i, c in enumerate(slot['candidates']):
+            if c['version'] == version:
+                candidate_index = i
+                break
+
+        if candidate_index is None:
+            return json.dumps({
+                "status": "error",
+                "message": f"Version {version} not found in candidates for {agent_name}"
+            })
+
+        candidate = slot['candidates'][candidate_index]
+        latest_evals = [e for e in self._eval_history.get(agent_name, []) if e['version'] == version]
+        quality = latest_evals[-1]['quality'] if latest_evals else 0
+
+        self._do_promotion(slot, candidate, candidate_index, reason, quality)
+
+        data_slush = self.slush_out(
+            signals={'agent_name': agent_name, 'promoted_version': version, 'reason': reason},
+        )
+
+        return json.dumps({
+            "status": "success",
+            "action": "promote",
+            "agent": agent_name,
+            "version": version,
+            "reason": reason,
+            "message": f"Promoted {agent_name} to v{version}",
+            "data_slush": data_slush,
+        })
+
+    # ── cycle ───────────────────────────────────────────────────────
+
+    def _run_cycle(self, kwargs):
+        test_cases_override = kwargs.get('testCases')
+        cycle_result = {
+            'timestamp': datetime.now().isoformat(),
+            'evaluated': [],
+            'comparisons': [],
+            'promotions': [],
+            'summary': '',
+        }
+
+        for name, slot in list(self._slots.items()):
+            test_cases = test_cases_override or \
+                self._default_test_cases.get(name) or \
+                [{'input': {'query': 'health check'}}]
+
+            eval_result = self._run_evaluation(name, slot['active'], test_cases)
+            self._eval_history[name].append(eval_result)
+            cycle_result['evaluated'].append(eval_result)
+
+            i = 0
+            while i < len(slot['candidates']):
+                candidate = slot['candidates'][i]
+                candidate_eval = self._run_evaluation(name, candidate, test_cases)
+                self._eval_history[name].append(candidate_eval)
+                cycle_result['evaluated'].append(candidate_eval)
+
+                comparison = self._build_comparison(name, eval_result, candidate_eval)
+                cycle_result['comparisons'].append(comparison)
+
+                if comparison['winner'] == 'B':
+                    record = self._do_promotion(
+                        slot, candidate, i,
+                        f"Outperformed active: quality {candidate_eval['quality']} vs {eval_result['quality']}",
+                        candidate_eval['quality'],
+                    )
+                    cycle_result['promotions'].append(record)
+                    # Don't increment i since list shifted
+                else:
+                    i += 1
+
+        evaluated_count = len(cycle_result['evaluated'])
+        comparisons_count = len(cycle_result['comparisons'])
+        promotions_count = len(cycle_result['promotions'])
+        cycle_result['summary'] = (
+            f"Evaluated {evaluated_count} versions, "
+            f"{comparisons_count} comparisons, "
+            f"{promotions_count} promotions"
+        )
+
+        self._cycle_history.append(cycle_result)
+
+        data_slush = self.slush_out(
+            signals={
+                'evaluations_run': evaluated_count,
+                'comparisons_run': comparisons_count,
+                'promotions_made': promotions_count,
+            },
+        )
+
+        return json.dumps({
+            "status": "success",
+            "action": "cycle",
+            "cycle": cycle_result,
+            "data_slush": data_slush,
+        }, default=str)
+
+    # ── status ──────────────────────────────────────────────────────
+
+    def _get_status(self, kwargs):
+        agent_name = kwargs.get('agent')
+
+        if not agent_name:
+            all_slots = [self._slot_summary(slot) for slot in self._slots.values()]
+            return json.dumps({
+                "status": "success",
+                "action": "status",
+                "slots": all_slots,
+                "count": len(all_slots),
+            })
+
+        slot = self._slots.get(agent_name)
+        if not slot:
+            return json.dumps({
+                "status": "error",
+                "message": f"Agent not found: {agent_name}"
+            })
+
+        return json.dumps({
+            "status": "success",
+            "action": "status",
+            "slot": self._slot_summary(slot),
+        })
+
+    # ── history ─────────────────────────────────────────────────────
+
+    def _get_history(self, kwargs):
+        agent_name = kwargs.get('agent')
+
+        if not agent_name:
+            return json.dumps({
+                "status": "success",
+                "action": "history",
+                "cycles": self._cycle_history,
+                "count": len(self._cycle_history),
+            }, default=str)
+
+        slot = self._slots.get(agent_name)
+        if not slot:
+            return json.dumps({
+                "status": "error",
+                "message": f"Agent not found: {agent_name}"
+            })
+
+        eval_history = self._eval_history.get(agent_name, [])
+
+        return json.dumps({
+            "status": "success",
+            "action": "history",
+            "agent": agent_name,
+            "evaluations": eval_history,
+            "promotions": slot['history'],
+            "evaluationCount": len(eval_history),
+            "promotionCount": len(slot['history']),
+        })
+
+    # ── Internal helpers ────────────────────────────────────────────
+
+    def _run_evaluation(self, agent_name, agent_version, test_cases):
+        checks = []
+        start_time = time.time()
+
+        for test_case in test_cases:
+            result = None
+            parsed = None
+            threw = False
+
+            try:
+                result = agent_version['agent'].execute(**test_case.get('input', {}))
+                if not isinstance(result, str):
+                    result = str(result)
+            except Exception:
+                threw = True
+
+            checks.append({
+                'name': 'executes_without_error',
+                'passed': not threw,
+                'detail': 'Agent threw an exception' if threw else 'Agent executed successfully',
+            })
+
+            if threw or result is None:
+                continue
+
+            is_valid_json = False
+            try:
+                parsed = json.loads(result) if isinstance(result, str) else result
+                is_valid_json = parsed is not None and isinstance(parsed, dict)
+            except (json.JSONDecodeError, TypeError):
+                is_valid_json = False
+
+            checks.append({
+                'name': 'returns_valid_json',
+                'passed': is_valid_json,
+                'detail': 'Valid JSON response' if is_valid_json else 'Response is not valid JSON',
+            })
+
+            if not is_valid_json or not parsed:
+                continue
+
+            expected_status = test_case.get('expectedStatus')
+            if expected_status:
+                status_matches = parsed.get('status') == expected_status
+                checks.append({
+                    'name': 'status_matches',
+                    'passed': status_matches,
+                    'detail': f'Status matches: {expected_status}' if status_matches
+                             else f'Expected status "{expected_status}", got "{parsed.get("status")}"',
+                })
+
+            expected_fields = test_case.get('expectedFields')
+            if expected_fields:
+                for field in expected_fields:
+                    has_field = field in parsed
+                    checks.append({
+                        'name': f'has_field_{field}',
+                        'passed': has_field,
+                        'detail': f'Field "{field}" present' if has_field else f'Field "{field}" missing',
+                    })
+
+            has_slush = 'data_slush' in parsed
+            checks.append({
+                'name': 'has_data_slush',
+                'passed': has_slush,
+                'detail': 'data_slush present' if has_slush else 'data_slush missing',
+            })
+
+        latency_ms = round((time.time() - start_time) * 1000)
+        passed_count = sum(1 for c in checks if c['passed'])
+        quality = round((passed_count / len(checks)) * 100) if checks else 0
+
+        if quality >= 80:
+            eval_status = 'strong'
+        elif quality >= 50:
+            eval_status = 'developing'
+        else:
+            eval_status = 'weak'
+
+        return {
+            'agentName': agent_name,
+            'version': agent_version['version'],
+            'timestamp': datetime.now().isoformat(),
+            'checks': checks,
+            'quality': quality,
+            'status': eval_status,
+            'latencyMs': latency_ms,
+        }
+
+    def _build_comparison(self, agent_name, result_a, result_b):
+        quality_delta = result_b['quality'] - result_a['quality']
+        latency_delta = result_b['latencyMs'] - result_a['latencyMs']
+
+        if abs(quality_delta) > 5:
+            winner = 'B' if quality_delta > 0 else 'A'
+            reason = f"Quality difference: {abs(quality_delta)} points"
+        else:
+            avg_latency = (result_a['latencyMs'] + result_b['latencyMs']) / 2
+            latency_threshold = abs(latency_delta) / avg_latency if avg_latency > 0 else 0
+            if latency_threshold > 0.2:
+                winner = 'B' if latency_delta < 0 else 'A'
+                reason = f"Latency tiebreaker: {abs(latency_delta)}ms difference"
+            else:
+                winner = 'tie'
+                reason = 'No significant difference in quality or latency'
+
+        return {
+            'agentName': agent_name,
+            'timestamp': datetime.now().isoformat(),
+            'versionA': result_a['version'],
+            'versionB': result_b['version'],
+            'resultA': result_a,
+            'resultB': result_b,
+            'winner': winner,
+            'qualityDelta': quality_delta,
+            'latencyDelta': latency_delta,
+            'reason': reason,
+        }
+
+    def _do_promotion(self, slot, candidate, candidate_index, reason, quality):
+        record = {
+            'fromVersion': slot['active']['version'],
+            'toVersion': candidate['version'],
+            'timestamp': datetime.now().isoformat(),
+            'reason': reason,
+            'quality': quality,
+        }
+
+        slot['active'] = candidate
+        slot['candidates'].pop(candidate_index)
+        slot['history'].append(record)
+
+        return record
+
+    def _slot_summary(self, slot):
+        eval_history = self._eval_history.get(slot['name'], [])
+        active_evals = [e for e in eval_history if e['version'] == slot['active']['version']]
+        latest_eval = active_evals[-1] if active_evals else None
+
+        return {
+            'name': slot['name'],
+            'activeVersion': slot['active']['version'],
+            'candidateCount': len(slot['candidates']),
+            'latestQuality': latest_eval['quality'] if latest_eval else None,
+            'latestStatus': latest_eval['status'] if latest_eval else None,
+            'promotionCount': len(slot['history']),
+        }

--- a/typescript/src/__tests__/parity/watchmaker.test.ts
+++ b/typescript/src/__tests__/parity/watchmaker.test.ts
@@ -1,0 +1,793 @@
+/**
+ * WatchmakerAgent Parity Tests
+ *
+ * Tests the self-evolving agent ecosystem manager that evaluates agent
+ * capabilities, A/B tests competing versions, and promotes winners.
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { WatchmakerAgent } from '../../agents/WatchmakerAgent.js';
+import { BasicAgent } from '../../agents/BasicAgent.js';
+
+// --- Mock agents ---
+
+class MockStrongAgent extends BasicAgent {
+  constructor(name = 'StrongAgent') {
+    super(name, {
+      name,
+      description: 'Always succeeds with data_slush',
+      parameters: { type: 'object', properties: {}, required: [] },
+    });
+  }
+
+  async perform(_kwargs: Record<string, unknown>): Promise<string> {
+    return JSON.stringify({
+      status: 'success',
+      result: 'strong response',
+      data_slush: { source_agent: this.name, quality: 100 },
+    });
+  }
+}
+
+class MockWeakAgent extends BasicAgent {
+  constructor(name = 'WeakAgent') {
+    super(name, {
+      name,
+      description: 'Always returns error status',
+      parameters: { type: 'object', properties: {}, required: [] },
+    });
+  }
+
+  async perform(_kwargs: Record<string, unknown>): Promise<string> {
+    return JSON.stringify({
+      status: 'error',
+      message: 'weak agent failed',
+    });
+  }
+}
+
+class MockCrashAgent extends BasicAgent {
+  constructor(name = 'CrashAgent') {
+    super(name, {
+      name,
+      description: 'Always throws',
+      parameters: { type: 'object', properties: {}, required: [] },
+    });
+  }
+
+  async perform(_kwargs: Record<string, unknown>): Promise<string> {
+    throw new Error('crash agent exploded');
+  }
+}
+
+class MockSlowAgent extends BasicAgent {
+  constructor(name = 'SlowAgent') {
+    super(name, {
+      name,
+      description: 'Adds 50ms delay then succeeds',
+      parameters: { type: 'object', properties: {}, required: [] },
+    });
+  }
+
+  async perform(_kwargs: Record<string, unknown>): Promise<string> {
+    await new Promise(resolve => setTimeout(resolve, 50));
+    return JSON.stringify({
+      status: 'success',
+      result: 'slow response',
+      data_slush: { source_agent: this.name },
+    });
+  }
+}
+
+// --- Helpers ---
+
+function registerStrong(agent: WatchmakerAgent, version = '1.0', name = 'TestAgent'): void {
+  agent.perform({
+    action: 'register',
+    agent: name,
+    version,
+    agentInstance: new MockStrongAgent(name),
+  });
+}
+
+function registerWeak(agent: WatchmakerAgent, version = '2.0', name = 'TestAgent'): void {
+  agent.perform({
+    action: 'register',
+    agent: name,
+    version,
+    agentInstance: new MockWeakAgent(name),
+  });
+}
+
+// --- Tests ---
+
+describe('WatchmakerAgent', () => {
+  let watchmaker: WatchmakerAgent;
+
+  beforeEach(() => {
+    watchmaker = new WatchmakerAgent();
+  });
+
+  describe('Constructor', () => {
+    it('should have correct metadata name', () => {
+      expect(watchmaker.name).toBe('Watchmaker');
+      expect(watchmaker.metadata.name).toBe('Watchmaker');
+    });
+
+    it('should have a description', () => {
+      expect(watchmaker.metadata.description).toBeDefined();
+      expect(watchmaker.metadata.description.length).toBeGreaterThan(0);
+    });
+
+    it('should have parameters schema with all 7 actions in enum', () => {
+      expect(watchmaker.metadata.parameters.type).toBe('object');
+      expect(watchmaker.metadata.parameters.properties.action).toBeDefined();
+      expect(watchmaker.metadata.parameters.properties.action.enum).toEqual([
+        'evaluate', 'compare', 'register', 'promote', 'cycle', 'status', 'history',
+      ]);
+    });
+
+    it('should extend BasicAgent', () => {
+      expect(watchmaker).toBeInstanceOf(BasicAgent);
+    });
+
+    it('should have all expected parameter properties', () => {
+      const props = watchmaker.metadata.parameters.properties;
+      expect(props.action).toBeDefined();
+      expect(props.agent).toBeDefined();
+      expect(props.version).toBeDefined();
+      expect(props.versionA).toBeDefined();
+      expect(props.versionB).toBeDefined();
+      expect(props.testCases).toBeDefined();
+      expect(props.reason).toBeDefined();
+    });
+  });
+
+  describe('No action / unknown action', () => {
+    it('should return error when no action specified', async () => {
+      const result = await watchmaker.perform({});
+      const parsed = JSON.parse(result);
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('No action specified');
+    });
+
+    it('should return error for unknown action', async () => {
+      const result = await watchmaker.perform({ action: 'unknown' });
+      const parsed = JSON.parse(result);
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('Unknown action');
+    });
+  });
+
+  describe('register action', () => {
+    it('should create slot with version as active', async () => {
+      const result = await watchmaker.perform({
+        action: 'register',
+        agent: 'MyAgent',
+        version: '1.0',
+        agentInstance: new MockStrongAgent('MyAgent'),
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.action).toBe('register');
+      expect(parsed.agent).toBe('MyAgent');
+      expect(parsed.version).toBe('1.0');
+      expect(parsed.role).toBe('active');
+    });
+
+    it('should add second version as candidate', async () => {
+      await watchmaker.perform({
+        action: 'register',
+        agent: 'MyAgent',
+        version: '1.0',
+        agentInstance: new MockStrongAgent('MyAgent'),
+      });
+      const result = await watchmaker.perform({
+        action: 'register',
+        agent: 'MyAgent',
+        version: '2.0',
+        agentInstance: new MockWeakAgent('MyAgent'),
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.role).toBe('candidate');
+    });
+
+    it('should prevent duplicate version', async () => {
+      await watchmaker.perform({
+        action: 'register',
+        agent: 'MyAgent',
+        version: '1.0',
+        agentInstance: new MockStrongAgent('MyAgent'),
+      });
+      const result = await watchmaker.perform({
+        action: 'register',
+        agent: 'MyAgent',
+        version: '1.0',
+        agentInstance: new MockStrongAgent('MyAgent'),
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('already registered');
+    });
+
+    it('should require agent, version, and agentInstance', async () => {
+      const result = await watchmaker.perform({ action: 'register', agent: 'MyAgent' });
+      const parsed = JSON.parse(result);
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('required');
+    });
+  });
+
+  describe('evaluate action', () => {
+    it('should score strong agent with quality 100 and status strong', async () => {
+      registerStrong(watchmaker);
+
+      const result = await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'TestAgent',
+        testCases: [{ input: { query: 'test' }, expectedStatus: 'success' }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.evaluation.quality).toBe(100);
+      expect(parsed.evaluation.status).toBe('strong');
+      expect(parsed.evaluation.checks.every((c: { passed: boolean }) => c.passed)).toBe(true);
+    });
+
+    it('should score weak agent lower with status_matches failing', async () => {
+      registerWeak(watchmaker, '1.0');
+
+      const result = await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'TestAgent',
+        testCases: [{ input: { query: 'test' }, expectedStatus: 'success' }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.evaluation.quality).toBeLessThan(100);
+      const statusCheck = parsed.evaluation.checks.find(
+        (c: { name: string }) => c.name === 'status_matches',
+      );
+      expect(statusCheck.passed).toBe(false);
+    });
+
+    it('should handle crash agent without throwing', async () => {
+      await watchmaker.perform({
+        action: 'register',
+        agent: 'CrashAgent',
+        version: '1.0',
+        agentInstance: new MockCrashAgent(),
+      });
+
+      const result = await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'CrashAgent',
+        testCases: [{ input: { query: 'test' } }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.evaluation.quality).toBe(0);
+      const errorCheck = parsed.evaluation.checks.find(
+        (c: { name: string }) => c.name === 'executes_without_error',
+      );
+      expect(errorCheck.passed).toBe(false);
+    });
+
+    it('should record evaluation in history', async () => {
+      registerStrong(watchmaker);
+
+      await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'TestAgent',
+      });
+
+      const historyResult = await watchmaker.perform({
+        action: 'history',
+        agent: 'TestAgent',
+      });
+      const historyParsed = JSON.parse(historyResult);
+
+      expect(historyParsed.evaluationCount).toBe(1);
+      expect(historyParsed.evaluations[0].agentName).toBe('TestAgent');
+    });
+
+    it('should work with no testCases provided (default)', async () => {
+      registerStrong(watchmaker);
+
+      const result = await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'TestAgent',
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.evaluation.checks.length).toBeGreaterThan(0);
+    });
+
+    it('should include data_slush with source_agent, quality, and eval_status', async () => {
+      registerStrong(watchmaker);
+
+      const result = await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'TestAgent',
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.data_slush).toBeDefined();
+      expect(parsed.data_slush.source_agent).toBe('Watchmaker');
+      expect(parsed.data_slush.signals.quality).toBeDefined();
+      expect(parsed.data_slush.signals.eval_status).toBeDefined();
+    });
+
+    it('should return error without agent name', async () => {
+      const result = await watchmaker.perform({ action: 'evaluate' });
+      const parsed = JSON.parse(result);
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('required');
+    });
+
+    it('should return error for unknown agent', async () => {
+      const result = await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'nonexistent',
+      });
+      const parsed = JSON.parse(result);
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('not found');
+    });
+
+    it('should check has_data_slush', async () => {
+      registerStrong(watchmaker);
+
+      const result = await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'TestAgent',
+        testCases: [{ input: { query: 'test' } }],
+      });
+      const parsed = JSON.parse(result);
+
+      const slushCheck = parsed.evaluation.checks.find(
+        (c: { name: string }) => c.name === 'has_data_slush',
+      );
+      expect(slushCheck).toBeDefined();
+      expect(slushCheck.passed).toBe(true);
+    });
+
+    it('should check expectedFields', async () => {
+      registerStrong(watchmaker);
+
+      const result = await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'TestAgent',
+        testCases: [{ input: { query: 'test' }, expectedFields: ['result', 'nonexistent'] }],
+      });
+      const parsed = JSON.parse(result);
+
+      const resultField = parsed.evaluation.checks.find(
+        (c: { name: string }) => c.name === 'has_field_result',
+      );
+      expect(resultField.passed).toBe(true);
+
+      const missingField = parsed.evaluation.checks.find(
+        (c: { name: string }) => c.name === 'has_field_nonexistent',
+      );
+      expect(missingField.passed).toBe(false);
+    });
+  });
+
+  describe('compare action', () => {
+    it('should declare strong agent wins over weak agent (A wins)', async () => {
+      registerStrong(watchmaker, '1.0');
+      registerWeak(watchmaker, '2.0');
+
+      const result = await watchmaker.perform({
+        action: 'compare',
+        agent: 'TestAgent',
+        versionA: '1.0',
+        versionB: '2.0',
+        testCases: [{ input: { query: 'test' }, expectedStatus: 'success' }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.comparison.winner).toBe('A');
+      expect(parsed.comparison.qualityDelta).toBeLessThan(0);
+    });
+
+    it('should declare B wins when B is stronger', async () => {
+      registerWeak(watchmaker, '1.0');
+      registerStrong(watchmaker, '2.0');
+
+      const result = await watchmaker.perform({
+        action: 'compare',
+        agent: 'TestAgent',
+        versionA: '1.0',
+        versionB: '2.0',
+        testCases: [{ input: { query: 'test' }, expectedStatus: 'success' }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.comparison.winner).toBe('B');
+      expect(parsed.comparison.qualityDelta).toBeGreaterThan(0);
+    });
+
+    it('should tie when agents are equal', async () => {
+      registerStrong(watchmaker, '1.0');
+      // Register a second strong agent as candidate
+      await watchmaker.perform({
+        action: 'register',
+        agent: 'TestAgent',
+        version: '2.0',
+        agentInstance: new MockStrongAgent('TestAgent'),
+      });
+
+      const result = await watchmaker.perform({
+        action: 'compare',
+        agent: 'TestAgent',
+        versionA: '1.0',
+        versionB: '2.0',
+        testCases: [{ input: { query: 'test' }, expectedStatus: 'success' }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.comparison.winner).toBe('tie');
+    });
+
+    it('should use latency tiebreaker when quality is similar', async () => {
+      // Both are strong (same quality), but one is slow
+      await watchmaker.perform({
+        action: 'register',
+        agent: 'RaceAgent',
+        version: 'slow',
+        agentInstance: new MockSlowAgent('RaceAgent'),
+      });
+      await watchmaker.perform({
+        action: 'register',
+        agent: 'RaceAgent',
+        version: 'fast',
+        agentInstance: new MockStrongAgent('RaceAgent'),
+      });
+
+      const result = await watchmaker.perform({
+        action: 'compare',
+        agent: 'RaceAgent',
+        versionA: 'slow',
+        versionB: 'fast',
+        testCases: [{ input: { query: 'test' }, expectedStatus: 'success' }],
+      });
+      const parsed = JSON.parse(result);
+
+      // Both have 100% quality so latency decides; fast agent (B) should win
+      expect(parsed.comparison.winner).toBe('B');
+      expect(parsed.comparison.reason).toContain('atency');
+    });
+
+    it('should require versionA and versionB', async () => {
+      const result = await watchmaker.perform({
+        action: 'compare',
+        agent: 'TestAgent',
+      });
+      const parsed = JSON.parse(result);
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('required');
+    });
+  });
+
+  describe('promote action', () => {
+    it('should swap candidate into active slot', async () => {
+      registerStrong(watchmaker, '1.0');
+      registerWeak(watchmaker, '2.0');
+
+      const result = await watchmaker.perform({
+        action: 'promote',
+        agent: 'TestAgent',
+        version: '2.0',
+        reason: 'testing promotion',
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.version).toBe('2.0');
+
+      // Verify active version changed
+      const statusResult = await watchmaker.perform({
+        action: 'status',
+        agent: 'TestAgent',
+      });
+      const statusParsed = JSON.parse(statusResult);
+      expect(statusParsed.slot.activeVersion).toBe('2.0');
+      expect(statusParsed.slot.candidateCount).toBe(0);
+    });
+
+    it('should record PromotionRecord in slot history', async () => {
+      registerStrong(watchmaker, '1.0');
+      registerWeak(watchmaker, '2.0');
+
+      await watchmaker.perform({
+        action: 'promote',
+        agent: 'TestAgent',
+        version: '2.0',
+        reason: 'test reason',
+      });
+
+      const historyResult = await watchmaker.perform({
+        action: 'history',
+        agent: 'TestAgent',
+      });
+      const parsed = JSON.parse(historyResult);
+
+      expect(parsed.promotionCount).toBe(1);
+      expect(parsed.promotions[0].fromVersion).toBe('1.0');
+      expect(parsed.promotions[0].toVersion).toBe('2.0');
+      expect(parsed.promotions[0].reason).toBe('test reason');
+    });
+
+    it('should return error when version not found in candidates', async () => {
+      registerStrong(watchmaker, '1.0');
+
+      const result = await watchmaker.perform({
+        action: 'promote',
+        agent: 'TestAgent',
+        version: '999',
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('not found');
+    });
+
+    it('should return error when slot not found', async () => {
+      const result = await watchmaker.perform({
+        action: 'promote',
+        agent: 'nonexistent',
+        version: '1.0',
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('not found');
+    });
+  });
+
+  describe('cycle action', () => {
+    it('should evaluate active with no candidates and no promotions', async () => {
+      registerStrong(watchmaker);
+
+      const result = await watchmaker.perform({ action: 'cycle' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.cycle.evaluated.length).toBe(1);
+      expect(parsed.cycle.comparisons.length).toBe(0);
+      expect(parsed.cycle.promotions.length).toBe(0);
+    });
+
+    it('should promote candidate that beats active', async () => {
+      // Weak is active, strong is candidate
+      registerWeak(watchmaker, '1.0');
+      registerStrong(watchmaker, '2.0');
+
+      const result = await watchmaker.perform({
+        action: 'cycle',
+        testCases: [{ input: { query: 'test' }, expectedStatus: 'success' }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.cycle.promotions.length).toBe(1);
+      expect(parsed.cycle.promotions[0].toVersion).toBe('2.0');
+
+      // Verify active is now the strong version
+      const statusResult = await watchmaker.perform({
+        action: 'status',
+        agent: 'TestAgent',
+      });
+      const statusParsed = JSON.parse(statusResult);
+      expect(statusParsed.slot.activeVersion).toBe('2.0');
+    });
+
+    it('should not promote when active beats candidate', async () => {
+      registerStrong(watchmaker, '1.0');
+      registerWeak(watchmaker, '2.0');
+
+      const result = await watchmaker.perform({
+        action: 'cycle',
+        testCases: [{ input: { query: 'test' }, expectedStatus: 'success' }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.cycle.promotions.length).toBe(0);
+
+      const statusResult = await watchmaker.perform({
+        action: 'status',
+        agent: 'TestAgent',
+      });
+      const statusParsed = JSON.parse(statusResult);
+      expect(statusParsed.slot.activeVersion).toBe('1.0');
+    });
+
+    it('should record in cycleHistory', async () => {
+      registerStrong(watchmaker);
+
+      await watchmaker.perform({ action: 'cycle' });
+
+      const historyResult = await watchmaker.perform({ action: 'history' });
+      const parsed = JSON.parse(historyResult);
+
+      expect(parsed.count).toBe(1);
+      expect(parsed.cycles[0].timestamp).toBeDefined();
+      expect(parsed.cycles[0].summary).toContain('Evaluated');
+    });
+
+    it('should include data_slush with evaluations_run, comparisons_run, promotions_made', async () => {
+      registerStrong(watchmaker, '1.0');
+      registerWeak(watchmaker, '2.0');
+
+      const result = await watchmaker.perform({
+        action: 'cycle',
+        testCases: [{ input: { query: 'test' }, expectedStatus: 'success' }],
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.data_slush).toBeDefined();
+      expect(parsed.data_slush.signals.evaluations_run).toBeGreaterThan(0);
+      expect(parsed.data_slush.signals.comparisons_run).toBeGreaterThan(0);
+      expect(typeof parsed.data_slush.signals.promotions_made).toBe('number');
+    });
+  });
+
+  describe('status action', () => {
+    it('should return slot info for single agent', async () => {
+      registerStrong(watchmaker);
+
+      const result = await watchmaker.perform({
+        action: 'status',
+        agent: 'TestAgent',
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.slot.name).toBe('TestAgent');
+      expect(parsed.slot.activeVersion).toBe('1.0');
+      expect(parsed.slot.candidateCount).toBe(0);
+    });
+
+    it('should return all slots when no agent name', async () => {
+      registerStrong(watchmaker, '1.0', 'AgentA');
+      registerStrong(watchmaker, '1.0', 'AgentB');
+
+      const result = await watchmaker.perform({ action: 'status' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.count).toBe(2);
+      expect(parsed.slots.length).toBe(2);
+    });
+
+    it('should return error for unknown agent', async () => {
+      const result = await watchmaker.perform({
+        action: 'status',
+        agent: 'nonexistent',
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('not found');
+    });
+  });
+
+  describe('history action', () => {
+    it('should return eval + promotion history for agent', async () => {
+      registerStrong(watchmaker, '1.0');
+      registerWeak(watchmaker, '2.0');
+
+      await watchmaker.perform({
+        action: 'evaluate',
+        agent: 'TestAgent',
+      });
+
+      await watchmaker.perform({
+        action: 'promote',
+        agent: 'TestAgent',
+        version: '2.0',
+      });
+
+      const result = await watchmaker.perform({
+        action: 'history',
+        agent: 'TestAgent',
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.evaluationCount).toBe(1);
+      expect(parsed.promotionCount).toBe(1);
+    });
+
+    it('should return cycleHistory when no agent name', async () => {
+      registerStrong(watchmaker);
+      await watchmaker.perform({ action: 'cycle' });
+
+      const result = await watchmaker.perform({ action: 'history' });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.count).toBe(1);
+      expect(parsed.cycles).toBeDefined();
+    });
+
+    it('should return error for unknown agent', async () => {
+      const result = await watchmaker.perform({
+        action: 'history',
+        agent: 'nonexistent',
+      });
+      const parsed = JSON.parse(result);
+
+      expect(parsed.status).toBe('error');
+      expect(parsed.message).toContain('not found');
+    });
+  });
+
+  describe('setAgents', () => {
+    it('should allow injecting agents for testing', async () => {
+      const freshWatchmaker = new WatchmakerAgent();
+      freshWatchmaker.setAgents([
+        { agent: new MockStrongAgent('Injected'), version: '1.0' },
+      ]);
+
+      const statusResult = await freshWatchmaker.perform({
+        action: 'status',
+        agent: 'Injected',
+      });
+      const parsed = JSON.parse(statusResult);
+
+      expect(parsed.status).toBe('success');
+      expect(parsed.slot.name).toBe('Injected');
+      expect(parsed.slot.activeVersion).toBe('1.0');
+    });
+
+    it('should add second injection as candidate', async () => {
+      const freshWatchmaker = new WatchmakerAgent();
+      freshWatchmaker.setAgents([
+        { agent: new MockStrongAgent('Injected'), version: '1.0' },
+        { agent: new MockWeakAgent('Injected'), version: '2.0' },
+      ]);
+
+      const statusResult = await freshWatchmaker.perform({
+        action: 'status',
+        agent: 'Injected',
+      });
+      const parsed = JSON.parse(statusResult);
+
+      expect(parsed.slot.activeVersion).toBe('1.0');
+      expect(parsed.slot.candidateCount).toBe(1);
+    });
+  });
+
+  describe('Python parity', () => {
+    it('should follow single-file agent pattern', () => {
+      expect(watchmaker).toBeInstanceOf(BasicAgent);
+      expect(watchmaker.name).toBe('Watchmaker');
+      expect(watchmaker.metadata.name).toBe('Watchmaker');
+      expect(watchmaker.metadata.description).toBeDefined();
+      expect(watchmaker.metadata.parameters).toBeDefined();
+    });
+
+    it('should have same metadata schema as Python version', () => {
+      const params = watchmaker.metadata.parameters;
+      expect(params.type).toBe('object');
+      expect(params.properties.action.enum).toEqual([
+        'evaluate', 'compare', 'register', 'promote', 'cycle', 'status', 'history',
+      ]);
+      expect(params.properties.agent.type).toBe('string');
+      expect(params.properties.version.type).toBe('string');
+      expect(params.properties.versionA.type).toBe('string');
+      expect(params.properties.versionB.type).toBe('string');
+      expect(params.properties.testCases.type).toBe('array');
+      expect(params.properties.reason.type).toBe('string');
+    });
+  });
+});

--- a/typescript/src/agents/WatchmakerAgent.ts
+++ b/typescript/src/agents/WatchmakerAgent.ts
@@ -1,0 +1,771 @@
+/**
+ * WatchmakerAgent - Self-evolving agent ecosystem manager.
+ *
+ * Evaluates agent capabilities, A/B tests competing versions, and promotes
+ * winners. Natural selection for software: external processes produce
+ * candidate mutations; the Watchmaker decides which survive.
+ *
+ * Actions: evaluate, compare, register, promote, cycle, status, history
+ *
+ * Flow (cycle action):
+ *   1. Evaluate all active agents with test cases
+ *   2. For each slot with candidates, compare active vs candidate
+ *   3. Auto-promote candidates that beat active
+ *   4. Return full CycleResult audit trail
+ *
+ * Mirrors Python agents/watchmaker_agent.py
+ */
+
+import { BasicAgent } from './BasicAgent.js';
+import type { AgentMetadata } from './types.js';
+
+// ── Type Definitions ────────────────────────────────────────────────
+
+export interface AgentVersion {
+  agent: BasicAgent;
+  version: string;
+  registeredAt: string;
+  source: 'manual' | 'learnNew' | 'mutation';
+}
+
+export interface AgentSlot {
+  name: string;
+  active: AgentVersion;
+  candidates: AgentVersion[];
+  history: PromotionRecord[];
+}
+
+export interface TestCase {
+  input: Record<string, unknown>;
+  expectedFields?: string[];
+  expectedStatus?: string;
+}
+
+export interface EvaluationCheck {
+  name: string;
+  passed: boolean;
+  detail: string;
+}
+
+export interface EvaluationResult {
+  agentName: string;
+  version: string;
+  timestamp: string;
+  checks: EvaluationCheck[];
+  quality: number;
+  status: 'strong' | 'developing' | 'weak';
+  latencyMs: number;
+}
+
+export interface ComparisonResult {
+  agentName: string;
+  timestamp: string;
+  versionA: string;
+  versionB: string;
+  resultA: EvaluationResult;
+  resultB: EvaluationResult;
+  winner: 'A' | 'B' | 'tie';
+  qualityDelta: number;
+  latencyDelta: number;
+  reason: string;
+}
+
+export interface PromotionRecord {
+  fromVersion: string;
+  toVersion: string;
+  timestamp: string;
+  reason: string;
+  quality: number;
+}
+
+export interface CycleResult {
+  timestamp: string;
+  evaluated: EvaluationResult[];
+  comparisons: ComparisonResult[];
+  promotions: PromotionRecord[];
+  summary: string;
+}
+
+// ── WatchmakerAgent ─────────────────────────────────────────────────
+
+export class WatchmakerAgent extends BasicAgent {
+  private slots: Map<string, AgentSlot> = new Map();
+  private evaluationHistory: Map<string, EvaluationResult[]> = new Map();
+  private cycleHistory: CycleResult[] = [];
+  private defaultTestCases: Map<string, TestCase[]> = new Map();
+
+  constructor() {
+    const metadata: AgentMetadata = {
+      name: 'Watchmaker',
+      description:
+        'Self-evolving agent ecosystem manager. Evaluates agent capabilities, A/B tests competing versions, and promotes winners.',
+      parameters: {
+        type: 'object',
+        properties: {
+          action: {
+            type: 'string',
+            description: 'The action to perform.',
+            enum: ['evaluate', 'compare', 'register', 'promote', 'cycle', 'status', 'history'],
+          },
+          agent: {
+            type: 'string',
+            description: 'Agent name (slot key).',
+          },
+          version: {
+            type: 'string',
+            description: 'Version identifier.',
+          },
+          versionA: {
+            type: 'string',
+            description: 'Version A for comparison.',
+          },
+          versionB: {
+            type: 'string',
+            description: 'Version B for comparison.',
+          },
+          testCases: {
+            type: 'array',
+            description: 'Test inputs for evaluation.',
+            items: { type: 'object' },
+          },
+          reason: {
+            type: 'string',
+            description: 'Promotion reason.',
+          },
+        },
+        required: [],
+      },
+    };
+    super('Watchmaker', metadata);
+  }
+
+  /**
+   * Inject agents for testing.
+   */
+  setAgents(agents: Array<{ agent: BasicAgent; version: string; source?: 'manual' | 'learnNew' | 'mutation' }>): void {
+    for (const entry of agents) {
+      const name = entry.agent.name;
+      const agentVersion: AgentVersion = {
+        agent: entry.agent,
+        version: entry.version,
+        registeredAt: new Date().toISOString(),
+        source: entry.source ?? 'manual',
+      };
+      if (!this.slots.has(name)) {
+        this.slots.set(name, {
+          name,
+          active: agentVersion,
+          candidates: [],
+          history: [],
+        });
+      } else {
+        this.slots.get(name)!.candidates.push(agentVersion);
+      }
+      if (!this.evaluationHistory.has(name)) {
+        this.evaluationHistory.set(name, []);
+      }
+    }
+  }
+
+  async perform(kwargs: Record<string, unknown>): Promise<string> {
+    const action = kwargs.action as string | undefined;
+
+    if (!action) {
+      return JSON.stringify({
+        status: 'error',
+        message: 'No action specified. Use: evaluate, compare, register, promote, cycle, status, or history',
+      });
+    }
+
+    try {
+      switch (action) {
+        case 'register':
+          return this.registerAgent(kwargs);
+        case 'evaluate':
+          return await this.evaluateAgent(kwargs);
+        case 'compare':
+          return await this.compareAgents(kwargs);
+        case 'promote':
+          return this.promoteAgent(kwargs);
+        case 'cycle':
+          return await this.runCycle(kwargs);
+        case 'status':
+          return this.getStatus(kwargs);
+        case 'history':
+          return this.getHistory(kwargs);
+        default:
+          return JSON.stringify({
+            status: 'error',
+            message: `Unknown action: ${action}`,
+          });
+      }
+    } catch (error) {
+      return JSON.stringify({
+        status: 'error',
+        action,
+        message: (error as Error).message,
+      });
+    }
+  }
+
+  // ── register ────────────────────────────────────────────────────
+
+  private registerAgent(kwargs: Record<string, unknown>): string {
+    const agentName = kwargs.agent as string | undefined;
+    const version = kwargs.version as string | undefined;
+    const agentInstance = kwargs.agentInstance as BasicAgent | undefined;
+    const source = (kwargs.source as 'manual' | 'learnNew' | 'mutation') ?? 'manual';
+
+    if (!agentName || !version || !agentInstance) {
+      return JSON.stringify({
+        status: 'error',
+        message: 'agent, version, and agentInstance are required for register',
+      });
+    }
+
+    const agentVersion: AgentVersion = {
+      agent: agentInstance,
+      version,
+      registeredAt: new Date().toISOString(),
+      source,
+    };
+
+    if (!this.evaluationHistory.has(agentName)) {
+      this.evaluationHistory.set(agentName, []);
+    }
+
+    const slot = this.slots.get(agentName);
+    if (!slot) {
+      // First version becomes active
+      this.slots.set(agentName, {
+        name: agentName,
+        active: agentVersion,
+        candidates: [],
+        history: [],
+      });
+
+      const dataSlush = this.slushOut({
+        signals: { agent_name: agentName, version, action: 'register' },
+        registered: 'active',
+      });
+
+      return JSON.stringify({
+        status: 'success',
+        action: 'register',
+        agent: agentName,
+        version,
+        role: 'active',
+        message: `Registered ${agentName} v${version} as active`,
+        data_slush: dataSlush,
+      });
+    }
+
+    // Check for duplicate version
+    const allVersions = [slot.active, ...slot.candidates];
+    if (allVersions.some(v => v.version === version)) {
+      return JSON.stringify({
+        status: 'error',
+        message: `Version ${version} already registered for ${agentName}`,
+      });
+    }
+
+    slot.candidates.push(agentVersion);
+
+    const dataSlush = this.slushOut({
+      signals: { agent_name: agentName, version, action: 'register' },
+      registered: 'candidate',
+    });
+
+    return JSON.stringify({
+      status: 'success',
+      action: 'register',
+      agent: agentName,
+      version,
+      role: 'candidate',
+      message: `Registered ${agentName} v${version} as candidate`,
+      data_slush: dataSlush,
+    });
+  }
+
+  // ── evaluate ────────────────────────────────────────────────────
+
+  private async evaluateAgent(kwargs: Record<string, unknown>): Promise<string> {
+    const agentName = kwargs.agent as string | undefined;
+    if (!agentName) {
+      return JSON.stringify({
+        status: 'error',
+        message: 'agent name is required for evaluate',
+      });
+    }
+
+    const slot = this.slots.get(agentName);
+    if (!slot) {
+      return JSON.stringify({
+        status: 'error',
+        message: `Agent not found: ${agentName}`,
+      });
+    }
+
+    const targetVersion = kwargs.version as string | undefined;
+    let agentVersion: AgentVersion;
+
+    if (targetVersion) {
+      const found = [slot.active, ...slot.candidates].find(v => v.version === targetVersion);
+      if (!found) {
+        return JSON.stringify({
+          status: 'error',
+          message: `Version ${targetVersion} not found for ${agentName}`,
+        });
+      }
+      agentVersion = found;
+    } else {
+      agentVersion = slot.active;
+    }
+
+    const testCases = (kwargs.testCases as TestCase[]) ??
+      this.defaultTestCases.get(agentName) ??
+      [{ input: { query: 'health check' } }];
+
+    const evalResult = await this.runEvaluation(agentName, agentVersion, testCases);
+
+    // Store in history
+    this.evaluationHistory.get(agentName)!.push(evalResult);
+
+    const dataSlush = this.slushOut({
+      signals: {
+        agent_name: agentName,
+        version: agentVersion.version,
+        quality: evalResult.quality,
+        eval_status: evalResult.status,
+      },
+    });
+
+    return JSON.stringify({
+      status: 'success',
+      action: 'evaluate',
+      evaluation: evalResult,
+      data_slush: dataSlush,
+    });
+  }
+
+  // ── compare ─────────────────────────────────────────────────────
+
+  private async compareAgents(kwargs: Record<string, unknown>): Promise<string> {
+    const agentName = kwargs.agent as string | undefined;
+    const versionA = kwargs.versionA as string | undefined;
+    const versionB = kwargs.versionB as string | undefined;
+
+    if (!agentName || !versionA || !versionB) {
+      return JSON.stringify({
+        status: 'error',
+        message: 'agent, versionA, and versionB are required for compare',
+      });
+    }
+
+    const slot = this.slots.get(agentName);
+    if (!slot) {
+      return JSON.stringify({
+        status: 'error',
+        message: `Agent not found: ${agentName}`,
+      });
+    }
+
+    const allVersions = [slot.active, ...slot.candidates];
+    const foundA = allVersions.find(v => v.version === versionA);
+    const foundB = allVersions.find(v => v.version === versionB);
+
+    if (!foundA || !foundB) {
+      return JSON.stringify({
+        status: 'error',
+        message: `One or both versions not found: ${versionA}, ${versionB}`,
+      });
+    }
+
+    const testCases = (kwargs.testCases as TestCase[]) ??
+      this.defaultTestCases.get(agentName) ??
+      [{ input: { query: 'health check' } }];
+
+    const resultA = await this.runEvaluation(agentName, foundA, testCases);
+    const resultB = await this.runEvaluation(agentName, foundB, testCases);
+
+    const comparison = this.buildComparison(agentName, resultA, resultB);
+
+    return JSON.stringify({
+      status: 'success',
+      action: 'compare',
+      comparison,
+    });
+  }
+
+  // ── promote ─────────────────────────────────────────────────────
+
+  private promoteAgent(kwargs: Record<string, unknown>): string {
+    const agentName = kwargs.agent as string | undefined;
+    const version = kwargs.version as string | undefined;
+    const reason = (kwargs.reason as string) ?? 'manual promotion';
+
+    if (!agentName || !version) {
+      return JSON.stringify({
+        status: 'error',
+        message: 'agent and version are required for promote',
+      });
+    }
+
+    const slot = this.slots.get(agentName);
+    if (!slot) {
+      return JSON.stringify({
+        status: 'error',
+        message: `Agent not found: ${agentName}`,
+      });
+    }
+
+    const candidateIndex = slot.candidates.findIndex(v => v.version === version);
+    if (candidateIndex === -1) {
+      return JSON.stringify({
+        status: 'error',
+        message: `Version ${version} not found in candidates for ${agentName}`,
+      });
+    }
+
+    const candidate = slot.candidates[candidateIndex];
+    const latestEval = this.evaluationHistory.get(agentName)?.filter(e => e.version === version).pop();
+
+    this.doPromotion(slot, candidate, candidateIndex, reason, latestEval?.quality ?? 0);
+
+    const dataSlush = this.slushOut({
+      signals: { agent_name: agentName, promoted_version: version, reason },
+    });
+
+    return JSON.stringify({
+      status: 'success',
+      action: 'promote',
+      agent: agentName,
+      version,
+      reason,
+      message: `Promoted ${agentName} to v${version}`,
+      data_slush: dataSlush,
+    });
+  }
+
+  // ── cycle ───────────────────────────────────────────────────────
+
+  private async runCycle(kwargs: Record<string, unknown>): Promise<string> {
+    const testCasesOverride = kwargs.testCases as TestCase[] | undefined;
+    const cycleResult: CycleResult = {
+      timestamp: new Date().toISOString(),
+      evaluated: [],
+      comparisons: [],
+      promotions: [],
+      summary: '',
+    };
+
+    // Phase 1: Evaluate all active agents
+    for (const [name, slot] of this.slots) {
+      const testCases = testCasesOverride ??
+        this.defaultTestCases.get(name) ??
+        [{ input: { query: 'health check' } }];
+
+      const evalResult = await this.runEvaluation(name, slot.active, testCases);
+      this.evaluationHistory.get(name)!.push(evalResult);
+      cycleResult.evaluated.push(evalResult);
+
+      // Phase 2: Compare active vs each candidate
+      for (let i = 0; i < slot.candidates.length; i++) {
+        const candidate = slot.candidates[i];
+        const candidateEval = await this.runEvaluation(name, candidate, testCases);
+        this.evaluationHistory.get(name)!.push(candidateEval);
+        cycleResult.evaluated.push(candidateEval);
+
+        const comparison = this.buildComparison(name, evalResult, candidateEval);
+        cycleResult.comparisons.push(comparison);
+
+        // Phase 3: Auto-promote if candidate wins
+        if (comparison.winner === 'B') {
+          const record = this.doPromotion(
+            slot,
+            candidate,
+            i,
+            `Outperformed active: quality ${candidateEval.quality} vs ${evalResult.quality}`,
+            candidateEval.quality,
+          );
+          cycleResult.promotions.push(record);
+          // After promotion, the candidate is removed from the array,
+          // so decrement i to account for the shift
+          i--;
+        }
+      }
+    }
+
+    cycleResult.summary = `Evaluated ${cycleResult.evaluated.length} versions, ` +
+      `${cycleResult.comparisons.length} comparisons, ` +
+      `${cycleResult.promotions.length} promotions`;
+
+    this.cycleHistory.push(cycleResult);
+
+    const dataSlush = this.slushOut({
+      signals: {
+        evaluations_run: cycleResult.evaluated.length,
+        comparisons_run: cycleResult.comparisons.length,
+        promotions_made: cycleResult.promotions.length,
+      },
+    });
+
+    return JSON.stringify({
+      status: 'success',
+      action: 'cycle',
+      cycle: cycleResult,
+      data_slush: dataSlush,
+    });
+  }
+
+  // ── status ──────────────────────────────────────────────────────
+
+  private getStatus(kwargs: Record<string, unknown>): string {
+    const agentName = kwargs.agent as string | undefined;
+
+    if (!agentName) {
+      // Return all slots
+      const allSlots: Record<string, unknown>[] = [];
+      for (const [, slot] of this.slots) {
+        allSlots.push(this.slotSummary(slot));
+      }
+      return JSON.stringify({
+        status: 'success',
+        action: 'status',
+        slots: allSlots,
+        count: allSlots.length,
+      });
+    }
+
+    const slot = this.slots.get(agentName);
+    if (!slot) {
+      return JSON.stringify({
+        status: 'error',
+        message: `Agent not found: ${agentName}`,
+      });
+    }
+
+    return JSON.stringify({
+      status: 'success',
+      action: 'status',
+      slot: this.slotSummary(slot),
+    });
+  }
+
+  // ── history ─────────────────────────────────────────────────────
+
+  private getHistory(kwargs: Record<string, unknown>): string {
+    const agentName = kwargs.agent as string | undefined;
+
+    if (!agentName) {
+      // Return cycle history
+      return JSON.stringify({
+        status: 'success',
+        action: 'history',
+        cycles: this.cycleHistory,
+        count: this.cycleHistory.length,
+      });
+    }
+
+    const slot = this.slots.get(agentName);
+    if (!slot) {
+      return JSON.stringify({
+        status: 'error',
+        message: `Agent not found: ${agentName}`,
+      });
+    }
+
+    const evalHistory = this.evaluationHistory.get(agentName) ?? [];
+
+    return JSON.stringify({
+      status: 'success',
+      action: 'history',
+      agent: agentName,
+      evaluations: evalHistory,
+      promotions: slot.history,
+      evaluationCount: evalHistory.length,
+      promotionCount: slot.history.length,
+    });
+  }
+
+  // ── Internal helpers ────────────────────────────────────────────
+
+  private async runEvaluation(
+    agentName: string,
+    agentVersion: AgentVersion,
+    testCases: TestCase[],
+  ): Promise<EvaluationResult> {
+    const checks: EvaluationCheck[] = [];
+    const startTime = Date.now();
+
+    for (const testCase of testCases) {
+      let result: string | null = null;
+      let parsed: Record<string, unknown> | null = null;
+      let threw = false;
+
+      try {
+        result = await agentVersion.agent.execute(testCase.input);
+      } catch {
+        threw = true;
+      }
+
+      // Check: executes_without_error
+      checks.push({
+        name: 'executes_without_error',
+        passed: !threw,
+        detail: threw ? 'Agent threw an exception' : 'Agent executed successfully',
+      });
+
+      if (threw || result === null) continue;
+
+      // Check: returns_valid_json
+      let isValidJson = false;
+      try {
+        parsed = JSON.parse(result);
+        isValidJson = parsed !== null && typeof parsed === 'object';
+      } catch {
+        isValidJson = false;
+      }
+      checks.push({
+        name: 'returns_valid_json',
+        passed: isValidJson,
+        detail: isValidJson ? 'Valid JSON response' : 'Response is not valid JSON',
+      });
+
+      if (!isValidJson || !parsed) continue;
+
+      // Check: status_matches
+      if (testCase.expectedStatus) {
+        const statusMatches = parsed.status === testCase.expectedStatus;
+        checks.push({
+          name: 'status_matches',
+          passed: statusMatches,
+          detail: statusMatches
+            ? `Status matches: ${testCase.expectedStatus}`
+            : `Expected status "${testCase.expectedStatus}", got "${parsed.status}"`,
+        });
+      }
+
+      // Check: has_field_X
+      if (testCase.expectedFields) {
+        for (const field of testCase.expectedFields) {
+          const hasField = field in parsed;
+          checks.push({
+            name: `has_field_${field}`,
+            passed: hasField,
+            detail: hasField ? `Field "${field}" present` : `Field "${field}" missing`,
+          });
+        }
+      }
+
+      // Check: has_data_slush
+      const hasSlush = 'data_slush' in parsed;
+      checks.push({
+        name: 'has_data_slush',
+        passed: hasSlush,
+        detail: hasSlush ? 'data_slush present' : 'data_slush missing',
+      });
+    }
+
+    const latencyMs = Date.now() - startTime;
+    const passedCount = checks.filter(c => c.passed).length;
+    const quality = checks.length > 0 ? Math.round((passedCount / checks.length) * 100) : 0;
+
+    let evalStatus: 'strong' | 'developing' | 'weak';
+    if (quality >= 80) {
+      evalStatus = 'strong';
+    } else if (quality >= 50) {
+      evalStatus = 'developing';
+    } else {
+      evalStatus = 'weak';
+    }
+
+    return {
+      agentName,
+      version: agentVersion.version,
+      timestamp: new Date().toISOString(),
+      checks,
+      quality,
+      status: evalStatus,
+      latencyMs,
+    };
+  }
+
+  private buildComparison(
+    agentName: string,
+    resultA: EvaluationResult,
+    resultB: EvaluationResult,
+  ): ComparisonResult {
+    const qualityDelta = resultB.quality - resultA.quality;
+    const latencyDelta = resultB.latencyMs - resultA.latencyMs;
+
+    let winner: 'A' | 'B' | 'tie';
+    let reason: string;
+
+    if (Math.abs(qualityDelta) > 5) {
+      winner = qualityDelta > 0 ? 'B' : 'A';
+      reason = `Quality difference: ${Math.abs(qualityDelta)} points`;
+    } else {
+      const avgLatency = (resultA.latencyMs + resultB.latencyMs) / 2;
+      const latencyThreshold = avgLatency > 0 ? Math.abs(latencyDelta) / avgLatency : 0;
+      if (latencyThreshold > 0.2) {
+        winner = latencyDelta < 0 ? 'B' : 'A';
+        reason = `Latency tiebreaker: ${Math.abs(latencyDelta)}ms difference`;
+      } else {
+        winner = 'tie';
+        reason = 'No significant difference in quality or latency';
+      }
+    }
+
+    return {
+      agentName,
+      timestamp: new Date().toISOString(),
+      versionA: resultA.version,
+      versionB: resultB.version,
+      resultA,
+      resultB,
+      winner,
+      qualityDelta,
+      latencyDelta,
+      reason,
+    };
+  }
+
+  private doPromotion(
+    slot: AgentSlot,
+    candidate: AgentVersion,
+    candidateIndex: number,
+    reason: string,
+    quality: number,
+  ): PromotionRecord {
+    const record: PromotionRecord = {
+      fromVersion: slot.active.version,
+      toVersion: candidate.version,
+      timestamp: new Date().toISOString(),
+      reason,
+      quality,
+    };
+
+    slot.active = candidate;
+    slot.candidates.splice(candidateIndex, 1);
+    slot.history.push(record);
+
+    return record;
+  }
+
+  private slotSummary(slot: AgentSlot): Record<string, unknown> {
+    const latestEval = this.evaluationHistory
+      .get(slot.name)
+      ?.filter(e => e.version === slot.active.version)
+      .pop();
+
+    return {
+      name: slot.name,
+      activeVersion: slot.active.version,
+      candidateCount: slot.candidates.length,
+      latestQuality: latestEval?.quality ?? null,
+      latestStatus: latestEval?.status ?? null,
+      promotionCount: slot.history.length,
+    };
+  }
+}

--- a/typescript/src/agents/index.ts
+++ b/typescript/src/agents/index.ts
@@ -24,3 +24,5 @@ export { OuroborosAgent, EVOLUTION_CATALOG, assessEvolution, loadLineageLog, sav
 export type { EvolutionEntry, EvolutionReport, EvolutionLineage, LineageRunSummary, RunDelta, CapabilityTrend, CapabilityScore, Check } from './OuroborosAgent.js';
 export { SelfHealingCronAgent } from './SelfHealingCronAgent.js';
 export type { JobConfig, CheckResult } from './SelfHealingCronAgent.js';
+export { WatchmakerAgent } from './WatchmakerAgent.js';
+export type { AgentVersion, AgentSlot, TestCase, EvaluationCheck, EvaluationResult, ComparisonResult, PromotionRecord, CycleResult } from './WatchmakerAgent.js';


### PR DESCRIPTION
## Summary
- Adds `WatchmakerAgent` — a self-evolving agent ecosystem manager that evaluates agent capabilities, A/B tests competing versions, and promotes winners via natural selection
- Implements 7 actions: `register`, `evaluate`, `compare`, `promote`, `cycle`, `status`, `history`
- Includes Python mirror at `python/openrappter/agents/watchmaker_agent.py` and 45-test parity suite

## Test plan
- [x] All 45 WatchmakerAgent tests pass (`npx vitest run src/__tests__/parity/watchmaker.test.ts`)
- [x] Full regression suite passes (2105 tests, 71 files, 0 failures)
- [ ] Verify Python mirror matches TypeScript behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)