### PR TITLE
Sense seam (|||TAG|||) + wire Copilot CLI backend

### DIFF
--- a/typescript/src/agents/Assistant.ts
+++ b/typescript/src/agents/Assistant.ts
@@ -12,6 +12,7 @@
  */
 
 import { CopilotProvider, COPILOT_DEFAULT_MODEL } from '../providers/copilot.js';
+import { CopilotCliProvider } from '../providers/copilot-cli.js';
 import { truncateHistory } from '../providers/messages.js';
 import type { LLMProvider, Message, Tool, ToolCall } from '../providers/types.js';
 import type { BasicAgent } from './BasicAgent.js';
@@ -82,9 +83,13 @@ export class Assistant {
 
     this.provider =
       config?.provider ??
-      new CopilotProvider({
-        githubToken: config?.githubToken,
-      });
+      // Prefer the GitHub Copilot CLI when explicitly selected: it owns its own
+      // auth + refresh, so openrappter never runs the flaky device-code flow.
+      (process.env.OPENRAPPTER_AI_BACKEND === 'copilot-cli'
+        ? new CopilotCliProvider({ model: this.config.model })
+        : new CopilotProvider({
+            githubToken: config?.githubToken,
+          }));
   }
 
   /** Parsed identity from IDENTITY.md (updated each turn) */

--- a/typescript/src/channels/__tests__/senses.test.ts
+++ b/typescript/src/channels/__tests__/senses.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from 'vitest';
+import { parseSenses, voiceOf } from '../senses.js';
+
+describe('parseSenses — the sense weld point', () => {
+  it('returns the whole reply as text when there are no markers', () => {
+    const r = parseSenses('Just a plain reply.');
+    expect(r.text).toBe('Just a plain reply.');
+    expect(r.senses).toEqual({});
+  });
+
+  it('splits a single |||VOICE||| block', () => {
+    const r = parseSenses('Here is the full answer.\n|||VOICE|||\nHere is the spoken version.');
+    expect(r.text).toBe('Here is the full answer.');
+    expect(r.senses.voice).toBe('Here is the spoken version.');
+    expect(voiceOf(r)).toBe('Here is the spoken version.');
+  });
+
+  it('parses multiple senses in one reply', () => {
+    const reply = 'Main text here.'
+      + '|||VOICE|||Spoken form.'
+      + '|||HOLO|||{"creature":"rex","pose":"wave"}'
+      + '|||EMOJI|||🦖✨';
+    const r = parseSenses(reply);
+    expect(r.text).toBe('Main text here.');
+    expect(r.senses.voice).toBe('Spoken form.');
+    expect(r.senses.holo).toBe('{"creature":"rex","pose":"wave"}');
+    expect(r.senses.emoji).toBe('🦖✨');
+  });
+
+  it('lower-cases tags and trims content', () => {
+    const r = parseSenses('T |||TLDR|||   short   ');
+    expect(r.senses.tldr).toBe('short');
+  });
+
+  it('drops empty sense blocks', () => {
+    const r = parseSenses('body|||VOICE|||   |||EMOJI|||🦕');
+    expect(r.senses.voice).toBeUndefined();
+    expect(r.senses.emoji).toBe('🦕');
+  });
+
+  it('handles a reply that is only a sense block (empty main text)', () => {
+    const r = parseSenses('|||VOICE|||just speak this');
+    expect(r.text).toBe('');
+    expect(r.senses.voice).toBe('just speak this');
+  });
+
+  it('is safe on empty / whitespace input', () => {
+    expect(parseSenses('')).toEqual({ text: '', senses: {} });
+    expect(parseSenses('   ')).toEqual({ text: '', senses: {} });
+  });
+
+  it('ignores malformed markers (wrong pipe count / lowercase tag)', () => {
+    const r = parseSenses('keep ||VOICE|| and |||voice||| literal');
+    expect(r.text).toBe('keep ||VOICE|| and |||voice||| literal');
+    expect(r.senses).toEqual({});
+  });
+
+  it('last duplicate tag wins', () => {
+    const r = parseSenses('x|||VOICE|||first|||VOICE|||second');
+    expect(r.senses.voice).toBe('second');
+  });
+});

