### PR TITLE
fix: stop silently discarding config written to config.json5 (#43)

### DIFF
--- a/typescript/src/__tests__/unit/env-config-merge.test.ts
+++ b/typescript/src/__tests__/unit/env-config-merge.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression tests for kody-w/openrappter#43.
+ *
+ * `config/loader.ts` (schema-validated) reads `config.json5`, while every
+ * consumer going through `env.ts` reads `config.json`. Configuration written to
+ * `config.json5` — which is the file the Zod schema describes — was silently
+ * discarded, so `channels.imessage` could never be enabled that way and
+ * `install-service` told the user to set what they had already set.
+ *
+ * `config.json` still wins every conflict, so an install that already worked
+ * cannot change behaviour.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+let home: string;
+let originalHome: string | undefined;
+
+/** Import env.ts fresh so its module-level path constants see the temp HOME. */
+async function freshEnv() {
+  const { resetModules } = await import('vitest').then(m => ({ resetModules: m.vi.resetModules }));
+  resetModules();
+  return import('../../env.js');
+}
+
+async function writeConfig(name: string, body: string) {
+  await fs.writeFile(path.join(home, name), body, 'utf-8');
+}
+
+beforeEach(async () => {
+  originalHome = process.env.HOME;
+  home = await fs.mkdtemp(path.join(os.tmpdir(), 'openrappter-cfg-'));
+  // os.homedir() honours $HOME on POSIX, so this relocates HOME_DIR/CONFIG_FILE.
+  process.env.HOME = home;
+  await fs.mkdir(path.join(home, '.openrappter'), { recursive: true });
+  home = path.join(home, '.openrappter');
+});
+
+afterEach(async () => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  await fs.rm(path.dirname(home), { recursive: true, force: true });
+});
+
+describe('loadConfig merges config.json5 without displacing config.json', () => {
+  it('still returns config.json alone when it is the only file', async () => {
+    await writeConfig('config.json', JSON.stringify({ setupComplete: true }));
+    const env = await freshEnv();
+    expect(await env.loadConfig()).toEqual({ setupComplete: true });
+  });
+
+  it('no longer discards config written to config.json5 (the bug)', async () => {
+    await writeConfig('config.json', JSON.stringify({ setupComplete: true }));
+    await writeConfig(
+      'config.json5',
+      `{
+        // the Zod schema describes this file
+        channels: { imessage: { enabled: true, allowFrom: ['+15551234567'] } },
+      }`,
+    );
+    const env = await freshEnv();
+    const cfg = await env.loadConfig() as Record<string, any>;
+
+    expect(cfg.channels.imessage.enabled).toBe(true);
+    expect(cfg.channels.imessage.allowFrom).toEqual(['+15551234567']);
+    expect(cfg.setupComplete).toBe(true);
+  });
+
+  it('works when only config.json5 exists', async () => {
+    await writeConfig('config.json5', `{ channels: { imessage: { enabled: true } } }`);
+    const env = await freshEnv();
+    const cfg = await env.loadConfig() as Record<string, any>;
+    expect(cfg.channels.imessage.enabled).toBe(true);
+  });
+
+  it('lets config.json win every conflict, so working installs cannot change', async () => {
+    await writeConfig('config.json', JSON.stringify({
+      channels: { imessage: { enabled: true, allowFrom: ['+15550000000'] } },
+    }));
+    await writeConfig('config.json5', `{
+      channels: { imessage: { enabled: false, allowFrom: ['+15551111111'], mode: 'applescript' } },
+    }`);
+    const env = await freshEnv();
+    const cfg = await env.loadConfig() as Record<string, any>;
+
+    expect(cfg.channels.imessage.enabled).toBe(true);
+    expect(cfg.channels.imessage.allowFrom).toEqual(['+15550000000']);
+    // non-conflicting keys from config.json5 still fill in
+    expect(cfg.channels.imessage.mode).toBe('applescript');
+  });
+
+  it('survives a malformed config.json5 rather than taking the runtime down', async () => {
+    await writeConfig('config.json', JSON.stringify({ setupComplete: true }));
+    await writeConfig('config.json5', '{ this is not valid json5 ');
+    const env = await freshEnv();
+    await expect(env.loadConfig()).resolves.toEqual({ setupComplete: true });
+  });
+
+  it('reads only the given file when an explicit path is passed', async () => {
+    await writeConfig('config.json5', `{ channels: { imessage: { enabled: true } } }`);
+    await writeConfig('other.json', JSON.stringify({ only: 'this' }));
+    const env = await freshEnv();
+    expect(await env.loadConfig(path.join(home, 'other.json'))).toEqual({ only: 'this' });
+  });
+
+  it('reports which config files actually contributed', async () => {
+    await writeConfig('config.json', JSON.stringify({ a: 1 }));
+    const env = await freshEnv();
+    expect(await env.resolvedConfigSources()).toEqual([env.CONFIG_FILE]);
+
+    await writeConfig('config.json5', '{ b: 2 }');
+    expect(await env.resolvedConfigSources()).toEqual([env.CONFIG_FILE_JSON5, env.CONFIG_FILE]);
+  });
+});

