### PR TITLE
fix: chunk migrated replies the same way live ones are chunked

### DIFF
--- a/typescript/src/channels/imessage-chunking.test.ts
+++ b/typescript/src/channels/imessage-chunking.test.ts
@@ -1,0 +1,66 @@
+/**
+ * There were two chunkers.
+ *
+ * `chunkIMessageText` split live replies; `chunkLegacyReply` in
+ * imessage-state-store.ts split migrated ones, by slicing code points at 3,000
+ * — which is what the live one did before openrappter#58 taught it about
+ * grapheme clusters. That fix never reached the copy, so a migrated reply
+ * crossing the boundary mid-cluster went into the outbox broken:
+ *
+ *     legacy chunk0 tail: "a<man><zwj><woman>"
+ *     legacy chunk1 head: "<zwj><girl><zwj><boy>"
+ *
+ * The outbox is what gets sent, so the recipient saw that.
+ *
+ * These tests pin the property at the boundary the copy got wrong, and are run
+ * through both entry points so a fix reaching only one of them fails.
+ */
+import { describe, it, expect } from 'vitest';
+import { chunkIMessageText, IMESSAGE_MAX_CHUNK_LENGTH } from './imessage-chunking.js';
+import { chunkIMessageText as reExported } from './imessage.js';
+
+const FAMILY = '\u{1F468}\u200D\u{1F469}\u200D\u{1F467}\u200D\u{1F466}';
+const FLAG = '\u{1F1FA}\u{1F1F8}';
+
+const entryPoints: Array<[string, typeof chunkIMessageText]> = [
+  ['imessage-chunking', chunkIMessageText],
+  ['imessage re-export', reExported],
+];
+
+describe.each(entryPoints)('%s at the real 3000 boundary', (_name, chunk) => {
+  it.each([
+    ['a family emoji', FAMILY],
+    ['a regional-indicator flag', FLAG],
+    ['a skin-tone modifier', '\u{1F44D}\u{1F3FD}'],
+    ['a combining accent', 'e\u0301'],
+  ])('does not split %s straddling the boundary', (_label, cluster) => {
+    // Place the cluster so a code-point slice at 3000 would cut through it.
+    const head = 'a'.repeat(IMESSAGE_MAX_CHUNK_LENGTH - 2);
+    const content = `${head}${cluster}${'b'.repeat(50)}`;
+
+    const chunks = chunk(content);
+
+    expect(chunks.join('')).toBe(content);
+    for (const piece of chunks) {
+      expect(/^[\u0300-\u036F\u200D\u{1F3FB}-\u{1F3FF}]/u.test(piece), JSON.stringify(piece.slice(0, 8))).toBe(false);
+      expect(piece.endsWith('\u200D')).toBe(false);
+    }
+    // The cluster survives intact inside one chunk.
+    expect(chunks.some(piece => piece.includes(cluster))).toBe(true);
+  });
+
+  it('still splits a long plain reply at the limit', () => {
+    const content = 'a'.repeat(IMESSAGE_MAX_CHUNK_LENGTH + 10);
+    const chunks = chunk(content);
+
+    expect(chunks).toHaveLength(2);
+    expect(Array.from(chunks[0]).length).toBe(IMESSAGE_MAX_CHUNK_LENGTH);
+    expect(chunks.join('')).toBe(content);
+  });
+
+  it('returns a single empty chunk for empty content', () => {
+    // The legacy copy did this too; keeping it means the outbox still gets a
+    // row rather than nothing.
+    expect(chunk('')).toEqual(['']);
+  });
+});

