### PR TITLE
test: cover the parts of the idempotency fingerprint nothing was checking

### DIFF
--- a/typescript/src/gateway/gateway.protocol.test.ts
+++ b/typescript/src/gateway/gateway.protocol.test.ts
@@ -313,6 +313,92 @@ describe('Gateway Protocol (openclaw-compatible)', () => {
       expect(calls).toBe(1);
     });
 
+    it('rejects a reused idempotency key from a different session', async () => {
+      // The fingerprint exists so one key cannot stand for two different
+      // requests. Only `message` was covered: dropping `session_id` from it
+      // left every test passing, while a second session reusing a key would
+      // silently receive the first session's reply instead of a 409.
+      let calls = 0;
+      server.setAgentHandler(async req => {
+        calls += 1;
+        return {
+          sessionId: req.sessionId ?? 'generated',
+          content: `answer for ${req.sessionId}`,
+          finishReason: 'stop',
+        };
+      });
+      const send = (body: Record<string, unknown>) => fetch(
+        `http://127.0.0.1:${TEST_PORT}/chat`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${TEST_TOKEN}`,
+            Connection: 'close',
+          },
+          body: JSON.stringify(body),
+        },
+      );
+      const base = {
+        schema: 'rapp-chat/1.0',
+        message: 'same words',
+        idempotency_key: 'shared-key-across-sessions',
+      };
+
+      const first = await send({ ...base, session_id: 'session-a' });
+      expect(first.status).toBe(200);
+      expect((await first.json()).response).toBe('answer for session-a');
+
+      const second = await send({ ...base, session_id: 'session-b' });
+
+      expect(second.status).toBe(409);
+      expect(calls).toBe(1);
+    });
+
+    it('rejects a reused idempotency key carrying different conversation history', async () => {
+      let calls = 0;
+      server.setAgentHandler(async req => {
+        calls += 1;
+        return {
+          sessionId: req.sessionId ?? 'generated',
+          content: 'ok',
+          finishReason: 'stop',
+        };
+      });
+      const send = (body: Record<string, unknown>) => fetch(
+        `http://127.0.0.1:${TEST_PORT}/chat`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${TEST_TOKEN}`,
+            Connection: 'close',
+          },
+          body: JSON.stringify(body),
+        },
+      );
+      const base = {
+        schema: 'rapp-chat/1.0',
+        message: 'same words',
+        session_id: 'history-session',
+        idempotency_key: 'shared-key-different-history',
+      };
+
+      const first = await send({
+        ...base,
+        conversation_history: [{ role: 'user', content: 'first turn' }],
+      });
+      expect(first.status).toBe(200);
+
+      const second = await send({
+        ...base,
+        conversation_history: [{ role: 'user', content: 'a different turn' }],
+      });
+
+      expect(second.status).toBe(409);
+      expect(calls).toBe(1);
+    });
+
     it('should preserve session history when history is omitted', async () => {
       const histories: unknown[] = [];
       server.setAgentHandler(async req => {


### PR DESCRIPTION
The idempotency fingerprint exists so **one key cannot stand for two different requests**. It is computed over three things:

```
message
session_id
conversation_history
```

**Only the first was covered.** Dropping either of the other two from the fingerprint left the entire **3956-test suite green**.

## Why session_id matters most

Two requests sharing a key but belonging to **different sessions** have identical fingerprints once `session_id` is excluded. The second is then treated as a retry of the first and served the first session's **cached response body** — a reply from someone else's conversation, returned with status `200` and no indication anything was wrong.

The 409 is the only thing standing between a reused key and a cross-session answer.

`conversation_history` is quieter but the same shape: a client retrying with the same key after the history moved on receives a reply computed from history it no longer has.

## Tests — 2

Matching the existing dedup test's style:

- same key + same message from a **different session** → `409`, handler not invoked a second time
- same key + same message with **different conversation history** → `409`, handler not invoked a second time

## Mutation-checked

| Mutation | Failures now | Before |
|---|---|---|
| fingerprint drops `conversation_history` | 1 | **0** |
| fingerprint drops `session_id` | 1 | **0** |
| remove the conflict check entirely | 3 | 1 |

## Also checked this round and found sound

Following the same "unescaped interpolation into a structured format" thread as #59/#60, I checked and found **no defect** in:

- **SQL** — `storage/sqlite.ts` uses `?` placeholders throughout with fixed condition strings; the iMessage `chat.db` queries interpolate only integers already validated with `Number.isSafeInteger`
- **Dashboard HTML** — no `innerHTML` / `dangerouslySetInnerHTML` anywhere

Recording those as verified rather than filing noise.

**No production code changed.** Full TS suite: **3958 passed**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
