### PR TITLE
test: isolate the Origin checks that decide CORS access

### DIFF
--- a/typescript/src/__tests__/integration/gateway.test.ts
+++ b/typescript/src/__tests__/integration/gateway.test.ts
@@ -224,6 +224,52 @@ describe('Gateway Integration', () => {
     // the sake of a pre-parse bound with no demonstrated security consequence.
     // Recorded as unverified rather than covered by a test that proves nothing.
 
+    // The Origin half of the same guard had the same problem, and worse. The
+    // one cross-origin test sends `https://malicious.example`, which trips the
+    // protocol check AND the host check at once — so neither is individually
+    // verified. Dropping the host comparison, the actual CORS boundary, left
+    // the full suite green.
+    //
+    // Each Origin below is chosen to fail exactly one condition.
+    it.each([
+      // http, so the protocol matches; only the host differs.
+      ['a different host', () => 'http://evil.example'],
+      // Host matches exactly; only the scheme differs.
+      ['a different scheme', (port: number) => `https://127.0.0.1:${port}`],
+      // Host and scheme match; carries userinfo.
+      ['userinfo', (port: number) => `http://user@127.0.0.1:${port}`],
+      // Host and scheme match; carries a path.
+      ['a path', (port: number) => `http://127.0.0.1:${port}/evil`],
+    ])('rejects a browser Origin with %s', async (_label, build) => {
+      const port = await reserveTestPort();
+      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      await server.start();
+
+      const res = await rawHttpGet(port, {
+        Host: `127.0.0.1:${port}`,
+        Origin: build(port),
+      });
+
+      expect(res.status).toBe(403);
+      expect(res.headers['access-control-allow-origin']).toBeUndefined();
+    });
+
+    it('accepts a browser Origin that matches the gateway exactly', async () => {
+      // Positive control. Without it the four refusals would pass if any Origin
+      // header at all were rejected, which would break the dashboard.
+      const port = await reserveTestPort();
+      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      await server.start();
+
+      const res = await rawHttpGet(port, {
+        Host: `127.0.0.1:${port}`,
+        Origin: `http://127.0.0.1:${port}`,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers['access-control-allow-origin']).toBe(`http://127.0.0.1:${port}`);
+    });
+
     it('still accepts an ordinary loopback Host header', async () => {
       // Positive control: without it, the six refusals above would all pass if
       // validateRequestSource simply rejected everything.


### PR DESCRIPTION
#62 covered the Host half of `validateRequestSource`. The Origin half had the same problem — and a sharper example of it.

## A green test that verified nothing

There is one cross-origin test, and it sends `https://malicious.example`.

That value fails the **protocol** check and the **host** check *simultaneously*. A green result says only that *something* rejected it. Neither condition was individually verified — and dropping any of them left the full 3964-test suite green:

| Mutation | Failures before |
|---|---|
| drop `origin.host !== authority.host` | **0** |
| drop `origin.protocol !== expectedProtocol` | **0** |
| drop `origin.username` / `password` | **0** |
| drop `origin.pathname !== '/'` | **0** |

## Why the host comparison matters

It is the CORS boundary. Without it, an Origin of `http://evil.example` is **accepted** — the scheme matches and nothing else objects — and the gateway answers with:

```
Access-Control-Allow-Origin: http://evil.example
```

Any page in any browser could then read the responses of a loopback gateway that requires no authentication.

## Five tests

Each Origin is chosen to fail **exactly one** condition:

| Origin | isolates |
|---|---|
| `http://evil.example` | scheme matches, **host differs** |
| `https://127.0.0.1:PORT` | host matches, **scheme differs** |
| `http://user@127.0.0.1:PORT` | both match, **userinfo** |
| `http://127.0.0.1:PORT/evil` | both match, **path** |

Plus a **positive control**: an exactly-matching Origin still returns 200 *and* receives the CORS header — without which all four refusals would pass if the gateway simply rejected every Origin, which would break the dashboard.

**Mutation-checked:** each of the four now fails a test where previously each failed none.

**No production code changed.** Full TS suite: **3969 passed**. Diff is purely additive (46 insertions, 0 deletions).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
