### PR TITLE
fix: fence stale iMessage backlog on startup

### DIFF
--- a/python/openrappter/imessage/service.py
+++ b/python/openrappter/imessage/service.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import threading
 import time
+from datetime import datetime, timezone
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 from typing import Any, Callable, Mapping, Sequence
@@ -212,6 +213,16 @@ class IMessageService:
                 self._dropped_count += 1
                 return "outbound_echo"
 
+            age = self._message_age_seconds(parsed.get("created_at"))
+            if (
+                age is not None
+                and age > 15 * 60
+                and self.state.retry_attempts(guid) == 0
+            ):
+                self.state.mark_decision(rowid, guid, "stale_backlog")
+                self._dropped_count += 1
+                return "stale_backlog"
+
             allowed, reason = self._authorize(parsed, conversation)
             if not allowed:
                 self.state.mark_decision(rowid, guid, reason)
@@ -387,6 +398,7 @@ class IMessageService:
             "chat_id": chat_id,
             "chat_guid": chat_guid,
             "chat_identifier": str(raw.get("chat_identifier") or "").strip(),
+            "created_at": str(raw.get("created_at") or "").strip(),
             "participants": participants,
         }
 
@@ -611,6 +623,18 @@ class IMessageService:
         if isinstance(value, int) and value in (0, 1):
             return bool(value)
         raise IMessageServiceError(f"incoming {field} must be boolean")
+
+    @staticmethod
+    def _message_age_seconds(value: object) -> float | None:
+        if not isinstance(value, str) or not value.strip():
+            return None
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+        if parsed.tzinfo is None:
+            parsed = parsed.replace(tzinfo=timezone.utc)
+        return max(0.0, (datetime.now(timezone.utc) - parsed).total_seconds())
 
     def _publish_status(self, lifecycle: str) -> None:
         current = self.status()

--- a/python/openrappter/imessage/state.py
+++ b/python/openrappter/imessage/state.py
@@ -289,6 +289,13 @@ class IMessageState:
                 continue
         return messages
 
+    def retry_attempts(self, guid: str) -> int:
+        row = self._db.execute(
+            "SELECT attempts FROM inbox WHERE guid_hash=?",
+            (self._digest("message-guid", guid),),
+        ).fetchone()
+        return int(row["attempts"]) if row else 0
+
     def mark_decision(self, rowid: int | None, guid: str, outcome: str) -> None:
         guid_hash = self._digest("message-guid", guid)
         with self._transaction():

--- a/python/tests/test_imessage_core.py
+++ b/python/tests/test_imessage_core.py
@@ -2,6 +2,7 @@ import json
 import multiprocessing
 import time
 from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 import pytest
@@ -207,6 +208,41 @@ def test_failed_brainstem_turn_remains_retryable(tmp_path):
     assert service.state.cursor_rowid is None
     assert service.process_message(message) == "replied"
     assert service.state.cursor_rowid == 10
+
+
+def test_never_seen_stale_backlog_is_dropped_without_model_call(tmp_path):
+    calls = {"count": 0}
+
+    def runner(*_):
+        calls["count"] += 1
+        return {"response": "must not run"}
+
+    service = IMessageService(
+        config(tmp_path),
+        supervisor=FakeSupervisor(),
+        chat_runner=runner,
+    )
+    message = owner_message(guid="STALE", rowid=11)
+    message["created_at"] = (
+        datetime.now(timezone.utc) - timedelta(hours=2)
+    ).isoformat()
+    assert service.process_message(message) == "stale_backlog"
+    assert calls["count"] == 0
+
+
+def test_previously_failed_message_retries_even_after_live_fence(tmp_path):
+    service = IMessageService(
+        config(tmp_path),
+        supervisor=FakeSupervisor(),
+        chat_runner=lambda *_: {"response": "recovered"},
+    )
+    message = owner_message(guid="OLD-RETRY", rowid=12)
+    message["created_at"] = (
+        datetime.now(timezone.utc) - timedelta(hours=2)
+    ).isoformat()
+    service.state.observe(12, "OLD-RETRY", message)
+    service.state.mark_retryable(12, "OLD-RETRY")
+    assert service.process_message(message) == "replied"
 
 
 def test_first_pending_message_resumes_before_tail_after_restart(tmp_path):


### PR DESCRIPTION
## Summary

- drop never-seen iMessage events older than 15 minutes before model execution
- preserve old messages that already failed and are intentionally retryable
- persist/read retry-attempt state through the SQLite inbox

## Verification

- 82 focused iMessage/brainstem/memory tests pass
- all 779 Python tests pass