### PR TITLE
test: cover the iMessage send guards, which nothing was checking

### DIFF
--- a/typescript/src/channels/imessage.test.ts
+++ b/typescript/src/channels/imessage.test.ts
@@ -378,6 +378,131 @@ describe('IMessageChannel Apple transport', () => {
     expect(harness.stateStore.value?.appleRowId).toBe(12);
   });
 
+  it('rejects a sender who is not on the allowlist', async () => {
+    // The allowlist is the primary control on who can reach the model at all.
+    // Until this test existed, deleting `allowedSenders.has(...)` from
+    // authorizeSender broke only a test about ROWID *ordering* — the property
+    // was protected by accident rather than on purpose.
+    const harness = appleHarness({
+      rows: [appleRow(11, { sender: '+15559999999' })],
+      allowFrom: ['(555) 123-4567'],
+    });
+    const delivered: string[] = [];
+    harness.channel.onMessage(async message => {
+      delivered.push(message.id);
+    });
+
+    await harness.channel.connect();
+    await harness.channel.pollNow();
+
+    expect(delivered).toEqual([]);
+    // Still acknowledged, so an unauthorized sender cannot wedge the cursor.
+    expect(harness.stateStore.value?.appleRowId).toBe(11);
+  });
+
+  it('refuses to send to an address that is not on the allowlist', async () => {
+    const harness = appleHarness({ rows: [appleRow(11)] });
+    harness.channel.onMessage(async () => undefined);
+    await harness.channel.connect();
+    await harness.channel.pollNow();
+
+    await expect(
+      harness.channel.send('+15559999999', { channel: 'imessage', content: 'hi' }),
+    ).rejects.toThrow(/not authorized/);
+
+    expect(
+      harness.calls.filter(call => call.executable === 'osascript' && call.args.length === 4),
+    ).toHaveLength(0);
+  });
+
+  it('refuses to open a conversation with an allowlisted address that never wrote first', async () => {
+    // Being on the allowlist grants the right to be *answered*, not to be
+    // contacted. Without this, an allowlisted address could be cold-messaged by
+    // anything that can reach send() — which is the difference between a reply
+    // bot and an outbound sender.
+    const harness = appleHarness({ rows: [] });
+    harness.channel.onMessage(async () => undefined);
+    await harness.channel.connect();
+
+    await expect(
+      harness.channel.send('(555) 123-4567', { channel: 'imessage', content: 'hi' }),
+    ).rejects.toThrow(/not authorized/);
+
+    expect(
+      harness.calls.filter(call => call.executable === 'osascript' && call.args.length === 4),
+    ).toHaveLength(0);
+  });
+
+  it('a group message does not establish a reply target for its sender', async () => {
+    // The two guards compose: a group message is refused on the way in, so it
+    // must not leave behind permission to send on the way out. Testing them
+    // separately would miss this.
+    const harness = appleHarness({
+      rows: [appleRow(11, { participant_count: 4 })],
+    });
+    harness.channel.onMessage(async () => undefined);
+    await harness.channel.connect();
+    await harness.channel.pollNow();
+
+    await expect(
+      harness.channel.send('(555) 123-4567', { channel: 'imessage', content: 'hi' }),
+    ).rejects.toThrow(/not authorized/);
+  });
+
+  it('only ever becomes willing to reply to senders that passed authorization', async () => {
+    // The egress allowlist check is redundant *given* this invariant: the only
+    // writer of allowedReplyTargets is authorizeSender, which already requires
+    // allowlist membership, and the config cannot be mutated at runtime. That
+    // makes the redundancy unreachable rather than untested — deleting it
+    // cannot be caught by any behavioural test.
+    //
+    // What can be pinned is the invariant itself. If a future change ever
+    // populates reply targets from another path, this fails and the redundant
+    // check stops being redundant.
+    const harness = appleHarness({
+      rows: [
+        appleRow(11, { sender: '+15551234567', participant_count: 1 }),   // authorized
+        appleRow(12, { sender: '+15551234567', participant_count: 5 }),   // group
+        appleRow(13, { sender: '+15559999999', participant_count: 1 }),   // not allowlisted
+      ],
+      allowFrom: ['(555) 123-4567'],
+    });
+    harness.channel.onMessage(async () => undefined);
+    await harness.channel.connect();
+    await harness.channel.pollNow();
+
+    // The one that passed authorization is replyable.
+    await harness.channel.send('(555) 123-4567', { channel: 'imessage', content: 'ok' });
+    // The one that never did is not, even though it appeared in the same batch.
+    await expect(
+      harness.channel.send('+15559999999', { channel: 'imessage', content: 'no' }),
+    ).rejects.toThrow(/not authorized/);
+
+    const sends = harness.calls.filter(
+      call => call.executable === 'osascript' && call.args.length === 4,
+    );
+    expect(sends).toHaveLength(1);
+    expect(sends[0]?.privateTarget).toBe('+15551234567');
+  });
+
+  it('does send to an allowlisted address that wrote first', async () => {
+    // Positive control. Without it the four refusals above would still pass if
+    // send() simply always threw.
+    const harness = appleHarness({ rows: [appleRow(11)] });
+    harness.channel.onMessage(async () => undefined);
+    await harness.channel.connect();
+    await harness.channel.pollNow();
+
+    await harness.channel.send('(555) 123-4567', { channel: 'imessage', content: 'hi' });
+
+    const sendCalls = harness.calls.filter(
+      call => call.executable === 'osascript' && call.args.length === 4,
+    );
+    expect(sendCalls).toHaveLength(1);
+    expect(sendCalls[0]?.privateTarget).toBe('+15551234567');
+    expect(sendCalls[0]?.privateContent).toBe('hi');
+  });
+
   it('does not acknowledge or mark an authorized row seen when its handler fails', async () => {
     const harness = appleHarness({ rows: [appleRow(11)] });
     let attempts = 0;


### PR DESCRIPTION
The rule this channel exists to enforce is that it answers two allowlisted people and nobody else. I mutation-tested that rule against the suite. **Two of the four guards were not protected at all.**

Deleting the reply-target check from `prepareAppleScriptSend` — the guard that stops the channel opening a conversation nobody asked for — left **all 3929 tests passing**. So did deleting the allowlist check from the same function.

| Guard | Before | After |
|---|---|---|
| ingress allowlist | 1 *unrelated* test | dedicated test |
| ingress group-chat refusal | covered | covered |
| egress allowlist | **nothing** | see below |
| egress reply-target (cold-messaging) | **nothing** | 2 tests |

The ingress allowlist was technically caught — but only by a test asserting **ROWID ordering**. The property was protected by accident, and a failure there would not have told anyone that authorization had broken.

## Six tests

- a sender off the allowlist is not delivered, **and** its row is still acknowledged so it cannot wedge the cursor
- sending to an address off the allowlist is refused
- **sending to an allowlisted address that never wrote first is refused.** Being on the allowlist is the right to be *answered*, not to be contacted; without this the channel is an outbound sender wearing a reply bot's name
- **a group message does not leave behind permission to send.** The two guards compose, and testing them separately misses this
- a **positive control**: an allowlisted address that did write first *is* reachable. Without it, the four refusals above would still pass if `send()` simply always threw
- the invariant that makes the egress allowlist check redundant

## On the one mutation I could not kill

Deleting the egress allowlist check **alone** cannot be caught by any behavioural test. `allowedReplyTargets` is only ever written by `authorizeSender`, which already requires allowlist membership, and the config cannot change at runtime (there is a test for that). It is **unreachable, not untested**, and claiming coverage would be false.

It is also **not dead code**. Simulating a plausible future change — a writer that records senders *before* authorizing them — the redundant check is the only thing preventing a send to a non-allowlisted address:

| Mutation | Result |
|---|---|
| rogue writer alone | refused (redundant check holds the line) |
| egress allowlist removed alone | refused (invariant holds the line) |
| **both together** | **invariant test fails** |

That is what defense in depth is supposed to look like when you actually measure it.

## Verification

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **3935 passed, 0 failures** |
| Mutation: ingress allowlist | now fails a **named** authorization test |
| Mutation: egress reply-target | fails 2 tests (previously 0) |

**No production code changed** — this PR is entirely test coverage for guards that were already correct but unverified.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
