### PR TITLE
fix: refuse an embedding batch size that cannot terminate

### DIFF
--- a/typescript/src/memory/embeddings.test.ts
+++ b/typescript/src/memory/embeddings.test.ts
@@ -1,0 +1,54 @@
+/**
+ * `embed` batches with `i += this.batchSize`, and `batchSize` is a plain
+ * constructor option with no validation.
+ *
+ * At zero the loop never advances and spins forever without producing
+ * anything. Below zero the index walks backwards, away from the termination
+ * check, while `results` keeps growing — so the process dies instead of
+ * hanging. Measured with a bounded reproduction of the same loop over 50
+ * inputs:
+ *
+ *     batchSize  20 -> 50 results
+ *     batchSize   1 -> 50 results
+ *     batchSize   0 -> did not terminate (0 results, pure spin)
+ *     batchSize  -5 -> did not terminate (45 results and climbing)
+ *
+ * This is the same defect as the memory chunker's unguarded step (#65), in a
+ * second file, reached the same way: a size taken from caller options and used
+ * directly as a loop increment.
+ */
+import { describe, it, expect } from 'vitest';
+import { OpenAIEmbeddingProvider } from './embeddings.js';
+
+describe('OpenAIEmbeddingProvider batch size', () => {
+  it.each([0, -1, -20, 1.5, NaN, Infinity])('refuses a batchSize of %s', (batchSize) => {
+    expect(() => new OpenAIEmbeddingProvider({ batchSize }))
+      .toThrow(/batchSize must be a positive integer/);
+  });
+
+  it.each([1, 5, 20, 1000])('accepts a batchSize of %s', (batchSize) => {
+    expect(() => new OpenAIEmbeddingProvider({ batchSize })).not.toThrow();
+  });
+
+  it('defaults to a usable batch size', () => {
+    expect(() => new OpenAIEmbeddingProvider()).not.toThrow();
+  });
+
+  it('embeds every input exactly once across batch boundaries', async () => {
+    // Positive control: the guard above would also be satisfied by a provider
+    // that refused everything, or one that dropped inputs.
+    const texts = Array.from({ length: 50 }, (_, i) => `text-${i}`);
+
+    for (const batchSize of [1, 7, 20, 100]) {
+      const provider = new OpenAIEmbeddingProvider({ batchSize, dimensions: 3 });
+      const vectors = await provider.embed(texts);
+
+      expect(vectors, `batchSize ${batchSize}`).toHaveLength(texts.length);
+      for (const vector of vectors) expect(vector).toHaveLength(3);
+    }
+  });
+
+  it('returns nothing for no input', async () => {
+    expect(await new OpenAIEmbeddingProvider({ dimensions: 3 }).embed([])).toEqual([]);
+  });
+});

--- a/typescript/src/memory/embeddings.ts
+++ b/typescript/src/memory/embeddings.ts
@@ -16,6 +16,16 @@ export class OpenAIEmbeddingProvider implements EmbeddingProvider {
     this.apiKey = options?.apiKey ?? process.env.OPENAI_API_KEY ?? '';
     this.dimensions = options?.dimensions ?? 1536;
     this.batchSize = options?.batchSize ?? 20;
+
+    // `embed` advances by this value. At zero the loop never advances and spins
+    // forever; below zero the index walks backwards away from the termination
+    // check while `results` keeps growing, so the process dies rather than
+    // hangs. Neither is something a caller can diagnose from the outside, so
+    // refuse it here where the value is set, the way chunkIMessageText refuses
+    // a non-positive chunk length.
+    if (!Number.isSafeInteger(this.batchSize) || this.batchSize < 1) {
+      throw new Error('embedding batchSize must be a positive integer');
+    }
   }
 
   async embed(texts: string[]): Promise<number[][]> {


### PR DESCRIPTION
`OpenAIEmbeddingProvider.embed` advances with `i += this.batchSize`, and `batchSize` is a plain constructor option with **no validation**.

- **zero** → the loop never advances and spins forever, producing nothing
- **negative** → the index walks backwards, away from the termination check, while `results` keeps growing — so the process **dies** rather than hangs

Measured with a bounded reproduction of the same loop over 50 inputs:

```
batchSize  20 -> 50 results
batchSize   1 -> 50 results
batchSize   0 -> did not terminate (0 results, pure spin)
batchSize  -5 -> did not terminate (45 results and climbing)
```

## This is the second instance of one defect

Identical to the memory chunker's unguarded step in #65 — a size taken from caller options and used directly as a loop increment. I found it by grepping for that shape after #65, on the theory that a bug worth fixing is worth looking for twice.

Finding it twice is also why this one is **rejected where the value is set** rather than clamped at the point of use: a caller passing zero has a bug, and the error should say so at construction instead of the process disappearing later.

Refused rather than clamped to match `chunkIMessageText`, which already treats a non-positive length as caller error.

## Tests — 13

Six rejected values (including `1.5`, `NaN`, `Infinity`), four accepted sizes, the default, and a **positive control** that every input is embedded exactly once across batch boundaries at sizes both above and below the input count — the guard alone would also be satisfied by a provider that refused everything or silently dropped inputs. Plus the empty-input case.

**Mutation-checked:** removing the guard fails **6**; admitting zero by relaxing the bound to `< 0` fails **1**.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **4008 passed, 0 failures** |

## Checked this round and found sound

Continuing the runtime-diff sweep from #65/#67, I compared and found **no drift** in: `cosineSimilarity` (guards both length mismatch and a zero denominator), full-text search scoring (same term filter, same `matches/terms` score, same ordering in both bodies), and the hybrid `mergeResults` weighting. Recording those as verified rather than filing noise.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
