### PR TITLE
Harden the installer: fail closed, and never run an unverified script

### DIFF
--- a/.github/workflows/pinned-install.yml
+++ b/.github/workflows/pinned-install.yml
@@ -1,0 +1,109 @@
+name: Pinned install
+
+# rapp-local-install/1.0 sections 3.10 and 4.8: run the REAL installer on every
+# supported platform, and prove the mutable-reference refusal by observing it
+# fire. Asserting that a guard exists is not the same as watching it work.
+
+on:
+  pull_request:
+    paths:
+      - 'install-pinned.sh'
+      - '.github/workflows/pinned-install.yml'
+      - 'typescript/package-lock.json'
+  push:
+    branches: [main]
+    paths:
+      - 'install-pinned.sh'
+  workflow_dispatch: {}
+
+concurrency:
+  group: pinned-install-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  install:
+    name: ${{ matrix.name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 25
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-latest    # Apple Silicon
+            name: macOS-arm64
+          - os: macos-13        # Intel
+            name: macOS-x64
+          - os: ubuntu-latest
+            name: Ubuntu-x64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Shell syntax
+        run: bash -n install-pinned.sh
+
+      # The negative test. If the installer ACCEPTS a branch name, two people
+      # running the same command a day apart get different bytes, and the whole
+      # pin is decoration. Fail loudly when that happens.
+      - name: Refuses a mutable reference
+        run: |
+          for ref in main HEAD latest v1.0.0 abc123; do
+            if OPENRAPPTER_COMMIT="$ref" bash install-pinned.sh >/dev/null 2>&1; then
+              echo "install-pinned.sh accepted a mutable source reference: $ref" >&2
+              exit 1
+            fi
+          done
+          echo "refused every mutable reference"
+
+      - name: Refuses a missing pin
+        run: |
+          if bash install-pinned.sh >/dev/null 2>&1; then
+            echo "install-pinned.sh installed with no pin" >&2
+            exit 1
+          fi
+          echo "refused an absent pin"
+
+      # And the positive test: the same script must still install for real.
+      - name: Installs the commit under test
+        env:
+          OPENRAPPTER_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          OPENRAPPTER_INSTALL_ROOT: ${{ runner.temp }}/openrappter-install
+        run: bash install-pinned.sh
+
+      - name: Provenance record is written and well-formed
+        env:
+          OPENRAPPTER_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          record="${{ runner.temp }}/openrappter-install/versions/$OPENRAPPTER_COMMIT/.rapp-install.json"
+          test -f "$record" || { echo "no provenance record at $record" >&2; exit 1; }
+          python3 - "$record" "$OPENRAPPTER_COMMIT" <<'PY'
+          import json, sys
+          record, pin = json.load(open(sys.argv[1])), sys.argv[2]
+          assert record["schema"] == "rapp-local-install/1.0", record["schema"]
+          assert record["pin"] == pin, (record["pin"], pin)
+          for field in ("lockfile_sha256", "installed_utc", "platform", "architecture"):
+              assert record.get(field), f"missing {field}"
+          assert record["runtime"]["binary_sha256"], "no runtime binary hash"
+          print("provenance OK:", record["pin"][:12], record["platform"], record["architecture"])
+          PY
+
+      # Second run must REUSE, not rebuild - that is the re-verification path.
+      - name: Re-runs idempotently
+        env:
+          OPENRAPPTER_COMMIT: ${{ github.event.pull_request.head.sha || github.sha }}
+          OPENRAPPTER_INSTALL_ROOT: ${{ runner.temp }}/openrappter-install
+        run: |
+          out="$(bash install-pinned.sh 2>&1)"
+          printf '%s\n' "$out"
+          printf '%s' "$out" | grep -q "Reusing verified install" \
+            || { echo "second run did not reuse the verified install" >&2; exit 1; }
+
+      - name: Nothing installed globally
+        run: |
+          if npm ls -g --depth=0 2>/dev/null | grep -q openrappter; then
+            echo "installer put openrappter in the global npm prefix" >&2
+            exit 1
+          fi
+          echo "no global footprint"

--- a/.github/workflows/pinned-install.yml
+++ b/.github/workflows/pinned-install.yml
@@ -34,7 +34,9 @@ jobs:
         include:
           - os: macos-latest    # Apple Silicon
             name: macOS-arm64
-          - os: macos-13        # Intel
+          # macos-13 was retired 2025-12-04; the job queued forever instead of
+          # failing, so the Intel leg looked green-adjacent while never running.
+          - os: macos-15-intel  # Intel
             name: macOS-x64
           - os: ubuntu-latest
             name: Ubuntu-x64

--- a/docs/install.sh
+++ b/docs/install.sh
@@ -65,11 +65,56 @@ download_file() {
     wget -q --https-only --secure-protocol=TLSv1_2 --tries=3 --timeout=20 -O "$output" "$url"
 }
 
-run_remote_bash() {
-    local url="$1"
-    local tmp
+# Third-party bootstrap scripts, pinned to an immutable revision and hashed.
+# rapp-local-install/1.0 sections 3.1 (pin or refuse) and 3.2 (never execute an
+# unverified remote script). Refresh deliberately, after reading the diff:
+#
+#   commit="$(gh api repos/Homebrew/install/commits/HEAD --jq .sha)"
+#   curl -sS "https://raw.githubusercontent.com/Homebrew/install/$commit/install.sh" | shasum -a 256
+#
+# A tag is NOT a pin - tags move. Homebrew is pinned by commit; nvm publishes
+# immutable release tags but is hash-verified regardless, because the tag being
+# immutable is a promise rather than something we can check.
+HOMEBREW_INSTALL_COMMIT="609e8f75a42bcad1ce90acaf4e15fc89aebaf026"
+HOMEBREW_INSTALL_SHA256="12479a24be3f5307eecac7cde670fad7118640f031229e964f544b1367b52a41"
+NVM_INSTALL_REF="v0.40.1"
+NVM_INSTALL_SHA256="abdb525ee9f5b48b34d8ed9fc67c6013fb0f659712e401ecd88ab989b3af8f53"
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        return 1
+    fi
+}
+
+# Download a script, verify it against an expected SHA-256, and only then run it.
+# Fails closed on every path, including the one where no hashing tool exists -
+# an unverifiable script is not a script we run.
+run_verified_remote_bash() {
+    local url="$1" expected="$2" label="${3:-remote script}"
+    case "$url" in
+        https://*) ;;
+        *) ui_error "Refusing non-HTTPS download for $label: $url"; return 1 ;;
+    esac
+
+    local tmp actual
     tmp="$(mktempfile)"
-    download_file "$url" "$tmp"
+    if ! download_file "$url" "$tmp"; then
+        ui_error "Could not download $label - refusing to continue"
+        return 1
+    fi
+    if ! actual="$(sha256_of "$tmp")" || [[ -z "$actual" ]]; then
+        ui_error "No SHA-256 tool available - refusing to run unverified $label"
+        return 1
+    fi
+    if [[ "$actual" != "$expected" ]]; then
+        ui_error "$label checksum mismatch (expected $expected, got $actual)"
+        ui_error "Upstream changed. Review the diff, then update the pin in install.sh."
+        return 1
+    fi
     /bin/bash "$tmp"
 }
 
@@ -936,7 +981,7 @@ install_homebrew() {
     if [[ "$OS" == "macos" ]]; then
         if ! command -v brew &> /dev/null; then
             ui_info "Homebrew not found, installing"
-            run_quiet_step "Installing Homebrew" run_remote_bash "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+            run_quiet_step "Installing Homebrew" run_verified_remote_bash "https://raw.githubusercontent.com/Homebrew/install/${HOMEBREW_INSTALL_COMMIT}/install.sh" "$HOMEBREW_INSTALL_SHA256" "Homebrew installer"
 
             if [[ -f "/opt/homebrew/bin/brew" ]]; then
                 eval "$(/opt/homebrew/bin/brew shellenv)"
@@ -1132,7 +1177,7 @@ install_node() {
 
 install_node_nvm() {
     if [[ ! -d "$HOME/.nvm" ]]; then
-        run_quiet_step "Installing nvm" run_remote_bash "https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh"
+        run_quiet_step "Installing nvm" run_verified_remote_bash "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_INSTALL_REF}/install.sh" "$NVM_INSTALL_SHA256" "nvm installer"
     fi
 
     export NVM_DIR="$HOME/.nvm"
@@ -1288,29 +1333,51 @@ install_node_tarball() {
         fi
     fi
 
-    # Verify SHA-256
+    # Verify SHA-256 — FAIL CLOSED on every path (rapp-local-install/1.0 §3.3).
+    #
+    # This block used to fail OPEN three separate ways, each proceeding to
+    # install an unverified Node.js runtime:
+    #   1. checksum manifest could not be downloaded  -> warn, continue
+    #   2. tarball absent from the manifest            -> silently continue
+    #   3. neither sha256sum nor shasum on the machine -> actual_sha empty,
+    #      the != comparison never fired, silently continue
+    #
+    # The third is the one that hides: an empty computed hash compared against
+    # a real expected hash is not a match and must never be treated as "skip".
+    # A check that degrades to a no-op and reports success is worse than no
+    # check, because it also removes the suspicion that would make someone look.
     local shasums_tmp
     shasums_tmp="$(mktempfile)"
-    if download_file "https://nodejs.org/dist/v${node_ver}/SHASUMS256.txt" "$shasums_tmp" 2>/dev/null; then
-        local expected_sha actual_sha=""
-        expected_sha="$(grep "$tarball" "$shasums_tmp" | awk '{print $1}' | head -1)"
-        if [[ -n "$expected_sha" ]]; then
-            if command -v sha256sum &>/dev/null; then
-                actual_sha="$(sha256sum "$tmp_tar" | awk '{print $1}')"
-            elif command -v shasum &>/dev/null; then
-                actual_sha="$(shasum -a 256 "$tmp_tar" | awk '{print $1}')"
-            fi
-            if [[ -n "$actual_sha" && "$actual_sha" != "$expected_sha" ]]; then
-                ui_error "Node.js checksum mismatch (expected $expected_sha, got $actual_sha)"
-                return 1
-            fi
-            if [[ -n "$actual_sha" ]]; then
-                ui_success "Node.js checksum verified"
-            fi
-        fi
-    else
-        ui_warn "Could not download checksums — skipping verification"
+    if ! download_file "https://nodejs.org/dist/v${node_ver}/SHASUMS256.txt" "$shasums_tmp" 2>/dev/null; then
+        ui_error "Could not download Node.js checksums — refusing to install unverified runtime"
+        return 1
     fi
+
+    local expected_sha actual_sha=""
+    expected_sha="$(grep "$tarball" "$shasums_tmp" | awk '{print $1}' | head -1)"
+    if [[ -z "$expected_sha" ]]; then
+        ui_error "Node.js checksums do not list $tarball — refusing to install"
+        return 1
+    fi
+
+    if command -v sha256sum &>/dev/null; then
+        actual_sha="$(sha256sum "$tmp_tar" | awk '{print $1}')"
+    elif command -v shasum &>/dev/null; then
+        actual_sha="$(shasum -a 256 "$tmp_tar" | awk '{print $1}')"
+    else
+        ui_error "No SHA-256 tool available (sha256sum/shasum) — refusing to install unverified runtime"
+        return 1
+    fi
+
+    if [[ -z "$actual_sha" ]]; then
+        ui_error "Could not compute a SHA-256 for $tarball — refusing to install"
+        return 1
+    fi
+    if [[ "$actual_sha" != "$expected_sha" ]]; then
+        ui_error "Node.js checksum mismatch (expected $expected_sha, got $actual_sha)"
+        return 1
+    fi
+    ui_success "Node.js checksum verified"
 
     mkdir -p "$node_dir"
     if [[ "$use_xz" == "true" ]]; then

--- a/install-pinned.sh
+++ b/install-pinned.sh
@@ -28,11 +28,14 @@ die()  { printf '[openrappter] ERROR: %s\n' "$*" >&2; exit 1; }
 # bytes or an error. `main`, `HEAD` and `latest` are refused by shape, not by
 # name, so a new mutable ref cannot slip through an allowlist nobody updated.
 [ -n "$COMMIT" ] || die "OPENRAPPTER_COMMIT is required (an exact 40-character commit)."
+# Echo what the caller typed, not the case-folded value: lowercasing HEAD
+# reports it back as "Head", which reads like a bug in the installer.
+COMMIT_INPUT="$COMMIT"
 COMMIT="$(printf '%s' "$COMMIT" | tr 'A-F' 'a-f')"
 case "$COMMIT" in
-  *[!0-9a-f]* | "") die "OPENRAPPTER_COMMIT must be 40 hex characters, got: $COMMIT" ;;
+  *[!0-9a-f]* | "") die "OPENRAPPTER_COMMIT must be 40 hex characters, got: $COMMIT_INPUT" ;;
 esac
-[ "${#COMMIT}" -eq 40 ] || die "OPENRAPPTER_COMMIT must be exactly 40 characters, got ${#COMMIT}."
+[ "${#COMMIT}" -eq 40 ] || die "OPENRAPPTER_COMMIT must be exactly 40 characters, got ${#COMMIT} ($COMMIT_INPUT)."
 
 # ── 4.1/4.2/4.3 Enumerate, normalise, then refuse ────────────────────────────
 SYSTEM="$(uname -s)"

--- a/install-pinned.sh
+++ b/install-pinned.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+#
+# Install OpenRappter from an exact source commit, verifiably, with nothing
+# installed globally. Conformant with rapp-local-install/1.0:
+#   https://github.com/kody-w/rapp-local-install
+#
+# Every rule this satisfies is there because its absence is a real failure mode
+# somebody has already hit, not because it sounded rigorous.
+#
+#   OPENRAPPTER_COMMIT=<40-hex> bash install-pinned.sh
+#
+# Uninstall is `rm -rf` of one directory. There is no other footprint.
+set -euo pipefail
+
+SPEC="rapp-local-install/1.0"
+REPO="kody-w/openrappter"
+NODE_MAJOR="24"
+
+COMMIT="${OPENRAPPTER_COMMIT:-}"
+INSTALL_ROOT="${OPENRAPPTER_INSTALL_ROOT:-}"
+
+info() { printf '[openrappter] %s\n' "$*"; }
+die()  { printf '[openrappter] ERROR: %s\n' "$*" >&2; exit 1; }
+
+# ── 3.1 Pin or refuse ────────────────────────────────────────────────────────
+# A branch is not a pin. Two users running this a day apart must get identical
+# bytes or an error. `main`, `HEAD` and `latest` are refused by shape, not by
+# name, so a new mutable ref cannot slip through an allowlist nobody updated.
+[ -n "$COMMIT" ] || die "OPENRAPPTER_COMMIT is required (an exact 40-character commit)."
+COMMIT="$(printf '%s' "$COMMIT" | tr 'A-F' 'a-f')"
+case "$COMMIT" in
+  *[!0-9a-f]* | "") die "OPENRAPPTER_COMMIT must be 40 hex characters, got: $COMMIT" ;;
+esac
+[ "${#COMMIT}" -eq 40 ] || die "OPENRAPPTER_COMMIT must be exactly 40 characters, got ${#COMMIT}."
+
+# ── 4.1/4.2/4.3 Enumerate, normalise, then refuse ────────────────────────────
+SYSTEM="$(uname -s)"
+MACHINE="$(uname -m)"
+case "$SYSTEM" in
+  Darwin)
+    PLATFORM="darwin"
+    DEFAULT_ROOT="$HOME/Library/Application Support/OpenRappter"
+    ;;
+  Linux)
+    [ -r /etc/os-release ] || die "Cannot identify this Linux distribution from /etc/os-release."
+    OS_ID="$(sed -n 's/^ID=//p' /etc/os-release | head -n 1 | tr -d '\"')"
+    case "$OS_ID" in
+      ubuntu|debian) ;;
+      *) die "install-pinned.sh is tested on Ubuntu and Debian only; found ${OS_ID:-unknown}." ;;
+    esac
+    PLATFORM="linux"
+    DEFAULT_ROOT="${XDG_DATA_HOME:-$HOME/.local/share}/OpenRappter"
+    ;;
+  *) die "install-pinned.sh supports macOS and Ubuntu/Debian only; found $SYSTEM." ;;
+esac
+case "$MACHINE" in
+  x86_64|amd64)  ARCH="x64"   ;;
+  arm64|aarch64) ARCH="arm64" ;;
+  *) die "Unsupported processor architecture: $MACHINE." ;;
+esac
+
+INSTALL_ROOT="${INSTALL_ROOT:-$DEFAULT_ROOT}"
+mkdir -p "$INSTALL_ROOT"
+INSTALL_ROOT="$(cd "$INSTALL_ROOT" && pwd -P)"
+RUNTIME_ROOT="$INSTALL_ROOT/runtime"
+VERSIONS_ROOT="$INSTALL_ROOT/versions"      # 3.7 content-addressed
+SOURCE_DIR="$VERSIONS_ROOT/$COMMIT"
+mkdir -p "$RUNTIME_ROOT" "$VERSIONS_ROOT"
+
+WORK_DIR="$(mktemp -d "${TMPDIR:-/tmp}/openrappter-install.XXXXXX")"
+cleanup() { [ -n "${WORK_DIR:-}" ] && rm -rf -- "$WORK_DIR"; }
+trap cleanup EXIT
+
+sha256_file() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
+  elif command -v shasum >/dev/null 2>&1;   then shasum -a 256 "$1" | awk '{print $1}'
+  else die "No SHA-256 tool available (sha256sum or shasum). Refusing to install unverified bytes."
+  fi
+}
+
+# ── 3.2 HTTPS only, refused explicitly ───────────────────────────────────────
+download() {
+  local url="$1" dest="$2"
+  case "$url" in
+    https://*) ;;
+    *) die "Refusing non-HTTPS download: $url" ;;
+  esac
+  curl --fail --location --silent --show-error "$url" --output "$dest" \
+    || die "Download failed: $url"
+  [ -s "$dest" ] || die "Download produced an empty file: $url"
+}
+
+# ── 3.3/3.4 Verify the runtime, fail closed, check the name ──────────────────
+install_node_runtime() {
+  local channel="https://nodejs.org/dist/latest-v${NODE_MAJOR}.x"
+  local sums="$WORK_DIR/SHASUMS256.txt"
+  download "$channel/SHASUMS256.txt" "$sums"
+
+  local suffix="-${PLATFORM}-${ARCH}.tar.gz" archive
+  archive="$(awk -v s="$suffix" 'index($2, s) && substr($2, length($2)-length(s)+1) == s {print $2; exit}' "$sums")"
+  [ -n "$archive" ] || die "Node.js ${NODE_MAJOR} publishes no ${PLATFORM}-${ARCH} archive."
+
+  # 3.4 — a hash proves the bytes are unmodified, not that they are the bytes
+  # you asked for. Check the name against an expected shape as well.
+  case "$archive" in
+    node-v${NODE_MAJOR}.*-"$PLATFORM"-"$ARCH".tar.gz) ;;
+    *) die "Unexpected Node.js archive name: $archive" ;;
+  esac
+
+  local expected
+  expected="$(awk -v n="$archive" '$2 == n || $2 == "*" n {print tolower($1); exit}' "$sums")"
+  [ -n "$expected" ] || die "Node.js checksums do not list $archive."
+
+  local base="${archive%.tar.gz}"
+  RUNTIME_DIR="$RUNTIME_ROOT/$base"
+  NODE="$RUNTIME_DIR/bin/node"
+  NPM="$RUNTIME_DIR/bin/npm"
+
+  # 3.5 — re-verify what is already on disk. Presence is not integrity: a
+  # directory that exists proves only that something wrote to it once.
+  if [ -x "$NODE" ] && [ -x "$NPM" ] &&
+     [ "$(cat "$RUNTIME_DIR/.archive-sha256" 2>/dev/null || true)" = "$expected" ] &&
+     [ "$(cat "$RUNTIME_DIR/.node-sha256" 2>/dev/null || true)" = "$(sha256_file "$NODE")" ]; then
+    info "Reusing verified Node.js runtime $base."
+  else
+    info "Downloading official Node.js ${NODE_MAJOR} for ${PLATFORM}-${ARCH}."
+    download "$channel/$archive" "$WORK_DIR/$archive"
+    local actual; actual="$(sha256_file "$WORK_DIR/$archive")"
+    [ "$actual" = "$expected" ] \
+      || die "Node.js archive SHA-256 mismatch. Expected $expected, got $actual."
+
+    rm -rf -- "$RUNTIME_DIR"
+    mkdir -p "$WORK_DIR/x"
+    tar -xzf "$WORK_DIR/$archive" -C "$WORK_DIR/x"
+    [ -d "$WORK_DIR/x/$base" ] || die "Node.js archive did not contain $base."
+    mv "$WORK_DIR/x/$base" "$RUNTIME_DIR"
+    [ -x "$NODE" ] && [ -x "$NPM" ] || die "Extracted Node.js runtime is incomplete."
+    printf '%s\n' "$expected" > "$RUNTIME_DIR/.archive-sha256"
+    sha256_file "$NODE" > "$RUNTIME_DIR/.node-sha256"
+  fi
+
+  PATH="$RUNTIME_DIR/bin:$PATH"; export PATH
+
+  # 3.8 — ask the runtime what it is. An archive named darwin-arm64 that
+  # reports linux-x64 is worth learning now rather than at first run.
+  local v p a
+  v="$("$NODE" -p 'process.versions.node')"
+  p="$("$NODE" -p 'process.platform')"
+  a="$("$NODE" -p 'process.arch')"
+  [ "${v%%.*}" = "$NODE_MAJOR" ] || die "Expected Node.js ${NODE_MAJOR}, got $v."
+  [ "$p" = "$PLATFORM" ] || die "Expected platform $PLATFORM, got $p."
+  [ "$a" = "$ARCH" ]     || die "Expected architecture $ARCH, got $a."
+  NODE_VERSION="$v"
+}
+
+# ── 3.9 Completeness manifest ────────────────────────────────────────────────
+REQUIRED_FILES="
+LICENSE
+typescript/package.json
+typescript/package-lock.json
+typescript/dist/index.js
+"
+check_required_files() {
+  local d="$1" rel
+  while IFS= read -r rel; do
+    [ -z "$rel" ] && continue
+    [ -e "$d/$rel" ] || die "Installed source is missing a required file: $rel"
+  done <<EOF
+$REQUIRED_FILES
+EOF
+}
+
+# ── 3.5 Re-verify an existing install before reusing it ──────────────────────
+validate_existing_install() {
+  local d="$1" record="$1/.rapp-install.json"
+  [ -f "$record" ] || return 1
+  local pin lock_expected lock_actual
+  pin="$("$NODE" -p "JSON.parse(require('fs').readFileSync('$record','utf8')).pin" 2>/dev/null || true)"
+  [ "$pin" = "$COMMIT" ] || return 1
+  lock_expected="$("$NODE" -p "JSON.parse(require('fs').readFileSync('$record','utf8')).lockfile_sha256" 2>/dev/null || true)"
+  lock_actual="$(sha256_file "$d/typescript/package-lock.json" 2>/dev/null || true)"
+  [ -n "$lock_expected" ] && [ "$lock_expected" = "$lock_actual" ] || return 1
+  check_required_files "$d"
+  return 0
+}
+
+build_from_source() {
+  local archive="$WORK_DIR/src.tar.gz"
+  info "Downloading $REPO at $COMMIT."
+  download "https://codeload.github.com/$REPO/tar.gz/$COMMIT" "$archive"
+  SOURCE_SHA256="$(sha256_file "$archive")"
+
+  local staging="$WORK_DIR/staging"
+  mkdir -p "$staging"
+  tar -xzf "$archive" -C "$staging"
+  local extracted; extracted="$(find "$staging" -mindepth 1 -maxdepth 1 -type d | head -n 1)"
+  [ -d "$extracted" ] || die "Source archive did not contain a directory."
+
+  info "Installing dependencies from the lockfile."
+  # 3.11 — `npm ci` fails on lockfile drift; `npm install` silently resolves it.
+  ( cd "$extracted/typescript" && npm ci --no-fund --no-audit >/dev/null ) \
+    || die "npm ci failed. The lockfile and package.json disagree."
+  ( cd "$extracted/typescript" && npm run build >/dev/null ) \
+    || die "Build failed for commit $COMMIT."
+
+  check_required_files "$extracted"
+  rm -rf -- "$SOURCE_DIR"
+  mkdir -p "$(dirname "$SOURCE_DIR")"
+  mv "$extracted" "$SOURCE_DIR"
+}
+
+# ── 3.9 Provenance record ────────────────────────────────────────────────────
+write_provenance() {
+  local d="$1"
+  cat > "$d/.rapp-install.json" <<JSON
+{
+  "schema": "$SPEC",
+  "pin": "$COMMIT",
+  "pin_kind": "git-commit",
+  "installed_utc": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+  "platform": "$PLATFORM",
+  "architecture": "$ARCH",
+  "sources": [
+    {
+      "url": "https://codeload.github.com/$REPO/tar.gz/$COMMIT",
+      "sha256": "${SOURCE_SHA256:-reused}"
+    }
+  ],
+  "runtime": {
+    "name": "node",
+    "version": "$NODE_VERSION",
+    "archive_sha256": "$(cat "$RUNTIME_DIR/.archive-sha256")",
+    "binary_sha256": "$(cat "$RUNTIME_DIR/.node-sha256")"
+  },
+  "lockfile_sha256": "$(sha256_file "$d/typescript/package-lock.json")"
+}
+JSON
+}
+
+install_node_runtime
+
+if [ -d "$SOURCE_DIR" ] && validate_existing_install "$SOURCE_DIR"; then
+  info "Reusing verified install at $SOURCE_DIR."
+else
+  build_from_source
+  write_provenance "$SOURCE_DIR"
+fi
+
+# 3.6 — nothing global. One launcher inside the root; no sudo, no PATH edits,
+# no npm -g. Uninstall is `rm -rf "$INSTALL_ROOT"`.
+mkdir -p "$INSTALL_ROOT/bin"
+cat > "$INSTALL_ROOT/bin/openrappter" <<LAUNCH
+#!/usr/bin/env bash
+set -euo pipefail
+exec "$RUNTIME_DIR/bin/node" "$SOURCE_DIR/typescript/dist/index.js" "\$@"
+LAUNCH
+chmod +x "$INSTALL_ROOT/bin/openrappter"
+
+info "Installed $REPO@${COMMIT:0:12} (${PLATFORM}-${ARCH}, node $NODE_VERSION)."
+info "Launcher: $INSTALL_ROOT/bin/openrappter"
+info "Uninstall: rm -rf \"$INSTALL_ROOT\""

