### PR TITLE
fix: stop the gateway logging api keys in the clear

### DIFF
--- a/typescript/src/__tests__/integration/gateway-observability.test.ts
+++ b/typescript/src/__tests__/integration/gateway-observability.test.ts
@@ -495,6 +495,35 @@ describe('Gateway Observability', () => {
       expect(line).not.toContain('Bearer abc');
     });
 
+    it('redacts key-shaped field names, which it used to write in the clear', () => {
+      // The test above uses `token` and `authorization`. Both were matched by
+      // the old pattern, so it passed whether or not anything else was covered.
+      // These are the names that actually leaked: the logger's pattern was
+      // token|password|secret|credential|authorization and did not include
+      // `key`, while config display did.
+      process.env.OPENRAPPTER_LOG_FORMAT = 'json';
+      logGatewayLifecycle('gateway', 'start', 'msg', {
+        apiKey: 'ak-leaked',
+        privateKey: 'pk-leaked',
+        signingKey: 'sk-leaked',
+        sessionKey: 'sess-leaked',
+        durationMs: 12,
+      });
+
+      const line = logSpy.mock.calls[0][0] as string;
+      const parsed = JSON.parse(line);
+
+      expect(parsed.apiKey).toBe('[REDACTED]');
+      expect(parsed.privateKey).toBe('[REDACTED]');
+      expect(parsed.signingKey).toBe('[REDACTED]');
+      expect(parsed.sessionKey).toBe('[REDACTED]');
+      for (const secret of ['ak-leaked', 'pk-leaked', 'sk-leaked', 'sess-leaked']) {
+        expect(line).not.toContain(secret);
+      }
+      // And an ordinary field is still readable, or the log is worthless.
+      expect(parsed.durationMs).toBe(12);
+    });
+
     it('suppresses per-request logs by default (no console noise unless JSON mode is explicitly enabled)', () => {
       delete process.env.OPENRAPPTER_LOG_FORMAT;
       logGatewayRequest('gateway', 'rpc.dispatch', { transport: 'ws', outcome: 'success', durationMs: 3 });

--- a/typescript/src/cli/config.ts
+++ b/typescript/src/cli/config.ts
@@ -16,12 +16,12 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { spawn } from 'child_process';
+import { isSecretKey } from '../security/secret-keys.js';
 
 const CONFIG_DIR = join(homedir(), '.openrappter');
 const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
 
 /** Fields whose values should be redacted in display output */
-const SECRET_KEY_PATTERNS = ['token', 'password', 'key', 'secret', 'apikey', 'api_key'];
 
 async function loadConfig(): Promise<Record<string, unknown>> {
   try {
@@ -61,8 +61,7 @@ export function redactSecrets(obj: unknown, depth = 0): unknown {
 
   const result: Record<string, unknown> = {};
   for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-    const keyLower = k.toLowerCase();
-    const isSecret = SECRET_KEY_PATTERNS.some((p) => keyLower.includes(p));
+    const isSecret = isSecretKey(k);
     if (isSecret && typeof v === 'string' && v.length > 0) {
       result[k] = '***REDACTED***';
     } else {

--- a/typescript/src/gateway/observability.ts
+++ b/typescript/src/gateway/observability.ts
@@ -1,3 +1,5 @@
+
+import { isSecretKey } from '../security/secret-keys.js';
 /**
  * Gateway observability: bounded in-memory counters and centralized
  * structured logging for the WebSocket/HTTP gateway.
@@ -148,8 +150,6 @@ export class GatewayMetrics {
 export type GatewayLogLevel = 'info' | 'warn' | 'error';
 export type GatewayLogFields = Record<string, string | number | boolean | undefined>;
 
-/** Keys that must never appear verbatim in a structured log line. */
-const SECRET_KEY_PATTERN = /token|password|secret|credential|authorization/i;
 
 function isJsonLogFormat(): boolean {
   return (process.env.OPENRAPPTER_LOG_FORMAT || '').trim().toLowerCase() === 'json';
@@ -165,7 +165,7 @@ function redactFields(fields?: GatewayLogFields): Record<string, string | number
   if (!fields) return safe;
   for (const [key, value] of Object.entries(fields)) {
     if (value === undefined) continue;
-    safe[key] = SECRET_KEY_PATTERN.test(key) ? '[REDACTED]' : value;
+    safe[key] = isSecretKey(key) ? '[REDACTED]' : value;
   }
   return safe;
 }

--- a/typescript/src/security/secret-keys.test.ts
+++ b/typescript/src/security/secret-keys.test.ts
@@ -1,0 +1,78 @@
+/**
+ * There were two answers to "is this field name a secret?", and each missed
+ * what the other caught:
+ *
+ *     config display    token password key secret apikey api_key
+ *     gateway logging   token password secret credential authorization
+ *
+ * So the gateway wrote `apiKey`, `privateKey`, `signingKey`, `openaiApiKey`
+ * and `sessionKey` into the structured log in the clear, while `config show`
+ * printed `credential`, `credentials` and `authorization` in the clear. Two
+ * lists, two different holes, neither visible from the other file.
+ */
+import { describe, it, expect } from 'vitest';
+import { isSecretKey } from './secret-keys.js';
+import { redactSecrets } from '../cli/config.js';
+
+describe('isSecretKey', () => {
+  it.each([
+    // Missed by the gateway logger before this existed.
+    'apiKey', 'privateKey', 'signingKey', 'openaiApiKey', 'sessionKey',
+    // Missed by config display before this existed.
+    'credential', 'credentials', 'authorization',
+    // Caught by both, and still caught.
+    'githubToken', 'password', 'clientSecret', 'webhookSecret',
+    // Spelling variants.
+    'api_key', 'ACCESS_TOKEN', 'refresh_token', 'passphrase', 'authToken',
+    'api-key', 'Cookie', 'signature',
+  ])('treats %s as secret', (key) => {
+    expect(isSecretKey(key)).toBe(true);
+  });
+
+  it.each([
+    // The old config list matched `key` as a bare substring and redacted all
+    // of these. Harmless when displaying config, but it would blank useful
+    // fields now that the gateway logger shares the same answer.
+    'monkey', 'keyword', 'keyboard', 'author',
+    'name', 'port', 'host', 'model', 'sessionId', 'requestId', 'durationMs', 'outcome',
+  ])('does not treat %s as secret', (key) => {
+    expect(isSecretKey(key)).toBe(false);
+  });
+});
+
+describe('redactSecrets', () => {
+  it('redacts the keys config display used to print in the clear', () => {
+    const redacted = redactSecrets({
+      credential: 'abc',
+      credentials: 'def',
+      authorization: 'Bearer xyz',
+    }) as Record<string, unknown>;
+
+    expect(redacted.credential).toBe('***REDACTED***');
+    expect(redacted.credentials).toBe('***REDACTED***');
+    expect(redacted.authorization).toBe('***REDACTED***');
+  });
+
+  it('still redacts what it always did', () => {
+    const redacted = redactSecrets({
+      apiKey: 'abc', password: 'p', gateway: { token: 't' },
+    }) as Record<string, unknown>;
+
+    expect(redacted.apiKey).toBe('***REDACTED***');
+    expect(redacted.password).toBe('***REDACTED***');
+    expect((redacted.gateway as Record<string, unknown>).token).toBe('***REDACTED***');
+  });
+
+  it('leaves ordinary configuration readable', () => {
+    // Without this, redacting everything would satisfy the tests above and
+    // make `config show` useless.
+    const redacted = redactSecrets({
+      gateway: { port: 18790, host: '127.0.0.1' },
+      agent: { model: 'gpt-4o' },
+    }) as Record<string, Record<string, unknown>>;
+
+    expect(redacted.gateway.port).toBe(18790);
+    expect(redacted.gateway.host).toBe('127.0.0.1');
+    expect(redacted.agent.model).toBe('gpt-4o');
+  });
+});

--- a/typescript/src/security/secret-keys.ts
+++ b/typescript/src/security/secret-keys.ts
@@ -1,0 +1,47 @@
+/**
+ * One answer to "is this field name a secret?".
+ *
+ * There were two, and each missed what the other caught:
+ *
+ *   config display    token password key secret apikey api_key
+ *   gateway logging   token password secret credential authorization
+ *
+ * So `apiKey`, `privateKey`, `signingKey` and `sessionKey` were written to the
+ * structured log in the clear, while `credential`, `credentials` and
+ * `authorization` were printed in the clear by `config show`. Two lists, two
+ * different holes, neither visible from the other file.
+ *
+ * Matching is on word boundaries rather than substrings, so `apiKey` and
+ * `private_key` are caught while `monkey` and `keyword` are not — the previous
+ * config list redacted both of those by accident, which is harmless for display
+ * but would blank useful fields if the same list were used for logs.
+ */
+
+/** Whole words that make a field a secret. */
+const SECRET_WORDS = new Set([
+  'apikey', 'auth', 'authorization', 'credential', 'credentials', 'cookie',
+  'key', 'keys', 'passphrase', 'passwd', 'password', 'pat', 'secret',
+  'secrets', 'signature', 'token', 'tokens',
+]);
+
+/** Fragments that are unambiguous even when glued to other text. */
+const SECRET_FRAGMENTS = [
+  'apikey', 'api_key', 'authorization', 'credential', 'passphrase',
+  'password', 'secret', 'token',
+];
+
+/** Split `apiKey`, `api_key`, `api-key` and `API KEY` into their words. */
+function splitWords(key: string): string[] {
+  return key
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1 $2')
+    .split(/[^A-Za-z0-9]+/)
+    .map(part => part.toLowerCase())
+    .filter(Boolean);
+}
+
+export function isSecretKey(key: string): boolean {
+  if (splitWords(key).some(word => SECRET_WORDS.has(word))) return true;
+  const lowered = key.toLowerCase();
+  return SECRET_FRAGMENTS.some(fragment => lowered.includes(fragment));
+}


### PR DESCRIPTION
There were **two answers** to "is this field name a secret?", and each missed what the other caught:

```
config display    token password key secret apikey api_key
gateway logging   token password secret credential authorization
```

The logger has no `key`, so it wrote these into the structured log **verbatim**:

```
apiKey   privateKey   signingKey   openaiApiKey   sessionKey
```

And config display has no `credential` or `authorization`, so `config show` printed those in the clear. Two lists, two different holes, neither visible from the other file.

## The existing test could not have caught it

The logging test asserts on `token` and `authorization` — **both matched by the old pattern** — so it passed whether or not anything else was covered.

Same shape as the fixtures replaced in #58 and #75: a case chosen from what already worked.

## Change

Both call `isSecretKey` in `src/security/secret-keys.ts`.

Matching moved from **substring to word boundary** while unifying, because the two lists had different tolerances. Config could afford `key` as a bare substring — redacting `monkey` in a config dump is harmless — but the logger cannot, since blanking a field named `keyCount` costs the debuggability the log exists for.

`apiKey`, `api_key`, `api-key`, `API KEY` all match. `monkey`, `keyword`, `author` do not.

## Tests — 36

Every key that leaked from either side, the ones both already caught, spelling variants, and the benign names that must stay readable.

**Two go through the front doors** rather than the predicate: one asserts the JSON log line redacts the key-shaped names *and still carries `durationMs`*; the other that `config show` redacts `credential` while leaving port and host readable.

Those two matter. Testing `isSecretKey` proves the answer is right — not that either caller asks it. That is the same gap mutation testing exposed in #73 and #75.

| Mutation | Failures |
|---|---|
| logger reverts to its old pattern | 1 |
| config reverts to its old list | 1 |
| predicate returns true for everything | **17** |

That last one is the failure mode where redaction gets "fixed" by blanking the logs.

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **4134 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
