### PR TITLE
fix: give ImageAgent the URL checks WebAgent already had

### DIFF
--- a/typescript/src/agents/ImageAgent.ts
+++ b/typescript/src/agents/ImageAgent.ts
@@ -9,6 +9,7 @@
 
 import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
+import { assertFetchableUrl } from '../net/url-guard.js';
 
 
 export const __manifest__ = {
@@ -139,32 +140,14 @@ export class ImageAgent extends BasicAgent {
     }
   }
 
+  /**
+   * Shared with WebAgent. This was a character-for-character copy of that
+   * agent's checks, and when openrappter#72 fixed those, this one kept every
+   * hole: `http://[::1]/`, `http://localtest.me/`, `file://` and `data:` were
+   * all accepted here while the identical-looking function next door refused
+   * them.
+   */
   private validateUrl(url: string): void {
-    const parsed = new URL(url);
-    const hostname = parsed.hostname;
-
-    // Block private IP ranges (SSRF protection)
-    const privatePatterns = [
-      /^10\./,
-      /^172\.(1[6-9]|2[0-9]|3[01])\./,
-      /^192\.168\./,
-      /^127\./,
-      /^0\./,
-      /^169\.254\./,
-      /^::1$/,
-      /^fc00:/,
-      /^fe80:/,
-    ];
-
-    for (const pattern of privatePatterns) {
-      if (pattern.test(hostname)) {
-        throw new Error(`Access to private IP range blocked: ${hostname}`);
-      }
-    }
-
-    // Block localhost
-    if (hostname === 'localhost' || hostname.endsWith('.local')) {
-      throw new Error(`Access to localhost blocked: ${hostname}`);
-    }
+    assertFetchableUrl(url);
   }
 }

--- a/typescript/src/agents/WebAgent.ts
+++ b/typescript/src/agents/WebAgent.ts
@@ -11,6 +11,11 @@ import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
 import { lookup } from 'dns/promises';
 
