### PR TITLE
fix: stop reporting a rejected GitHub token as a missing one

### DIFF
--- a/typescript/src/__tests__/unit/copilot-auth-outcome.test.ts
+++ b/typescript/src/__tests__/unit/copilot-auth-outcome.test.ts
@@ -1,0 +1,64 @@
+/**
+ * The daemon used to print one line for three different failures:
+ *
+ *   🦖 Cached GitHub token rejected by Copilot API — re-authenticating…
+ *   🦖 No GitHub token found. Run 'openrappter onboard' to set up Copilot.
+ *
+ * Those two lines are adjacent in a real log from this machine, and they
+ * contradict each other: a token was found, and then reported as absent. Under
+ * launchd there is also no TTY, so the re-auth the first line promises never
+ * runs — which is why the second line appears at all.
+ */
+import { describe, it, expect } from 'vitest';
+import { describeCopilotAuth } from '../../index.js';
+import type { CopilotAuthOutcome } from '../../copilot-check.js';
+
+const lines = (o: CopilotAuthOutcome) => describeCopilotAuth(o).join('\n');
+
+describe('describeCopilotAuth', () => {
+  it('does not claim a token is missing when one was found and rejected', () => {
+    const text = lines({ status: 'rejected', interactive: false });
+    expect(text).not.toMatch(/No GitHub token found/);
+    expect(text).toMatch(/rejected it/);
+  });
+
+  it('says a rejected token is stale or unentitled, which is the actionable part', () => {
+    expect(lines({ status: 'rejected', interactive: false })).toMatch(/stale or lacks Copilot access/);
+  });
+
+  it('still reports a genuinely absent token as absent', () => {
+    const text = lines({ status: 'missing', interactive: false });
+    expect(text).toMatch(/No GitHub token found/);
+    expect(text).not.toMatch(/rejected/);
+  });
+
+  it('tells a non-interactive process where onboard has to be run', () => {
+    for (const outcome of [
+      { status: 'rejected', interactive: false },
+      { status: 'missing', interactive: false },
+    ] as CopilotAuthOutcome[]) {
+      expect(lines(outcome)).toMatch(/no terminal/);
+      expect(lines(outcome)).toMatch(/in a shell/);
+    }
+  });
+
+  it('distinguishes the two failures from each other', () => {
+    expect(lines({ status: 'rejected', interactive: false }))
+      .not.toBe(lines({ status: 'missing', interactive: false }));
+  });
+
+  it('surfaces the underlying error when interactive auth failed', () => {
+    expect(lines({ status: 'failed', error: 'device flow timed out' }))
+      .toMatch(/device flow timed out/);
+  });
+
+  it('names how a successful token was obtained', () => {
+    expect(lines({ status: 'authenticated', token: 'ghu_x', source: 'cache' })).toMatch(/cache/);
+    expect(lines({ status: 'authenticated', token: 'ghu_x', source: 'device-code' })).toMatch(/device-code/);
+  });
+
+  it('never leaks the token into operator output', () => {
+    expect(lines({ status: 'authenticated', token: 'ghu_supersecret', source: 'cache' }))
+      .not.toMatch(/ghu_supersecret/);
+  });
+});

