### PR TITLE
fix: stop service status vouching for a process it does not supervise (closes #44)

### DIFF
--- a/typescript/src/__tests__/unit/service-status-ownership.test.ts
+++ b/typescript/src/__tests__/unit/service-status-ownership.test.ts
@@ -1,0 +1,187 @@
+/**
+ * `getIMessageServiceStatus()` used to report three things that were each
+ * individually defensible and collectively false.
+ *
+ * Observed on the machine that motivated this, all at the same moment:
+ *
+ *   launchctl print gui/501/com.openrappter.gateway  -> exit 0
+ *                                                       state = not running
+ *                                                       last exit code = (never exited)
+ *   ~/.openrappter/gateway.pid                       -> 44229
+ *   lsof -nP -iTCP:18790 -sTCP:LISTEN                -> node 44229
+ *
+ * Status therefore said loaded=true (exit 0 means *registered*, not running)
+ * and live=true ready=true (the port answered — from pid 44229, a process the
+ * installed agent does not own). Nothing was lying on its own; the composite
+ * told an operator the service was healthy when the job they installed was not
+ * executing at all.
+ */
+import { describe, it, expect } from 'vitest';
+import os from 'os';
+import path from 'path';
+import fs from 'fs/promises';
+import http from 'http';
+import { reserveTestPort } from '../support/test-port.js';
+import {
+  getIMessageServiceStatus,
+  parseLaunchdPid,
+  isLaunchdRunning,
+  OPENRAPPTER_LAUNCH_AGENT_LABEL,
+} from '../../channels/imessage-launchd.js';
+
+const RUNNING = 'state = running\n\tpid = 44229\n\tlast exit code = 0\n';
+const REGISTERED_ONLY = 'state = not running\n\tlast exit code = (never exited)\n';
+
+async function homeWithPlist(): Promise<string> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'svc-status-'));
+  const agents = path.join(dir, 'Library', 'LaunchAgents');
+  await fs.mkdir(agents, { recursive: true });
+  await fs.writeFile(path.join(agents, `${OPENRAPPTER_LAUNCH_AGENT_LABEL}.plist`), '<plist/>');
+  return dir;
+}
+
+function statusWith(opts: {
+  home: string;
+  userPrint: { stdout: string; exitCode: number };
+  lockPid: number | null;
+}) {
+  return getIMessageServiceStatus({
+    homeDirectory: opts.home,
+    checkHttp: false,
+    lockOwnerReader: () => ({ pid: opts.lockPid, alive: opts.lockPid !== null }),
+    commandRunner: async (_exe: string, args: readonly string[]) =>
+      args[1]?.startsWith('system/')
+        ? { stdout: '', exitCode: 113 }
+        : opts.userPrint,
+  } as never);
+}
+
+describe('launchctl output parsing', () => {
+  it('reads the pid of a running job', () => {
+    expect(parseLaunchdPid(RUNNING)).toBe(44229);
+  });
+
+  it('reports no pid for a job that is registered but never started', () => {
+    expect(parseLaunchdPid(REGISTERED_ONLY)).toBeNull();
+  });
+
+  it('does not mistake a registered job for a running one', () => {
+    expect(isLaunchdRunning(REGISTERED_ONLY)).toBe(false);
+    expect(isLaunchdRunning(RUNNING)).toBe(true);
+  });
+
+  it('ignores a non-positive pid rather than trusting it', () => {
+    expect(parseLaunchdPid('state = running\n\tpid = 0\n')).toBeNull();
+  });
+});
+
+describe('getIMessageServiceStatus ownership', () => {
+
+  /** Run a status check against a real listener, so `live` is genuinely true. */
+  async function withLiveListener(
+    lockPid: number | null,
+    userPrint: { stdout: string; exitCode: number },
+  ) {
+    const port = await reserveTestPort();
+    const server = http.createServer((_req, res) => { res.writeHead(200); res.end('{}'); });
+    await new Promise<void>((r) => server.listen(port, '127.0.0.1', r));
+    try {
+      const home = await homeWithPlist();
+      return await getIMessageServiceStatus({
+        homeDirectory: home,
+        port,
+        checkHttp: true,
+        lockOwnerReader: () => ({ pid: lockPid, alive: lockPid !== null }),
+        commandRunner: async (_exe: string, args: readonly string[]) =>
+          args[1]?.startsWith('system/') ? { stdout: '', exitCode: 113 } : userPrint,
+      } as never);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  }
+
+  it('separates "registered" from "running" — the exact case observed', async () => {
+    const home = await homeWithPlist();
+    const status = await statusWith({
+      home, userPrint: { stdout: REGISTERED_ONLY, exitCode: 0 }, lockPid: 44229,
+    });
+
+    expect(status.loaded).toBe(true);   // registered, as launchd reports
+    expect(status.running).toBe(false); // but not executing
+    expect(status.supervisedPid).toBeNull();
+  });
+
+  it('reports the pid that actually holds the port', async () => {
+    const home = await homeWithPlist();
+    const status = await statusWith({
+      home, userPrint: { stdout: REGISTERED_ONLY, exitCode: 0 }, lockPid: 44229,
+    });
+    expect(status.servingPid).toBe(44229);
+  });
+
+  it('does not claim a foreign owner when the supervised job is the one serving', async () => {
+    const home = await homeWithPlist();
+    const status = await statusWith({
+      home, userPrint: { stdout: RUNNING, exitCode: 0 }, lockPid: 44229,
+    });
+    expect(status.supervisedPid).toBe(44229);
+    expect(status.servedByForeignProcess).toBe(false);
+  });
+
+  it('names a foreign owner when the port answers from a pid the supervisor does not own', async () => {
+    // A real listener, because `live` is only true when something actually
+    // answers — which is precisely how the false "healthy" reading arose.
+    const port = await reserveTestPort();
+    const server = http.createServer((_req, res) => { res.writeHead(200); res.end('{}'); });
+    await new Promise<void>((r) => server.listen(port, '127.0.0.1', r));
+    try {
+      const home = await homeWithPlist();
+      const status = await getIMessageServiceStatus({
+        homeDirectory: home,
+        port,
+        checkHttp: true,
+        lockOwnerReader: () => ({ pid: 44229, alive: true }),
+        commandRunner: async (_exe: string, args: readonly string[]) =>
+          args[1]?.startsWith('system/')
+            ? { stdout: '', exitCode: 113 }
+            : { stdout: 'state = running\n\tpid = 999\n', exitCode: 0 },
+      } as never);
+
+      expect(status.live).toBe(true);
+      expect(status.supervisedPid).toBe(999);
+      expect(status.servingPid).toBe(44229);
+      expect(status.servedByForeignProcess).toBe(true);
+    } finally {
+      await new Promise<void>((r) => server.close(() => r()));
+    }
+  });
+
+  it('stays silent about ownership when there is no evidence either way', async () => {
+    const home = await homeWithPlist();
+    const status = await statusWith({
+      home, userPrint: { stdout: REGISTERED_ONLY, exitCode: 0 }, lockPid: null,
+    });
+    // No serving pid known: assert nothing rather than guess.
+    expect(status.servedByForeignProcess).toBe(false);
+  });
+
+  it('does not accuse a foreign process when the supervised job has no pid to compare', async () => {
+    // The port answers and the job is registered but not running. That is worth
+    // saying — and it is said by the "registered, not running" path — but it is
+    // not evidence that some *other* process is the owner, so do not claim it.
+    const status = await withLiveListener(44229, { stdout: REGISTERED_ONLY, exitCode: 0 });
+
+    expect(status.live).toBe(true);
+    expect(status.supervisedPid).toBeNull();
+    expect(status.running).toBe(false);
+    expect(status.servedByForeignProcess).toBe(false);
+  });
+
+  it('does not accuse a foreign process when the lock owner is unknown', async () => {
+    const status = await withLiveListener(null, { stdout: RUNNING, exitCode: 0 });
+
+    expect(status.live).toBe(true);
+    expect(status.servingPid).toBeNull();
+    expect(status.servedByForeignProcess).toBe(false);
+  });
+});

--- a/typescript/src/channels/imessage-launchd.ts
+++ b/typescript/src/channels/imessage-launchd.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import os from 'os';
 import path from 'path';
 import { fileURLToPath } from 'url';
+import { readGatewayLockOwner } from '../infra/gateway-lock.js';
 
 export const OPENRAPPTER_LAUNCH_AGENT_LABEL = 'com.openrappter.gateway';
 export const OPENRAPPTER_SYSTEM_DAEMON_LABEL = 'com.openrappter.rappterone';
@@ -51,14 +52,42 @@ export interface IMessageLaunchAgentOptions {
   healthTimeoutMs?: number;
   checkHttp?: boolean;
   delegateSystemService?: boolean;
+  /** Test seam: who holds the gateway runtime lock. Defaults to the real file. */
+  lockOwnerReader?: () => { pid: number | null; alive: boolean };
 }
 
 export interface IMessageServiceStatus {
   installed: boolean;
+  /**
+   * The job is registered with launchd.
+   *
+   * This is *not* "the job is running". `launchctl print` exits 0 for a loaded
+   * job that has never started, and did so on the machine that motivated this
+   * field — `state = not running`, `last exit code = (never exited)`, exit 0.
+   * Use {@link running} to ask whether anything is executing.
+   */
   loaded: boolean;
+  /** The supervised job is actually executing (`state = running`). */
+  running: boolean;
+  /** The pid launchd reports for the supervised job, when it has one. */
+  supervisedPid: number | null;
   supervisor: 'user' | 'system' | 'none';
   live: boolean;
   ready: boolean;
+  /**
+   * The pid holding the gateway runtime lock — i.e. what actually answered
+   * `live`/`ready`, which is not necessarily the job described above.
+   */
+  servingPid: number | null;
+  /**
+   * `live`/`ready` came from a process the supervisor above does not own.
+   *
+   * Each field on its own is defensible and the composite is still false: the
+   * port answers, so the service looks healthy, while the job you installed is
+   * not the thing answering and holds none of the config or credentials it was
+   * given.
+   */
+  servedByForeignProcess: boolean;
   readinessReason?: string;
 }
 
@@ -75,6 +104,7 @@ interface ResolvedLaunchAgentOptions {
   healthTimeoutMs: number;
   checkHttp: boolean;
   delegateSystemService: boolean;
+  lockOwnerReader: () => { pid: number | null; alive: boolean };
 }
 
 const defaultCommandRunner: LaunchdCommandRunner = (
@@ -165,6 +195,7 @@ function resolveOptions(
         : 180_000,
     checkHttp: options.checkHttp ?? true,
     delegateSystemService: options.delegateSystemService ?? true,
+    lockOwnerReader: options.lockOwnerReader ?? readGatewayLockOwner,
   };
 }
 
@@ -516,9 +547,16 @@ export async function getIMessageServiceStatus(
         fetchLocalStatus(resolved.port, '/readyz'),
       ])
     : [{ ok: false }, { ok: false }];