--- a/install.sh
+++ b/install.sh
@@ -65,11 +65,56 @@ download_file() {
     wget -q --https-only --secure-protocol=TLSv1_2 --tries=3 --timeout=20 -O "$output" "$url"
 }
 
-run_remote_bash() {
-    local url="$1"
-    local tmp
+# Third-party bootstrap scripts, pinned to an immutable revision and hashed.
+# rapp-local-install/1.0 sections 3.1 (pin or refuse) and 3.2 (never execute an
+# unverified remote script). Refresh deliberately, after reading the diff:
+#
+#   commit="$(gh api repos/Homebrew/install/commits/HEAD --jq .sha)"
+#   curl -sS "https://raw.githubusercontent.com/Homebrew/install/$commit/install.sh" | shasum -a 256
+#
+# A tag is NOT a pin - tags move. Homebrew is pinned by commit; nvm publishes
+# immutable release tags but is hash-verified regardless, because the tag being
+# immutable is a promise rather than something we can check.
+HOMEBREW_INSTALL_COMMIT="609e8f75a42bcad1ce90acaf4e15fc89aebaf026"
+HOMEBREW_INSTALL_SHA256="12479a24be3f5307eecac7cde670fad7118640f031229e964f544b1367b52a41"
+NVM_INSTALL_REF="v0.40.1"
+NVM_INSTALL_SHA256="abdb525ee9f5b48b34d8ed9fc67c6013fb0f659712e401ecd88ab989b3af8f53"
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    elif command -v shasum >/dev/null 2>&1; then
+        shasum -a 256 "$1" | awk '{print $1}'
+    else
+        return 1
+    fi
+}
+
+# Download a script, verify it against an expected SHA-256, and only then run it.
+# Fails closed on every path, including the one where no hashing tool exists -
+# an unverifiable script is not a script we run.
+run_verified_remote_bash() {
+    local url="$1" expected="$2" label="${3:-remote script}"
+    case "$url" in
+        https://*) ;;
+        *) ui_error "Refusing non-HTTPS download for $label: $url"; return 1 ;;
+    esac
+
+    local tmp actual
     tmp="$(mktempfile)"