--- a/typescript/src/__tests__/unit/resolve-copilot-auth.test.ts
+++ b/typescript/src/__tests__/unit/resolve-copilot-auth.test.ts
@@ -1,0 +1,98 @@
+/**
+ * `resolveCopilotAuth` is where "rejected" and "missing" become distinguishable.
+ *
+ * Before it existed, both returned `null` and the daemon guessed — wrongly. This
+ * pair of lines is from a real log on this machine, seconds apart:
+ *
+ *   🦖 Cached GitHub token rejected by Copilot API — re-authenticating…
+ *   🦖 No GitHub token found. Run 'openrappter onboard' to set up Copilot.
+ *
+ * A token was found, then reported absent. Under launchd there is no TTY, so
+ * the re-authentication the first line promises never ran.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { resolveCopilotAuth, autoAuthIfNeeded } from '../../copilot-check.js';
+
+const accepts = async () => undefined;
+const refuses = async () => { throw new Error('401 Unauthorized'); };
+
+describe('resolveCopilotAuth', () => {
+  it('reports "rejected" when a token exists but Copilot refuses it', async () => {
+    const outcome = await resolveCopilotAuth({
+      silent: true, interactive: false,
+      discoverToken: async () => 'ghu_stale', validateToken: refuses,
+    });
+    expect(outcome).toEqual({ status: 'rejected', interactive: false });
+  });
+
+  it('reports "missing" when no token is discovered at all', async () => {
+    const outcome = await resolveCopilotAuth({
+      silent: true, interactive: false,
+      discoverToken: async () => null, validateToken: accepts,
+    });
+    expect(outcome).toEqual({ status: 'missing', interactive: false });
+  });
+
+  it('distinguishes the two, which is the entire point', async () => {
+    const rejected = await resolveCopilotAuth({
+      silent: true, interactive: false,
+      discoverToken: async () => 'ghu_stale', validateToken: refuses,
+    });
+    const missing = await resolveCopilotAuth({
+      silent: true, interactive: false,
+      discoverToken: async () => null, validateToken: accepts,
+    });
+    expect(rejected.status).not.toBe(missing.status);
+  });
+
+  it('reports "authenticated" from cache when Copilot accepts the token', async () => {
+    const outcome = await resolveCopilotAuth({
+      silent: true, interactive: false,
+      discoverToken: async () => 'ghu_good', validateToken: accepts,
+    });
+    expect(outcome).toMatchObject({ status: 'authenticated', token: 'ghu_good', source: 'cache' });
+  });
+
+  it('does not attempt validation when there is no token to validate', async () => {
+    const validate = vi.fn(accepts);
+    await resolveCopilotAuth({
+      silent: true, interactive: false,
+      discoverToken: async () => null, validateToken: validate,
+    });
+    expect(validate).not.toHaveBeenCalled();
+  });
+
+  it('stays silent about the rejection when asked to', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await resolveCopilotAuth({
+      silent: true, interactive: false,
+      discoverToken: async () => 'ghu_stale', validateToken: refuses,
+    });
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
+  it('warns about the rejection when not silenced', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+    await resolveCopilotAuth({
+      interactive: false,
+      discoverToken: async () => 'ghu_stale', validateToken: refuses,
+    });
+    expect(warn).toHaveBeenCalledWith(expect.stringMatching(/rejected by Copilot API/));
+    warn.mockRestore();
+  });
+
+  it('autoAuthIfNeeded still collapses every failure to null, unchanged', async () => {
+    expect(await autoAuthIfNeeded({
+      silent: true, interactive: false,
+      discoverToken: async () => 'ghu_stale', validateToken: refuses,
+    })).toBeNull();
+  });
+
+  it('autoAuthIfNeeded still returns the token on success, unchanged', async () => {
+    expect(await autoAuthIfNeeded({
+      silent: true, interactive: false,
+      discoverToken: async () => 'ghu_good', validateToken: accepts,
+    })).toBe("ghu_good");
+  });
+});

--- a/typescript/src/copilot-check.ts
+++ b/typescript/src/copilot-check.ts
@@ -157,35 +157,73 @@ export async function resolveGithubToken(): Promise<string | null> {
 }
 
 /**
- * Run inline device code auth when no cached token exists.
- * Saves the token to credentials file and .env for future use.
- * Returns the token or null if the flow was skipped/failed.
+ * Why authentication did not produce a usable Copilot token.
+ *
+ * These are genuinely different failures with different fixes, and collapsing
+ * them into `null` made the daemon report the wrong one. A token that Copilot
+ * *rejected* was announced as "No GitHub token found", which sends an operator
+ * to `onboard` to fix an absence that is not the problem — the token is present
+ * and stale. Under launchd there is no TTY either, so the re-auth that message
+ * implies cannot run at all.
  */
