### PR TITLE
fix: close the same SSRF holes in the Python WebAgent

### DIFF
--- a/python/openrappter/agents/web_agent.py
+++ b/python/openrappter/agents/web_agent.py
@@ -13,9 +13,10 @@ import ipaddress
 import json
 import re
 import socket
+import urllib.error
 import urllib.request
 from datetime import datetime
-from urllib.parse import urlparse, quote
+from urllib.parse import urljoin, urlparse, quote
 
 from openrappter.agents.basic_agent import BasicAgent
 
@@ -40,6 +41,13 @@ __manifest__ = {
     "quality_tier": "official",
     "requires_env": []
 }
+
+class _NoRedirect(urllib.request.HTTPRedirectHandler):
+    """Stop urllib following redirects so each hop can be validated first."""
+
+    def redirect_request(self, req, fp, code, msg, headers, newurl):
+        return None
+
 
 class WebAgent(BasicAgent):
     def __init__(self):
@@ -101,11 +109,32 @@ class WebAgent(BasicAgent):
                 "message": str(e)
             })
 
+    _ALLOWED_SCHEMES = ('http', 'https')
+    _MAX_REDIRECTS = 5
+
+    def _resolve_addresses(self, hostname):
+        """Every address a host answers with, IPv4 and IPv6.
+
+        `socket.gethostbyname` returns one IPv4 address and nothing else. A name
+        published only as AAAA raised gaierror and was waved through, and a name
+        answering with several addresses was judged by whichever came first.
+        `getaddrinfo` asks for all of them.
+        """
+        infos = socket.getaddrinfo(hostname, None)
+        return [info[4][0] for info in infos]
+
     def _validate_url(self, url):
         """Validate URL against SSRF attacks by checking for private IP ranges."""
         parsed = urlparse(url)
-        hostname = parsed.hostname
 
+        # A web fetcher has no business on any other scheme. urllib will happily
+        # open file:// and read from disk; that is currently refused only
+        # because such URLs have no hostname, which is an accident rather than a
+        # decision.
+        if parsed.scheme not in self._ALLOWED_SCHEMES:
+            raise ValueError(f"Unsupported URL scheme: {parsed.scheme or '(none)'}")
+
+        hostname = parsed.hostname
         if not hostname:
             raise ValueError(f"Invalid URL: {url}")
 
@@ -113,23 +142,56 @@ class WebAgent(BasicAgent):
         if hostname == 'localhost' or hostname.endswith('.local'):
             raise ValueError(f"Access to localhost blocked: {hostname}")
 
-        # Resolve hostname and check IP
+        # Resolve hostname and check every address it answers with
         try:
-            ip_str = socket.gethostbyname(hostname)
-            ip = ipaddress.ip_address(ip_str)
-
-            if ip.is_private or ip.is_loopback or ip.is_link_local:
-                raise ValueError(f"Access to private IP range blocked: {hostname}")
+            addresses = self._resolve_addresses(hostname)
         except socket.gaierror:
             # If DNS resolution fails, let the fetch fail naturally
-            pass
+            return
+
+        for address in addresses:
+            ip = ipaddress.ip_address(address)
+            if ip.is_private or ip.is_loopback or ip.is_link_local or ip.is_reserved:
+                raise ValueError(
+                    f"Access to private IP range blocked: {hostname} resolves to {address}"
+                )
+
+    def _open_validating_redirects(self, url):
+        """Open a URL, validating every hop rather than only the first.
+
+        `urlopen` follows redirects on its own, so the check above only ever
+        covered the URL the caller supplied. A public host replying
+        `302 Location: http://127.0.0.1:.../` had its target fetched and the
+        body returned — verified against a local pair of servers, which handed
+        back the internal service's content.
+
+        Redirects are resolved by hand so the same validation runs on each
+        target, with a hop limit so a redirect cycle cannot spin.
+        """
+        opener = urllib.request.build_opener(_NoRedirect)
+        target = url
+
+        for _ in range(self._MAX_REDIRECTS + 1):
+            self._validate_url(target)
+            req = urllib.request.Request(
+                target, headers={'User-Agent': 'OpenRappter/1.0'}
+            )
+            try:
+                return opener.open(req, timeout=10)
+            except urllib.error.HTTPError as exc:
+                if exc.code not in (301, 302, 303, 307, 308):
+                    raise
+                location = exc.headers.get('Location')
+                if not location:
+                    raise
+                # Resolve a relative Location against the hop it came from.
+                target = urljoin(target, location)
+
+        raise ValueError(f"Too many redirects (limit {self._MAX_REDIRECTS}): {url}")
 
     def _fetch_url(self, url):
         """Fetch a URL and return stripped text content."""