--- a/typescript/src/env.ts
+++ b/typescript/src/env.ts
@@ -1,9 +1,18 @@
 import fs from 'fs/promises';
 import path from 'path';
 import os from 'os';
+import JSON5 from 'json5';
 
 export const HOME_DIR = path.join(os.homedir(), '.openrappter');
 export const CONFIG_FILE = path.join(HOME_DIR, 'config.json');
+/**
+ * The schema-validated loader (`config/loader.ts`) reads `config.json5`, so a
+ * user who follows the Zod config schema writes there — while every consumer
+ * that goes through this module reads `config.json`. That split silently
+ * discarded real configuration (notably `channels.imessage`), and the error
+ * text then told the user to set the very thing they had just set.
+ */
+export const CONFIG_FILE_JSON5 = path.join(HOME_DIR, 'config.json5');
 export const ENV_FILE = path.join(HOME_DIR, '.env');
 
 export async function ensureHomeDir(): Promise<void> {
@@ -52,13 +61,73 @@ export async function saveEnv(env: Record<string, string>, filePath: string = EN
   }
 }
 
-export async function loadConfig(filePath: string = CONFIG_FILE): Promise<Record<string, unknown>> {
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Recursive merge where `override` wins on conflict. */
+function mergeConfigObjects(
+  base: Record<string, unknown>,
+  override: Record<string, unknown>,
+): Record<string, unknown> {
+  const merged: Record<string, unknown> = { ...base };
+  for (const [key, value] of Object.entries(override)) {
+    const existing = merged[key];
+    merged[key] = isPlainObject(existing) && isPlainObject(value)
+      ? mergeConfigObjects(existing, value)
+      : value;
+  }
+  return merged;
+}
+
+async function readJsonFile(filePath: string): Promise<Record<string, unknown>> {
   try {
     const data = await fs.readFile(filePath, 'utf-8');
-    return JSON.parse(data);
+    const parsed = JSON.parse(data);
+    return isPlainObject(parsed) ? parsed : {};
   } catch {
     return {};
   }
+}
+
+async function readJson5File(filePath: string): Promise<Record<string, unknown>> {
+  try {
+    const data = await fs.readFile(filePath, 'utf-8');
+    const parsed = JSON5.parse(data);
+    return isPlainObject(parsed) ? parsed : {};
+  } catch {
+    // A malformed or absent config.json5 must never take down a runtime that
+    // was previously reading config.json alone.
+    return {};
+  }
+}
+
+/**
+ * Report which config files actually contributed, so a mismatch is visible
+ * instead of looking like a missing setting.
+ */
+export async function resolvedConfigSources(): Promise<string[]> {
+  const sources: string[] = [];
+  for (const candidate of [CONFIG_FILE_JSON5, CONFIG_FILE]) {
+    try {
+      await fs.access(candidate);
+      sources.push(candidate);
+    } catch { /* not present */ }
+  }
+  return sources;
+}
+
+export async function loadConfig(filePath: string = CONFIG_FILE): Promise<Record<string, unknown>> {
+  const primary = await readJsonFile(filePath);
+  // Only merge the sibling file when loading the default location; an explicit
+  // path means the caller wants exactly that file.
+  if (filePath !== CONFIG_FILE) return primary;
+
+  // `config.json` still wins every conflict, so this cannot change the
+  // behaviour of an install that already worked — it only stops `config.json5`
+  // from being silently discarded.
+  const secondary = await readJson5File(CONFIG_FILE_JSON5);
+  return mergeConfigObjects(secondary, primary);
 }
 
 export async function saveConfig(config: Record<string, unknown>, filePath: string = CONFIG_FILE): Promise<void> {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { AgentRegistry } from './agents/index.js';
 import type { AgentInfo } from './agents/types.js';
-import { ensureHomeDir, loadEnv, saveEnv, loadConfig, saveConfig, HOME_DIR, CONFIG_FILE, ENV_FILE } from './env.js';
+import { ensureHomeDir, loadEnv, saveEnv, loadConfig, saveConfig, resolvedConfigSources, HOME_DIR, CONFIG_FILE, ENV_FILE } from './env.js';
 import { hasCopilotAvailable, autoAuthIfNeeded, resolveGithubToken, saveGitHubToken } from './copilot-check.js';
 import { chat, displayResult } from './chat.js';
 import { VERSION } from './version.js';
@@ -1890,6 +1890,10 @@ imessageCommand
     }
     console.log(`${EMOJI} iMessage diagnostics: ${result.ready ? 'ready' : 'not ready'}`);
     console.log(`  Configured allowlist entries: ${result.allowlistEntries}`);
+    // Name the files that actually contributed. A zero allowlist because the
+    // config landed in a file this path never reads is indistinguishable from
+    // 'you forgot to configure it' without this line.
+    console.log(`  Config sources: ${(await resolvedConfigSources()).join(', ') || 'none found'}`);
     console.log(`  Messages database: ${result.databaseQueryable ? 'readable' : 'unavailable'}`);
     console.log(`  Messages automation: ${result.automationAvailable ? 'available' : 'unavailable'}`);
     console.log(`  Copilot token: ${result.tokenConfigured ? 'configured' : 'missing'}`);


### PR DESCRIPTION
Fixes #43.

## Problem

There are two `loadConfig` functions:

```ts
// src/config/loader.ts — schema-validated, JSON5
const DEFAULT_CONFIG_FILE = 'config.json5';

// src/env.ts — plain JSON.parse
export const CONFIG_FILE = path.join(HOME_DIR, 'config.json');
```

`src/index.ts` imports the **`env.ts`** one, so the daemon, `imessage diagnose`, and `imessage install-service` all read `config.json` — never `config.json5`, which is the file the Zod schema describes.

The failure mode is worse than a silent no-op. `install-service` refuses with *"Enable `channels.imessage` with a non-empty `allowFrom` list before installing the service"* while reading a file that, per the schema, is not where that setting lives. `diagnose` then reports `channel_disabled, allowlist_empty` — indistinguishable from having forgotten to configure it, so the natural next step is to re-edit the file being ignored.

## Fix

`env.ts:loadConfig` merges `config.json5` **beneath** `config.json` when loading the default location.

- `config.json` wins every conflict → an install that already worked cannot change behaviour. This only stops the other file being discarded.
- A malformed `config.json5` is swallowed, not fatal.
- An explicit path argument still reads exactly that file.

Also adds `resolvedConfigSources()`, printed by `imessage diagnose`:

```
  Configured allowlist entries: 2
  Config sources: /Users/…/config.json5, /Users/…/config.json
```

so a mismatch is visible rather than looking like a missing setting.

## Tests

7 cases in `src/__tests__/unit/env-config-merge.test.ts`: the bug itself, `config.json` precedence, json5-only, malformed json5, explicit path, and source reporting. They use a temp `HOME` with a fresh module import so the real path constants are exercised.

**Mutation-checked** — with the fix reverted, **4 of 7 fail**:

```
× no longer discards config written to config.json5 (the bug)
× works when only config.json5 exists
× lets config.json win every conflict, so working installs cannot change
× reports which config files actually contributed
```

The 3 that still pass are the backward-compatibility cases, which should pass either way.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **3835 passed** (baseline 3828), 19 skipped |
| Failures | same 4 pre-existing `chat-envelope-parity` — tracked in #46, verified failing on clean `main` |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
