### PR TITLE
fix: validate every redirect hop, not just the URL the caller gave

### DIFF
--- a/typescript/src/agents/WebAgent.ssrf.test.ts
+++ b/typescript/src/agents/WebAgent.ssrf.test.ts
@@ -1,0 +1,143 @@
+/**
+ * WebAgent advertises "SSRF protection to prevent access to private networks",
+ * and it validated only the URL the caller supplied. `fetch` follows redirects
+ * by default, so a public host could hand back a `302` pointing anywhere and
+ * the fetch would follow it:
+ *
+ *     caller asks for   http://public.example/go
+ *     validateUrl       passes — the host is public
+ *     server replies    302 Location: http://127.0.0.1:PORT/
+ *     fetch follows     and returns the internal response body
+ *
+ * Reproduced against a local pair of servers before this file existed: the
+ * body of the blocked host came back intact.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { WebAgent } from './WebAgent.js';
+
+const servers: http.Server[] = [];
+
+function listen(handler: http.RequestListener): Promise<number> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    servers.push(server);
+    server.listen(0, '127.0.0.1', () => resolve((server.address() as AddressInfo).port));
+  });
+}
+
+async function fetchVia(agent: WebAgent, url: string): Promise<Record<string, unknown>> {
+  const raw = await (agent as unknown as {
+    fetchUrl(url: string): Promise<string>;
+  }).fetchUrl(url);
+  return JSON.parse(raw) as Record<string, unknown>;
+}
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    await new Promise<void>((resolve) => servers.pop()!.close(() => resolve()));
+  }
+});
+
+describe('WebAgent redirect handling', () => {
+  it('refuses a redirect that lands on a blocked address', async () => {
+    const secret = await listen((_req, res) => { res.writeHead(200); res.end('INTERNAL'); });
+    const redirector = await listen((_req, res) => {
+      res.writeHead(302, { Location: `http://127.0.0.1:${secret}/` });
+      res.end();
+    });
+
+    // The first hop has to pass validation for this to test the second one, so
+    // the redirector is reached through a host the validator accepts.
+    const agent = new WebAgent();
+    const permissive = agent as unknown as { validateUrl(url: string): void };
+    const realValidate = permissive.validateUrl.bind(permissive);
+    let firstCall = true;
+    permissive.validateUrl = (url: string) => {
+      if (firstCall) { firstCall = false; return; }  // stand in for a public host
+      realValidate(url);
+    };
+
+    await expect(fetchVia(agent, `http://127.0.0.1:${redirector}/`))
+      .rejects.toThrow(/blocked/i);
+  });
+
+  it('does not return the blocked body', async () => {
+    const secret = await listen((_req, res) => { res.writeHead(200); res.end('INTERNAL'); });
+    const redirector = await listen((_req, res) => {
+      res.writeHead(302, { Location: `http://127.0.0.1:${secret}/` });
+      res.end();
+    });
+
+    const agent = new WebAgent();
+    const permissive = agent as unknown as { validateUrl(url: string): void };
+    const realValidate = permissive.validateUrl.bind(permissive);
+    let firstCall = true;
+    permissive.validateUrl = (url: string) => {
+      if (firstCall) { firstCall = false; return; }
+      realValidate(url);
+    };
+
+    await expect(fetchVia(agent, `http://127.0.0.1:${redirector}/`))
+      .rejects.toThrow();
+    // The assertion that matters: nothing from the internal service escaped.
+  });
+
+  it('stops a redirect loop after a bounded number of hops', async () => {
+    // Counting the requests matters: asserting only that it eventually throws
+    // would also pass with a limit of 100,000, which is not a limit worth
+    // having. The server records how many times it was actually asked.
+    let hits = 0;
+    let port = 0;
+    port = await listen((_req, res) => {
+      hits += 1;
+      res.writeHead(302, { Location: `http://127.0.0.1:${port}/` });
+      res.end();
+    });
+
+    const agent = new WebAgent();
+    const permissive = agent as unknown as { validateUrl(url: string): void };
+    permissive.validateUrl = () => undefined;  // allow every hop
+
+    await expect(fetchVia(agent, `http://127.0.0.1:${port}/`))
+      .rejects.toThrow(/too many redirects/i);
+
+    expect(hits).toBeLessThanOrEqual(10);
+  });
+
+  it('still follows a redirect to an allowed address', async () => {
+    // Positive control. Refusing every redirect would satisfy the tests above
+    // and break ordinary browsing, where redirects are routine.
+    const target = await listen((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<p>DESTINATION</p>');
+    });
+    const redirector = await listen((_req, res) => {
+      res.writeHead(302, { Location: `http://127.0.0.1:${target}/` });
+      res.end();
+    });
+
+    const agent = new WebAgent();
+    const permissive = agent as unknown as { validateUrl(url: string): void };
+    permissive.validateUrl = () => undefined;
+
+    const result = await fetchVia(agent, `http://127.0.0.1:${redirector}/`);
+    expect(result.status).toBe('success');
+    expect(String(result.content)).toContain('DESTINATION');
+  });
+
+  it('still fetches a direct response with no redirect', async () => {
+    const port = await listen((_req, res) => {
+      res.writeHead(200, { 'Content-Type': 'text/html' });
+      res.end('<p>DIRECT</p>');
+    });
+
+    const agent = new WebAgent();
+    (agent as unknown as { validateUrl(url: string): void }).validateUrl = () => undefined;
+
+    const result = await fetchVia(agent, `http://127.0.0.1:${port}/`);
+    expect(result.status).toBe('success');
+    expect(String(result.content)).toContain('DIRECT');
+  });
+});

--- a/typescript/src/agents/WebAgent.ts
+++ b/typescript/src/agents/WebAgent.ts
@@ -100,6 +100,8 @@ export class WebAgent extends BasicAgent {
     }
   }
 
+  private static readonly MAX_REDIRECTS = 5;
+
   private validateUrl(url: string): void {
     const parsed = new URL(url);
     const hostname = parsed.hostname;
@@ -129,10 +131,48 @@ export class WebAgent extends BasicAgent {
     }
   }
 
-  private async fetchUrl(url: string): Promise<string> {
-    this.validateUrl(url);
+  /**
+   * Fetch, validating every hop rather than only the first.
+   *
+   * `validateUrl` was called once, on the URL the caller supplied, and then
+   * `fetch` was left to follow redirects on its own. Redirects are followed by
+   * default, so the check only ever covered the first hop:
+   *
+   *     caller asks for   http://public.example/go
+   *     validateUrl       passes — the host is public
+   *     server replies    302 Location: http://127.0.0.1:18790/
+   *     fetch follows     and returns the local gateway's response
+   *
+   * Verified against a local pair of servers: the redirect was followed and the
+   * blocked host's body came back. Every address this class exists to refuse —
+   * loopback, link-local, RFC 1918, cloud metadata at 169.254.169.254 — was
+   * reachable by asking a public host to point there.
+   *
+   * Redirects are now resolved by hand so the same validation runs on each
+   * target, with a hop limit so a redirect cycle cannot spin.
+   */
+  private async fetchWithValidatedRedirects(url: string): Promise<Response> {
+    let target = url;
 
-    const response = await fetch(url);
+    for (let hop = 0; hop <= WebAgent.MAX_REDIRECTS; hop++) {
+      this.validateUrl(target);
+      const response = await fetch(target, { redirect: 'manual' });
+
+      const isRedirect = response.status >= 300 && response.status < 400;
+      if (!isRedirect) return response;
+
+      const location = response.headers.get('location');
+      if (!location) return response;
+
+      // Resolve relative redirects against the hop they came from.
+      target = new URL(location, target).toString();
+    }
+
+    throw new Error(`Too many redirects (limit ${WebAgent.MAX_REDIRECTS}): ${url}`);
+  }
+
+  private async fetchUrl(url: string): Promise<string> {
+    const response = await this.fetchWithValidatedRedirects(url);
     if (!response.ok) {
       return JSON.stringify({
         status: 'error',


### PR DESCRIPTION
`WebAgent` describes itself as including *"SSRF protection to prevent access to private networks"*, and it blocks loopback, link-local, RFC 1918 and cloud metadata addresses.

It checked the URL it was handed, then let `fetch` follow redirects on its own — which it does **by default**. So the check only ever covered the **first hop**:

```
caller asks for   http://public.example/go
validateUrl       passes, the host is public
server replies    302 Location: http://127.0.0.1:18790/
fetch follows     and returns the local gateway's response
```

Reproduced against a local pair of servers — the redirect was followed and the blocked host's body came back intact:

```
(b) redirect : validateUrl runs once on the FIRST url only
    followed to : http://127.0.0.1:64858/ -> INTERNAL-SERVICE-CONTENT
```

Every address this class exists to refuse is reachable by asking a public host to point at it — including the gateway on this machine and `169.254.169.254`.

## Fix

Redirects are resolved by hand so the **same validation runs on each target**, relative `Location`s resolve against the hop they came from, and a hop limit stops a redirect cycle.

## Tests — 5

A redirect onto a blocked address is refused and its body does not escape; a redirect loop stops after a bounded number of hops; a redirect to an **allowed** address is still followed, and a direct response still works — the last two are **positive controls**, since refusing every redirect would satisfy the first three and quietly break ordinary browsing.

**Mutation-checked:** restoring automatic redirect following fails **3**.

The hop-limit test originally asserted only that it *eventually threw* — which still passed with the limit raised to **100,000**, not a limit worth having. It now counts the requests the server actually received, and fails that mutation too.

## A bypass that turned out not to exist

`http://2130706433/` is the decimal form of `127.0.0.1`, and the hostname patterns are string matches — so it looked like it would slip straight through. **It does not.** WHATWG URL parsing normalises the host to `127.0.0.1` before `validateUrl` sees it, and the existing check catches it. Recording it because it is the obvious next thing someone will try.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **4024 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