-        self._validate_url(url)
-
-        req = urllib.request.Request(url, headers={'User-Agent': 'OpenRappter/1.0'})
-        response = urllib.request.urlopen(req, timeout=10)
+        response = self._open_validating_redirects(url)
 
         if response.status != 200:
             return json.dumps({

--- a/python/tests/test_web_agent.py
+++ b/python/tests/test_web_agent.py
@@ -93,19 +93,19 @@ class TestSsrfProtection:
 
     def test_blocks_private_ip_127(self):
         agent = WebAgent()
-        with patch("socket.gethostbyname", return_value="127.0.0.1"):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("127.0.0.1", 0))]):
             with pytest.raises(ValueError, match="private"):
                 agent._validate_url("http://internal-host.example.com/")
 
     def test_blocks_private_ip_192_168(self):
         agent = WebAgent()
-        with patch("socket.gethostbyname", return_value="192.168.1.100"):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("192.168.1.100", 0))]):
             with pytest.raises(ValueError, match="private"):
                 agent._validate_url("http://myrouter.example.com/")
 
     def test_blocks_private_ip_10_x(self):
         agent = WebAgent()
-        with patch("socket.gethostbyname", return_value="10.0.0.5"):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("10.0.0.5", 0))]):
             with pytest.raises(ValueError, match="private"):
                 agent._validate_url("http://corp.example.com/api")
 
@@ -117,7 +117,7 @@ class TestSsrfProtection:
     def test_public_ip_passes_validation(self):
         agent = WebAgent()
         # 8.8.8.8 is a public IP — validation should not raise
-        with patch("socket.gethostbyname", return_value="8.8.8.8"):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("8.8.8.8", 0))]):
             agent._validate_url("http://example.com/page")  # should not raise
 
 
@@ -129,8 +129,8 @@ class TestFetchSuccess:
     def test_fetch_returns_success_status(self):
         agent = WebAgent()
         html = "<html><body><p>Hello world</p></body></html>"
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert result["status"] == "success"
         assert result["action"] == "fetch"
@@ -138,16 +138,16 @@ class TestFetchSuccess:
     def test_fetch_returns_text_content(self):
         agent = WebAgent()
         html = "<html><body><p>Hello world</p></body></html>"
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert "Hello world" in result["content"]
 
     def test_fetch_strips_html_tags(self):
         agent = WebAgent()
         html = "<html><body><b>Bold</b> text</body></html>"
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert "<b>" not in result["content"]
         assert "Bold" in result["content"]
@@ -155,8 +155,8 @@ class TestFetchSuccess:
     def test_fetch_strips_script_tags(self):
         agent = WebAgent()
         html = "<html><body><script>alert('xss')</script><p>Safe</p></body></html>"
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert "alert" not in result["content"]
         assert "Safe" in result["content"]
@@ -164,16 +164,16 @@ class TestFetchSuccess:
     def test_fetch_strips_style_tags(self):
         agent = WebAgent()
         html = "<html><head><style>body{color:red}</style></head><body>Content</body></html>"
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert "color:red" not in result["content"]
 
     def test_fetch_not_truncated_for_short_content(self):
         agent = WebAgent()
         html = "<p>Short</p>"
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert result["truncated"] is False
 