-export async function autoAuthIfNeeded(options?: {
+export type CopilotAuthOutcome =
+  /** A token was obtained and Copilot accepted it. */
+  | { status: 'authenticated'; token: string; source: 'cache' | 'device-code' }
+  /** A token was found, Copilot refused it, and no TTY was available to redo it. */
+  | { status: 'rejected'; interactive: false }
+  /** No token was discovered anywhere, and no TTY was available to obtain one. */
+  | { status: 'missing'; interactive: false }
+  /** Interactive auth ran and failed. */
+  | { status: 'failed'; error: string };
+
+/**
+ * Resolve a Copilot-capable GitHub token, saying *why* when it cannot.
+ *
+ * Prefer this over {@link autoAuthIfNeeded} when the caller reports the result
+ * to a human: it is the difference between "no token" and "the token you have
+ * is no longer good", which are not the same instruction.
+ */
+export async function resolveCopilotAuth(options?: {
   silent?: boolean;
-}): Promise<string | null> {
-  const existing = await resolveGithubToken();
+  /** Test seam: how a token is discovered. Defaults to {@link resolveGithubToken}. */
+  discoverToken?: () => Promise<string | null>;
+  /** Test seam: how a token is checked against Copilot. Rejects when unusable. */
+  validateToken?: (token: string) => Promise<void>;
+  /** Test seam: whether an interactive prompt is possible. Defaults to `stdin.isTTY`. */
+  interactive?: boolean;
+}): Promise<CopilotAuthOutcome> {
+  let rejected = false;
+  const existing = await (options?.discoverToken ?? resolveGithubToken)();
   if (existing) {
     // Validate the existing token actually works with Copilot
     try {
-      const { resolveCopilotApiToken } = await import('./providers/copilot-token.js');
-      await resolveCopilotApiToken({ githubToken: existing });
+      if (options?.validateToken) {
+        await options.validateToken(existing);
+      } else {
+        const { resolveCopilotApiToken } = await import('./providers/copilot-token.js');
+        await resolveCopilotApiToken({ githubToken: existing });
+      }
       // Token is valid and cached — save to credentials file if not already there
       if (!loadCachedGitHubToken()) {
         saveGitHubToken(existing, 'env');
       }
-      return existing;
+      return { status: 'authenticated', token: existing, source: 'cache' };
     } catch {
       // Token exists but doesn't work with Copilot — fall through to re-auth
+      rejected = true;
       if (!options?.silent) {
         console.warn('🦖 Cached GitHub token rejected by Copilot API — re-authenticating…');
       }
     }
   }
 
-  // No TTY = can't do interactive auth
-  if (!process.stdin.isTTY) {
-    return null;
+  // No TTY = can't do interactive auth. Report which of the two states we are
+  // in, because the remedy differs and the caller cannot tell from `null`.
+  const interactive = options?.interactive ?? Boolean(process.stdin.isTTY);
+  if (!interactive) {
+    return rejected
+      ? { status: 'rejected', interactive: false }
+      : { status: 'missing', interactive: false };
   }
 
   try {
@@ -233,14 +271,28 @@ export async function autoAuthIfNeeded(options?: {
       console.log(chalk.green('\n  ✓ Authenticated! Token cached locally.\n'));
     }
 
-    return token;
+    return { status: 'authenticated', token, source: 'device-code' };
   } catch (err) {
+    const error = (err as Error).message;
     if (!options?.silent) {
-      console.warn(`🦖 Auth failed: ${(err as Error).message}`);
+      console.warn(`🦖 Auth failed: ${error}`);
       console.warn("🦖 Run 'openrappter onboard' for full setup.\n");
     }
-    return null;
+    return { status: 'failed', error };
   }
+}
+
+/**
+ * Back-compatible wrapper: the token, or `null` for every failure.
+ *
+ * Callers that report to a human should use {@link resolveCopilotAuth} instead,
+ * so they can name the actual cause.
+ */
+export async function autoAuthIfNeeded(
+  options?: Parameters<typeof resolveCopilotAuth>[0],
+): Promise<string | null> {
+  const outcome = await resolveCopilotAuth(options);
+  return outcome.status === 'authenticated' ? outcome.token : null;
 }
 
 export async function validateTelegramToken(token: string): Promise<{ valid: boolean; username?: string; error?: string }> {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -10,7 +10,8 @@ import { fileURLToPath } from 'url';
 import { AgentRegistry } from './agents/index.js';
 import type { AgentInfo } from './agents/types.js';
 import { ensureHomeDir, loadEnv, saveEnv, hydrateManagedEnv, loadConfig, saveConfig, resolvedConfigSources, HOME_DIR, CONFIG_FILE, ENV_FILE } from './env.js';
-import { hasCopilotAvailable, autoAuthIfNeeded, resolveGithubToken, saveGitHubToken } from './copilot-check.js';
+import { hasCopilotAvailable, autoAuthIfNeeded, resolveCopilotAuth, resolveGithubToken, saveGitHubToken } from './copilot-check.js';
+import type { CopilotAuthOutcome } from './copilot-check.js';
 import { chat, displayResult } from './chat.js';
 import { VERSION } from './version.js';
 import { registerTelephonyCommands } from './telephony/cli.js';
@@ -42,6 +43,34 @@ async function getGhToken(): Promise<string | null> {
 // ═══════════════════════════════════════════════════════════════════════════════
 // GATEWAY IN-PROCESS
 // ═══════════════════════════════════════════════════════════════════════════════
+
+/**
+ * Turn an auth outcome into what an operator should actually do about it.
+ *
+ * The daemon runs under launchd with no controlling terminal, so any advice
+ * that requires a prompt has to say where to run it. Previously every failure
+ * printed "No GitHub token found", which named the wrong cause whenever a token
+ * was present but stale — the operator would onboard, obtain a fresh token, and
+ * still see the same line if the underlying entitlement was the problem.
+ */
+export function describeCopilotAuth(outcome: CopilotAuthOutcome): string[] {
+  switch (outcome.status) {
+    case 'authenticated':
+      return [`${EMOJI} Copilot token validated (${outcome.source})`];
+    case 'rejected':
+      return [
+        `${EMOJI} GitHub token found, but Copilot rejected it — it is stale or lacks Copilot access.`,
+        `${EMOJI} This process has no terminal, so it cannot re-authenticate. Run 'openrappter onboard' in a shell.`,
+      ];
+    case 'missing':
+      return [
+        `${EMOJI} No GitHub token found.`,
+        `${EMOJI} This process has no terminal, so it cannot prompt. Run 'openrappter onboard' in a shell.`,
+      ];
+    case 'failed':
+      return [`${EMOJI} Copilot authentication failed: ${outcome.error}`];
+  }
+}
 
 async function startGatewayInProcess(opts?: {
   silent?: boolean;
@@ -91,12 +120,14 @@ async function startGatewayInProcess(opts?: {
   // Create the Assistant powered by direct Copilot API (no CLI needed)
   const agents = await registry.getAllAgents();
 
-  // Auto-authenticate: try cached token first, then inline device code flow
-  const githubToken = await autoAuthIfNeeded({ silent: opts?.silent });
-  if (githubToken) {
-    log(`${EMOJI} Copilot token validated`);
-  } else {
-    console.warn(`${EMOJI} No GitHub token found. Run 'openrappter onboard' to set up Copilot.`);
+  // Auto-authenticate: try cached token first, then inline device code flow.
+  // Report which failure actually occurred — under launchd there is no TTY, so
+  // "run onboard" is advice the daemon itself cannot take, and a *rejected*
+  // token is not a *missing* one.
+  const auth = await resolveCopilotAuth({ silent: opts?.silent });
+  const githubToken = auth.status === 'authenticated' ? auth.token : null;
+  for (const line of describeCopilotAuth(auth)) {
+    if (auth.status === 'authenticated') log(line); else console.warn(line);
   }
 
   // Choose a backend that can actually answer.


### PR DESCRIPTION
## Evidence

Two lines from this machine's live `~/.openrappter/logs/daemon.stderr.log`, seconds apart:

```
🦖 Cached GitHub token rejected by Copilot API — re-authenticating…
🦖 No GitHub token found. Run 'openrappter onboard' to set up Copilot.
```

A token was **found**, and then reported as **absent**. Both cannot be true.

## Cause

`autoAuthIfNeeded()` returned `null` for three different failures, so its caller could not tell them apart and printed one sentence for all three:

1. no token exists anywhere
2. a token exists and **Copilot rejected it** — stale, or the account has no Copilot entitlement
3. neither could be resolved because **there is no TTY** to re-authenticate on

Under launchd the daemon is always case 3, which is why the promised "re-authenticating…" never happens — the very next statement is:

```ts
if (!process.stdin.isTTY) {
  return null;
}
```

So the operator is told to run `onboard` **by a process that cannot run it**, about an absence that **is not the problem**. Onboarding then writes a fresh token, and if the account lacks Copilot access the same line returns unchanged. The message never named the cause, so it could not be acted on.

This is the same failure mode as #50: a diagnostic confidently naming the wrong thing costs far more than no diagnostic at all.

## Change

`resolveCopilotAuth()` returns a discriminated outcome:

| Outcome | Meaning |
|---|---|
| `authenticated` | with `source: 'cache' \| 'device-code'` |
| `rejected` | a token was found; Copilot refused it |
| `missing` | nothing found anywhere |
| `failed` | interactive auth ran and errored |

`describeCopilotAuth()` turns each into advice that is true *for the process printing it*:

```
🦖 GitHub token found, but Copilot rejected it — it is stale or lacks Copilot access.
🦖 This process has no terminal, so it cannot re-authenticate. Run 'openrappter onboard' in a shell.
```

`autoAuthIfNeeded()` is kept as a wrapper with **identical** behaviour, so callers that only want the token are untouched.

## Tests — 17

- **9 on the state machine**, driven through explicit `discoverToken` / `validateToken` / `interactive` seams — the same injection style already used in `imessage-diagnostics.ts`.
- **8 on the wording** — a rejected token is never described as missing, the two messages differ from each other, non-interactive advice says where to run `onboard`, and a token never leaks into operator output.

**Mutation-checked both halves** by reintroducing the original bug:

| Mutation | Result |
|---|---|
| collapse `rejected` into `missing` | **2 tests fail** |
| restore the old "No GitHub token found" wording | **2 tests fail** |

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **3911 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