--- a/typescript/src/channels/imessage-chunking.ts
+++ b/typescript/src/channels/imessage-chunking.ts
@@ -1,0 +1,87 @@
+/**
+ * Splitting a reply into sendable chunks, in one place.
+ *
+ * This lived in imessage.ts, and a second copy — `chunkLegacyReply`, in
+ * imessage-state-store.ts — did the same job by slicing code points. When
+ * openrappter#58 taught this one about grapheme clusters, that copy kept the
+ * old behaviour and went on cutting families, flags and skin tones in half on
+ * its way into the outbox.
+ *
+ * It is a module rather than an import from imessage.ts because imessage.ts
+ * already imports from the state store; importing a value back would close a
+ * runtime cycle.
+ */
+
+export const IMESSAGE_MAX_CHUNK_LENGTH = 3000;
+
+const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
+
+/** Split by code point. Only used for a single grapheme too large to fit. */
+function chunkByCodePoint(content: string, maxLength: number): string[] {
+  const codePoints = Array.from(content);
+  const chunks: string[] = [];
+  for (let index = 0; index < codePoints.length; index += maxLength) {
+    chunks.push(codePoints.slice(index, index + maxLength).join(''));
+  }
+  return chunks;
+}
+
+/**
+ * Split a reply into sendable chunks without breaking what the reader sees.
+ *
+ * This used to slice on code points, which keeps surrogate pairs intact but is
+ * not what a character is. Many everyday characters are several code points,
+ * and cutting between them corrupts the message in a way that is obvious to the
+ * recipient and invisible to us:
+ *
+ *   👨‍👩‍👧‍👦  ->  "👨‍" + "👩‍👧‍" + "👦"   a family becomes four people and stray joiners
+ *   🇺🇸       ->  "🇺"  + "🇸"            a flag becomes two letters
+ *   👍🏽       ->  "👍" + "🏽"             the skin tone is orphaned as a colour swatch
+ *   é (e+◌́)   ->  "e"  + "́"              the accent lands on the next message
+ *
+ * Segmenting by grapheme cluster is the correct unit. `maxLength` still counts
+ * code points so the existing limit means the same thing as before.
+ *
+ * A single grapheme larger than `maxLength` cannot be honoured both ways. We
+ * keep the limit — exceeding it risks the send failing outright — and fall back
+ * to code points for that one cluster, which also guarantees progress rather
+ * than looping forever on something that never fits.
+ */
+export function chunkIMessageText(
+  content: string,
+  maxLength = IMESSAGE_MAX_CHUNK_LENGTH,
+): string[] {
+  if (!Number.isSafeInteger(maxLength) || maxLength < 1) {
+    throw new Error('iMessage chunk length must be a positive integer');
+  }
+  if (content.length === 0) return [''];
+
+  const chunks: string[] = [];
+  let current = '';
+  let currentLength = 0;
+
+  for (const { segment } of graphemeSegmenter.segment(content)) {
+    const segmentLength = Array.from(segment).length;
+
+    if (segmentLength > maxLength) {
+      if (current) {
+        chunks.push(current);
+        current = '';
+        currentLength = 0;
+      }
+      chunks.push(...chunkByCodePoint(segment, maxLength));
+      continue;
+    }
+
+    if (currentLength + segmentLength > maxLength) {
+      chunks.push(current);
+      current = '';
+      currentLength = 0;
+    }
+    current += segment;
+    currentLength += segmentLength;
+  }
+
+  if (current) chunks.push(current);
+  return chunks;
+}

--- a/typescript/src/channels/imessage-state-store.test.ts
+++ b/typescript/src/channels/imessage-state-store.test.ts
@@ -439,6 +439,56 @@ describe('IMessageStateStore legacy migration and privacy', () => {
     await store.close();
   });
 
