### PR TITLE
fix: hydrate ~/.openrappter/.env in the supervised gateway (#44)

### DIFF
--- a/typescript/src/__tests__/unit/env-hydrate.test.ts
+++ b/typescript/src/__tests__/unit/env-hydrate.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Regression tests for kody-w/openrappter#44.
+ *
+ * The `openrappter` wrapper sources `~/.openrappter/.env` before exec, so every
+ * interactive command sees it. launchd runs `node` directly with a fixed
+ * environment (`HOME`, `PATH`, `NODE_ENV`, `OPENRAPPTER_LAUNCHD`), so a
+ * supervised gateway started with none of it — the Copilot provider had no
+ * credential and the iMessage model preflight failed forever, while `diagnose`
+ * (running under the wrapper) reported `Copilot token: configured`.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { hydrateManagedEnv } from '../../env.js';
+
+let dir: string;
+let envFile: string;
+const TOUCHED = ['COPILOT_GITHUB_TOKEN', 'OPENRAPPTER_MODEL', 'OPENRAPPTER_PORT'];
+let saved: Record<string, string | undefined>;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'openrappter-env-'));
+  envFile = path.join(dir, '.env');
+  saved = Object.fromEntries(TOUCHED.map(k => [k, process.env[k]]));
+  for (const k of TOUCHED) delete process.env[k];
+});
+
+afterEach(async () => {
+  for (const [k, v] of Object.entries(saved)) {
+    if (v === undefined) delete process.env[k];
+    else process.env[k] = v;
+  }
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('hydrateManagedEnv', () => {
+  it('applies .env values that launchd would never have supplied', async () => {
+    await fs.writeFile(envFile, 'COPILOT_GITHUB_TOKEN=ghu_example\nOPENRAPPTER_MODEL=gpt-5.6-sol\n');
+
+    const applied = await hydrateManagedEnv(envFile);
+
+    expect(process.env.COPILOT_GITHUB_TOKEN).toBe('ghu_example');
+    expect(process.env.OPENRAPPTER_MODEL).toBe('gpt-5.6-sol');
+    expect(applied.sort()).toEqual(['COPILOT_GITHUB_TOKEN', 'OPENRAPPTER_MODEL']);
+  });
+
+  it('never overrides a variable that is already exported', async () => {
+    process.env.OPENRAPPTER_MODEL = 'already-set';
+    await fs.writeFile(envFile, 'OPENRAPPTER_MODEL=from-file\nOPENRAPPTER_PORT=19999\n');
+
+    const applied = await hydrateManagedEnv(envFile);
+
+    expect(process.env.OPENRAPPTER_MODEL).toBe('already-set');
+    expect(process.env.OPENRAPPTER_PORT).toBe('19999');
+    expect(applied).toEqual(['OPENRAPPTER_PORT']);
+  });
+
+  it('is a no-op when there is no .env, rather than throwing', async () => {
+    await expect(hydrateManagedEnv(path.join(dir, 'absent.env'))).resolves.toEqual([]);
+    expect(process.env.COPILOT_GITHUB_TOKEN).toBeUndefined();
+  });
+
+  it('reports nothing applied when every key is already present', async () => {
+    process.env.COPILOT_GITHUB_TOKEN = 'exported';
+    await fs.writeFile(envFile, 'COPILOT_GITHUB_TOKEN=from-file\n');
+
+    expect(await hydrateManagedEnv(envFile)).toEqual([]);
+    expect(process.env.COPILOT_GITHUB_TOKEN).toBe('exported');
+  });
+
+  it('makes the credential resolvable exactly as the provider looks for it', async () => {
+    // CopilotCliProvider reads these keys, in this order, from process.env.
+    const TOKEN_ENV_KEYS = ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN'];
+    expect(TOKEN_ENV_KEYS.some(k => process.env[k])).toBe(false);
+
+    await fs.writeFile(envFile, 'COPILOT_GITHUB_TOKEN=ghu_example\n');
+    await hydrateManagedEnv(envFile);
+
+    expect(TOKEN_ENV_KEYS.some(k => process.env[k])).toBe(true);
+  });
+});

--- a/typescript/src/env.ts
+++ b/typescript/src/env.ts
@@ -43,6 +43,30 @@ export async function loadEnv(filePath: string = ENV_FILE): Promise<Record<strin
   }
 }
 
