### PR TITLE
feat: report who owns the gateway lock in imessage diagnose (#44)

### DIFF
--- a/typescript/src/__tests__/unit/gateway-lock-owner.test.ts
+++ b/typescript/src/__tests__/unit/gateway-lock-owner.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Tests for gateway lock ownership reporting (second half of #44).
+ *
+ * `isGatewayRunning()` answers *whether* the gateway is held, which is not
+ * enough to debug the case that actually bites: a second supervisor holding the
+ * lock while the installed launch agent loops on "Another OpenRappter gateway
+ * already owns the runtime lock". `install-service` then reports live/ready for
+ * a listener it does not own, and the symptoms read as a credential problem.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { readGatewayLockOwner } from '../../infra/gateway-lock.js';
+import { diagnoseIMessage } from '../../channels/imessage-diagnostics.js';
+
+let dir: string;
+let lockFile: string;
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'openrappter-lock-'));
+  lockFile = path.join(dir, 'gateway.pid');
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('readGatewayLockOwner', () => {
+  it('reports the live process recorded in the lock file', async () => {
+    await fs.writeFile(lockFile, String(process.pid));
+    expect(readGatewayLockOwner({ filePath: lockFile }))
+      .toEqual({ pid: process.pid, alive: true });
+  });
+
+  it('reports a recorded pid that is no longer running as stale', async () => {
+    // PID 2^22 is above the default macOS/Linux pid_max and is not in use.
+    await fs.writeFile(lockFile, '4194304');
+    expect(readGatewayLockOwner({ filePath: lockFile }))
+      .toEqual({ pid: 4194304, alive: false });
+  });
+
+  it('reports no owner when the lock file is absent', () => {
+    expect(readGatewayLockOwner({ filePath: path.join(dir, 'absent.pid') }))
+      .toEqual({ pid: null, alive: false });
+  });
+
+  it('treats a malformed lock file as unowned rather than throwing', async () => {
+    await fs.writeFile(lockFile, 'not-a-pid');
+    expect(readGatewayLockOwner({ filePath: lockFile })).toEqual({ pid: null, alive: false });
+  });
+
+  it('rejects a non-positive pid', async () => {
+    await fs.writeFile(lockFile, '0');
+    expect(readGatewayLockOwner({ filePath: lockFile })).toEqual({ pid: null, alive: false });
+  });
+
+  it('tolerates trailing content after the pid', async () => {
+    await fs.writeFile(lockFile, `${process.pid}\n`);
+    expect(readGatewayLockOwner({ filePath: lockFile }).pid).toBe(process.pid);
+  });
+});
+
+describe('diagnoseIMessage surfaces a foreign gateway owner', () => {
+  const LABEL = 'com.openrappter.gateway';
+
+  /** Drive the real service-status path: plist on disk, launchctl print fails. */
+  async function optionsWith(loaded: boolean, lockOwner: { pid: number | null; alive: boolean }) {
+    const agentDir = path.join(dir, 'Library', 'LaunchAgents');
+    await fs.mkdir(agentDir, { recursive: true });
+    await fs.writeFile(path.join(agentDir, `${LABEL}.plist`), '<plist/>');
+    return {
+      config: { enabled: true, allowFrom: ['+15551234567'] },
+      tokenConfigured: true,
+      platform: 'darwin' as NodeJS.Platform,
+      homeDirectory: dir,
+      accessFile: async () => undefined,
+      lockOwnerReader: () => lockOwner,
+      commandRunner: async (_exe: string, args: readonly string[]) =>
+        args[0] === 'print'
+          ? { stdout: loaded ? "state = running" : "", exitCode: loaded ? 0 : 113 }
+          : { stdout: "1", exitCode: 0 },
+      launchAgent: { homeDirectory: dir, checkHttp: false },
+    };
+  }
+
+  it('flags a live lock owner while the installed agent is not loaded', async () => {
+    const result = await diagnoseIMessage(
+      await optionsWith(false, { pid: 4242, alive: true }) as never,
+    );
+    expect(result.lockOwner).toEqual({ pid: 4242, alive: true });
+    expect(result.service.installed).toBe(true);
+    expect(result.service.loaded).toBe(false);
+    expect(result.reasons).toContain('gateway_lock_foreign');
+  });
+
+  it('does not flag when the installed agent is the loaded supervisor', async () => {
+    const result = await diagnoseIMessage(
+      await optionsWith(true, { pid: 4242, alive: true }) as never,
+    );
+    expect(result.reasons).not.toContain('gateway_lock_foreign');
+  });
+
+  it('does not flag a stale lock file', async () => {
+    const result = await diagnoseIMessage(
+      await optionsWith(false, { pid: 4242, alive: false }) as never,
+    );
+    expect(result.reasons).not.toContain('gateway_lock_foreign');
+  });
+});

