### PR TITLE
fix: make the voice parity vector able to fail

### DIFF
--- a/.github/workflows/rapp-conformance.yml
+++ b/.github/workflows/rapp-conformance.yml
@@ -113,6 +113,21 @@ jobs:
       - name: Golden parity vectors (both runtimes)
         run: python3 parity_harness.py --runtime both --report parity-report.json
 
+      # SPEC.md §1 does not only declare a tier, it makes a second, narrower
+      # claim in prose: "The one `full`-only vector — `voice-sentinel-split` —
+      # we do in fact implement". The step above cannot check that, because the
+      # declared tier is `core` and that vector is tagged full-only, so it is
+      # selected out. Nothing else executed it either — the claim was written
+      # down and never measured.
+      #
+      # This does not raise the declared tier. The gating run above still reads
+      # its tier from SPEC.md and is still what the tier attestation rests on.
+      # This run exists so the *prose* claim is held to the same standard as the
+      # declaration: if the voice seam ever drifts between the two runtimes,
+      # SPEC.md becomes false and CI says so instead of staying quiet.
+      - name: Verify the full-only vectors SPEC.md claims to implement
+        run: python3 parity_harness.py --tier full --runtime both --report parity-report-full.json
+
       - name: Parity summary
         if: always()
         run: |

--- a/SPEC.md
+++ b/SPEC.md
@@ -132,6 +132,17 @@ openrappter generalises this to `|||TAG|||` sense projections (`rapp-sense/1.0`)
 `HOLO`, and others — parsed by one shared parser. The envelope behaviour for `VOICE`
 matches PARITY §2.4 exactly, which is what the spec requires of an optional capability.
 
+**Both halves are trimmed.** PARITY §2.4 says "text before" and "text after" without
+saying what happens to whitespace around the sentinel, so a model that emits
+`written  |||VOICE|||  spoken` leaves the runtimes free to disagree. Both of ours trim,
+and the `voice-sentinel-split` vector now pins that: its fixture carries whitespace on
+both halves, so the two runtimes are compared on it rather than on a string where the
+question does not arise. Until that fixture changed, deleting `.strip()` from one runtime
+left the corpus reporting 14/14 on both while they disagreed on three inputs.
+
+This is a place where the two runtimes agree by choice and not by specification. It is
+worth raising upstream: §2.4 should say which it means.
+
 ---
 
 ## 4. Agent discovery

--- a/parity_vectors/CORPUS.json
+++ b/parity_vectors/CORPUS.json
@@ -1,6 +1,6 @@
 {
   "canonicalization": "sha256 over JSON with sorted keys and (',',':') separators, UTF-8",
-  "corpus_sha256": "571decb2d78d41e354008b182cef58d5d927dc3522c1194c66201ff4fb7dec0f",
+  "corpus_sha256": "f8f05099895e62966e354ba684e62c96291f674d9e21ce9b5d455c2af431ca4c",
   "spec": "rapp-runtime-parity/1.0",
   "vector_count": 14,
   "vectors": {
@@ -17,6 +17,6 @@
     "session-id-minted": "dda4a21939f679f806f2a47ca4625692cd45549df64e4a18cbd0ea285fb31822",
     "single-tool-then-answer": "b55e1d6043baa4afa6494b77de19fbd930003f2369bf8aef3da0c2de57f1fc7d",
     "system-context-injection": "a52b1c07b31842c6a6f918311b1ca6c53145086ce281ff34a0ad73a766d538ca",
-    "voice-sentinel-split": "6ef0e45fa778910ec3f1a30dc91d85b979cd4d0840adf28960adbd9454d1a82c"
+    "voice-sentinel-split": "6f12df957d953ec3e082fe062b62be32570762af5d5123d6aaea06773340f5aa"
   }
 }

--- a/parity_vectors/voice-sentinel-split.json
+++ b/parity_vectors/voice-sentinel-split.json
@@ -29,7 +29,7 @@
   "model_script": [
     {
       "emit": {
-        "content": "written form|||VOICE|||spoken form"
+        "content": "  written form  |||VOICE|||  spoken form  "
       },
       "round": 1
     }

--- a/python/tests/test_parity_corpus.py
+++ b/python/tests/test_parity_corpus.py
@@ -48,6 +48,37 @@ class TestParityCorpus:
         }
         assert present == required
 
