### PR TITLE
fix: say "wrong Python", not "there is no current event loop"

### DIFF
--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -1,8 +1,52 @@
 """Shared fixtures for openrappter tests."""
 
 import json
+import sys
 import pytest
 from pathlib import Path
+
+#: Mirrors ``requires-python`` in pyproject.toml. Kept in sync by a test.
+MIN_PYTHON = (3, 10)
+
+
+def unsupported_python_message(version_info, executable="python3", platform=sys.platform):
+    """Explain an unsupported interpreter, or return ``None`` when it is fine.
+
+    macOS still ships 3.9 as ``/usr/bin/python3``, so this is the interpreter a
+    contributor gets by default. The suite does not merely fail there, it fails
+    *misleadingly*: ``GatewayServer.__init__`` constructs an ``asyncio.Lock()``,
+    and on 3.9 a Lock binds an event loop at construction, so once any earlier
+    test has finished an ``asyncio.run()`` — which clears the current loop — the
+    next construction raises
+
+        RuntimeError: There is no current event loop in thread 'MainThread'.
+
+    That reads like a product bug in the gateway. It is not; the loop parameter
+    was removed from ``asyncio.Lock`` in 3.10 and the binding became lazy. The
+    failure is also order-dependent, so the file passes 31/31 on its own and
+    fails only in a full run — which sends you looking for a race that is not
+    there. Say what is actually wrong instead.
+    """
+    if version_info >= MIN_PYTHON:
+        return None
+    running = ".".join(str(part) for part in version_info[:3])
+    wanted = ".".join(str(part) for part in MIN_PYTHON)
+    lines = [
+        f"openrappter requires Python {wanted}+ and this is {running} ({executable}).",
+        "",
+        "pyproject.toml declares requires-python = \">=%s\", so pip refuses to" % wanted,
+        "install here; running the suite from a source checkout is the one path that",
+        "gets this far. It would fail deep inside asyncio with",
+        "\"There is no current event loop\", which looks like a gateway bug and is not:",
+        f"asyncio.Lock binds a loop at construction before {wanted}.",
+    ]
+    if platform == "darwin":
+        lines += [
+            "",
+            "macOS ships 3.9 as /usr/bin/python3. Use a newer one, e.g.:",
+            "    brew install python@3.12 && python3.12 -m pytest tests/",
+        ]
+    return "\n".join(lines)
 
 
 @pytest.fixture(autouse=True)
@@ -35,6 +79,9 @@ def no_live_model_generation(monkeypatch, request):
 
 
 def pytest_configure(config):
+    message = unsupported_python_message(sys.version_info, sys.executable)
+    if message is not None:
+        pytest.exit(message, returncode=pytest.ExitCode.USAGE_ERROR)
     config.addinivalue_line(
         "markers", "live_model: test calls a real model and may be slow",
     )

