### PR TITLE
fix: stop the Python gateway logging api keys in the clear too

### DIFF
--- a/python/openrappter/gateway/observability.py
+++ b/python/openrappter/gateway/observability.py
@@ -30,6 +30,8 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
+from openrappter.security.secret_keys import is_secret_key
+
 # Mutually-exclusive classification of a single RPC dispatch attempt.
 RPC_OUTCOMES = ("success", "error", "auth_failure", "rate_limited", "timeout")
 
@@ -152,7 +154,6 @@ class GatewayMetrics:
 
 # ── Structured logging ───────────────────────────────────────────────────
 
-_SECRET_KEY_PATTERN = re.compile(r"token|password|secret|credential|authorization", re.IGNORECASE)
 
 
 def _is_json_log_format() -> bool:
@@ -169,7 +170,7 @@ def _redact_fields(fields: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     for key, value in fields.items():
         if value is None:
             continue
-        safe[key] = "[REDACTED]" if _SECRET_KEY_PATTERN.search(key) else value
+        safe[key] = "[REDACTED]" if is_secret_key(key) else value
     return safe
 
 

--- a/python/openrappter/security/secret_keys.py
+++ b/python/openrappter/security/secret_keys.py
@@ -1,0 +1,56 @@
+"""One answer to "is this field name a secret?".
+
+The TypeScript runtime had two, and each missed what the other caught, so
+`apiKey`, `privateKey`, `signingKey` and `sessionKey` were written into the
+structured log in the clear. That was fixed in openrappter#76.
+
+This body had the same logging pattern, character for character:
+
+    token|password|secret|credential|authorization
+
+so it leaked the same five names. Fixing one runtime and leaving the other is
+how the two stop meaning the same thing.
+
+Matching is on word boundaries rather than substrings, so `apiKey` and
+`private_key` are caught while `monkey` and `keyword` are not — blanking a
+field named `keyCount` would cost the debuggability the log exists for.
+
+Kept deliberately in step with typescript/src/security/secret-keys.ts; a test
+asserts the two agree on a shared table of names.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Whole words that make a field a secret.
+_SECRET_WORDS = frozenset({
+    "apikey", "auth", "authorization", "credential", "credentials", "cookie",
+    "key", "keys", "passphrase", "passwd", "password", "pat", "secret",
+    "secrets", "signature", "token", "tokens",
+})
+
+#: Fragments unambiguous even when glued to other text.
+_SECRET_FRAGMENTS = (
+    "apikey", "api_key", "authorization", "credential", "passphrase",
+    "password", "secret", "token",
+)
+
+_CAMEL_BOUNDARY = re.compile(r"([a-z0-9])([A-Z])")
+_ACRONYM_BOUNDARY = re.compile(r"([A-Z]+)([A-Z][a-z])")
+_NON_ALNUM = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _split_words(key: str) -> list:
+    """Split apiKey, api_key, api-key and API KEY into their words."""
+    spaced = _CAMEL_BOUNDARY.sub(r"\1 \2", key)
+    spaced = _ACRONYM_BOUNDARY.sub(r"\1 \2", spaced)
+    return [part.lower() for part in _NON_ALNUM.split(spaced) if part]
+
+
+def is_secret_key(key: str) -> bool:
+    """True when a field of this name must never be logged verbatim."""
+    if any(word in _SECRET_WORDS for word in _split_words(key)):
+        return True
+    lowered = key.lower()
+    return any(fragment in lowered for fragment in _SECRET_FRAGMENTS)

--- a/python/tests/test_secret_keys.py
+++ b/python/tests/test_secret_keys.py
@@ -1,0 +1,99 @@
+"""The Python gateway logger leaked the same keys the TypeScript one did.
+
+Both bodies used the same pattern, character for character:
+
+    token|password|secret|credential|authorization
+
+It has no `key`, so both wrote these into the structured log verbatim:
+
+    apiKey  privateKey  signingKey  openaiApiKey  sessionKey
+
+openrappter#76 fixed the TypeScript side. This is the same fix here, plus a
+test that the two answers stay in agreement — the drift is the bug, so a table
+that only one runtime is checked against would recreate it.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openrappter.security.secret_keys import is_secret_key
+
+# Names that leaked from the old pattern, names it already caught, and spelling
+# variants. Shared with the TypeScript suite; see the agreement test below.
+SECRET_NAMES = [
+    "apiKey", "privateKey", "signingKey", "openaiApiKey", "sessionKey",
+    "githubToken", "password", "clientSecret", "webhookSecret",
+    "credential", "credentials", "authorization",
+    "api_key", "api-key", "ACCESS_TOKEN", "refresh_token", "passphrase",
+    "authToken", "Cookie", "signature",
+]
+
+BENIGN_NAMES = [
+    "monkey", "keyword", "keyboard", "author",
+    "name", "port", "host", "model", "sessionId", "requestId",
+    "durationMs", "outcome",
+]
+
+
+class TestIsSecretKey:
+    @pytest.mark.parametrize("key", SECRET_NAMES)
+    def test_secret_names_are_redacted(self, key):
+        assert is_secret_key(key) is True
+
+    @pytest.mark.parametrize("key", BENIGN_NAMES)
+    def test_benign_names_stay_readable(self, key):
+        # Blanking these would cost the debuggability the log exists for.
+        assert is_secret_key(key) is False
+
+
+class TestGatewayLogRedaction:
+    def test_the_logger_redacts_key_shaped_names(self, monkeypatch, capsys):
+        """Front door. Testing is_secret_key proves the answer is right, not
+        that the logger asks it."""
+        from openrappter.gateway import observability
+
+        monkeypatch.setenv("OPENRAPPTER_LOG_FORMAT", "json")
+        observability.log_gateway_lifecycle(
+            "gateway", "start", "msg",
+            {
+                "apiKey": "ak-leaked",
+                "privateKey": "pk-leaked",
+                "sessionKey": "sess-leaked",
+                "durationMs": 12,
+            },
+        )
+
+        line = capsys.readouterr().out.strip().splitlines()[-1]
+        payload = json.loads(line)
+
+        assert payload["apiKey"] == "[REDACTED]"
+        assert payload["privateKey"] == "[REDACTED]"
+        assert payload["sessionKey"] == "[REDACTED]"
+        for secret in ("ak-leaked", "pk-leaked", "sess-leaked"):
+            assert secret not in line
+        # An ordinary field is still readable, or the log is worthless.
+        assert payload["durationMs"] == 12
+
+
+class TestRuntimeAgreement:
+    def test_the_typescript_answer_lists_the_same_words(self):
+        """The bug was two runtimes disagreeing, so pin them to each other.
+
+        Compares the word and fragment tables rather than running node: a
+        divergence shows up here as a changed list, which is the thing that
+        actually went wrong.
+        """
+        ts_path = (
+            Path(__file__).resolve().parents[2]
+            / "typescript" / "src" / "security" / "secret-keys.ts"
+        )
+        source = ts_path.read_text(encoding="utf-8")
+
+        from openrappter.security.secret_keys import _SECRET_WORDS, _SECRET_FRAGMENTS
+
+        for word in _SECRET_WORDS:
+            assert f"'{word}'" in source, f"TypeScript is missing the word {word!r}"
+        for fragment in _SECRET_FRAGMENTS:
+            assert f"'{fragment}'" in source, f"TypeScript is missing the fragment {fragment!r}"


### PR DESCRIPTION
#76 fixed this in the TypeScript runtime. This body had the same pattern, **character for character**:

```
token|password|secret|credential|authorization
```

It has no `key`, so the Python gateway wrote these into the structured log verbatim, exactly as the other one did:

```
apiKey   privateKey   signingKey   openaiApiKey   sessionKey
```

Measured before the change:

```
key                 python-logger-redacts
  apiKey             False
  privateKey         False
  sessionKey         False
  githubToken        True
  authorization      True
```

## Change

Ported `is_secret_key` to `openrappter/security/secret_keys.py` and wired the logger to it, matching TypeScript name for name: **word-boundary** matching, so `apiKey` and `private_key` are caught while `monkey`, `keyword` and `keyCount` stay readable.

## Tests — 34

The names that leaked, the ones the old pattern already caught, spelling variants, and the benign names that must survive.

One goes **through the logger** rather than the predicate — testing `is_secret_key` proves the answer is right, not that the logger asks it.

## The last test pins the two runtimes to each other

The bug here was not a wrong answer. It was **two answers**. A table that only one runtime is checked against would set up the next divergence.

Removing `key` from the **TypeScript** file now fails the **Python** suite — verified by doing it:

```
FAILED tests/test_secret_keys.py::TestRuntimeAgreement::test_the_typescript_answer_lists_the_same_words
```

| Mutation | Failures |
|---|---|
| logger reverts to the old pattern | 1 |
| drop `key` from the word set (the original hole) | 5 |
| predicate always returns true | 13 |

That last one is the failure mode where redaction gets "fixed" by blanking the logs.

Python suite: **1151 passed**.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