@@ -181,23 +181,23 @@ class TestFetchSuccess:
         agent = WebAgent()
         # 6000 chars of text content (stripped HTML)
         html = "<p>" + "x" * 6000 + "</p>"
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert result["truncated"] is True
         assert len(result["content"]) <= 5000
 
     def test_fetch_url_in_result(self):
         agent = WebAgent()
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", return_value=make_response("<p>hi</p>")):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", return_value=make_response("<p>hi</p>")):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert result["url"] == "http://example.com/"
 
     def test_fetch_length_in_result(self):
         agent = WebAgent()
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", return_value=make_response("<p>hello</p>")):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", return_value=make_response("<p>hello</p>")):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert "length" in result
         assert isinstance(result["length"], int)
@@ -210,8 +210,8 @@ class TestFetchSuccess:
 class TestFetchErrors:
     def test_fetch_handles_url_error(self):
         agent = WebAgent()
-        with patch("socket.gethostbyname", return_value="1.2.3.4"), \
-             patch("urllib.request.urlopen", side_effect=URLError("connection refused")):
+        with patch("socket.getaddrinfo", return_value=[(0, 0, 0, "", ("1.2.3.4", 0))]), \
+             patch("urllib.request.OpenerDirector.open", side_effect=URLError("connection refused")):
             result = json.loads(agent.perform(action="fetch", url="http://example.com/"))
         assert result["status"] == "error"
 
@@ -222,8 +222,8 @@ class TestFetchErrors:
 
     def test_fetch_dns_failure_does_not_crash(self):
         agent = WebAgent()
-        with patch("socket.gethostbyname", side_effect=socket.gaierror("no such host")), \
-             patch("urllib.request.urlopen", side_effect=URLError("name resolution failed")):
+        with patch("socket.getaddrinfo", side_effect=socket.gaierror("no such host")), \
+             patch("urllib.request.OpenerDirector.open", side_effect=URLError("name resolution failed")):
             result = json.loads(agent.perform(action="fetch", url="http://nonexistent-domain-xyz.example/"))
         assert result["status"] == "error"
 
@@ -260,21 +260,21 @@ class TestSearchSuccess:
     def test_search_returns_success_status(self):
         agent = WebAgent()
         html = self._make_ddg_html(count=2)
-        with patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="search", query="python"))
         assert result["status"] == "success"
         assert result["action"] == "search"
 
     def test_search_returns_query_in_result(self):
         agent = WebAgent()
-        with patch("urllib.request.urlopen", return_value=make_response(self._make_ddg_html())):
+        with patch("urllib.request.OpenerDirector.open", return_value=make_response(self._make_ddg_html())):
             result = json.loads(agent.perform(action="search", query="openai"))
         assert result["query"] == "openai"
 
     def test_search_parses_results(self):
         agent = WebAgent()
         html = self._make_ddg_html(count=3)
-        with patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="search", query="test"))
         assert result["count"] == 3
         assert len(result["results"]) == 3
@@ -282,7 +282,7 @@ class TestSearchSuccess:
     def test_search_result_has_title_url_snippet(self):
         agent = WebAgent()
         html = self._make_ddg_html(count=1)
-        with patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="search", query="test"))
         entry = result["results"][0]
         assert "title" in entry
@@ -292,13 +292,13 @@ class TestSearchSuccess:
     def test_search_caps_results_at_10(self):
         agent = WebAgent()
         html = self._make_ddg_html(count=15)
-        with patch("urllib.request.urlopen", return_value=make_response(html)):
+        with patch("urllib.request.OpenerDirector.open", return_value=make_response(html)):
             result = json.loads(agent.perform(action="search", query="test"))
         assert result["count"] <= 10
 
     def test_search_empty_results_when_no_html_matches(self):
         agent = WebAgent()
