### PR TITLE
fix: don't crash sloshing on a non-string query (#41)

### DIFF
--- a/python/openrappter/agents/basic_agent.py
+++ b/python/openrappter/agents/basic_agent.py
@@ -88,7 +88,7 @@ class BasicAgent:
         interpreting between calls.
         """
         self._user_guid = kwargs.get('user_guid')
-        query = kwargs.get('query', kwargs.get('request', kwargs.get('user_input', '')))
+        query = self._resolve_slosh_query(kwargs)
 
         # Extract per-call overrides
         call_filter = kwargs.pop('_slosh_filter', None)
@@ -218,11 +218,36 @@ class BasicAgent:
         """Override this in subclasses. Context is available via self.context"""
         pass
     
+    @staticmethod
+    def _resolve_slosh_query(kwargs):
+        """Resolve the text used for data sloshing.
+
+        Tool arguments are usually produced by a model, so 'query' legitimately
+        arrives as an int, bool, list, or dict. Sloshing only needs text, and
+        perform() still receives the untouched original value, so each agent
+        keeps ownership of its own input contract instead of the framework
+        raising before perform() ever runs.
+
+        Missing/None keys fall through to the next candidate; a present but
+        non-string value sloshes as empty text.
+        """
+        for key in ('query', 'request', 'user_input'):
+            value = kwargs.get(key)
+            if value is None:
+                continue
+            return value if isinstance(value, str) else ''
+        return ''
+
     def slosh(self, query='', user_guid=None):
         """
         Data sloshing - gather contextual signals from multiple sources.
         Returns enriched context frame.
         """
+        # Defensive: slosh() is also callable directly, and every downstream
+        # signal helper assumes text. A non-string here must not crash the agent.
+        if not isinstance(query, str):
+            query = ''
+
         context = {
             'timestamp': datetime.now().isoformat(),
             'temporal': self._slosh_temporal(),

--- a/python/tests/test_basic_agent_query_guard.py
+++ b/python/tests/test_basic_agent_query_guard.py
@@ -1,0 +1,115 @@
+"""Regression tests for kody-w/openrappter#41.
+
+``execute()`` used to hand ``kwargs['query']`` straight to ``slosh()``, so any
+non-string query raised ``AttributeError: 'int' object has no attribute 'lower'``
+inside the framework — before ``perform()`` ran. An agent could not validate its
+own inputs. Mirrors ``typescript/src/__tests__/parity/basic-agent-query-guard.test.ts``.
+"""
+
+import json
+
+import pytest
+
+from openrappter.agents.basic_agent import BasicAgent
+
+
+class EchoAgent(BasicAgent):
+    def __init__(self):
+        self.name = 'Echo'
+        self.metadata = {
+            "name": self.name,
+            "description": "Echoes the received query type",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "query": {"type": "string", "description": "User input"}
+                },
+                "required": [],
+            },
+        }
+        self.seen = None
+        super().__init__(name=self.name, metadata=self.metadata)
+
+    def perform(self, **kwargs):
+        self.seen = kwargs
+        return json.dumps({"status": "success", "received": repr(kwargs.get('query'))})
+
+
+NON_STRING_QUERIES = [
+    pytest.param(42, id="int"),
+    pytest.param(True, id="bool"),
+    pytest.param(['a', 'b'], id="list"),
+    pytest.param({'a': 1}, id="dict"),
+    pytest.param(3.5, id="float"),
+]
+
+
+@pytest.mark.parametrize("value", NON_STRING_QUERIES)
+def test_executes_instead_of_raising(value):
+    agent = EchoAgent()
+    assert json.loads(agent.execute(query=value))["status"] == "success"
+
+
+@pytest.mark.parametrize("value", NON_STRING_QUERIES)
+def test_untouched_value_reaches_perform(value):
+    agent = EchoAgent()
+    agent.execute(query=value)
+    assert agent.seen['query'] == value
+
+
+def test_context_is_still_sloshed_for_non_string_query():
+    agent = EchoAgent()
+    agent.execute(query=42)
+
+    assert agent.context is not None
+    assert 'temporal' in agent.context
+    assert 'query_signals' in agent.context
+    assert 'orientation' in agent.context
+
+
+def test_non_string_query_sloshes_as_empty_text():
+    non_string = EchoAgent()
+    non_string.execute(query=['ignored', 'tokens'])
+
+    empty = EchoAgent()
+    empty.execute(query='')
+
+    assert non_string.context['query_signals'] == empty.context['query_signals']
+
+
+def test_string_query_still_sloshes_real_text():
+    agent = EchoAgent()
+    agent.execute(query='deploy the staging cluster now')
+
+    assert agent.context['query_signals'] != EchoAgent().slosh('')['query_signals']
+
+
+def test_nullish_keys_fall_through():
+    via_request = EchoAgent()
+    via_request.execute(query=None, request='from request')
+
+    via_user_input = EchoAgent()
+    via_user_input.execute(query=None, request=None, user_input='from user_input')
+
+    direct = EchoAgent()
+
+    assert via_request.context['query_signals'] == direct.slosh('from request')['query_signals']
+    assert (
+        via_user_input.context['query_signals']
+        == direct.slosh('from user_input')['query_signals']
+    )
+
+
+def test_present_non_string_query_does_not_fall_through_to_request():
+    agent = EchoAgent()
+    agent.execute(query=42, request='should not be used')
+
+    empty = EchoAgent()
+    empty.execute(query='')
+
+    assert agent.context['query_signals'] == empty.context['query_signals']
+
+
+@pytest.mark.parametrize("value", NON_STRING_QUERIES)
+def test_direct_slosh_does_not_raise(value):
+    assert EchoAgent().slosh(value) is not None

--- a/typescript/src/__tests__/parity/basic-agent-query-guard.test.ts
+++ b/typescript/src/__tests__/parity/basic-agent-query-guard.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from 'vitest';
+import { BasicAgent } from '../../agents/BasicAgent.js';
+import type { AgentMetadata } from '../../agents/types.js';
+
+/**
+ * Regression tests for kody-w/openrappter#41.
+ *
+ * `execute()` used to assert `kwargs.query as string` and hand the value
+ * straight to `slosh()`, so any non-string query threw
+ * `TypeError: query.toLowerCase is not a function` inside the framework —
+ * before `perform()` ran. An agent could not validate its own inputs.
+ */
+
+class EchoAgent extends BasicAgent {
+  seen: Record<string, unknown> | null = null;
+
+  constructor() {
+    const metadata: AgentMetadata = {
+      name: 'Echo',
+      description: 'Echoes the received query type',
+      parameters: {
+        type: 'object',
+        properties: { query: { type: 'string', description: 'User input' } },
+        required: [],
+      },
+    };
+    super('Echo', metadata);
+  }
+
+  async perform(kwargs: Record<string, unknown>): Promise<string> {
+    this.seen = kwargs;
+    return JSON.stringify({ status: 'success', received: kwargs.query ?? null });
+  }
+}
+
+const NON_STRING_QUERIES: Array<[string, unknown]> = [
+  ['number', 42],
+  ['boolean', true],
+  ['array', ['a', 'b']],
+  ['object', { a: 1 }],
+  ['float', 3.5],
+];
+
+describe('BasicAgent non-string query guard', () => {
+  it.each(NON_STRING_QUERIES)(
+    'executes instead of throwing when query is a %s',
+    async (_label, value) => {
+      const agent = new EchoAgent();
+      const result = await agent.execute({ query: value });
+      expect(JSON.parse(result).status).toBe('success');
+    },
+  );
+
+  it.each(NON_STRING_QUERIES)(
+    'passes the untouched %s value through to perform()',
+    async (_label, value) => {
+      const agent = new EchoAgent();
+      await agent.execute({ query: value });
+      expect(agent.seen?.query).toEqual(value);
+    },
+  );
+
+  it('still sloshes a full context for a non-string query', async () => {
+    const agent = new EchoAgent();
+    await agent.execute({ query: 42 });
+
+    expect(agent.context).not.toBeNull();
+    expect(agent.context?.temporal).toBeDefined();
+    expect(agent.context?.query_signals).toBeDefined();
+    expect(agent.context?.orientation).toBeDefined();
+  });
+
+  it('treats a non-string query as empty text when sloshing', async () => {
+    const nonString = new EchoAgent();
+    await nonString.execute({ query: ['ignored', 'tokens'] });
+
+    const empty = new EchoAgent();
+    await empty.execute({ query: '' });
+
+    expect(nonString.context?.query_signals).toEqual(empty.context?.query_signals);
+  });
+
+  it('still sloshes real text for a string query', async () => {
+    const agent = new EchoAgent();
+    await agent.execute({ query: 'deploy the staging cluster now' });
+
+    expect(agent.context?.query_signals).not.toEqual(
+      new EchoAgent().slosh('').query_signals,
+    );
+  });
+
+  it('falls through nullish keys to request and user_input', async () => {
+    const viaRequest = new EchoAgent();
+    await viaRequest.execute({ query: null, request: 'from request' });
+
+    const viaUserInput = new EchoAgent();
+    await viaUserInput.execute({ query: null, request: null, user_input: 'from user_input' });
+
+    const direct = new EchoAgent();
+
+    expect(viaRequest.context?.query_signals).toEqual(
+      direct.slosh('from request').query_signals,
+    );
+    expect(viaUserInput.context?.query_signals).toEqual(
+      direct.slosh('from user_input').query_signals,
+    );
+  });
+
+  it('does not fall through to request when query is present but non-string', async () => {
+    const agent = new EchoAgent();
+    await agent.execute({ query: 42, request: 'should not be used' });
+
+    const empty = new EchoAgent();
+    await empty.execute({ query: '' });
+
+    expect(agent.context?.query_signals).toEqual(empty.context?.query_signals);
+  });
+
+  it('does not throw when slosh() is called directly with a non-string', () => {
+    const agent = new EchoAgent();
+    for (const [, value] of NON_STRING_QUERIES) {
+      expect(() => agent.slosh(value as unknown as string)).not.toThrow();
+    }
+  });
+});

--- a/typescript/src/agents/BasicAgent.ts
+++ b/typescript/src/agents/BasicAgent.ts
@@ -83,7 +83,7 @@ export abstract class BasicAgent {
    * interpreting between calls.
    */
   async execute(kwargs: Record<string, unknown> = {}): Promise<string> {
-    const query = (kwargs.query ?? kwargs.request ?? kwargs.user_input ?? '') as string;
+    const query = BasicAgent.resolveSloshQuery(kwargs);
 
     // Extract per-call overrides
     const callFilter = kwargs._sloshFilter as SloshFilter | undefined;
@@ -219,10 +219,35 @@ export abstract class BasicAgent {
   abstract perform(kwargs: Record<string, unknown>): Promise<string>;
 
   /**
+   * Resolve the text used for data sloshing.
+   *
+   * Tool arguments are usually produced by a model, so `query` legitimately
+   * arrives as a number, boolean, array, or object. Sloshing only needs text,
+   * and `perform()` still receives the untouched original value, so each agent
+   * keeps ownership of its own input contract instead of the framework
+   * throwing before `perform()` ever runs.
+   *
+   * Nullish keys fall through to the next candidate (matching the previous `??`
+   * chain); a present-but-non-string value sloshes as empty text.
+   */
+  protected static resolveSloshQuery(kwargs: Record<string, unknown>): string {
+    for (const key of ['query', 'request', 'user_input'] as const) {
+      const value = kwargs[key];
+      if (value === undefined || value === null) continue;
+      return typeof value === 'string' ? value : '';
+    }
+    return '';
+  }
+
+  /**
    * Data sloshing - gather contextual signals from multiple sources.
    * Returns enriched context frame.
    */
   slosh(query: string = ''): AgentContext {
+    // Defensive: slosh() is also callable directly, and every downstream
+    // signal helper assumes text. A non-string here must not crash the agent.
+    if (typeof query !== 'string') query = '';
+
     const context: AgentContext = {
       timestamp: new Date().toISOString(),
       temporal: this.sloshTemporal(),


### PR DESCRIPTION
Fixes #41.

## Problem

`execute()` asserted `kwargs.query as string` (TypeScript) / read it directly (Python) and passed the value straight into `slosh()`, which calls `.toLowerCase()` / `.lower()` and `.split()` on it. Any non-string `query` threw **inside the framework, before `perform()` ran**:

```
query=42      -> TypeError: query.toLowerCase is not a function        (TS)
query=42      -> AttributeError: 'int' object has no attribute 'lower' (Python)
query=["a"]   -> same
query={"a":1} -> same
query=true    -> same
```

Both runtimes were affected, so this was a shared defect rather than a parity gap between them.

Tool arguments are normally produced by a model, so `{"query": 42}` is an ordinary runtime event. The practical consequence is that an agent which carefully validates its own inputs and returns `{"status":"error", ...}` never gets the chance — the framework has already thrown.

## Fix

Resolve the sloshing text without asserting a type, in both runtimes:

- nullish keys still fall through `query` → `request` → `user_input` (unchanged `??` semantics);
- a present-but-non-string value sloshes as **empty text** rather than throwing;
- `perform()` still receives the **untouched original value**, so each agent keeps ownership of its own input contract;
- `slosh()` is guarded directly too, since it is callable on its own.

No behaviour changes for string queries.

## Tests

New parity-mirrored regression suites:

- `typescript/src/__tests__/parity/basic-agent-query-guard.test.ts` — 16 tests
- `python/tests/test_basic_agent_query_guard.py` — 20 tests

They cover: executing instead of throwing for number/boolean/array/object/float; the untouched value reaching `perform()`; context still fully sloshed; non-string sloshing equivalently to `''`; string queries still sloshing real text; nullish fall-through to `request`/`user_input`; a present non-string **not** falling through; and direct `slosh()` calls.

Verified these are genuine regression tests — with the source fix reverted, **19/20 Python** and **14/16 TypeScript** fail.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| `eslint` on changed files | clean |
| Python suite | `1036 passed, 2 skipped` (was 1016 passed) |
| TypeScript suite | `3828 passed, 19 skipped` |

Two failures show up in the full runs — `python/tests/test_gateway_server.py::test_loopback_host_allows_no_token` and `typescript/src/gateway/__tests__/chat-envelope-parity.test.ts` (4 tests). I confirmed both **fail identically on clean `main`** with these changes stashed, so they are pre-existing and unrelated to this PR.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
