### PR TITLE
fix: support modern Copilot CLI OAuth tokens

### DIFF
--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -393,6 +393,15 @@ def copilot_session():
     gh = _github_token()
     if not gh:
         return None
+    if gh.startswith("gho_") or gh.startswith("github_pat_"):
+        _copilot_cache["token"] = gh
+        _copilot_cache["endpoint"] = os.environ.get(
+            "OPENRAPPTER_COPILOT_CAPI_URL",
+            "https://api.enterprise.githubcopilot.com",
+        )
+        _copilot_cache["expires_at"] = time.time() + 3600
+        _copilot_cache["direct_capi"] = True
+        return _copilot_cache
     prefix = "token" if gh.startswith("ghu_") else "Bearer"
     try:
         status, data = _http_json(
@@ -498,6 +507,15 @@ def llm_chat(messages, tools):
     session = copilot_session()
     if not session:
         raise RuntimeError("Copilot not authenticated — set GITHUB_TOKEN or run `gh auth login`")
+    direct_capi = bool(session.get("direct_capi"))
+    model = (
+        os.environ.get("OPENRAPPTER_CAPI_MODEL", "gpt-4o")
+        if direct_capi
+        else MODEL
+    )
+    payload = {"model": model, "messages": messages, "tools": tools or None}
+    if not direct_capi:
+        payload["max_tokens"] = 2000
     try:
         status, data = _http_json(
             f"{session['endpoint']}/chat/completions",
@@ -509,7 +527,7 @@ def llm_chat(messages, tools):
                 "Copilot-Integration-Id": "vscode-chat",
                 "Content-Type": "application/json",
             },
-            payload={"model": MODEL, "messages": messages, "tools": tools or None, "max_tokens": 2000},
+            payload=payload,
             timeout=120,
         )
     except urllib.error.HTTPError as e:

--- a/python/tests/test_openrappter_brainstem.py
+++ b/python/tests/test_openrappter_brainstem.py
@@ -449,6 +449,52 @@ def test_github_token_reuses_openrappter_consumer_profile(tmp_path, monkeypatch)
     assert brainstem._github_token() == "ghu_consumer_profile"
 
 
+def test_copilot_session_uses_direct_capi_for_modern_oauth(monkeypatch):
+    monkeypatch.setattr(brainstem, "_github_token", lambda: "gho_modern")
+    monkeypatch.setattr(
+        brainstem,
+        "_http_json",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            AssertionError("modern OAuth must not use the legacy exchange")
+        ),
+    )
+    brainstem._copilot_cache.update(
+        {"token": None, "endpoint": None, "expires_at": 0}
+    )
+    session = brainstem.copilot_session()
+    assert session["token"] == "gho_modern"
+    assert session["direct_capi"] is True
+    assert session["endpoint"] == "https://api.enterprise.githubcopilot.com"
+
+
+def test_direct_capi_chat_uses_supported_model_and_body(monkeypatch):
+    captured = {}
+    monkeypatch.setattr(
+        brainstem,
+        "copilot_session",
+        lambda: {
+            "token": "gho_modern",
+            "endpoint": "https://api.enterprise.githubcopilot.com",
+            "expires_at": 9999999999,
+            "direct_capi": True,
+        },
+    )
+
+    def fake_http(url, headers, payload=None, timeout=60):
+        captured["url"] = url
+        captured["payload"] = payload
+        return 200, {
+            "choices": [{"message": {"role": "assistant", "content": "ok"}}]
+        }
+
+    monkeypatch.setattr(brainstem, "_http_json", fake_http)
+    reply = brainstem.llm_chat([{"role": "user", "content": "hello"}], [])
+    assert reply["content"] == "ok"
+    assert captured["url"].endswith("/chat/completions")
+    assert captured["payload"]["model"] == "gpt-4o"
+    assert "max_tokens" not in captured["payload"]
+
+
 def test_copilot_session_refreshes_when_expired(tmp_path, monkeypatch):
     import time
 


### PR DESCRIPTION
## Summary

- recognize official Copilot CLI `gho_` and fine-grained Copilot credentials
- use them directly against modern CAPI instead of the legacy internal token exchange
- retain the existing `ghu_` exchange path for RAPP/backward compatibility
- default direct CAPI to supported `gpt-4o` and omit the legacy-only `max_tokens` field

## Verification

- 80 focused brainstem/iMessage/memory tests pass
- live official keychain credential creates a direct CAPI session
- live brainstem chat returned `MODERN_AUTH_READY`