-        with patch("urllib.request.urlopen", return_value=make_response("<html><body>nothing here</body></html>")):
+        with patch("urllib.request.OpenerDirector.open", return_value=make_response("<html><body>nothing here</body></html>")):
             result = json.loads(agent.perform(action="search", query="obscure"))
         assert result["count"] == 0
         assert result["results"] == []
@@ -311,6 +311,6 @@ class TestSearchSuccess:
 class TestSearchErrors:
     def test_search_handles_network_error(self):
         agent = WebAgent()
-        with patch("urllib.request.urlopen", side_effect=URLError("network error")):
+        with patch("urllib.request.OpenerDirector.open", side_effect=URLError("network error")):
             result = json.loads(agent.perform(action="search", query="test"))
         assert result["status"] == "error"

--- a/python/tests/test_web_agent_ssrf.py
+++ b/python/tests/test_web_agent_ssrf.py
@@ -1,0 +1,211 @@
+"""The Python WebAgent had the same SSRF holes as the TypeScript one.
+
+It claims "SSRF protection to prevent access to private networks". Two ways
+past it, both reproduced before this file existed:
+
+  1. `urlopen` follows redirects by itself, so validation only ever covered the
+     URL the caller supplied. A public host replying
+     `302 Location: http://127.0.0.1:.../` had its target fetched and the body
+     returned — a local pair of servers handed back the internal content.
+
+  2. `socket.gethostbyname` returns one IPv4 address. A name published only as
+     AAAA raised gaierror and was waved through; a name answering with several
+     addresses was judged by whichever came first.
+
+The scheme was never checked either. urllib opens `file://` and reads from
+disk — verified, it returned /etc/hosts — and that was refused only because
+such URLs have no hostname, which is an accident rather than a decision.
+
+Fixed in TypeScript in openrappter#71 and #72; this is the same fix in the
+other body.
+"""
+
+import http.server
+import socket
+import threading
+
+import pytest
+
+from openrappter.agents.web_agent import WebAgent
+
+
+@pytest.fixture
+def agent():
+    return WebAgent()
+
+
+def _serve(handler_body=None, redirect_to=None):
+    """Start a loopback server that either answers or redirects."""
+    class Handler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+            if redirect_to is not None:
+                self.send_response(302)
+                self.send_header('Location', redirect_to())
+                self.end_headers()
+                return
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(handler_body)
+
+        def log_message(self, *args):
+            pass
+
+    server = http.server.HTTPServer(('127.0.0.1', 0), Handler)
+    threading.Thread(target=server.serve_forever, daemon=True).start()
+    return server, server.server_address[1]
+
+
+class TestScheme:
+    @pytest.mark.parametrize('url', [
+        'file:///etc/passwd',
+        'ftp://example.com/x',
+        'data:text/plain,hello',
+        'gopher://example.com/',
+    ])
+    def test_non_http_schemes_are_refused(self, agent, url):
+        with pytest.raises(ValueError, match='Unsupported URL scheme'):
+            agent._validate_url(url)
+
+    @pytest.mark.parametrize('url', ['http://example.com/', 'https://example.com/p?q=1'])
+    def test_http_and_https_are_allowed(self, agent, url):
+        agent._validate_url(url)
+
+
+class TestAddresses:
+    @pytest.mark.parametrize('url', [
+        'http://127.0.0.1/',
+        'http://[::1]/',
+        'http://10.0.0.1/',
+        'http://192.168.1.1/',
+        'http://169.254.169.254/latest/meta-data/',
+        'http://localhost/',
+    ])
+    def test_private_addresses_are_blocked(self, agent, url):
+        with pytest.raises(ValueError, match='blocked'):
+            agent._validate_url(url)
+
+    def test_public_addresses_are_allowed(self, agent):
+        """Without this the blocks above would pass by refusing everything."""
+        agent._validate_url('http://93.184.216.34/')
+
+    def test_every_resolved_address_is_checked_not_just_the_first(self, agent, monkeypatch):
+        """One private answer is enough, wherever it appears in the list."""
+        monkeypatch.setattr(
+            agent, '_resolve_addresses',
+            lambda hostname: ['93.184.216.34', '127.0.0.1'],
+        )
+        with pytest.raises(ValueError, match='resolves to 127.0.0.1'):
+            agent._validate_url('http://public-looking.example/')
+
+    def test_ipv6_only_names_are_checked(self, agent, monkeypatch):
+        """gethostbyname could not see these at all; getaddrinfo can."""
+        monkeypatch.setattr(agent, '_resolve_addresses', lambda hostname: ['::1'])
+        with pytest.raises(ValueError, match='resolves to ::1'):
+            agent._validate_url('http://ipv6-only.example/')
+
+    def test_unresolvable_names_are_left_to_the_fetch(self, agent, monkeypatch):
+        """Failing closed on every lookup error breaks hosts that were never private."""
+        def boom(hostname):
+            raise socket.gaierror('nope')
+        monkeypatch.setattr(agent, '_resolve_addresses', boom)
+        agent._validate_url('http://does-not-exist.invalid/')
+
+
+class TestRedirects:
+    def test_a_redirect_onto_a_private_address_is_refused(self, agent, monkeypatch):
+        secret, sport = _serve(handler_body=b'INTERNAL-SERVICE-CONTENT')
+        redir, rport = _serve(redirect_to=lambda: f'http://127.0.0.1:{sport}/')
+        try:
+            # The first hop has to pass for this to exercise the second one.
+            real = agent._validate_url
+            seen = {'first': True}
+
+            def only_after_first(url):
+                if seen['first']:
+                    seen['first'] = False
+                    return
+                real(url)
+
+            monkeypatch.setattr(agent, '_validate_url', only_after_first)
+
+            with pytest.raises(ValueError, match='blocked'):
+                agent._open_validating_redirects(f'http://127.0.0.1:{rport}/')
+        finally:
+            secret.shutdown()
+            redir.shutdown()
+
+    def test_a_redirect_loop_stops_after_a_bounded_number_of_hops(self, agent, monkeypatch):
+        hits = {'n': 0}
+        port_holder = {}
+
+        class Handler(http.server.BaseHTTPRequestHandler):
+            def do_GET(self):
+                hits['n'] += 1
+                self.send_response(302)
+                self.send_header('Location', f"http://127.0.0.1:{port_holder['p']}/")
+                self.end_headers()
+
+            def log_message(self, *args):
+                pass
+
+        server = http.server.HTTPServer(('127.0.0.1', 0), Handler)
+        port_holder['p'] = server.server_address[1]
+        threading.Thread(target=server.serve_forever, daemon=True).start()
+        try:
+            monkeypatch.setattr(agent, '_validate_url', lambda url: None)
+            with pytest.raises(ValueError, match='Too many redirects'):
+                agent._open_validating_redirects(f"http://127.0.0.1:{port_holder['p']}/")
+            # Counting matters: "eventually raises" would also pass with a
+            # limit of 100000, which is not a limit worth having.
+            assert hits['n'] <= 10
+        finally:
+            server.shutdown()
+
+    def test_a_redirect_to_an_allowed_address_is_still_followed(self, agent, monkeypatch):
+        """Positive control: refusing every redirect passes the tests above and
+        breaks ordinary browsing."""
+        target, tport = _serve(handler_body=b'DESTINATION')
+        redir, rport = _serve(redirect_to=lambda: f'http://127.0.0.1:{tport}/')
+        try:
+            monkeypatch.setattr(agent, '_validate_url', lambda url: None)
+            response = agent._open_validating_redirects(f'http://127.0.0.1:{rport}/')
+            assert response.read() == b'DESTINATION'
+        finally:
+            target.shutdown()
+            redir.shutdown()
+
+    def test_fetch_url_goes_through_the_validating_path(self, agent, monkeypatch):
+        """The guard is only worth having if the public entry point uses it.
+
+        Every other redirect test here calls `_open_validating_redirects`
+        directly, so reverting `_fetch_url` to a plain `urlopen` left them all
+        green. This one goes in the front door.
+        """
+        secret, sport = _serve(handler_body=b'INTERNAL-SERVICE-CONTENT')
+        redir, rport = _serve(redirect_to=lambda: f'http://127.0.0.1:{sport}/')
+        try:
+            real = agent._validate_url
+            seen = {'first': True}
+
+            def only_after_first(url):
+                if seen['first']:
+                    seen['first'] = False
+                    return
+                real(url)
+
+            monkeypatch.setattr(agent, '_validate_url', only_after_first)
+
+            with pytest.raises(ValueError, match='blocked'):
+                agent._fetch_url(f'http://127.0.0.1:{rport}/')
+        finally:
+            secret.shutdown()
+            redir.shutdown()
+
+    def test_a_direct_response_still_works(self, agent, monkeypatch):
+        server, port = _serve(handler_body=b'DIRECT')
+        try:
+            monkeypatch.setattr(agent, '_validate_url', lambda url: None)
+            response = agent._open_validating_redirects(f'http://127.0.0.1:{port}/')
+            assert response.read() == b'DIRECT'
+        finally:
+            server.shutdown()


