### PR TITLE
fix: stop the embedding cache handing one chunk another chunk's vector

### DIFF
--- a/typescript/src/memory/chunker.test.ts
+++ b/typescript/src/memory/chunker.test.ts
@@ -18,7 +18,8 @@
  * tests pin the two runtimes together rather than only pinning this one.
  */
 import { describe, it, expect } from 'vitest';
-import { chunkContent } from './chunker.js';
+import { chunkContent, hashContent } from './chunker.js';
+import { MemoryManager } from './manager.js';
 
 const TEXT = 'x'.repeat(1000);
 
@@ -57,5 +58,81 @@ describe('chunkContent empty input', () => {
 
   it('still returns a single chunk for content that fits', () => {
     expect(chunkContent('short', { chunkSize: 512 })).toEqual(['short']);
+  });
+});
+
+
+/**
+ * The embedding cache was keyed on a 32-bit Java-style string hash passed
+ * through `Math.abs`. Collisions are trivial to produce and, worse, silent:
+ * the cache hands back the other chunk's vector, the provider is never called,
+ * and the chunk is afterwards retrieved by similarity to text it does not
+ * contain.
+ */
+describe('hashContent', () => {
+  // Classic 31-multiplier collisions. 'E'(69)*31+'a'(97) === 'F'(70)*31+'B'(66).
+  const collisions: Array<[string, string]> = [
+    ['Ea', 'FB'],
+    ['EaEa', 'FBFB'],
+    ['hello Ea world', 'hello FB world'],
+    // Found by sweeping synthetic chunk text; the old hash collided here at
+    // 42,484 entries, which is roughly the birthday bound for 2^31.
+    ['chunk-24862-xxxxx', 'chunk-42484-x'],
+  ];
+
+  it.each(collisions)('distinguishes %s from %s', (a, b) => {
+    expect(hashContent(a)).not.toBe(hashContent(b));
+  });
+
+  it('is deterministic, so the cache still works', () => {
+    expect(hashContent('some chunk of text')).toBe(hashContent('some chunk of text'));
+  });
+
+  it('handles non-ASCII content', () => {
+    expect(hashContent('caf\u00e9 \u{1F600}')).not.toBe(hashContent('cafe'));
+    expect(hashContent('caf\u00e9')).toBe(hashContent('caf\u00e9'));
+  });
+});
+
+describe('embedding cache keying', () => {
+  it('does not hand one chunk the embedding of another', async () => {
+    // The consequence, end to end. Before the fix 'FB' was given 'Ea's vector
+    // and the provider was never called for it.
+    const embedded: string[] = [];
+    const provider = {
+      async embed(texts: string[]): Promise<number[][]> {
+        return texts.map(text => {
+          embedded.push(text);
+          return [text.length, text.charCodeAt(0), embedded.length];
+        });
+      },
+    };
+
+    const memory = new MemoryManager({ embeddingProvider: provider as never });
+    const first = await memory.add('Ea', 'note' as never, 'a');
+    const second = await memory.add('FB', 'note' as never, 'b');
+
+    const a = await memory.getChunk(first);
+    const b = await memory.getChunk(second);
+
+    expect(embedded).toEqual(['Ea', 'FB']);
+    expect(a?.embedding).not.toEqual(b?.embedding);
+  });
+
+  it('still reuses the cache for identical content', async () => {
+    // Positive control: a hash that never collides would also never cache if it
+    // were, say, random per call.
+    const embedded: string[] = [];
+    const provider = {
+      async embed(texts: string[]): Promise<number[][]> {
+        return texts.map(text => { embedded.push(text); return [1, 2, 3]; });
+      },
+    };
+
+    const memory = new MemoryManager({ embeddingProvider: provider as never });
+    await memory.add('identical text', 'note' as never, 'a');
+    await memory.add('identical text', 'note' as never, 'b');
+
+    expect(embedded).toEqual(['identical text']);
   });
 });

--- a/typescript/src/memory/chunker.ts
+++ b/typescript/src/memory/chunker.ts
@@ -2,6 +2,8 @@
  * Content chunking utilities for memory system
  */
 
