### PR TITLE
fix: encode the description in the Python agent generator too

### DIFF
--- a/python/openrappter/agents/learn_new_agent.py
+++ b/python/openrappter/agents/learn_new_agent.py
@@ -40,6 +40,48 @@ __manifest__ = {
     "requires_env": []
 }
 
+def py_string_literal(value: str, max_length: int = None) -> str:
+    """Truncate first, then encode as a Python string literal.
+
+    The order is the whole point, and it used to be the other way round. The
+    previous code escaped quotes and then sliced the result at 200 characters,
+    which can cut between a backslash and the character it escapes. The
+    generated module then ends
+
+        "description": "AAAA\\",
+
+    and Python says exactly what happened:
+
+        unterminated string literal ... perhaps you escaped the end quote?
+
+    Truncating first means the escaping is applied to final text and can never
+    be sliced in half. json.dumps also covers what the hand-rolled version
+    missed -- backslashes, control characters, line separators -- none of which
+    were escaped when only quotes were replaced.
+    """
+    text = value if max_length is None else value[:max_length]
+    return json.dumps(text, ensure_ascii=False)
+
+
+def docstring_safe(value: str) -> str:
+    '''Make text safe to sit inside a triple-quoted docstring.
+
+    A description containing a triple quote closed the module docstring, and
+    everything after it became module-level code that ran on import. This was
+    reachable from an ordinary "create an agent that ..." request.
+
+    A docstring is a string literal, not a comment, which is where this differs
+    from the JavaScript runtime's equivalent: Python processes escapes inside
+    it. A description containing a backslash therefore produces
+    ``SyntaxWarning: invalid escape sequence``, and a NUL byte will not compile
+    at all. So backslashes are escaped first -- before the ones this function
+    introduces for the terminator -- and control characters are dropped.
+    '''
+    escaped = value.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+    flattened = escaped.replace("\r\n", " ").replace("\n", " ").replace("\r", " ")
+    return "".join(" " if ch < " " or ch == "\x7f" else ch for ch in flattened)
+
+
 class LearnNewAgent(BasicAgent):
     
     AGENT_TEMPLATE = '''""\"
@@ -57,7 +99,7 @@ class {class_name}(BasicAgent):
         self.name = '{agent_name}'
         self.metadata = {{
             "name": self.name,
-            "description": "{agent_description}",
+            "description": {agent_description},
             "parameters": {{
                 "type": "object",
                 "properties": {{
@@ -257,8 +299,6 @@ class {class_name}(BasicAgent):
         extra_params_yaml = self._generate_extra_params(description)
         extra_imports = self._generate_extra_imports(description)
         
-        # Escape quotes in description for string literals
-        safe_desc = description.replace('"', '\\"').replace('\n', ' ')
         
         # Generate tags from description keywords
         tags = self._generate_tags(description)
@@ -267,11 +307,11 @@ class {class_name}(BasicAgent):
         extra_params = self._generate_extra_params(description)
         
         return self.AGENT_TEMPLATE.format(
-            description=description,
+            description=docstring_safe(description),
             date=datetime.now().strftime("%Y-%m-%d %H:%M"),
             class_name=class_name,
             agent_name=name,
-            agent_description=safe_desc[:200],
+            agent_description=py_string_literal(description, 200),
             extra_imports=extra_imports,
             extra_params=extra_params,
             perform_body=perform_body,

--- a/python/tests/test_learn_new_codegen_escaping.py
+++ b/python/tests/test_learn_new_codegen_escaping.py
@@ -1,0 +1,138 @@
+"""Generated agent source must be escaped for the context it lands in.
+
+LearnNewAgent writes a Python module from a description a user supplies in an
+ordinary "create an agent that ..." request. That text was interpolated into
+the generated source twice without being encoded for either position.
+
+Both reproduced before this file existed:
+
+  1. A triple quote in the description closed the module docstring, and
+     everything after it became module-level code that ran on import. The
+     module compiled cleanly, so nothing downstream had reason to object.
+
+  2. The metadata description escaped quotes and *then* sliced to 200
+     characters, which can cut between a backslash and the character it
+     escapes. Python's own diagnostic named it:
+
+         unterminated string literal ... perhaps you escaped the end quote?
+
+The TypeScript runtime had the identical pair (openrappter#59); fixing one and
+not the other would have left the two bodies disagreeing about what a
+description may contain.
+"""
+
+import json
+import os
+
+import pytest
+
+from openrappter.agents.learn_new_agent import (
+    LearnNewAgent,
+    docstring_safe,
+    py_string_literal,
+)
+
+
+@pytest.fixture
+def generate():
+    agent = LearnNewAgent()
+
+    def _generate(description: str) -> str:
+        return agent._generate_agent_code(description, 'demo', 'DemoAgent')
+
+    return _generate
+
+
+def _compiles(source: str):
+    try:
+        compile(source, '<generated>', 'exec')
+        return True, ''
+    except SyntaxError as exc:
+        return False, f'{exc.msg} (line {exc.lineno})'
+
+
+class TestGeneratedSourceIsEscaped:
+    def test_a_triple_quote_cannot_close_the_docstring_and_run_as_code(self, generate):
+        source = generate('x """\nimport os\nos.environ["LEARN_NEW_PWNED"]="yes"\n"""  y')
+        os.environ.pop('LEARN_NEW_PWNED', None)
+
+        exec(compile(source, '<generated>', 'exec'), {})
+
+        assert os.environ.get('LEARN_NEW_PWNED') is None
+
+    def test_the_docstring_still_carries_the_text(self, generate):
+        """A fix that simply dropped the description would also pass the test above."""
+        source = generate('before """ after')
+        header = source.splitlines()[1]
+
+        assert 'before' in header
+        assert 'after' in header
+
+    @pytest.mark.parametrize('label,description', [
+        ('trailing backslash', 'ends with a backslash \\'),
+        ('escape cut at the truncation boundary', 'A' * 199 + '"' + 'B' * 20),
+        ('embedded newlines and quotes', 'line1\n"quoted"\nline2'),
+        ('control characters', 'tab\there\x00null'),
+        ('a lone double quote', 'say "hi"'),
+        ('a backslash-u sequence', 'literal \\u0041 text'),
+        ('braces', 'uses {curly} braces {{doubled}}'),
+    ])
+    def test_generates_compilable_source(self, generate, label, description):
+        ok, error = _compiles(generate(description))
+        assert ok, f'{label}: {error}'
+
+    def test_generated_source_compiles_without_warnings(self, generate):
+        """A docstring is a string literal, so Python processes escapes in it.
+
+        The first version of the fix escaped the terminator but not backslashes,
+        which compiled but emitted `SyntaxWarning: invalid escape sequence` from
+        the generated module. Warning-free is the property; compiling is not
+        enough.
+        """
+        import warnings
+
+        for description in [
+            'a path C:\\temp\\new and a trailing one \\',
+            'has "quotes" and a backslash \\ and unicode \u00e9',
+            'null\x00byte and \x07bell',
+        ]:
+            with warnings.catch_warnings(record=True) as caught:
+                warnings.simplefilter('always')
+                compile(generate(description), '<generated>', 'exec')
+            assert caught == [], f'{description!r} -> {[str(w.message) for w in caught]}'
+
+    def test_the_metadata_description_survives_as_the_original_text(self, generate):
+        description = 'has "quotes" and a backslash \\ and unicode é'
+        source = generate(description)
+
+        namespace = {}
+        exec(compile(source, '<generated>', 'exec'), namespace)
+        agent = namespace['DemoAgent']()
+
+        assert agent.metadata['description'] == description
+
+
+class TestPyStringLiteral:
+    @pytest.mark.parametrize('value', [
+        'plain', 'say "hi"', 'back\\slash', 'new\nline', 'nul\x00', 'emoji 😀', '{braces}',
+    ])
+    def test_round_trips_through_python_and_json(self, value):
+        assert json.loads(py_string_literal(value)) == value
+        assert eval(py_string_literal(value)) == value  # noqa: S307 - generated literal
+
+    def test_truncates_before_encoding_so_escaping_is_never_cut(self):
+        literal = py_string_literal('A' * 199 + '"BBBB', 200)
+
+        assert len(eval(literal)) == 200  # noqa: S307
+        assert eval(literal).endswith('"')  # noqa: S307
+
+
+class TestDocstringSafe:
+    def test_neutralises_the_docstring_terminator(self):
+        assert '"""' not in docstring_safe('a """ b')
+
+    def test_flattens_newlines_so_the_body_cannot_escape(self):
+        assert docstring_safe('a\nb\r\nc') == 'a b c'
+
+    def test_leaves_ordinary_text_alone(self):
+        assert docstring_safe('a normal description') == 'a normal description'


### PR DESCRIPTION
#59 fixed this in the TypeScript runtime. The Python runtime had **the identical pair of bugs, line for line** — and fixing one body and not the other would leave them disagreeing about what a description may contain.

```python
safe_desc = description.replace('"', '\\"').replace('\n', ' ')
...
agent_description=safe_desc[:200],
description=description,          # straight into the module docstring
```

## 1. Code injection through the docstring

A triple quote closes the module docstring, and everything after it becomes module-level code. Verified **by executing the generated module**:

```
PWNED env after exec: yes     (before)
PWNED env after exec: None    (after)
```

The module compiles cleanly, which is why nothing downstream objected.

## 2. Escaping before truncating

Cutting between a backslash and the character it escapes. Python names the result exactly:

```
unterminated string literal (detected at line 16); perhaps you escaped the end quote?
```

A description ending in a lone backslash did the same — only quotes were ever escaped.

## The part that did **not** mirror #59

A docstring is a **string literal, not a comment**, so Python processes escapes inside it. The JavaScript version had no equivalent problem.

Escaping only the terminator left generated modules emitting `SyntaxWarning: invalid escape sequence` for any description containing a backslash, and a NUL byte would not compile at all. `docstring_safe` therefore escapes **backslashes first** — before the ones it introduces — and drops control characters.

**My own tests caught that; the first version of this fix was wrong.** There is now a test asserting generated source compiles *with no warnings*, not merely without errors.

## Tests — 22

The injection no longer executes; the docstring still **carries** the text rather than dropping it; seven descriptions that previously produced uncompilable source; warning-free compilation; the metadata description round-trips to the exact original; plus unit tests for both helpers.

**Mutation-checked five ways:**

| Mutation | Failures |
|---|---|
| raw description into the docstring | 3 |
| escape-then-slice | 8 |
| stop escaping backslashes | 1 |
| stop dropping control characters | 2 |
| truncate after encoding | 2 |

## Cross-runtime parity

One hostile description containing quotes, a backslash, `"""`, `*/` and non-ASCII, read from the same file by both runtimes:

```
python     preserved exactly: True
typescript preserved exactly: true
```

Python suite: **1096 passed**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