+/**
+ * Copy `~/.openrappter/.env` into `process.env` for keys that are not already
+ * set, and report which keys were applied.
+ *
+ * The `openrappter` shell wrapper sources `.env` before exec, so every
+ * interactive command sees it. launchd does not — it runs `node` directly with
+ * a fixed environment — so a supervised gateway started with none of it, the
+ * Copilot provider had no credential, and the iMessage model preflight failed
+ * forever while `diagnose` (running under the wrapper) reported the token as
+ * configured. Existing values always win, so this can never override a
+ * deliberately exported variable.
+ */
+export async function hydrateManagedEnv(filePath: string = ENV_FILE): Promise<string[]> {
+  const applied: string[] = [];
+  const managed = await loadEnv(filePath);
+  for (const [key, value] of Object.entries(managed)) {
+    if (!process.env[key]) {
+      process.env[key] = value;
+      applied.push(key);
+    }
+  }
+  return applied;
+}
+
 export async function saveEnv(env: Record<string, string>, filePath: string = ENV_FILE): Promise<void> {
   const dir = path.dirname(filePath);
   await fs.mkdir(dir, { recursive: true });

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -9,7 +9,7 @@ import path from 'path';
 import { fileURLToPath } from 'url';
 import { AgentRegistry } from './agents/index.js';
 import type { AgentInfo } from './agents/types.js';
-import { ensureHomeDir, loadEnv, saveEnv, loadConfig, saveConfig, resolvedConfigSources, HOME_DIR, CONFIG_FILE, ENV_FILE } from './env.js';
+import { ensureHomeDir, loadEnv, saveEnv, hydrateManagedEnv, loadConfig, saveConfig, resolvedConfigSources, HOME_DIR, CONFIG_FILE, ENV_FILE } from './env.js';
 import { hasCopilotAvailable, autoAuthIfNeeded, resolveGithubToken, saveGitHubToken } from './copilot-check.js';
 import { chat, displayResult } from './chat.js';
 import { VERSION } from './version.js';
@@ -68,6 +68,13 @@ async function startGatewayInProcess(opts?: {
     readIMessageConfig,
   } = await import('./channels/imessage-gateway.js');
   const { listBundledSkills } = await import('./skills/bundled.js');
+
+  // launchd runs `node` directly with a fixed environment, so a supervised
+  // gateway never sees ~/.openrappter/.env — the wrapper script is what sources
+  // it for interactive commands. Without this the Copilot provider starts with
+  // no credential and the iMessage model preflight fails forever, while
+  // `diagnose` (run under the wrapper) reports the token as configured. #44
+  await hydrateManagedEnv();
 
   const port = opts?.port ?? parseInt(process.env.OPENRAPPTER_PORT ?? '18790', 10);
   const token = process.env.OPENRAPPTER_TOKEN || undefined;


### PR DESCRIPTION
Refs #44 — fixes the credential half. The lock-ownership reporting is left for a follow-up.

## Problem

`install-service` produces a launchd service that can never pass model preflight.

The generated plist carries only `HOME`, `PATH`, `NODE_ENV`, `OPENRAPPTER_LAUNCHD`. The `openrappter` **wrapper script** is what sources `~/.openrappter/.env` — launchd execs `node` directly, so the supervised gateway starts with no credential, `CopilotCliProvider` has nothing to authenticate with, and the iMessage runtime sits at:

```
ready=false  reason=model_preflight_failed
```

retrying every 60s forever.

What makes this expensive is that **it looks green from the outside**:

- `imessage diagnose` prints `Copilot token: configured` — that check runs in the *CLI's* process, which the wrapper already fed from `.env`.
- The exact preflight command succeeds when pasted into a terminal, for the same reason.

So every signal available to the operator says the credential is fine, while the process that actually runs the channel has none of it.

## Fix

`startGatewayInProcess()` now hydrates the managed env **before** reading any of it — exactly what the `chat` command (`index.ts:896`) and `imessage diagnose` (`index.ts:1873`) already do at their entry points. The daemon path was simply missing it.

Extracted as `hydrateManagedEnv()` in `env.ts` so the behaviour is unit-testable rather than only reachable by starting a real gateway.

- Already-exported variables always win → cannot override a deliberately set environment.
- Missing `.env` is a no-op, not a throw.
- Hydrating before the port is read means `OPENRAPPTER_PORT` in `.env` is now honoured by the daemon too.

## Tests

5 cases in `src/__tests__/unit/env-hydrate.test.ts`, including one asserting the credential becomes visible under exactly the keys `CopilotCliProvider` looks for.

**Mutation-checked twice:**

| Mutation | Result |
|---|---|
| Remove `hydrateManagedEnv` | 5/5 fail |
| Let hydration clobber exported vars | 2/5 fail (the precedence cases), 3 still pass |

The second one matters — it proves the tests check behaviour, not just that a symbol exists.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **3873 passed**, 19 skipped |
| Failures | same 4 pre-existing `chat-envelope-parity` (#46) |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