+  const supervisedPrint = print.exitCode === 0 ? print : systemPrint;
+  const supervisedPid = parseLaunchdPid(supervisedPrint.stdout);
+  const running = supervisedPrint.exitCode === 0 && isLaunchdRunning(supervisedPrint.stdout);
+  const servingPid = resolved.lockOwnerReader().pid;
+
   return {
     installed: installed || systemPrint.exitCode === 0,
     loaded: print.exitCode === 0 || systemPrint.exitCode === 0,
+    running,
+    supervisedPid,
     supervisor:
       print.exitCode === 0
         ? 'user'
@@ -527,11 +565,38 @@ export async function getIMessageServiceStatus(
           : 'none',
     live: liveResponse.ok,
     ready: readyResponse.ok,
+    servingPid,
+    // Only claim a foreign owner when we can see both pids and they differ.
+    // Absent evidence we say nothing rather than guess.
+    servedByForeignProcess:
+      liveResponse.ok
+      && servingPid !== null
+      && supervisedPid !== null
+      && servingPid !== supervisedPid,
     readinessReason:
       typeof readyResponse.body?.reason === 'string'
         ? readyResponse.body.reason
         : undefined,
   };
+}
+
+/**
+ * Pull `pid = N` out of `launchctl print` output.
+ *
+ * launchd prints the pid only while the job is executing, so its absence is
+ * itself the answer rather than a parse failure.
+ */
+export function parseLaunchdPid(stdout: string): number | null {
+  const match = /^\s*pid\s*=\s*(\d+)\s*$/m.exec(stdout);
+  if (match === null) return null;
+  const pid = Number(match[1]);
+  return Number.isInteger(pid) && pid > 0 ? pid : null;
+}
+
+/** Read `state = running` from `launchctl print` output. */
+export function isLaunchdRunning(stdout: string): boolean {
+  const match = /^\s*state\s*=\s*(.+?)\s*$/m.exec(stdout);
+  return match !== null && match[1] === 'running';
 }
 
 async function fetchLocalStatus(

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1890,10 +1890,28 @@ imessageCommand
     console.log(
       `${EMOJI} iMessage service: `
       + `installed=${status.installed} loaded=${status.loaded} `
+      + `running=${status.running} `
       + `supervisor=${status.supervisor} `
       + `live=${status.live} ready=${status.ready}`
       + (status.readinessReason ? ` reason=${status.readinessReason}` : ''),
     );
+    // `live` describes whoever answered the port. Say so when that is not the
+    // job just described, instead of letting the two readings sit side by side
+    // and imply each other.
+    if (status.servedByForeignProcess) {
+      console.warn(
+        `${EMOJI} The port is answered by pid ${status.servingPid}, which is not the `
+        + `supervised job (pid ${status.supervisedPid}). live/ready describe that other `
+        + `process, not the service you installed — it holds none of the config or `
+        + `credentials this install wrote.`,
+      );
+    } else if (status.loaded && !status.running) {
+      console.warn(
+        `${EMOJI} The job is registered with launchd but not running `
+        + `(loaded is registration, not execution). Check 'last exit code' via `
+        + `launchctl print.`,
+      );
+    }
   });
 
 imessageCommand