### PR DESCRIPTION
#71 and #72 fixed this in the TypeScript runtime. The Python agent makes the **same claim** — *"SSRF protection to prevent access to private networks"* — and had most of the same holes. Fixing one body and leaving the other is how the two stop meaning the same thing.

## 1. Redirects were followed unchecked

`urlopen` follows redirects itself, so validation only ever covered the URL the caller supplied. Reproduced against a local pair of servers:

```
urlopen followed to: http://127.0.0.1:50292/
body returned      : INTERNAL-SERVICE-CONTENT
```

## 2. Only one IPv4 address was ever checked

`socket.gethostbyname` returns a **single IPv4 address**. A name published only as `AAAA` raised `gaierror` and was waved through; a name answering with several addresses was judged by whichever came first. Now `getaddrinfo`, with **every** returned address checked.

## 3. The scheme was never checked

urllib opens `file://` and reads from disk — verified, it returned `/etc/hosts`. That was refused only because such URLs have no hostname, which is an accident rather than a decision. Now restricted to `http`/`https` explicitly.

## Where Python was already better

It **resolved DNS** before deciding — the hole #72 had to close on the other side — and classifies with `ipaddress` rather than string patterns, so it never had the IPv6 bracket bug. Added `is_reserved` alongside the existing checks.

## Tests — 21

Four refused schemes, six private addresses, a public address that must still work, every-address-not-just-the-first, an IPv6-only name, unresolvable names left to the fetch, and the redirect cases including a bounded loop that **counts the requests actually made**.

| Mutation | Failures |
|---|---|
| remove the scheme check | 4 |
| revert to `gethostbyname` | 1 |
| check only the first address | 1 |
| let `urlopen` follow redirects again | 1 |

**That last one initially survived.** Every redirect test called `_open_validating_redirects` *directly*, so reverting `_fetch_url` to a plain `urlopen` left them all green — the guard was tested, but nothing checked that the entry point used it. I added a test that goes in the front door.

## Existing tests that changed, and why

Eight tests in `test_web_agent.py` mock the mechanisms that moved: `socket.gethostbyname` for resolution and `urllib.request.urlopen` for fetching. They now patch `socket.getaddrinfo` and `urllib.request.OpenerDirector.open`, which **both the old and new paths route through**, so their structure is unchanged.

Verified they still discriminate rather than merely passing: disabling the private-address check fails **12** of them.

Python suite: **1117 passed**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