--- a/typescript/src/channels/senses.ts
+++ b/typescript/src/channels/senses.ts
@@ -1,0 +1,61 @@
+/**
+ * Sense parsing — the weld point between the brain (which produces modality
+ * projections) and the surfaces that render them.
+ *
+ * A "sense" (per the RAPP Sense Spec, `rapp-sense/1.0`) is a modality overlay:
+ * the LLM ends a reply with one or more `|||TAG|||`-delimited blocks, each shaped
+ * for a channel — `|||VOICE|||` (text-to-speech), `|||HOLO|||` (visual/gesture
+ * projection), `|||EMOJI|||`, `|||TLDR|||`, and so on. A single reply carries
+ * many projections; each surface renders only the blocks it cares about.
+ *
+ * This module is that seam. It replaces openrappter's one-off `|||VOICE|||`
+ * split with a general parser so every surface (iMessage, VUI, cards…) reads
+ * the same structured shape. It is intentionally tiny and dependency-free —
+ * the weld point, nothing more.
+ */
+
+/** A reply split into its main text and its sense projections. */
+export interface ParsedSenses {
+  /** The main reply — everything before the first sense marker. */
+  text: string;
+  /** Sense tag (lower-cased, e.g. "voice", "holo") → that block's content. */
+  senses: Record<string, string>;
+}
+
+// A sense marker: |||TAG||| where TAG is 2–16 uppercase letters/digits/underscore.
+const SENSE_MARKER = /\|\|\|([A-Z][A-Z0-9_]{1,15})\|\|\|/g;
+
+/**
+ * Parse a reply into its main text plus any `|||TAG|||` sense blocks.
+ *
+ * - No markers → `{ text: <whole reply>, senses: {} }`.
+ * - Content before the first marker is the main text; each marker owns the
+ *   text up to the next marker (or end of string).
+ * - Empty blocks are dropped. Duplicate tags: last one wins.
+ */
+export function parseSenses(reply: string): ParsedSenses {
+  if (!reply) return { text: '', senses: {} };
+
+  const markers: Array<{ tag: string; start: number; contentStart: number }> = [];
+  SENSE_MARKER.lastIndex = 0;
+  let m: RegExpExecArray | null;
+  while ((m = SENSE_MARKER.exec(reply)) !== null) {
+    markers.push({ tag: m[1].toLowerCase(), start: m.index, contentStart: m.index + m[0].length });
+  }
+
+  if (markers.length === 0) return { text: reply.trim(), senses: {} };
+
+  const text = reply.slice(0, markers[0].start).trim();
+  const senses: Record<string, string> = {};
+  for (let i = 0; i < markers.length; i++) {
+    const stop = i + 1 < markers.length ? markers[i + 1].start : reply.length;
+    const content = reply.slice(markers[i].contentStart, stop).trim();
+    if (content) senses[markers[i].tag] = content;
+  }
+  return { text, senses };
+}
+
+/** Convenience: the spoken (`|||VOICE|||`) projection, or '' if none. */
+export function voiceOf(parsed: ParsedSenses): string {
+  return parsed.senses.voice ?? '';
+}

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -6,6 +6,7 @@
 
 import { WebSocketServer, WebSocket } from 'ws';
 import { randomUUID, createHash, timingSafeEqual } from 'crypto';
+import { parseSenses } from '../channels/senses.js';
 import { createServer, IncomingMessage, ServerResponse } from 'http';
 import fs from 'fs';
 import path from 'path';
@@ -44,23 +45,24 @@ const DEFAULT_SHUTDOWN_TIMEOUT = 250;
 const RATE_LIMIT_WINDOW_MS = 60000;
 const RATE_LIMIT_MAX_REQUESTS = 100;
 const PROTOCOL_VERSION = 3;
-const VOICE_DELIMITER = '|||VOICE|||';
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
 /** Parse a response that may contain a |||VOICE||| delimiter into formatted + voice parts */
 function parseVoiceDelimiter(content: string): { text: string; voiceText: string } {
   if (!content) return { text: '', voiceText: '' };
 
-  const parts = content.split(VOICE_DELIMITER);
-  if (parts.length >= 2) {
-    return { text: parts[0].trim(), voiceText: parts[1].trim() };
+  // Route through the shared sense seam so the gateway parses |||VOICE||| the
+  // same way every other surface does.
+  const parsed = parseSenses(content);
+  if (parsed.senses.voice) {
+    return { text: parsed.text, voiceText: parsed.senses.voice };
   }
 
-  // No delimiter — extract first sentence as fallback voice text
+  // No |||VOICE||| sense — extract first sentence as fallback voice text
   const stripped = content.replace(/\*\*|`{1,3}[^`]*`{1,3}|#{1,3}\s|>|---/g, '').trim();
   const sentences = stripped.split(/(?<=[.!?])\s+/);
   const voiceText = sentences[0]?.trim() || "I've completed your request.";
-  return { text: content.trim(), voiceText };
+  return { text: parsed.text || content.trim(), voiceText };
 }
 
 /** Resolve a session identifier from params that may use either the
@@ -1910,6 +1912,9 @@ export class GatewayServer {
       // Send final response only (no streaming deltas — avoids duplication from multi-turn tool-call loops)
       const raw = result.content || '';
       const { text: finalText, voiceText } = parseVoiceDelimiter(raw);
+      // Forward modality senses (|||HOLO|||, …) so surfaces like the Voice UI
+      // can render a creature/visual from the same reply.
+      const allSenses = parseSenses(raw).senses;
       this.broadcastEvent(GatewayEvents.CHAT, {
         runId: run.runId,
         sessionKey: run.sessionId,
@@ -1917,6 +1922,8 @@ export class GatewayServer {
         state: 'final',
         message: finalText ? { role: 'assistant', content: [{ type: 'text', text: finalText }], timestamp: Date.now() } : undefined,
         voiceText: voiceText || undefined,
+        holo: allSenses.holo || undefined,
+        senses: Object.keys(allSenses).length ? allSenses : undefined,
       });
 
       // Store assistant message


### PR DESCRIPTION
Clean, additive changes on top of current \`main\` (keeps all the parallel iMessage/notarization work intact).

## What this adds
- **Sense seam** — \`typescript/src/channels/senses.ts\`: a shared \`parseSenses(reply) → { text, senses }\` parser for \`|||TAG|||\` modality projections (per the RAPP Sense spec). The gateway's \`|||VOICE|||\` handling now routes through it, and the chat \`final\` event **forwards all senses** (\`|||HOLO|||\`, …) so voice/visual surfaces can render from one reply. 9 unit tests.
- **Copilot CLI backend wiring** — the existing \`CopilotCliProvider\` is now selected by the Assistant when \`OPENRAPPTER_AI_BACKEND=copilot-cli\`. It owns its own auth + refresh, so openrappter never runs the flaky \`github.com/login/device\` flow. **Default is unchanged** (opt-in via env).

## Consumes this
The standalone **[rappter-vui](https://github.com/kody-w/rappter-vui)** fauna player ([live](https://kody-w.github.io/rappter-vui/)) drives the gateway and renders the \`|||HOLO|||\` sense as a rapp·go creature.

## Verified
- Full suite green (3124 tests), build clean.
- Copilot-CLI backend verified live earlier through the gateway: \`chat.send\` → CLI-backed reply, no device-code prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)