+    def test_voice_vector_can_actually_detect_a_trim_change(self):
+        """A vector that cannot fail is not coverage.
+
+        The fixture used to emit ``written form|||VOICE|||spoken form`` — no
+        whitespace anywhere — so whether a runtime trimmed the two halves was
+        unobservable. Deleting ``.strip()`` from the Python runtime left the
+        corpus reporting 14/14 PASS on both runtimes while they disagreed on
+        three whitespace inputs.
+
+        Pin the property that made it blind, so the fixture cannot quietly
+        revert to one that agrees with everything.
+        """
+        vector = json.loads(
+            (VECTORS / "voice-sentinel-split.json").read_text(encoding="utf-8")
+        )
+        content = vector["model_script"][0]["emit"]["content"]
+        written, _, spoken = content.partition("|||VOICE|||")
+
+        assert written != written.strip(), (
+            "the written half carries no surrounding whitespace, so trimming is "
+            "unobservable and the vector cannot detect a change to it"
+        )
+        assert spoken != spoken.strip(), (
+            "the spoken half carries no surrounding whitespace, so trimming is "
+            "unobservable and the vector cannot detect a change to it"
+        )
+        # And the expectation must be the trimmed form, or the assertion above
+        # would be satisfied by a vector that simply expects the raw text.
+        assert vector["expect"]["envelope"]["response"] == written.strip()
+        assert vector["expect"]["envelope"]["voice_response"] == spoken.strip()
+
     def test_corpus_digest_matches_the_vectors_on_disk(self):
         """A stale digest would let a runtime attest to a corpus it did not run."""
         import hashlib


### PR DESCRIPTION
The `voice-sentinel-split` vector **could not detect a change to the behaviour it exists to protect**, and nothing in CI ran it either.

## The blindness

Its fixture emitted:

```
written form|||VOICE|||spoken form
```

No whitespace anywhere — so whether a runtime *trimmed* the two halves was unobservable.

I deleted `.strip()` from the Python runtime's voice split. The corpus reported **14/14 PASS on both runtimes**. Meanwhile the two runtimes disagreed on three inputs:

| input | python | typescript |
|---|---|---|
| `written form␣␣\|\|\|VOICE\|\|\|␣␣spoken` | `'written form  '` | `'written form'` |
| `written form\n\n\|\|\|VOICE\|\|\|\n\n…` | `'written form\n\n'` | `'written form'` |
| `␣␣written form\|\|\|VOICE\|\|\|spoken` | `'  written form'` | `'written form'` |

A green parity report, and a live cross-runtime disagreement, at the same time.

This matters because the runtimes reach this seam **by different routes** — Python partitions and strips; TypeScript goes through `parseSenses`. Agreement here is a fact to be *measured*, not assumed. **They do agree today.** Nothing was checking.

## The coverage gap

CI never executed this vector at all. The declared tier is `core`, the vector is tagged full-only, so it was selected out of the only run there was.

SPEC.md §1 makes a second, narrower claim **in prose**:

> The one `full`-only vector — `voice-sentinel-split` — we do in fact implement

Nothing measured that sentence.

## Changes

1. **Fixture now carries whitespace on both halves.** Both runtimes still pass 14/14; removing *either* `.strip()` from Python now **fails** the vector, where before both mutations survived.
2. **A separate full-tier CI step** verifies the vectors SPEC.md claims to implement. The gating run is **untouched** and still reads its tier from SPEC.md — so the declaration and the test still cannot drift apart. This holds the *prose* to the same standard as the declaration, rather than raising the tier.
3. **A corpus test** asserting the fixture keeps whitespace on both halves *and* expects the trimmed form — so it cannot quietly revert to a fixture that agrees with everything. Mutation-checked: restoring the old fixture fails it.
4. **SPEC.md §3** now records that both halves are trimmed, that PARITY §2.4 does **not** say so, and that this is therefore agreement by choice rather than specification — worth raising upstream.

Corpus digest regenerated: `571decb2d78d` → `f8f05099895e`.

## Verification

| Check | Result |
|---|---|
| `--tier core --runtime both` | 13/13 both runtimes |
| `--tier full --runtime both` | 14/14 both runtimes |
| Python suite | 1044 passed |
| Mutation: drop `spoken` strip | vector **FAILS** (previously passed) |
| Mutation: drop `voice` strip | vector **FAILS** (previously passed) |
| Mutation: revert fixture | corpus test **FAILS** |

The one Python failure (`test_loopback_host_allows_no_token`) reproduces identically on **clean main** under Python 3.9 and is an ordering issue — the file passes 31/31 in isolation. CI runs 3.10/3.12 and is green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