+  it('does not split a grapheme cluster when chunking a migrated reply', async () => {
+    // The migration had its own chunker, slicing code points at 3,000 — the
+    // behaviour the live chunker had before openrappter#58. The existing
+    // migration case above uses 'x'.repeat(3001), which cannot tell the two
+    // apart. This one puts a family emoji across the boundary, where the old
+    // code produced a chunk ending "a<man><zwj><woman>" and a next chunk
+    // beginning on a stray joiner. The outbox is what gets sent.
+    const family = '\u{1F468}\u200D\u{1F469}\u200D\u{1F467}\u200D\u{1F466}';
+    const content = `${'a'.repeat(2998)}${family}${'b'.repeat(20)}`;
+
+    const root = await temporaryRoot();
+    const directory = path.join(root, '.openrappter');
+    await fs.mkdir(directory, { recursive: true });
+    await fs.writeFile(
+      path.join(directory, 'imessage-state.json'),
+      JSON.stringify({ version: 1, appleRowId: 7 }),
+    );
+    await fs.writeFile(
+      path.join(directory, 'imessage-conversations.json'),
+      JSON.stringify({
+        version: 1,
+        conversations: {},
+        deliveries: {
+          emoji: {
+            status: 'ready',
+            updatedAt: '2026-07-16T21:01:00.000Z',
+            conversationKey: 'imessage:iMessage;-;chat-a',
+            reply: { target: '+15551234567', content, replyTo: 'emoji' },
+          },
+        },
+      }),
+    );
+
+    const store = new IMessageStateStore({ homeDirectory: root, now: () => NOW });
+    await store.initialize();
+
+    const first = await store.getOutbox('emoji:0');
+    const second = await store.getOutbox('emoji:1');
+    const chunks = [first?.content ?? '', second?.content ?? ''];
+
+    expect(chunks.join('')).toBe(content);
+    expect(chunks.some(chunk => chunk.includes(family))).toBe(true);
+    for (const chunk of chunks) {
+      expect(chunk.endsWith('\u200D')).toBe(false);
+      expect(/^[\u200D]/u.test(chunk)).toBe(false);
+    }
+
+    await store.close();
+  });
+
   it('fails explicitly without deleting corrupt legacy rollback data', async () => {
     const root = await temporaryRoot();
     const directory = path.join(root, '.openrappter');

--- a/typescript/src/channels/imessage-state-store.ts
+++ b/typescript/src/channels/imessage-state-store.ts
@@ -3,6 +3,7 @@ import os from 'os';
 import path from 'path';
 import type { AssistantConversationMessage } from '../agents/Assistant.js';
 import type { IncomingMessage } from './types.js';
+import { chunkIMessageText, IMESSAGE_MAX_CHUNK_LENGTH } from './imessage-chunking.js';
 
 export const IMESSAGE_STATE_SCHEMA_VERSION = 1;
 export const IMESSAGE_DEFAULT_STALE_AFTER_MS = 30 * 60 * 1000;
@@ -304,14 +305,18 @@ function validIsoTimestamp(value: string, fallback: string): string {
   return Number.isFinite(Date.parse(value)) ? value : fallback;
 }
 
+/**
+ * Split a migrated reply the same way a live one is split.
+ *
+ * This used to slice code points at 3,000, which is what the live chunker did
+ * before openrappter#58 taught it about grapheme clusters. That fix never
+ * reached here, so a migrated reply crossing the boundary mid-cluster went into
+ * the outbox broken — a family emoji arriving as `a<man><zwj><woman>` followed
+ * by a chunk starting on a stray joiner. The outbox is what gets sent, so the
+ * recipient saw it.
+ */
 function chunkLegacyReply(content: string): string[] {
-  const characters = Array.from(content);
-  if (characters.length === 0) return [''];
-  const chunks: string[] = [];
-  for (let index = 0; index < characters.length; index += 3_000) {
-    chunks.push(characters.slice(index, index + 3_000).join(''));
-  }
-  return chunks;
+  return chunkIMessageText(content, IMESSAGE_MAX_CHUNK_LENGTH);
 }
 
 function safeJsonParse<T>(content: string, description: string): T {

--- a/typescript/src/channels/imessage.ts
+++ b/typescript/src/channels/imessage.ts
@@ -19,8 +19,10 @@ import type {
   IncomingMessage,
   OutgoingMessage,
 } from './types.js';
+import { chunkIMessageText, IMESSAGE_MAX_CHUNK_LENGTH } from './imessage-chunking.js';
 
-export const IMESSAGE_MAX_CHUNK_LENGTH = 3000;
+export { chunkIMessageText, IMESSAGE_MAX_CHUNK_LENGTH };
+
 export const IMESSAGE_BLUEBUBBLES_UNSUPPORTED =
   'BlueBubbles mode is not supported by the live iMessage MVP; use applescript mode';
 const DEFAULT_POLL_INTERVAL = 5000;
@@ -328,78 +330,6 @@ export function decodeAttributedBodyHex(value: unknown): string | null {
     return null;
   }
   return body.toString('utf8', offset, offset + length);
-}
-
-const graphemeSegmenter = new Intl.Segmenter(undefined, { granularity: 'grapheme' });
-
-/** Split by code point. Only used for a single grapheme too large to fit. */
-function chunkByCodePoint(content: string, maxLength: number): string[] {
-  const codePoints = Array.from(content);
-  const chunks: string[] = [];
-  for (let index = 0; index < codePoints.length; index += maxLength) {
-    chunks.push(codePoints.slice(index, index + maxLength).join(''));
-  }
-  return chunks;
-}
-
-/**
- * Split a reply into sendable chunks without breaking what the reader sees.
- *
- * This used to slice on code points, which keeps surrogate pairs intact but is
- * not what a character is. Many everyday characters are several code points,
- * and cutting between them corrupts the message in a way that is obvious to the
- * recipient and invisible to us:
- *
- *   👨‍👩‍👧‍👦  ->  "👨‍" + "👩‍👧‍" + "👦"   a family becomes four people and stray joiners
- *   🇺🇸       ->  "🇺"  + "🇸"            a flag becomes two letters
- *   👍🏽       ->  "👍" + "🏽"             the skin tone is orphaned as a colour swatch
- *   é (e+◌́)   ->  "e"  + "́"              the accent lands on the next message
- *
- * Segmenting by grapheme cluster is the correct unit. `maxLength` still counts
- * code points so the existing limit means the same thing as before.
- *
- * A single grapheme larger than `maxLength` cannot be honoured both ways. We
- * keep the limit — exceeding it risks the send failing outright — and fall back
- * to code points for that one cluster, which also guarantees progress rather
- * than looping forever on something that never fits.
- */
-export function chunkIMessageText(
-  content: string,
-  maxLength = IMESSAGE_MAX_CHUNK_LENGTH,
-): string[] {
-  if (!Number.isSafeInteger(maxLength) || maxLength < 1) {
-    throw new Error('iMessage chunk length must be a positive integer');
-  }
-  if (content.length === 0) return [''];
-
-  const chunks: string[] = [];
-  let current = '';
-  let currentLength = 0;
-
-  for (const { segment } of graphemeSegmenter.segment(content)) {
-    const segmentLength = Array.from(segment).length;
-
-    if (segmentLength > maxLength) {
-      if (current) {
-        chunks.push(current);
-        current = '';
-        currentLength = 0;
-      }
-      chunks.push(...chunkByCodePoint(segment, maxLength));
-      continue;
-    }
-
-    if (currentLength + segmentLength > maxLength) {
-      chunks.push(current);
-      current = '';
-      currentLength = 0;
-    }
-    current += segment;
-    currentLength += segmentLength;
-  }
-
-  if (current) chunks.push(current);
-  return chunks;
 }
 
 function parseCursorState(value: IMessageCursorState): IMessageCursorState {


### PR DESCRIPTION
There were **two chunkers**. `chunkIMessageText` split live replies; `chunkLegacyReply`, in `imessage-state-store.ts`, split migrated ones by slicing **code points** at 3,000 — which is what the live one did before #58 taught it about grapheme clusters.

That fix never reached the copy:

```
legacy chunk0 tail: "a👨‍👩"
legacy chunk1 head: "‍👧‍👦"      <- starts on a stray joiner
fixed  chunk0 tail: "aaaaaa"
```

The outbox is what gets **sent**, so the recipient saw that.

## Why the existing test could not catch it

The migration test uses `'x'.repeat(3001)`. Plain ASCII splits identically either way.

That is the same shape as the test #58 replaced — *"never splits a Unicode code point"* — which was satisfied by every broken case. A fixture that cannot distinguish the bug from the fix is not coverage.

## Change

The chunker now lives in `imessage-chunking.ts` and both callers use it. A module rather than an import from `imessage.ts`, because `imessage.ts` already imports from the state store and importing a value back would close a **runtime cycle**. `imessage.ts` re-exports it, so nothing else changes.

## Tests — 13

Twelve run four cluster kinds (ZWJ family, regional-indicator flag, skin-tone modifier, combining accent) across **both entry points** at the real 3,000 boundary — asserting no chunk begins on a stranded mark or ends on a joiner, and the cluster survives inside one chunk — plus the plain-text split and the empty case.

The thirteenth goes **through the migration itself** and reads the outbox rows.

**That last one exists because the others were not enough.** With only the shared tests, giving the state store its own code-point copy back *still passed* — they exercised the function, not the caller's use of it. Same blindness as #73, found the same way: by mutating and watching nothing go red.

| Mutation | Result |
|---|---|
| restore code-point slicing in the shared chunker | 5 fail |
| give the state store its own copy back | migration test fails |

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **4098 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
