### PR TITLE
fix: stop predict-y spinning forever on a small field height

### DIFF
--- a/typescript/src/tui/lispy-predict-y.test.ts
+++ b/typescript/src/tui/lispy-predict-y.test.ts
@@ -1,0 +1,82 @@
+/**
+ * `predict-y` reflects a predicted ball position back inside the field.
+ *
+ * It used to do that with a loop that folded the value across each edge until
+ * it landed in range, and that loop could not always finish. At a field height
+ * of 1 the two folds undo one another and the value oscillates forever; at 0 or
+ * less, or a fractional height, it diverges — measured with a bounded copy, a
+ * height of 0 walked the value to -200005 in 100,000 iterations and kept going.
+ *
+ * `field-h` arrives as an ordinary argument from a lispy program, so a script
+ * could spin the process with a single call.
+ */
+import { describe, it, expect } from 'vitest';
+import { LispyVM } from './lispy.js';
+
+/** Surface predict-y's value through the one output the VM exposes. */
+function predictY(state: Record<string, number>): number {
+  const vm = new LispyVM();
+  vm.setStrategy('(move :down (predict-y paddle-x ball-x ball-y ball-vx ball-vy field-h))');
+  return vm.tick(state).speed;
+}
+
+function state(overrides: Partial<Record<string, number>> = {}): Record<string, number> {
+  return {
+    'paddle-x': 68, 'ball-x': 0, 'ball-y': 5,
+    'ball-vx': 1, 'ball-vy': 0, 'field-h': 16,
+    ...overrides,
+  };
+}
+
+describe('predict-y termination', () => {
+  it.each([
+    ['a field height of 1, where the two folds cancel', 1],
+    ['a field height of 0', 0],
+    ['a negative field height', -2],
+    ['a fractional field height below 1', 0.5],
+  ])('returns instead of spinning with %s', (_label, fieldHeight) => {
+    // Reaching the assertion at all is the point: this call did not return.
+    const result = predictY(state({ 'field-h': fieldHeight, 'ball-vy': 0.3 }));
+    expect(Number.isFinite(result)).toBe(true);
+    expect(result).toBe(0);
+  });
+});
+
+describe('predict-y reflection', () => {
+  it('leaves a position already inside the field alone', () => {
+    expect(predictY(state({ 'ball-y': 5, 'ball-vy': 0 }))).toBe(5);
+  });
+
+  it('reflects a position below the floor back up', () => {
+    // ball-y 5, vy -1 over 8 ticks lands at -3, which reflects to 3.
+    expect(predictY(state({ 'ball-x': 60, 'ball-y': 5, 'ball-vy': -1 }))).toBe(3);
+  });
+
+  it('reflects a position past the ceiling back down', () => {
+    // Lands at 25 in a field of height 16, reflecting to 2 * 15 - 25 = 5.
+    expect(predictY(state({ 'ball-x': 48, 'ball-y': 5, 'ball-vy': 1 }))).toBe(5);
+  });
+
+  it('folds repeatedly for a position several field-heights away', () => {
+    // The old loop needed many iterations here; the closed form does not.
+    const result = predictY(state({ 'ball-x': 0, 'ball-y': 5, 'ball-vy': 7 }));
+    expect(result).toBeGreaterThanOrEqual(0);
+    expect(result).toBeLessThanOrEqual(15);
+  });
+
+  it('always lands within [0, field-h - 1]', () => {
+    for (const vy of [-9.5, -4, -1, 0, 0.3, 2, 6, 13.25]) {
+      const result = predictY(state({ 'ball-vy': vy }));
+      expect(result, `vy ${vy}`).toBeGreaterThanOrEqual(0);
+      expect(result, `vy ${vy}`).toBeLessThanOrEqual(15);
+    }
+  });
+
+  it('returns the current position when the ball is moving away', () => {
+    expect(predictY(state({ 'ball-x': 70, 'ball-vx': 1, 'ball-y': 9 }))).toBe(9);
+  });
+
+  it('returns the current position when the ball has no horizontal motion', () => {
+    expect(predictY(state({ 'ball-vx': 0, 'ball-y': 11 }))).toBe(11);
+  });
+});

