### PR TITLE
fix: stop chunkContent running out of memory on a configured overlap

### DIFF
--- a/typescript/src/memory/chunker.test.ts
+++ b/typescript/src/memory/chunker.test.ts
@@ -1,0 +1,61 @@
+/**
+ * `chunkContent` could be made to never return.
+ *
+ * `step = chunkSize - overlap` was used unguarded. With `overlap === chunkSize`
+ * the step is zero and the loop never advances; with `overlap > chunkSize` it
+ * is negative and the index walks backwards away from the termination check.
+ * Either way the loop appends a chunk on every pass, so the process does not
+ * merely hang — it grows until it runs out of memory.
+ *
+ * Both values come straight from MemoryManagerOptions, so a caller could do
+ * this by configuration alone.
+ *
+ * The Python chunker has clamped the step since it was written:
+ *
+ *     step = max(1, chunk_size - overlap)
+ *
+ * The reference counts below were taken from that implementation, so these
+ * tests pin the two runtimes together rather than only pinning this one.
+ */
+import { describe, it, expect } from 'vitest';
+import { chunkContent } from './chunker.js';
+
+const TEXT = 'x'.repeat(1000);
+
+describe('chunkContent termination', () => {
+  it.each([
+    ['overlap equal to chunkSize', { chunkSize: 100, overlap: 100 }, 901],
+    ['overlap greater than chunkSize', { chunkSize: 100, overlap: 150 }, 901],
+    ['a chunkSize of zero', { chunkSize: 0, overlap: 50 }, 0],
+  ])('terminates with %s, and agrees with the Python chunker', (_label, options, expected) => {
+    // Reaching the assertion at all is the point: before the clamp this call
+    // did not return.
+    expect(chunkContent(TEXT, options)).toHaveLength(expected);
+  });
+
+  it('still chunks normally, unchanged', () => {
+    // Positive control. Without it, clamping the step to something absurd would
+    // still satisfy every test above.
+    expect(chunkContent(TEXT, { chunkSize: 100, overlap: 10 })).toHaveLength(11);
+  });
+
+  it('loses no content when the step is clamped', () => {
+    const chunks = chunkContent(TEXT, { chunkSize: 100, overlap: 100 });
+    expect(chunks[0]).toBe('x'.repeat(100));
+    // Every chunk is a real slice of the input, and the last one reaches the end.
+    for (const chunk of chunks) expect(TEXT).toContain(chunk);
+    expect(chunks.join('').length).toBeGreaterThanOrEqual(TEXT.length);
+  });
+});
+
+describe('chunkContent empty input', () => {
+  it('returns no chunks for empty content', () => {
+    // Previously [''], which made an empty memory chunk. The Python chunker has
+    // always returned [] here.
+    expect(chunkContent('')).toEqual([]);
+  });
+
+  it('still returns a single chunk for content that fits', () => {
+    expect(chunkContent('short', { chunkSize: 512 })).toEqual(['short']);
+  });
+});

--- a/typescript/src/memory/chunker.ts
+++ b/typescript/src/memory/chunker.ts
@@ -17,12 +17,24 @@ export function chunkContent(
   const chunkSize = options.chunkSize ?? DEFAULT_CHUNK_SIZE;
   const overlap = options.overlap ?? DEFAULT_OVERLAP;
 
+  // Empty content is no content. Returning [''] made an empty memory chunk,
+  // which the Python chunker has never produced.
+  if (content.length === 0) {
+    return [];
+  }
   if (content.length <= chunkSize) {
     return [content];
   }
 
   const chunks: string[] = [];
-  const step = chunkSize - overlap;
+  // A step of zero or less never advances. With `overlap >= chunkSize` — or a
+  // chunkSize of zero — the loop below ran forever, appending a chunk each
+  // time, until the process ran out of memory. Both values come straight from
+  // MemoryManagerOptions, so a caller could hang the runtime by configuring
+  // them. The Python chunker has clamped this since it was written:
+  //
+  //     step = max(1, chunk_size - overlap)
+  const step = Math.max(1, chunkSize - overlap);
 
   for (let i = 0; i < content.length; i += step) {
     const chunk = content.slice(i, i + chunkSize);


### PR DESCRIPTION
`chunkContent` used `step = chunkSize - overlap` **unguarded**.

- `overlap === chunkSize` → step is **zero**, the loop never advances
- `overlap > chunkSize` → step is **negative**, the index walks backwards *away* from the termination check
- `chunkSize: 0` → same

A chunk is appended on every pass, so this is not a hang that sits idle. It allocates until the process dies:

```
FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory
```

That output is from removing the fix and re-running the new tests — the mutation **kills the test worker** rather than failing an assertion.

## Reachable by configuration alone

Both values come straight from `MemoryManagerOptions`:

```ts
this.chunkSize = options.chunkSize ?? 512;
this.chunkOverlap = options.chunkOverlap ?? 50;
```

No malformed input required — a caller setting overlap ≥ chunk size is enough.

## This was runtime drift

The **Python** chunker has clamped the step since it was written:

```python
step = max(1, chunk_size - overlap)
```

So the runtime with the guard was the one nobody hit. Found by diffing the two implementations after #60, on the principle that a fix in one body is a question to ask of the other.

Also aligned empty content: `chunkContent('')` returned `['']` — an empty memory chunk. Python has always returned `[]`.

## The two runtimes now agree exactly

| case | typescript | python |
|---|---|---|
| `overlap == chunkSize` | 901 | 901 |
| `overlap > chunkSize` | 901 | 901 |
| `chunkSize 0` | 0 | 0 |
| normal | 11 | 11 |
| empty | `[]` | `[]` |

## Tests — 7

Reference counts are **taken from the Python implementation**, so they pin the two runtimes together rather than only pinning this one. Includes:

- a **positive control** that ordinary chunking is unchanged — without it, clamping the step to *anything* would satisfy the termination cases
- a check that **no content is lost** when the step is clamped

**Mutation-checked:** removing the clamp → OOM crash; restoring `['']` → 1 failure.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **3987 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