--- a/typescript/src/channels/imessage-diagnostics.ts
+++ b/typescript/src/channels/imessage-diagnostics.ts
@@ -13,6 +13,8 @@ import {
   type IMessageConfig,
 } from './imessage.js';
 
+import { readGatewayLockOwner, type GatewayLockOwner } from '../infra/gateway-lock.js';
+
 export interface IMessageDiagnosticResult {
   platformSupported: boolean;
   enabled: boolean;
@@ -24,6 +26,8 @@ export interface IMessageDiagnosticResult {
   iMessageServiceCount?: number;
   tokenConfigured: boolean;
   service: IMessageServiceStatus;
+  /** Who the lock file says owns the gateway. */
+  lockOwner: GatewayLockOwner;
   ready: boolean;
   reasons: string[];
 }
@@ -31,6 +35,8 @@ export interface IMessageDiagnosticResult {
 export interface IMessageDiagnosticOptions {
   config: IMessageConfig;
   tokenConfigured: boolean;
+  /** Injectable for tests; defaults to reading the real lock file. */
+  lockOwnerReader?: () => GatewayLockOwner;
   platform?: NodeJS.Platform;
   homeDirectory?: string;
   commandRunner?: (
@@ -155,6 +161,14 @@ export async function diagnoseIMessage(
     reasons.push(service.readinessReason ?? 'gateway_not_ready');
   }
 
+  const lockOwner = (options.lockOwnerReader ?? readGatewayLockOwner)();
+  // A gateway held by a live process while the installed agent is not loaded
+  // means the listener belongs to something else. Without this the operator
+  // sees install-service report live/ready for a process it does not own.
+  if (lockOwner.alive && service.installed && !service.loaded) {
+    reasons.push('gateway_lock_foreign');
+  }
+
   return {
     platformSupported,
     enabled: options.config.enabled === true,
@@ -166,6 +180,7 @@ export async function diagnoseIMessage(
     iMessageServiceCount,
     tokenConfigured: options.tokenConfigured,
     service,
+    lockOwner,
     ready:
       platformSupported
       && options.config.enabled === true

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1905,6 +1905,13 @@ imessageCommand
     console.log(`  Messages automation: ${result.automationAvailable ? 'available' : 'unavailable'}`);
     console.log(`  Copilot token: ${result.tokenConfigured ? 'configured' : 'missing'}`);
     console.log(`  Service: loaded=${result.service.loaded} live=${result.service.live} ready=${result.service.ready}`);
+    // Name who holds the gateway, so 'live' for a listener the installed
+    // agent does not own stops looking like a credential problem.
+    console.log(`  Gateway lock: ${
+      result.lockOwner.pid === null
+        ? 'unowned'
+        : `pid ${result.lockOwner.pid}${result.lockOwner.alive ? '' : ' (stale)'}`
+    }`);
     if (result.reasons.length > 0) {
       console.log(`  Reasons: ${result.reasons.join(', ')}`);
     }

--- a/typescript/src/infra/gateway-lock.ts
+++ b/typescript/src/infra/gateway-lock.ts
@@ -144,6 +144,48 @@ export function releaseLock(options: GatewayLockOptions = {}): void {
   heldLocks.delete(filePath);
 }
 
+export interface GatewayLockOwner {
+  /** PID recorded in the lock file, or null when absent/unreadable/malformed. */
+  pid: number | null;
+  /** Whether that recorded PID is a live process this user can signal. */
+  alive: boolean;
+}
+
+/**
+ * Report who the lock file says owns the gateway.
+ *
+ * `isGatewayRunning()` answers *whether* the gateway is held, which is not
+ * enough to debug the case that matters: another supervisor holding the lock
+ * while the installed launch agent loops on "Another OpenRappter gateway
+ * already owns the runtime lock". Then `install-service` reports live/ready for
+ * a listener it does not own, and the symptoms look like a credential problem
+ * instead of an ownership one.
+ */
+export function readGatewayLockOwner(options: GatewayLockOptions = {}): GatewayLockOwner {
+  const filePath = options.filePath ?? DEFAULT_GATEWAY_LOCK_FILE;
+  let pid: number | null = null;
+  try {
+    const raw = readFileSync(filePath, 'utf-8').trim();
+    // The file may carry trailing content; only a leading integer is meaningful.
+    const parsed = Number.parseInt(raw, 10);
+    if (Number.isSafeInteger(parsed) && parsed > 0) pid = parsed;
+  } catch {
+    return { pid: null, alive: false };
+  }
+  if (pid === null) return { pid: null, alive: false };
+
+  let alive = false;
+  try {
+    // Signal 0 tests for existence without delivering anything.
+    process.kill(pid, 0);
+    alive = true;
+  } catch (error) {
+    // EPERM means the process exists but belongs to someone else.
+    alive = (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+  return { pid, alive };
+}
+
 export function isGatewayRunning(options: GatewayLockOptions = {}): boolean {
   const filePath = options.filePath ?? DEFAULT_GATEWAY_LOCK_FILE;
   if (heldLocks.has(filePath)) return true;


### PR DESCRIPTION
Second half of #44. The [first half](https://github.com/kody-w/openrappter/pull/48) fixed the credential; this fixes the part that made the credential *look* like the problem.

## Problem

`isGatewayRunning()` answers **whether** the gateway is held. That is not enough to debug the case that actually bites: a second supervisor owning the runtime lock while the installed launch agent loops on

```
🦖 Another OpenRappter gateway already owns the runtime lock.
```

with `last exit code = 1`. Meanwhile `install-service` sees *a* listener on the port and reports **`live, ready`** — for a process it does not own, which never loaded the config you just wrote and holds none of the credentials the agent was given.

Every signal available to the operator says the service is fine while the wrong process is serving. That cost me a long detour before I found it in the log rather than in any diagnostic.

## Change

`readGatewayLockOwner()` reports the pid recorded in the lock file and whether it is still alive (signal `0`; `EPERM` counts as alive, since that means the process exists but belongs to another user).

`imessage diagnose` now prints:

```
  Service: loaded=true live=true ready=true
  Gateway lock: pid 40971
```

or `unowned`, or `pid N (stale)` when the recorded process is gone.

It also raises a new reason, **`gateway_lock_foreign`**, when a live process holds the lock while the installed agent is *not* loaded — the ownership mismatch above, stated rather than inferred from logs.

## Tests

9 cases:

- **6 on the reader** — live pid, dead pid, absent file, malformed contents, non-positive pid, trailing newline.
- **3 on the diagnosis** — driving the *real* service-status path (plist on disk, `launchctl print` mocked) rather than stubbing the result, so the reason is proven to fire only on the genuine mismatch.

**Mutation-checked:** widening the condition to flag whenever *any* live owner exists fails the "loaded supervisor" case. The tests discriminate on the part that matters, not merely on the reason being present.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **3889 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