--- a/typescript/src/tui/lispy.ts
+++ b/typescript/src/tui/lispy.ts
@@ -204,13 +204,25 @@ function evaluate(expr: LispVal, env: Env): LispVal {
       if (bvx === 0) return by;
       const ticks = (tx - bx) / bvx;
       if (ticks < 0) return by; // ball going away
-      let py = by + bvy * ticks;
-      // Bounce simulation
-      while (py < 0 || py >= fh) {
-        if (py < 0) py = -py;
-        if (py >= fh) py = 2 * (fh - 1) - py;
-      }
-      return py;
+      const py = by + bvy * ticks;
+      // Reflect into [0, fh - 1].
+      //
+      // This was a loop that repeatedly folded `py` back across each edge, and
+      // it could not always finish. With a field height of 1 the two folds undo
+      // each other, so `py` oscillates forever; with a height of 0 or less, or
+      // a fractional one, it diverges instead — at fh = 0 it walked to -200005
+      // in 100k iterations and kept going. Field height reaches here as a plain
+      // argument from a lispy program, so a script could spin the process.
+      //
+      // The fold is a triangle wave, which has a closed form. Verified against
+      // the loop over every integer position from -500 to 500 for heights 2 to
+      // 40 — 39,039 cases, no disagreement — so this is the same answer without
+      // the unbounded iteration.
+      const span = fh - 1;
+      if (!(span > 0)) return 0;
+      const period = 2 * span;
+      const folded = ((py % period) + period) % period;
+      return folded > span ? period - folded : folded;
     }
 
     default:


### PR DESCRIPTION
`predict-y` reflected a predicted ball position back inside the field with a loop that folded the value across each edge until it landed in range:

```ts
while (py < 0 || py >= fh) {
  if (py < 0) py = -py;
  if (py >= fh) py = 2 * (fh - 1) - py;
}
```

At a field height of **1** the two folds undo one another and the value oscillates forever. At **0 or less**, or a **fractional** height, it diverges instead. Measured with a bounded copy of the same loop:

```
py=5  fh=20  -> 5
py=25 fh=20  -> 13
py=5  fh=1   -> did not terminate (drifted to -5)
py=5  fh=0   -> did not terminate (drifted to -200005)
py=5  fh=0.5 -> did not terminate (drifted to -100005)
py=3  fh=-2  -> did not terminate (drifted to -600003)
```

`field-h` arrives as an ordinary argument from a lispy program, so a script can spin the process with **one call**.

## Why the tests assert a value rather than relying on a timeout

This is a **synchronous** loop, so nothing interrupts it — no `testTimeout`, no cancellation. Restoring the old code under the new tests does not fail them, it **hangs the runner**. I found that out by trying it: the mutation run had to be killed manually.

## Fix

The fold is a triangle wave, which has a closed form. Verified against the loop over **every integer position from -500 to 500 for heights 2 to 40 — 39,039 cases, no disagreement** — so this returns the same answer for every input the loop could actually finish on, in constant time.

Heights of 1 or less have no interior to reflect into, so they return `0`.

## Third instance of one shape

An unvalidated number driving a loop, after the memory chunker (#65) and the embedding batch size (#69). Found by grepping for `while` loops, not by reading this file for its own sake.

## Tests — 11

Four degenerate heights that previously did not return, plus reflection behaviour: already inside, below the floor, past the ceiling, several field-heights away, always landing within `[0, field-h - 1]`, and the two early-return paths (ball moving away, no horizontal motion).

**Mutation-checked:** dropping the height guard fails **4**; restoring the loop hangs the runner outright.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **4019 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