### PR DESCRIPTION
Closes the remaining half of #44. #48 fixed the credential and #50 named the lock owner; this fixes the *reading* that made both look fine while neither was.

## Evidence

Observed on this machine, all at the same moment:

```
launchctl print gui/501/com.openrappter.gateway
    -> exit 0,  state = not running,  last exit code = (never exited)

~/.openrappter/gateway.pid          -> 44229
lsof -nP -iTCP:18790 -sTCP:LISTEN   -> node  44229
```

`getIMessageServiceStatus()` reported:

```
installed=true loaded=true supervisor=user live=true ready=true
```

## Cause — two confusions, one false composite

| Field | Came from | Actually means |
|---|---|---|
| `loaded` | `launchctl print` exit 0 | the job is **registered** — not that it runs. The job above has *never executed*. |
| `live` / `ready` | HTTP probe of the port | whatever **answers the port** — here pid 44229, not the supervised job |

The two readings were printed side by side and left to imply each other. Nothing was individually false. The composite told an operator the service was healthy while the job they installed **was not running**, and the process answering held none of the config or credentials the install had just written.

This is the third instance of the same class in this repo (#50, #52): a diagnostic confidently naming the wrong thing.

## Change

New fields: `running` (from `state = running`), `supervisedPid` (from `pid = N`), `servingPid` (from the runtime lock), `servedByForeignProcess`.

`loaded` **keeps its old meaning** and is now documented as registration, so existing callers are unaffected.

`imessage service` prints `running=` and warns in the two cases that previously read as healthy:

```
🦖 The port is answered by pid 44229, which is not the supervised job (pid 999).
   live/ready describe that other process, not the service you installed — it holds
   none of the config or credentials this install wrote.

🦖 The job is registered with launchd but not running (loaded is registration,
   not execution). Check 'last exit code' via launchctl print.
```

`servedByForeignProcess` **requires both pids to be known**. Without them the mismatch is unproven, and the "registered but not running" path already covers that case honestly — accusing a process on missing evidence would repeat the original mistake in the opposite direction.

## Tests — 11

- **4 on parsing**: running pid, registered-with-no-pid, `state` discrimination, non-positive pid.
- **7 on status**: the observed case, and the foreign-owner case driven **against a real HTTP listener** — because `live` is only true when something actually answers, which is how the false reading arose in the first place.

**Mutation-checked three ways:**

| Mutation | Result |
|---|---|
| treat "registered" as "running" | 1 test fails |
| never report a foreign owner | 1 test fails |
| drop the evidence guards | 2 tests fail |

Worth noting: the *first* version of the guard test did **not** discriminate — it short-circuited on `live=false` and passed against the mutant. It was rewritten against a live listener until the mutant died. A green test proves nothing until it has been seen to fail.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **3922 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
