### PR TITLE
test: cover the Host checks that guard the loopback gateway

### DIFF
--- a/typescript/src/__tests__/integration/gateway.test.ts
+++ b/typescript/src/__tests__/integration/gateway.test.ts
@@ -188,6 +188,54 @@ describe('Gateway Integration', () => {
       expect(handlerCalled).toBe(false);
     });
 
+    // The loopback comparison is only one of six checks on the Host header, and
+    // it was the only one anything exercised. Every value below parses with
+    // hostname 127.0.0.1, so the loopback check passes them all — the specific
+    // sub-condition is the only thing standing in the way. Deleting any of them
+    // left the full suite green.
+    //
+    // These are shapes a browser will never send. They matter because a proxy,
+    // cache or WAF in front of the gateway may disagree with WHATWG URL parsing
+    // about where the authority ends, and the one that disagrees is the one that
+    // decides where the request really goes.
+    it.each([
+      ['userinfo in the authority', (port: number) => `evil.example@127.0.0.1:${port}`],
+      // No username, so this isolates the password check rather than being
+      // caught by the username one first.
+      ['a password but no user in the authority', (port: number) => `:pass@127.0.0.1:${port}`],
+      ['a path appended to the authority', (port: number) => `127.0.0.1:${port}/evil`],
+      ['a query string appended to the authority', (port: number) => `127.0.0.1:${port}?x=1`],
+      ['a fragment appended to the authority', (port: number) => `127.0.0.1:${port}#frag`],
+    ])('rejects a Host header carrying %s', async (_label, build) => {
+      const port = await reserveTestPort();
+      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      await server.start();
+
+      const res = await rawHttpGet(port, { Host: build(port) });
+
+      expect(res.status).toBe(403);
+      expect(JSON.parse(res.body)).toMatchObject({ error: 'Forbidden request origin' });
+    });
+
+    // Not tested: the `hostHeader.length > 255` bound. Under a loopback bind any
+    // host long enough to trip it is also non-loopback, so the loopback check
+    // rejects it first and a test there would pass with the bound deleted.
+    // Isolating it needs `bind: 'all'`, which opens a genuinely public port for
+    // the sake of a pre-parse bound with no demonstrated security consequence.
+    // Recorded as unverified rather than covered by a test that proves nothing.
+
+    it('still accepts an ordinary loopback Host header', async () => {
+      // Positive control: without it, the six refusals above would all pass if
+      // validateRequestSource simply rejected everything.
+      const port = await reserveTestPort();
+      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      await server.start();
+
+      const res = await rawHttpGet(port, { Host: `127.0.0.1:${port}` });
+
+      expect(res.status).toBe(200);
+    });
+
     it('rejects a non-loopback Host header to prevent DNS rebinding', async () => {
       const port = await reserveTestPort();
       server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });


### PR DESCRIPTION
`validateRequestSource` makes **six checks** on the Host header before an unauthenticated loopback gateway will answer. **One of them was exercised.** Deleting any of the other five left the full 3958-test suite green.

This is the same shape as #61: a guard with several inputs, where covering one input reads as covering the guard.

## The five are not hypothetical

Every value below **parses to hostname `127.0.0.1`**, so the loopback comparison — the one check that was tested — passes all of them. Only the specific sub-condition stands in the way:

| Host header | sub-condition |
|---|---|
| `evil.example@127.0.0.1:PORT` | userinfo |
| `:pass@127.0.0.1:PORT` | password, no user |
| `127.0.0.1:PORT/evil` | path |
| `127.0.0.1:PORT?x=1` | query |
| `127.0.0.1:PORT#frag` | fragment |

These are shapes a browser will never send. They matter because a proxy, cache or WAF in front of the gateway may disagree with WHATWG URL parsing about **where the authority ends** — and the component that disagrees is the one deciding where the request really goes.

## Tests — 7

Five refusals, plus a **positive control** that an ordinary loopback Host still returns 200 — without which all five would pass if the guard simply rejected everything.

Each refusal is **isolated against the condition it names**. The password case uses `:pass@` with no username; otherwise the username check catches it first and the test proves nothing about the password one. (My first version made exactly that mistake.)

**Mutation-checked:**

| Mutation | Failures now | Before |
|---|---|---|
| drop `username` | 1 | **0** |
| drop `password` | 1 | **0** |
| drop `pathname` | 1 | **0** |
| drop `search` | 1 | **0** |
| drop `hash` | 1 | **0** |
| drop loopback check | 2 | 2 |

## One check deliberately left unverified

The `hostHeader.length > 255` bound. Under a loopback bind, any host long enough to trip it is **also non-loopback**, so the loopback check rejects it first — a test there would pass with the bound deleted. Isolating it requires `bind: 'all'`, which opens a genuinely public port for the sake of a pre-parse bound with no demonstrated security consequence.

Left unverified with the reason recorded next to the tests, rather than covered by a test that proves nothing.

**No production code changed.** Full TS suite: **3964 passed**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
