### PR TITLE
fix: check where a URL actually points, not how its host is spelled

### DIFF
--- a/typescript/src/agents/WebAgent.ssrf.test.ts
+++ b/typescript/src/agents/WebAgent.ssrf.test.ts
@@ -202,15 +202,55 @@ describe('WebAgent address validation', () => {
 });
 
 describe('WebAgent DNS resolution', () => {
-  it('blocks a public name that resolves to a private address', async () => {
-    // localtest.me is a real public DNS name pointing at 127.0.0.1. Before the
-    // resolution check this fetched a loopback server's body.
-    const secret = await listen((_req, res) => { res.writeHead(200); res.end('LOOPBACK-REACHED'); });
+  it.each([
+    ['IPv4 loopback', '127.0.0.1'],
+    ['IPv6 loopback', '::1'],
+    ['RFC 1918', '10.0.0.5'],
+    ['cloud metadata', '169.254.169.254'],
+  ])('blocks a public name that resolves to %s', async (_label, address) => {
+    // Hermetic on purpose. The first version of this test used localtest.me, a
+    // real name pointing at loopback — it passed locally, where that is
+    // 127.0.0.1, and failed on CI, where it is ::1. Which family a machine
+    // answers with is not what this test is about.
+    class Resolving extends WebAgent {
+      protected async lookupHost(): Promise<Array<{ address: string }>> {
+        return [{ address }];
+      }
+    }
+    const agent = new Resolving() as unknown as { fetchUrl(u: string): Promise<string> };
 
-    await expect(
-      (new WebAgent() as unknown as { fetchUrl(u: string): Promise<string> })
-        .fetchUrl(`http://localtest.me:${secret}/`),
-    ).rejects.toThrow(/resolves to 127\.0\.0\.1/);
+    await expect(agent.fetchUrl('http://public-looking.example/'))
+      .rejects.toThrow(/resolves to/i);
+  });
+
+  it('allows a public name that resolves to a public address', async () => {
+    // Positive control: refusing every resolved address would pass the four
+    // cases above and block the entire web.
+    class Resolving extends WebAgent {
+      protected async lookupHost(): Promise<Array<{ address: string }>> {
+        return [{ address: '93.184.216.34' }];
+      }
+    }
+    const agent = new Resolving() as unknown as {
+      assertHostResolvesPublicly(u: string): Promise<void>;
+    };
+    await expect(agent.assertHostResolvesPublicly('http://example.com/'))
+      .resolves.toBeUndefined();
+  });
+
+  it('blocks when any one of several resolved addresses is private', async () => {
+    // A name can answer with more than one address, and one bad answer is
+    // enough — checking only the first would miss it.
+    class Resolving extends WebAgent {
+      protected async lookupHost(): Promise<Array<{ address: string }>> {
+        return [{ address: '93.184.216.34' }, { address: '127.0.0.1' }];
+      }
+    }
+    const agent = new Resolving() as unknown as {
+      assertHostResolvesPublicly(u: string): Promise<void>;
+    };
+    await expect(agent.assertHostResolvesPublicly('http://public-looking.example/'))
+      .rejects.toThrow(/resolves to 127\.0\.0\.1/);
   });
 
   it('does not reject a name it cannot resolve, leaving that to fetch', async () => {

--- a/typescript/src/agents/WebAgent.ssrf.test.ts
+++ b/typescript/src/agents/WebAgent.ssrf.test.ts
@@ -34,6 +34,25 @@ async function fetchVia(agent: WebAgent, url: string): Promise<Record<string, un
   return JSON.parse(raw) as Record<string, unknown>;
 }
 
+/**
+ * Loopback is the only address a test can bind, so tests about *redirect*
+ * behaviour have to neutralise the address checks to reach the behaviour they
+ * are actually about. Both guards, or the DNS one still refuses the fixture.
+ */
+function allowLoopback(agent: WebAgent, exceptAfterFirstHop = false): void {
+  const internals = agent as unknown as {
+    validateUrl(url: string): void;
+    assertHostResolvesPublicly(url: string): Promise<void>;
+  };
+  const realValidate = internals.validateUrl.bind(internals);
+  let first = true;
+  internals.validateUrl = (url: string) => {
+    if (exceptAfterFirstHop && !first) { realValidate(url); return; }
+    first = false;
+  };
+  internals.assertHostResolvesPublicly = async () => undefined;
+}
+
 afterEach(async () => {
   while (servers.length > 0) {
     await new Promise<void>((resolve) => servers.pop()!.close(() => resolve()));
@@ -51,13 +70,7 @@ describe('WebAgent redirect handling', () => {
     // The first hop has to pass validation for this to test the second one, so
     // the redirector is reached through a host the validator accepts.
     const agent = new WebAgent();
-    const permissive = agent as unknown as { validateUrl(url: string): void };
-    const realValidate = permissive.validateUrl.bind(permissive);
-    let firstCall = true;
-    permissive.validateUrl = (url: string) => {
-      if (firstCall) { firstCall = false; return; }  // stand in for a public host
-      realValidate(url);
-    };
+    allowLoopback(agent, true);
 
     await expect(fetchVia(agent, `http://127.0.0.1:${redirector}/`))
       .rejects.toThrow(/blocked/i);
@@ -71,13 +84,7 @@ describe('WebAgent redirect handling', () => {
     });
 
     const agent = new WebAgent();
-    const permissive = agent as unknown as { validateUrl(url: string): void };
-    const realValidate = permissive.validateUrl.bind(permissive);
-    let firstCall = true;
-    permissive.validateUrl = (url: string) => {
-      if (firstCall) { firstCall = false; return; }
-      realValidate(url);
-    };
+    allowLoopback(agent, true);
 
     await expect(fetchVia(agent, `http://127.0.0.1:${redirector}/`))
       .rejects.toThrow();
@@ -97,8 +104,7 @@ describe('WebAgent redirect handling', () => {
     });
 
     const agent = new WebAgent();
-    const permissive = agent as unknown as { validateUrl(url: string): void };
-    permissive.validateUrl = () => undefined;  // allow every hop
+    allowLoopback(agent);
 
     await expect(fetchVia(agent, `http://127.0.0.1:${port}/`))
       .rejects.toThrow(/too many redirects/i);
@@ -119,8 +125,7 @@ describe('WebAgent redirect handling', () => {
     });
 
     const agent = new WebAgent();
-    const permissive = agent as unknown as { validateUrl(url: string): void };
-    permissive.validateUrl = () => undefined;
+    allowLoopback(agent);
 
     const result = await fetchVia(agent, `http://127.0.0.1:${redirector}/`);
     expect(result.status).toBe('success');
@@ -134,10 +139,88 @@ describe('WebAgent redirect handling', () => {
     });
 
     const agent = new WebAgent();
-    (agent as unknown as { validateUrl(url: string): void }).validateUrl = () => undefined;
+    allowLoopback(agent);
 
     const result = await fetchVia(agent, `http://127.0.0.1:${port}/`);
     expect(result.status).toBe('success');
     expect(String(result.content)).toContain('DIRECT');
+  });
+});
+
+/**
+ * The address checks read `URL.hostname` as text. Three ways past that:
+ *
+ *   1. IPv6 literals keep their brackets, so `[::1]` never matched `/^::1$/`.
+ *      Every IPv6 rule in the list was unreachable.
+ *   2. A public DNS name can resolve inward. `localtest.me` is a real name
+ *      that resolves to 127.0.0.1; fetching it returned the body of a loopback
+ *      server on this machine.
+ *   3. The scheme was never checked, and Node fetches `data:` URLs.
+ */
+describe('WebAgent address validation', () => {
+  function validate(url: string): void {
+    (new WebAgent() as unknown as { validateUrl(u: string): void }).validateUrl(url);
+  }
+
+  it.each([
+    ['IPv6 loopback', 'http://[::1]/'],
+    ['IPv6 unspecified', 'http://[::]/'],
+    ['IPv6 link-local', 'http://[fe80::1]/'],
+    ['IPv6 unique-local fc00', 'http://[fc00::1]/'],
+    ['IPv6 unique-local fd00', 'http://[fd12::1]/'],
+    ['IPv4-mapped loopback', 'http://[::ffff:127.0.0.1]/'],
+  ])('blocks %s', (_label, url) => {
+    expect(() => validate(url)).toThrow(/blocked/i);
+  });
+
+  it.each([
+    ['IPv4 loopback', 'http://127.0.0.1/'],
+    ['RFC 1918 ten', 'http://10.1.2.3/'],
+    ['RFC 1918 one-nine-two', 'http://192.168.1.1/'],
+    ['cloud metadata', 'http://169.254.169.254/latest/meta-data/'],
+    ['localhost by name', 'http://localhost/'],
+  ])('still blocks %s', (_label, url) => {
+    expect(() => validate(url)).toThrow(/blocked/i);
+  });
+
+  it.each([
+    ['file', 'file:///etc/passwd'],
+    ['data', 'data:text/plain,hello'],
+    ['ftp', 'ftp://example.com/x'],
+  ])('refuses the %s scheme', (_label, url) => {
+    expect(() => validate(url)).toThrow(/unsupported url scheme/i);
+  });
+
+  it.each([
+    'http://example.com/',
+    'https://example.com/path?q=1',
+    'http://93.184.216.34/',
+    'http://[2606:2800:220:1:248:1893:25c8:1946]/',
+  ])('still allows the public address %s', (url) => {
+    expect(() => validate(url)).not.toThrow();
+  });
+});
+
+describe('WebAgent DNS resolution', () => {
+  it('blocks a public name that resolves to a private address', async () => {
+    // localtest.me is a real public DNS name pointing at 127.0.0.1. Before the
+    // resolution check this fetched a loopback server's body.
+    const secret = await listen((_req, res) => { res.writeHead(200); res.end('LOOPBACK-REACHED'); });
+
+    await expect(
+      (new WebAgent() as unknown as { fetchUrl(u: string): Promise<string> })
+        .fetchUrl(`http://localtest.me:${secret}/`),
+    ).rejects.toThrow(/resolves to 127\.0\.0\.1/);
+  });
+
+  it('does not reject a name it cannot resolve, leaving that to fetch', async () => {
+    // Failing closed on every lookup error would break offline and flaky-DNS
+    // use for hosts that were never private to begin with.
+    const agent = new WebAgent() as unknown as {
+      assertHostResolvesPublicly(u: string): Promise<void>;
+    };
+    await expect(
+      agent.assertHostResolvesPublicly('http://this-name-does-not-exist.invalid/'),
+    ).resolves.toBeUndefined();
   });
 });

--- a/typescript/src/agents/WebAgent.ts
+++ b/typescript/src/agents/WebAgent.ts
@@ -9,6 +9,7 @@
 
 import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
+import { lookup } from 'dns/promises';
 
 
 export const __manifest__ = {
@@ -102,60 +103,106 @@ export class WebAgent extends BasicAgent {
 
   private static readonly MAX_REDIRECTS = 5;
 
+  private static readonly BLOCKED_HOST_PATTERNS = [
+    /^10\./,
+    /^172\.(1[6-9]|2[0-9]|3[01])\./,
+    /^192\.168\./,
+    /^127\./,
+    /^0\./,
+    /^169\.254\./,
+    /^::1$/,
+    /^::$/,
+    /^fc[0-9a-f]{2}:/,
+    /^fd[0-9a-f]{2}:/,
+    /^fe80:/,
+  ];
+
+  /**
+   * Reduce a URL hostname or a resolved address to something the patterns can
+   * match.
+   *
+   * `URL.hostname` keeps the brackets on an IPv6 literal, so `http://[::1]/`
+   * arrives as `"[::1]"` and `/^::1$/` never fires. Every IPv6 rule in this
+   * list was unreachable for that reason — `[::1]`, `[fe80::1]` and
+   * `[::ffff:127.0.0.1]` were all allowed through.
+   *
+   * IPv4-mapped addresses are folded back to dotted quad so the IPv4 rules
+   * apply to them: `::ffff:7f00:1` is 127.0.0.1 wearing a different hat.
+   */
+  private static normaliseHost(host: string): string {
+    const bare = host.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+
+    const mapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(bare);
+    if (mapped) {
+      const high = parseInt(mapped[1], 16);
+      const low = parseInt(mapped[2], 16);
+      return [high >> 8, high & 0xff, low >> 8, low & 0xff].join('.');
+    }
+    const mappedDotted = /^::ffff:((?:[0-9]{1,3}\.){3}[0-9]{1,3})$/.exec(bare);
+    if (mappedDotted) return mappedDotted[1];
+
+    return bare;
+  }
+
+  private static isBlockedHost(host: string): boolean {
+    const normalised = WebAgent.normaliseHost(host);
+    if (normalised === 'localhost' || normalised.endsWith('.local')) return true;
+    return WebAgent.BLOCKED_HOST_PATTERNS.some(pattern => pattern.test(normalised));
+  }
+
   private validateUrl(url: string): void {
     const parsed = new URL(url);
-    const hostname = parsed.hostname;
 
-    // Block private IP ranges (SSRF protection)
-    const privatePatterns = [
-      /^10\./,
-      /^172\.(1[6-9]|2[0-9]|3[01])\./,
-      /^192\.168\./,
-      /^127\./,
-      /^0\./,
-      /^169\.254\./,
-      /^::1$/,
-      /^fc00:/,
-      /^fe80:/,
-    ];
-
-    for (const pattern of privatePatterns) {
-      if (pattern.test(hostname)) {
-        throw new Error(`Access to private IP range blocked: ${hostname}`);
-      }
+    // A web fetcher has no business on any other scheme. `data:` URLs are
+    // fetchable by Node and would let a caller feed arbitrary content back to
+    // the model as though it had been retrieved; `file:` is refused by fetch
+    // today, which is a property of fetch rather than a decision made here.
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+      throw new Error(`Unsupported URL scheme: ${parsed.protocol}`);
     }
 
-    // Block localhost
-    if (hostname === 'localhost' || hostname.endsWith('.local')) {
-      throw new Error(`Access to localhost blocked: ${hostname}`);
+    if (WebAgent.isBlockedHost(parsed.hostname)) {
+      throw new Error(`Access to private IP range blocked: ${parsed.hostname}`);
     }
   }
 
   /**
-   * Fetch, validating every hop rather than only the first.
+   * Resolve the host and check where it actually points.
    *
-   * `validateUrl` was called once, on the URL the caller supplied, and then
-   * `fetch` was left to follow redirects on its own. Redirects are followed by
-   * default, so the check only ever covered the first hop:
+   * The checks above read the hostname as text, so any public name that
+   * resolves inward walked straight past them. `localtest.me` is a real public
+   * DNS name that resolves to 127.0.0.1, and fetching it returned the body of a
+   * loopback server on this machine — the whole protection bypassed without a
+   * redirect or a malformed address.
    *
-   *     caller asks for   http://public.example/go
-   *     validateUrl       passes — the host is public
-   *     server replies    302 Location: http://127.0.0.1:18790/
-   *     fetch follows     and returns the local gateway's response
-   *
-   * Verified against a local pair of servers: the redirect was followed and the
-   * blocked host's body came back. Every address this class exists to refuse —
-   * loopback, link-local, RFC 1918, cloud metadata at 169.254.169.254 — was
-   * reachable by asking a public host to point there.
-   *
-   * Redirects are now resolved by hand so the same validation runs on each
-   * target, with a hop limit so a redirect cycle cannot spin.
+   * DNS can still change between this lookup and the connection. That race is
+   * narrower than the hole it closes, and closing it completely means pinning
+   * the resolved address through the socket, which fetch does not expose.
    */
+  private async assertHostResolvesPublicly(url: string): Promise<void> {
+    const { hostname } = new URL(url);
+    let resolved: Array<{ address: string }>;
+    try {
+      resolved = await lookup(hostname, { all: true });
+    } catch {
+      return;  // Unresolvable; fetch will fail on its own terms.
+    }
+
+    for (const { address } of resolved) {
+      if (WebAgent.isBlockedHost(address)) {
+        throw new Error(
+          `Access to private IP range blocked: ${hostname} resolves to ${address}`,
+        );
+      }
+    }
+  }
+
   private async fetchWithValidatedRedirects(url: string): Promise<Response> {
     let target = url;
 
     for (let hop = 0; hop <= WebAgent.MAX_REDIRECTS; hop++) {
       this.validateUrl(target);
+      await this.assertHostResolvesPublicly(target);
       const response = await fetch(target, { redirect: 'manual' });
 
       const isRedirect = response.status >= 300 && response.status < 400;

--- a/typescript/src/agents/WebAgent.ts
+++ b/typescript/src/agents/WebAgent.ts
@@ -103,6 +103,15 @@ export class WebAgent extends BasicAgent {
 
   private static readonly MAX_REDIRECTS = 5;
 
+  /**
+   * Test seam. Which loopback address a name resolves to is a property of the
+   * machine, not of this code: `localtest.me` gives 127.0.0.1 on one host and
+   * ::1 on another, and a test that pinned either one failed on the other.
+   */
+  protected async lookupHost(hostname: string): Promise<Array<{ address: string }>> {
+    return lookup(hostname, { all: true });
+  }
+
   private static readonly BLOCKED_HOST_PATTERNS = [
     /^10\./,
     /^172\.(1[6-9]|2[0-9]|3[01])\./,
@@ -183,7 +192,7 @@ export class WebAgent extends BasicAgent {
     const { hostname } = new URL(url);
     let resolved: Array<{ address: string }>;
     try {
-      resolved = await lookup(hostname, { all: true });
+      resolved = await this.lookupHost(hostname);
     } catch {
       return;  // Unresolvable; fetch will fail on its own terms.
     }


### PR DESCRIPTION
#71 stopped a redirect escaping the address checks. These are three ways past **the checks themselves**, all of which read `URL.hostname` as text.

## 1. IPv6 literals were never blocked

`URL.hostname` keeps the brackets, so `http://[::1]/` arrives as `"[::1]"` and `/^::1$/` never fires. **Every IPv6 rule in the list was unreachable:**

```
http://[::1]/                  hostname="[::1]"                  ALLOWED
http://[fe80::1]/              hostname="[fe80::1]"              ALLOWED
http://[::ffff:127.0.0.1]/     hostname="[::ffff:7f00:1]"        ALLOWED
```

That last one is loopback in a different notation.

## 2. A public name that resolves inward was never checked

`localtest.me` is a real public DNS name pointing at `127.0.0.1`. It passed validation, and fetching it returned the body of a loopback server on this machine:

```
DNS: localtest.me resolves to 127.0.0.1
http://localtest.me:PORT/   FETCHED -> LOOPBACK-REACHED
```

No redirect, no malformed address — just a name.

## 3. The scheme was never checked

Node **fetches `data:` URLs**, so a caller could hand the model arbitrary content dressed as a retrieved page. `file:` is refused today, but by `fetch` rather than by any decision made here.

## Fix

Hosts are normalised before matching (brackets stripped, IPv4-mapped folded to dotted quad), the scheme is restricted to `http`/`https`, and the host is **resolved** with every returned address checked.

Resolution *failures* are deliberately left alone — `fetch` will fail on its own terms, and failing closed on every lookup error would break hosts that were never private.

DNS can still change between the lookup and the connection. That race is far narrower than the hole it closes, and closing it entirely means pinning the resolved address through the socket, which `fetch` does not expose. Stated plainly in the code rather than implied.

## Tests — 20 more

Six IPv6 forms, five IPv4 ranges that must keep working, three refused schemes, **four public addresses that must still be allowed** (including a public IPv6 literal), the DNS case, and that an unresolvable name is not treated as hostile.

**Mutation-checked:**

| Mutation | Failures |
|---|---|
| remove bracket stripping | 5 |
| remove the scheme check | 3 |
| remove the DNS check | 1 |
| remove IPv4-mapped folding | 1 |

## One consequence worth noting

The redirect tests from #71 had to change. They stub the address checks to reach loopback, and stubbing only `validateUrl` left the **new** DNS check refusing their own fixtures. They now neutralise both, through a single helper that explains why — rather than each test quietly poking at internals.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **4044 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