+import {
+  assertFetchableUrl,
+  assertHostResolvesPublicly,
+} from '../net/url-guard.js';
+
 
 export const __manifest__ = {
   schema: 'rapp-agent/1.0',
@@ -103,6 +108,11 @@ export class WebAgent extends BasicAgent {
 
   private static readonly MAX_REDIRECTS = 5;
 
+  /** Shared with ImageAgent so the two cannot drift apart again. */
+  private validateUrl(url: string): void {
+    assertFetchableUrl(url);
+  }
+
   /**
    * Test seam. Which loopback address a name resolves to is a property of the
    * machine, not of this code: `localtest.me` gives 127.0.0.1 on one host and
@@ -112,98 +122,8 @@ export class WebAgent extends BasicAgent {
     return lookup(hostname, { all: true });
   }
 
-  private static readonly BLOCKED_HOST_PATTERNS = [
-    /^10\./,
-    /^172\.(1[6-9]|2[0-9]|3[01])\./,
-    /^192\.168\./,
-    /^127\./,
-    /^0\./,
-    /^169\.254\./,
-    /^::1$/,
-    /^::$/,
-    /^fc[0-9a-f]{2}:/,
-    /^fd[0-9a-f]{2}:/,
-    /^fe80:/,
-  ];
-
-  /**
-   * Reduce a URL hostname or a resolved address to something the patterns can
-   * match.
-   *
-   * `URL.hostname` keeps the brackets on an IPv6 literal, so `http://[::1]/`
-   * arrives as `"[::1]"` and `/^::1$/` never fires. Every IPv6 rule in this
-   * list was unreachable for that reason — `[::1]`, `[fe80::1]` and
-   * `[::ffff:127.0.0.1]` were all allowed through.
-   *
-   * IPv4-mapped addresses are folded back to dotted quad so the IPv4 rules
-   * apply to them: `::ffff:7f00:1` is 127.0.0.1 wearing a different hat.
-   */
-  private static normaliseHost(host: string): string {
-    const bare = host.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
-
-    const mapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(bare);
-    if (mapped) {
-      const high = parseInt(mapped[1], 16);
-      const low = parseInt(mapped[2], 16);
-      return [high >> 8, high & 0xff, low >> 8, low & 0xff].join('.');
-    }
-    const mappedDotted = /^::ffff:((?:[0-9]{1,3}\.){3}[0-9]{1,3})$/.exec(bare);
-    if (mappedDotted) return mappedDotted[1];
-
-    return bare;
-  }
-
-  private static isBlockedHost(host: string): boolean {
-    const normalised = WebAgent.normaliseHost(host);
-    if (normalised === 'localhost' || normalised.endsWith('.local')) return true;
-    return WebAgent.BLOCKED_HOST_PATTERNS.some(pattern => pattern.test(normalised));
-  }
-
-  private validateUrl(url: string): void {
-    const parsed = new URL(url);
-
-    // A web fetcher has no business on any other scheme. `data:` URLs are
-    // fetchable by Node and would let a caller feed arbitrary content back to
-    // the model as though it had been retrieved; `file:` is refused by fetch
-    // today, which is a property of fetch rather than a decision made here.
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      throw new Error(`Unsupported URL scheme: ${parsed.protocol}`);
-    }
-
-    if (WebAgent.isBlockedHost(parsed.hostname)) {
-      throw new Error(`Access to private IP range blocked: ${parsed.hostname}`);
-    }
-  }
-
-  /**
-   * Resolve the host and check where it actually points.
-   *
-   * The checks above read the hostname as text, so any public name that
-   * resolves inward walked straight past them. `localtest.me` is a real public
-   * DNS name that resolves to 127.0.0.1, and fetching it returned the body of a
-   * loopback server on this machine — the whole protection bypassed without a
-   * redirect or a malformed address.
-   *
-   * DNS can still change between this lookup and the connection. That race is
-   * narrower than the hole it closes, and closing it completely means pinning
-   * the resolved address through the socket, which fetch does not expose.
-   */
   private async assertHostResolvesPublicly(url: string): Promise<void> {
-    const { hostname } = new URL(url);
-    let resolved: Array<{ address: string }>;
-    try {
-      resolved = await this.lookupHost(hostname);
-    } catch {
-      return;  // Unresolvable; fetch will fail on its own terms.
-    }
-
-    for (const { address } of resolved) {
-      if (WebAgent.isBlockedHost(address)) {
-        throw new Error(
-          `Access to private IP range blocked: ${hostname} resolves to ${address}`,
-        );
-      }
-    }
+    await assertHostResolvesPublicly(url, hostname => this.lookupHost(hostname));
   }
 
   private async fetchWithValidatedRedirects(url: string): Promise<Response> {

--- a/typescript/src/net/url-guard.test.ts
+++ b/typescript/src/net/url-guard.test.ts
@@ -1,0 +1,83 @@
+/**
+ * One guard, two callers.
+ *
+ * WebAgent and ImageAgent each carried a character-for-character copy of these
+ * checks. openrappter#72 fixed WebAgent's; ImageAgent's kept every hole, and
+ * accepted all of the following while the identical-looking function next door
+ * refused them:
+ *
+ *     http://[::1]/x.png          ALLOWED
+ *     http://[fe80::1]/x.png      ALLOWED
+ *     http://localtest.me/x.png   ALLOWED
+ *     file:///etc/hosts           ALLOWED
+ *     data:image/png;base64,AAA   ALLOWED
+ *
+ * The tests below run the same table through both agents, so a fix that
+ * reaches only one of them fails here.
+ */
+import { describe, it, expect } from 'vitest';
+import { WebAgent } from '../agents/WebAgent.js';
+import { ImageAgent } from '../agents/ImageAgent.js';
+import { assertFetchableUrl, isBlockedHost, normaliseHost } from './url-guard.js';
+
+type Validator = { validateUrl(url: string): void };
+
+const agents: Array<[string, () => Validator]> = [
+  ['WebAgent', () => new WebAgent() as unknown as Validator],
+  ['ImageAgent', () => new ImageAgent() as unknown as Validator],
+];
+
+const REFUSED = [
+  ['IPv6 loopback', 'http://[::1]/'],
+  ['IPv6 link-local', 'http://[fe80::1]/'],
+  ['IPv4-mapped loopback', 'http://[::ffff:127.0.0.1]/'],
+  ['IPv4 loopback', 'http://127.0.0.1/'],
+  ['RFC 1918', 'http://10.0.0.1/'],
+  ['cloud metadata', 'http://169.254.169.254/latest/meta-data/'],
+  ['localhost', 'http://localhost/'],
+  ['file scheme', 'file:///etc/passwd'],
+  ['data scheme', 'data:text/plain,hello'],
+];
+
+describe.each(agents)('%s uses the shared URL guard', (_name, make) => {
+  it.each(REFUSED)('refuses %s', (_label, url) => {
+    expect(() => make().validateUrl(url)).toThrow();
+  });
+
+  it('still allows a public address', () => {
+    // Without this, an agent that refused everything would pass the table.
+    expect(() => make().validateUrl('https://example.com/a.png')).not.toThrow();
+  });
+});
+
+describe('normaliseHost', () => {
+  it('strips the brackets that made every IPv6 rule unreachable', () => {
+    expect(normaliseHost('[::1]')).toBe('::1');
+    expect(normaliseHost('[FE80::1]')).toBe('fe80::1');
+  });
+
+  it('folds IPv4-mapped addresses back to dotted quad', () => {
+    expect(normaliseHost('[::ffff:7f00:1]')).toBe('127.0.0.1');
+    expect(normaliseHost('::ffff:192.168.0.1')).toBe('192.168.0.1');
+  });
+
+  it('leaves an ordinary host alone', () => {
+    expect(normaliseHost('Example.COM')).toBe('example.com');
+  });
+});
+
+describe('isBlockedHost', () => {
+  it.each(['::1', '::', 'fe80::1', 'fc00::1', 'fd12::1', '127.0.0.1', '169.254.169.254', 'localhost'])(
+    'blocks %s', (host) => expect(isBlockedHost(host)).toBe(true),
+  );
+
+  it.each(['example.com', '93.184.216.34', '2606:2800:220:1:248:1893:25c8:1946', '8.8.8.8'])(
+    'allows %s', (host) => expect(isBlockedHost(host)).toBe(false),
+  );
+});
+
+describe('assertFetchableUrl', () => {
+  it('returns the parsed URL so callers need not parse twice', () => {
+    expect(assertFetchableUrl('https://example.com/a?b=1').hostname).toBe('example.com');
+  });
+});

--- a/typescript/src/net/url-guard.ts
+++ b/typescript/src/net/url-guard.ts
@@ -1,0 +1,111 @@
+/**
+ * One place that decides whether a URL may be fetched.
+ *
+ * This logic existed twice, character for character, in WebAgent and
+ * ImageAgent. openrappter#72 fixed WebAgent's copy; ImageAgent's kept every
+ * hole — `http://[::1]/`, `http://localtest.me/`, `file://` and `data:` were
+ * all accepted by it while the identical-looking function next door refused
+ * them.
+ *
+ * Duplicated security logic does not stay in agreement. It lives here now so
+ * the next fix reaches every caller.
+ */
+import { lookup } from 'dns/promises';
+
+const BLOCKED_HOST_PATTERNS = [
+  /^10\./,
+  /^172\.(1[6-9]|2[0-9]|3[01])\./,
+  /^192\.168\./,
+  /^127\./,
+  /^0\./,
+  /^169\.254\./,
+  /^::1$/,
+  /^::$/,
+  /^fc[0-9a-f]{2}:/,
+  /^fd[0-9a-f]{2}:/,
+  /^fe80:/,
+];
+
+const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);
+
+/**
+ * Reduce a URL hostname or resolved address to something the patterns match.
+ *
+ * `URL.hostname` keeps the brackets on an IPv6 literal, so `http://[::1]/`
+ * arrives as `"[::1]"` and `/^::1$/` never fires. IPv4-mapped addresses are
+ * folded back to dotted quad so the IPv4 rules apply: `::ffff:7f00:1` is
+ * 127.0.0.1 wearing a different hat.
+ */
+export function normaliseHost(host: string): string {
+  const bare = host.replace(/^\[/, '').replace(/\]$/, '').toLowerCase();
+
+  const mapped = /^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/.exec(bare);
+  if (mapped) {
+    const high = parseInt(mapped[1], 16);
+    const low = parseInt(mapped[2], 16);
+    return [high >> 8, high & 0xff, low >> 8, low & 0xff].join('.');
+  }
+  const mappedDotted = /^::ffff:((?:[0-9]{1,3}\.){3}[0-9]{1,3})$/.exec(bare);
+  if (mappedDotted) return mappedDotted[1];
+
+  return bare;
+}
+
+export function isBlockedHost(host: string): boolean {
+  const normalised = normaliseHost(host);
+  if (normalised === 'localhost' || normalised.endsWith('.local')) return true;
+  return BLOCKED_HOST_PATTERNS.some(pattern => pattern.test(normalised));
+}
+
+/** Reject by scheme and by literal address, without touching the network. */
+export function assertFetchableUrl(url: string): URL {
+  const parsed = new URL(url);
+
+  // A fetcher of web content has no business on any other scheme. `data:` URLs
+  // are fetchable by Node and would let a caller feed arbitrary bytes back as
+  // though they had been retrieved; `file:` is refused by fetch today, which is
+  // a property of fetch rather than a decision made here.
+  if (!ALLOWED_PROTOCOLS.has(parsed.protocol)) {
+    throw new Error(`Unsupported URL scheme: ${parsed.protocol}`);
+  }
+  if (isBlockedHost(parsed.hostname)) {
+    throw new Error(`Access to private IP range blocked: ${parsed.hostname}`);
+  }
+  return parsed;
+}
+
+export type HostLookup = (hostname: string) => Promise<Array<{ address: string }>>;
+
+const defaultLookup: HostLookup = hostname => lookup(hostname, { all: true });
+
+/**
+ * Resolve the host and check where it actually points.
+ *
+ * The checks above read the hostname as text, so any public name that resolves
+ * inward walks straight past them. `localtest.me` is a real public DNS name
+ * resolving to loopback.
+ *
+ * Resolution failures are deliberately not fatal: the fetch will fail on its
+ * own terms, and failing closed on every lookup error breaks hosts that were
+ * never private.
+ */
+export async function assertHostResolvesPublicly(
+  url: string,
+  hostLookup: HostLookup = defaultLookup,
+): Promise<void> {
+  const { hostname } = new URL(url);
+  let resolved: Array<{ address: string }>;
+  try {
+    resolved = await hostLookup(hostname);
+  } catch {
+    return;
+  }
+
+  for (const { address } of resolved) {
+    if (isBlockedHost(address)) {
+      throw new Error(
+        `Access to private IP range blocked: ${hostname} resolves to ${address}`,
+      );
+    }
+  }
+}


### PR DESCRIPTION
`ImageAgent` carried a **character-for-character copy** of `WebAgent`'s address checks. #72 fixed WebAgent's copy. This one kept every hole, and accepted all of these while the identical-looking function next door refused them:

```
http://[::1]/x.png          ALLOWED
http://[fe80::1]/x.png      ALLOWED
http://localtest.me/x.png   ALLOWED
file:///etc/hosts           ALLOWED
data:image/png;base64,AAA   ALLOWED
```

It is reachable: `process_url` passes the URL to `MediaProcessor.processUrl`, which fetches it.

## Why a shared module rather than a second fix

Duplicated security logic does not stay in agreement — that is the entire reason this bug existed. Repairing the copy would have set up the same divergence at the next fix.

Both agents now call one guard in `src/net/url-guard.ts`. WebAgent **loses 97 lines** it no longer needs to own; net diff is `20 insertions, 117 deletions` across the two agents.

## Tests — 36

The refusal table runs through **both** agents, so a fix that reaches only one of them fails here. Each agent is also asserted to still **allow a public address** — without that, an agent refusing everything would pass the whole table. Plus unit tests for host normalisation and classification.

| Mutation | Failures |
|---|---|
| give ImageAgent its old copy back | 5 |
| remove bracket stripping from the guard | 14 |
| remove the scheme check | 7 |

## Checked and deliberately not changed

`SelfHealingCronAgent` and `BrowserAgent` both take a caller-supplied URL and neither validates it. That looks like the same bug and **is not**.

A self-healing cron exists to watch a service and restart it; a browser agent is routinely pointed at a local app under development. `http://127.0.0.1:8080/health` is the *intended* use of both, not an attack on them. Blocking loopback there would break the feature to satisfy a pattern.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **4085 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