+import { createHash } from 'crypto';
+
 import type { ChunkOptions } from './types.js';
 
 const DEFAULT_CHUNK_SIZE = 512;
@@ -111,14 +113,28 @@ export function generateSnippet(
 }
 
 /**
- * Compute simple hash for content (for embedding cache)
+ * Content hash used as the embedding cache key.
+ *
+ * This was `hash * 31 + char` truncated to 32 bits and then passed through
+ * `Math.abs`, which is the classic Java string hash with half its range thrown
+ * away. It is not a hash you can key a cache on:
+ *
+ *     hashContent('Ea') === hashContent('FB')            // '1q4'
+ *     hashContent('hello Ea world') === hashContent('hello FB world')
+ *
+ * The collisions compose, so they survive being embedded in real text rather
+ * than only appearing in two-character strings. A collision is silent and
+ * wrong in the worst way: `embeddingCache.get(key)` returns the *other*
+ * chunk's vector, the provider is never called, and that chunk is then
+ * retrieved by similarity to text it does not contain.
+ *
+ * Beyond the crafted pairs, synthetic chunks began colliding naturally at
+ * 42,484 entries — about what the birthday bound predicts once `Math.abs`
+ * folds the space to 2^31.
+ *
+ * SHA-256 costs microseconds next to an embedding call, and the cache is
+ * in-memory only, so nothing persisted depends on the old key.
  */
 export function hashContent(content: string): string {
-  let hash = 0;
-  for (let i = 0; i < content.length; i++) {
-    const char = content.charCodeAt(i);
-    hash = ((hash << 5) - hash) + char;
-    hash = hash & hash; // Convert to 32bit integer
-  }
-  return Math.abs(hash).toString(36);
+  return createHash('sha256').update(content, 'utf8').digest('hex');
 }


### PR DESCRIPTION
`hashContent` keys the embedding cache. It was `hash * 31 + char` truncated to 32 bits and then passed through `Math.abs` — the classic Java string hash with **half its range discarded**.

## Collisions are trivial

```
hashContent('Ea')             === hashContent('FB')               // '1q4'
hashContent('EaEa')           === hashContent('FBFB')
hashContent('hello Ea world') === hashContent('hello FB world')
```

They **compose**, so they survive being embedded in real text rather than only appearing in two-character strings. Sweeping synthetic chunk text, collisions began naturally at **42,484 entries** — about the birthday bound once `Math.abs` folds the space to 2³¹.

## The consequence is silent

Demonstrated end to end through `MemoryManager`, with a provider returning a distinct vector per text:

```
content A : "Ea"  embedding: [2,69,1]
content B : "FB"  embedding: [2,69,1]
provider was called for: ["Ea"]
```

The provider is **never asked** about the second chunk. It is stored with the first chunk's vector, and is afterwards **retrieved by similarity to text it does not contain** — so memory recall returns a confidently wrong result, with nothing anywhere reporting an error.

## Fix

SHA-256. Microseconds beside an embedding call, and the cache is an in-memory `Map` with **no persisted keys**, so nothing depends on the old value. (Verified: one call site, no serialization.)

## Tests — 8

The four collision pairs, determinism so the cache still works, non-ASCII content, the **end-to-end** case asserting the provider is called for *both* chunks and their vectors differ, and a **positive control** that identical content still hits the cache — without which a hash that simply never repeated would pass everything else.

**Mutation-checked:** restoring the 32-bit hash fails **5**, including the end-to-end consequence rather than only the unit-level collisions.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **3995 passed, 0 failures** |

## Related, deliberately not changed here

While diffing the two runtimes I found `generateSnippet` and `generate_snippet` disagree on **8 of 10** inputs — window computation, word-boundary trimming (TypeScript only), and multi-term selection (Python takes the first query term, TypeScript the earliest position). Neither is obviously the correct one, so picking a winner is an owner decision rather than a drive-by fix. Filing separately with the evidence.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