-    download_file "$url" "$tmp"
+    if ! download_file "$url" "$tmp"; then
+        ui_error "Could not download $label - refusing to continue"
+        return 1
+    fi
+    if ! actual="$(sha256_of "$tmp")" || [[ -z "$actual" ]]; then
+        ui_error "No SHA-256 tool available - refusing to run unverified $label"
+        return 1
+    fi
+    if [[ "$actual" != "$expected" ]]; then
+        ui_error "$label checksum mismatch (expected $expected, got $actual)"
+        ui_error "Upstream changed. Review the diff, then update the pin in install.sh."
+        return 1
+    fi
     /bin/bash "$tmp"
 }
 
@@ -936,7 +981,7 @@ install_homebrew() {
     if [[ "$OS" == "macos" ]]; then
         if ! command -v brew &> /dev/null; then
             ui_info "Homebrew not found, installing"
-            run_quiet_step "Installing Homebrew" run_remote_bash "https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh"
+            run_quiet_step "Installing Homebrew" run_verified_remote_bash "https://raw.githubusercontent.com/Homebrew/install/${HOMEBREW_INSTALL_COMMIT}/install.sh" "$HOMEBREW_INSTALL_SHA256" "Homebrew installer"
 
             if [[ -f "/opt/homebrew/bin/brew" ]]; then
                 eval "$(/opt/homebrew/bin/brew shellenv)"
@@ -1132,7 +1177,7 @@ install_node() {
 
 install_node_nvm() {
     if [[ ! -d "$HOME/.nvm" ]]; then
-        run_quiet_step "Installing nvm" run_remote_bash "https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh"
+        run_quiet_step "Installing nvm" run_verified_remote_bash "https://raw.githubusercontent.com/nvm-sh/nvm/${NVM_INSTALL_REF}/install.sh" "$NVM_INSTALL_SHA256" "nvm installer"
     fi
 
     export NVM_DIR="$HOME/.nvm"
@@ -1288,29 +1333,51 @@ install_node_tarball() {
         fi
     fi
 
-    # Verify SHA-256
+    # Verify SHA-256 — FAIL CLOSED on every path (rapp-local-install/1.0 §3.3).
+    #
+    # This block used to fail OPEN three separate ways, each proceeding to
+    # install an unverified Node.js runtime:
+    #   1. checksum manifest could not be downloaded  -> warn, continue
+    #   2. tarball absent from the manifest            -> silently continue
+    #   3. neither sha256sum nor shasum on the machine -> actual_sha empty,
+    #      the != comparison never fired, silently continue
+    #
+    # The third is the one that hides: an empty computed hash compared against
+    # a real expected hash is not a match and must never be treated as "skip".
+    # A check that degrades to a no-op and reports success is worse than no
+    # check, because it also removes the suspicion that would make someone look.
     local shasums_tmp
     shasums_tmp="$(mktempfile)"
-    if download_file "https://nodejs.org/dist/v${node_ver}/SHASUMS256.txt" "$shasums_tmp" 2>/dev/null; then
-        local expected_sha actual_sha=""
-        expected_sha="$(grep "$tarball" "$shasums_tmp" | awk '{print $1}' | head -1)"
-        if [[ -n "$expected_sha" ]]; then
-            if command -v sha256sum &>/dev/null; then
-                actual_sha="$(sha256sum "$tmp_tar" | awk '{print $1}')"
-            elif command -v shasum &>/dev/null; then
-                actual_sha="$(shasum -a 256 "$tmp_tar" | awk '{print $1}')"
-            fi
-            if [[ -n "$actual_sha" && "$actual_sha" != "$expected_sha" ]]; then
-                ui_error "Node.js checksum mismatch (expected $expected_sha, got $actual_sha)"
-                return 1
-            fi
-            if [[ -n "$actual_sha" ]]; then
-                ui_success "Node.js checksum verified"
-            fi
-        fi
-    else
-        ui_warn "Could not download checksums — skipping verification"
+    if ! download_file "https://nodejs.org/dist/v${node_ver}/SHASUMS256.txt" "$shasums_tmp" 2>/dev/null; then
+        ui_error "Could not download Node.js checksums — refusing to install unverified runtime"
+        return 1
     fi
+
+    local expected_sha actual_sha=""
+    expected_sha="$(grep "$tarball" "$shasums_tmp" | awk '{print $1}' | head -1)"
+    if [[ -z "$expected_sha" ]]; then
+        ui_error "Node.js checksums do not list $tarball — refusing to install"
+        return 1
+    fi
+
+    if command -v sha256sum &>/dev/null; then
+        actual_sha="$(sha256sum "$tmp_tar" | awk '{print $1}')"
+    elif command -v shasum &>/dev/null; then
+        actual_sha="$(shasum -a 256 "$tmp_tar" | awk '{print $1}')"
+    else
+        ui_error "No SHA-256 tool available (sha256sum/shasum) — refusing to install unverified runtime"
+        return 1
+    fi
+
+    if [[ -z "$actual_sha" ]]; then
+        ui_error "Could not compute a SHA-256 for $tarball — refusing to install"
+        return 1
+    fi
+    if [[ "$actual_sha" != "$expected_sha" ]]; then
+        ui_error "Node.js checksum mismatch (expected $expected_sha, got $actual_sha)"
+        return 1
+    fi
+    ui_success "Node.js checksum verified"
 
     mkdir -p "$node_dir"
     if [[ "$use_xz" == "true" ]]; then

--- a/typescript/src/auth/profiles.ts
+++ b/typescript/src/auth/profiles.ts
@@ -129,6 +129,7 @@ export class AuthProfileStore {
       console.error('Failed to load auth profiles:', error);
       this.profiles = [];
     }
+    this.secureExistingFile();
   }
 
   save(): void {
@@ -138,8 +139,36 @@ export class AuthProfileStore {
         JSON.stringify(this.profiles, null, 2),
         { encoding: 'utf-8', mode: 0o600 }
       );
+      // The `mode` option above only applies when writeFileSync CREATES the
+      // file. On every subsequent save an existing file keeps whatever
+      // permissions it already had, so a profile store created before this
+      // option was added - or by an umask that allowed it - stays readable by
+      // everyone forever. Observed in the wild: -rw-r--r-- (0o644) on a file
+      // whose own writer specifies 0o600.
+      //
+      // chmod unconditionally. It is cheap, idempotent, and the failure it
+      // prevents is a credential file readable by every process on the box.
+      fs.chmodSync(this.profilesPath, 0o600);
     } catch (error) {
       console.error('Failed to save auth profiles:', error);
+    }
+  }
+
+  /**
+   * Repair permissions on an existing store without waiting for a write.
+   *
+   * Called at load time because the dangerous window is "the file already
+   * exists and nobody has saved since" - exactly the state a long-lived
+   * install sits in.
+   */
+  private secureExistingFile(): void {
+    try {
+      if (fs.existsSync(this.profilesPath)) {
+        const mode = fs.statSync(this.profilesPath).mode & 0o777;
+        if (mode !== 0o600) fs.chmodSync(this.profilesPath, 0o600);
+      }
+    } catch {
+      // Best effort: a store we cannot chmod is still a store we can read.
     }
   }
 }


### PR DESCRIPTION
Applies [`rapp-local-install/1.0`](https://github.com/kody-w/rapp-local-install) §3.2 and §3.3. Conformance score **3/14 → 7/14**; the remaining failures are real and listed at the bottom rather than papered over.

The spec was written by reading [`microsoft/skill-recorder`](https://github.com/microsoft/skill-recorder)'s installer line by line, which scores **13/14** and is the closest thing to a reference implementation that already existed.

## 1. Verification failed open three ways (§3.3)

The Node.js checksum block proceeded to install an **unverified runtime** on three separate paths:

| path | old behaviour |
|---|---|
| checksum manifest could not be downloaded | `ui_warn "…skipping verification"`, continue |
| tarball absent from the manifest | silently continue |
| **neither `sha256sum` nor `shasum` present** | `actual_sha` stayed empty, so `[[ -n "$actual_sha" && … ]]` never fired |

The third is the one that hides. An empty computed hash compared against a real expected hash is **not a match**, and must never be treated as "skip". All three now `return 1`.

This is the same failure class as the five-day outage: a check that degrades to a no-op and reports success is worse than no check, because it also removes the suspicion that would have made someone look.

## 2. Unverified remote script execution (§3.2)

`run_remote_bash` downloaded a script and ran it with **no pin and no hash**. It was called with:

- Homebrew's installer from **`HEAD`** — a moving reference
- nvm's installer from a **tag** — which can also move

Replaced with `run_verified_remote_bash`, which refuses non-HTTPS, refuses an undownloadable script, refuses when no hashing tool exists, and refuses on digest mismatch. Homebrew is now pinned by **commit** (`609e8f75`); both scripts carry a recorded SHA-256, with the refresh command in a comment so updating a pin is a deliberate, reviewed act.

## Proven, not asserted

Each guard was made to fire before this was committed:

```
1. non-HTTPS URL              OK: refused
2. wrong checksum             OK: refused
3. no hashing tool available  OK: refused
4. undownloadable URL         OK: refused
```

`bash -n install.sh` clean.

## Still non-conformant — deliberately not fixed here

Each needs a change larger than this PR, and hiding them would defeat the point:

- **The documented install is still `curl … | bash`** (§3.2). Fixing it means publishing a pinned release command, which is a release-process change.
- **No `versions/<pin>` layout** (§3.7), **no re-verification of installed binaries on later runs** (§3.5), **no artifact filename pattern check** (§3.4).
- **`sudo` is still used** for apt keyring writes (§3.6).
- **No explicit platform/arch allowlist** (§4.1) — currently best-effort on whatever it finds.
- **CI does not run the installer or prove the refusal** (§3.10, §4.8). skill-recorder runs its installer with `COMMIT=master` and fails if it is *accepted* — a negative test that observes the guard fire. That is the single highest-value thing to add next.

`rapp-installer` was not touched.