--- a/python/tests/test_python_version_guard.py
+++ b/python/tests/test_python_version_guard.py
@@ -1,0 +1,69 @@
+"""The suite must say why an unsupported interpreter cannot run it.
+
+macOS ships 3.9 as ``/usr/bin/python3``. Running ``pytest tests/`` there used to
+fail with
+
+    RuntimeError: There is no current event loop in thread 'MainThread'.
+
+raised from ``GatewayServer.__init__`` — which reads like a gateway bug. It is
+not one: ``asyncio.Lock`` bound a loop at construction before 3.10. The failure
+was also order-dependent (the file passes 31/31 alone, fails in a full run), so
+it sent you hunting a race that does not exist. It cost real time before anyone
+thought to check the interpreter.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+from tests.conftest import MIN_PYTHON, unsupported_python_message
+
+
+class TestUnsupportedPythonMessage:
+    def test_supported_versions_produce_no_message(self):
+        for version in [(3, 10, 0), (3, 11, 4), (3, 12, 1), (3, 13, 0), (4, 0, 0)]:
+            assert unsupported_python_message(version) is None, version
+
+    def test_unsupported_versions_produce_a_message(self):
+        for version in [(3, 9, 6), (3, 8, 10), (2, 7, 18)]:
+            assert unsupported_python_message(version) is not None, version
+
+    def test_the_message_names_both_versions_and_the_interpreter(self):
+        message = unsupported_python_message((3, 9, 6), "/usr/bin/python3")
+        assert "3.9.6" in message
+        assert "3.10" in message
+        assert "/usr/bin/python3" in message
+
+    def test_the_message_names_the_real_cause_not_the_symptom(self):
+        """The whole point is to stop the next person debugging the gateway."""
+        message = unsupported_python_message((3, 9, 6))
+        assert "asyncio.Lock" in message
+        assert "event loop" in message
+
+    def test_macos_gets_the_system_python_hint(self):
+        message = unsupported_python_message((3, 9, 6), platform="darwin")
+        assert "/usr/bin/python3" in message
+        assert "brew" in message
+
+    def test_other_platforms_do_not_get_the_macos_hint(self):
+        message = unsupported_python_message((3, 9, 6), "python3", platform="linux")
+        assert "brew" not in message
+
+    def test_the_boundary_is_exactly_the_declared_minimum(self):
+        assert unsupported_python_message((MIN_PYTHON[0], MIN_PYTHON[1] - 1, 0)) is not None
+        assert unsupported_python_message(MIN_PYTHON) is None
+
+
+class TestMinimumStaysInSyncWithPackaging:
+    def test_min_python_matches_requires_python(self):
+        """A guard that disagrees with pyproject would block a supported version."""
+        pyproject = (Path(__file__).resolve().parents[1] / "pyproject.toml").read_text(
+            encoding="utf-8"
+        )
+        match = re.search(r'requires-python\s*=\s*"\s*>=\s*([0-9]+)\.([0-9]+)', pyproject)
+        assert match is not None, "requires-python not found in pyproject.toml"
+        assert (int(match.group(1)), int(match.group(2))) == MIN_PYTHON
+
+    def test_the_running_interpreter_satisfies_the_minimum(self):
+        """If this fails, the guard let something through that it should not have."""
+        assert sys.version_info >= MIN_PYTHON


### PR DESCRIPTION
## Symptom

Running `pytest tests/` on macOS's default interpreter fails like this:

```
RuntimeError: There is no current event loop in thread 'MainThread'
  openrappter/gateway/server.py:307   self._lifecycle_lock = asyncio.Lock()
```

That reads like a bug in the gateway. **It is not one.**

## Cause

Before 3.10, `asyncio.Lock.__init__` called `get_event_loop()` and bound a loop **at construction**. `asyncio.run()` clears the current loop when it finishes, so once any earlier test has used it, the next `GatewayServer(...)` raises. The `loop` parameter was removed in 3.10 and the binding became lazy.

Three things made this expensive to diagnose rather than merely wrong:

- **the message names asyncio**, so you look for a race in the gateway
- **it is order-dependent** — `test_gateway_server.py` passes 31/31 by itself and fails only in a full run, which sends you looking for shared state
- **CI is green**, because CI runs 3.10 and 3.12

macOS still ships 3.9 as `/usr/bin/python3`, so this is what a contributor gets by default. `pyproject.toml` already declares `requires-python = ">=3.10"`, so pip refuses to install here — a **source checkout is the one path** that gets far enough to fail this way.

## Change

`pytest_configure` now exits with `USAGE_ERROR` and explains:

```
openrappter requires Python 3.10+ and this is 3.9.6 (/usr/bin/python3).

pyproject.toml declares requires-python = ">=3.10", so pip refuses to
install here; running the suite from a source checkout is the one path that
gets this far. It would fail deep inside asyncio with
"There is no current event loop", which looks like a gateway bug and is not:
asyncio.Lock binds a loop at construction before 3.10.

macOS ships 3.9 as /usr/bin/python3. Use a newer one, e.g.:
    brew install python@3.12 && python3.12 -m pytest tests/
```

**Deliberately scoped to the test suite.** `import openrappter` works on 3.9 today and the parity harness runs there — raising on import would break something that currently works in order to fix something that does not.

## Verification — both sides of the boundary

| Interpreter | Result |
|---|---|
| **Python 3.9.6** | pytest exits **4** with the explanation, no obscure traceback |
| **Python 3.13** | guard silent, full suite **1068 passed / 0 failed** |

The 3.13 run is also the proof of the diagnosis: the original failure simply does not exist on a supported interpreter.

## Tests — 9

Boundary cases either side of the minimum; that the message names both versions and the interpreter; that it names the **cause** rather than the symptom; that the darwin hint appears **only** on darwin; and that `MIN_PYTHON` stays equal to `requires-python` in pyproject — a guard that disagreed with packaging would block a *supported* version.

**Mutation-checked four ways** against a 1-failed baseline (the running-interpreter assertion cannot pass on 3.9):

| Mutation | Failures |
|---|---|
| never flag an unsupported version | 7 |
| drop the cause from the message | 2 |
| ignore the platform | 2 |
| off-by-one on the minimum | 7 |

Note: this deliberately does **not** add 3.9 to the CI matrix — that would claim support the project does not offer.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
