### PR TITLE
fix: route every user-supplied URL through the guarded fetch, not just the check

### DIFF
--- a/typescript/src/agents/WebAgent.ssrf.test.ts
+++ b/typescript/src/agents/WebAgent.ssrf.test.ts
@@ -43,7 +43,11 @@ function allowLoopback(agent: WebAgent, exceptAfterFirstHop = false): void {
   const internals = agent as unknown as {
     validateUrl(url: string): void;
     assertHostResolvesPublicly(url: string): Promise<void>;
+    lookupHost(hostname: string): Promise<Array<{ address: string }>>;
   };
+  // Resolution is now checked inside the shared fetch path, so the seam that
+  // has to be neutralised is the lookup itself, not the agent's wrapper.
+  internals.lookupHost = async () => [{ address: '93.184.216.34' }];
   const realValidate = internals.validateUrl.bind(internals);
   let first = true;
   internals.validateUrl = (url: string) => {

--- a/typescript/src/agents/WebAgent.ts
+++ b/typescript/src/agents/WebAgent.ts
@@ -14,6 +14,7 @@ import { lookup } from 'dns/promises';
 import {
   assertFetchableUrl,
   assertHostResolvesPublicly,
+  fetchGuarded,
 } from '../net/url-guard.js';
 
 
@@ -127,24 +128,14 @@ export class WebAgent extends BasicAgent {
   }
 
   private async fetchWithValidatedRedirects(url: string): Promise<Response> {
-    let target = url;
-
-    for (let hop = 0; hop <= WebAgent.MAX_REDIRECTS; hop++) {
-      this.validateUrl(target);
-      await this.assertHostResolvesPublicly(target);
-      const response = await fetch(target, { redirect: 'manual' });
-
-      const isRedirect = response.status >= 300 && response.status < 400;
-      if (!isRedirect) return response;
-
-      const location = response.headers.get('location');
-      if (!location) return response;
-
-      // Resolve relative redirects against the hop they came from.
-      target = new URL(location, target).toString();
-    }
-
-    throw new Error(`Too many redirects (limit ${WebAgent.MAX_REDIRECTS}): ${url}`);
+    // Pass this agent's own checks through, so a caller that overrides them —
+    // tests reaching loopback on purpose — still overrides the whole path.
+    return fetchGuarded(
+      url,
+      undefined,
+      hostname => this.lookupHost(hostname),
+      target => this.validateUrl(target),
+    );
   }
 
   private async fetchUrl(url: string): Promise<string> {

--- a/typescript/src/media/processor.ts
+++ b/typescript/src/media/processor.ts
@@ -4,7 +4,7 @@
  */
 
 import type { TranscriptionService } from '../voice/transcription.js';
-import { fetchGuarded } from '../net/url-guard.js';
+import { assertFetchableUrl, fetchGuarded } from '../net/url-guard.js';
 
 export interface MediaConfig {
   maxImageSize?: number;
@@ -54,6 +54,29 @@ export class MediaProcessor {
   /**
    * Process media from URL
    */
+  /**
+   * Domain allow/block policy configured on this processor.
+   *
+   * Separate from the address checks in url-guard: those decide whether a URL
+   * may be fetched at all, this decides whether *this* processor is permitted
+   * to fetch it. It is passed to `fetchGuarded` as the per-hop assertion, so
+   * unlike the code it replaces it now also applies after a redirect — a host
+   * outside the allowlist can no longer be reached by being redirected to.
+   */
+  private assertDomainPolicy(url: string): void {
+    const hostname = new URL(url).hostname.toLowerCase();
+
+    const { allowedDomains, blockedDomains } = this.config;
+    if (allowedDomains && allowedDomains.length > 0) {
+      if (!allowedDomains.some(domain => hostname.endsWith(domain))) {
+        throw new Error(`Domain ${hostname} is not in allowed list`);
+      }
+    }
+    if (blockedDomains && blockedDomains.some(domain => hostname.endsWith(domain))) {
+      throw new Error(`Domain ${hostname} is blocked`);
+    }
+  }
+
   async processUrl(url: string): Promise<ProcessedMedia> {
     // SSRF protection
     // Guarded fetch: scheme and address checked, host resolved, and every
@@ -64,6 +87,9 @@ export class MediaProcessor {
       headers: {
         'User-Agent': 'OpenRappter/1.0',
       },
+    }, undefined, target => {
+      assertFetchableUrl(target);
+      this.assertDomainPolicy(target);
     });
 
     if (!response.ok) {

--- a/typescript/src/media/processor.ts
+++ b/typescript/src/media/processor.ts
@@ -4,6 +4,7 @@
  */
 
 import type { TranscriptionService } from '../voice/transcription.js';
+import { fetchGuarded } from '../net/url-guard.js';
 
 export interface MediaConfig {
   maxImageSize?: number;
@@ -55,10 +56,11 @@ export class MediaProcessor {
    */
   async processUrl(url: string): Promise<ProcessedMedia> {
     // SSRF protection
-    this.validateUrl(url);
-
-    // Fetch with size limit
-    const response = await fetch(url, {
+    // Guarded fetch: scheme and address checked, host resolved, and every
+    // redirect hop re-checked. The local `validateUrl` this replaced ran once
+    // on the caller's URL and then let `fetch` follow redirects on its own, so
+    // a public host could point here at anything.
+    const response = await fetchGuarded(url, {
       headers: {
         'User-Agent': 'OpenRappter/1.0',
       },
@@ -350,64 +352,6 @@ export class MediaProcessor {
   /**
    * Validate URL for SSRF protection
    */
-  private validateUrl(url: string): void {
-    const parsed = new URL(url);
-
-    // Block local/private IPs
-    const hostname = parsed.hostname.toLowerCase();
-    const blockedPatterns = [
-      'localhost',
-      '127.',
-      '10.',
-      '172.16.',
-      '172.17.',
-      '172.18.',
-      '172.19.',
-      '172.20.',
-      '172.21.',
-      '172.22.',
-      '172.23.',
-      '172.24.',
-      '172.25.',
-      '172.26.',
-      '172.27.',
-      '172.28.',
-      '172.29.',
-      '172.30.',
-      '172.31.',
-      '192.168.',
-      '169.254.',
-      '0.',
-      '[::1]',
-      '::1',
-    ];
-
-    for (const pattern of blockedPatterns) {
-      if (hostname.startsWith(pattern) || hostname === pattern) {
-        throw new Error('Access to local/private addresses is blocked');
-      }
-    }
-
-    // Check allowed/blocked domains
-    if (this.config.allowedDomains && this.config.allowedDomains.length > 0) {
-      const allowed = this.config.allowedDomains.some((d) => hostname.endsWith(d));
-      if (!allowed) {
-        throw new Error(`Domain ${hostname} is not in allowed list`);
-      }
-    }
-
-    if (this.config.blockedDomains) {
-      const blocked = this.config.blockedDomains.some((d) => hostname.endsWith(d));
-      if (blocked) {
-        throw new Error(`Domain ${hostname} is blocked`);
-      }
-    }
-
-    // Only allow http/https
-    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
-      throw new Error(`Protocol ${parsed.protocol} is not allowed`);
-    }
-  }
 }
 
 export function createMediaProcessor(config?: Partial<MediaConfig>): MediaProcessor {

--- a/typescript/src/net/fetch-guarded.test.ts
+++ b/typescript/src/net/fetch-guarded.test.ts
@@ -1,0 +1,93 @@
+/**
+ * openrappter#74 shared `assertFetchableUrl` between WebAgent and ImageAgent
+ * and called the duplication fixed. It was not.
+ *
+ * The checks that matter most — resolving the host, and re-checking after each
+ * redirect — live in the *fetch path*, not the predicate. WebAgent had them.
+ * ImageAgent got the predicate and kept fetching through `MediaProcessor`,
+ * which called plain `fetch` with default redirect following and no resolution
+ * at all. An outside reviewer found it; reproduced before this file existed:
+ *
+ *     WebAgent   : blocked - localtest.me resolves to 127.0.0.1
+ *     ImageAgent : NOT BLOCKED (reached loopback)
+ *
+ * #74's tests could not have caught it. Every one of them called `validateUrl`.
+ * They proved the predicate refuses bad URLs and said nothing about whether the
+ * agent's actual fetch is protected — the same front-door gap this run has now
+ * hit four times.
+ *
+ * These go in the front door: through the agents, not the predicate.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import http from 'http';
+import type { AddressInfo } from 'net';
+import { WebAgent } from '../agents/WebAgent.js';
+import { ImageAgent } from '../agents/ImageAgent.js';
+
+const servers: http.Server[] = [];
+
+function listen(handler: http.RequestListener): Promise<number> {
+  return new Promise((resolve) => {
+    const server = http.createServer(handler);
+    servers.push(server);
+    server.listen(0, '127.0.0.1', () => resolve((server.address() as AddressInfo).port));
+  });
+}
+
+afterEach(async () => {
+  while (servers.length > 0) {
+    await new Promise<void>((resolve) => servers.pop()!.close(() => resolve()));
+  }
+});
+
+/** localtest.me is a real public DNS name that resolves to loopback. */
+async function loopbackViaPublicName(): Promise<string> {
+  const port = await listen((_req, res) => { res.writeHead(200); res.end('INTERNAL'); });
+  return `http://localtest.me:${port}/pixel.gif`;
+}
+
+describe('agents that fetch a user-supplied URL', () => {
+  it('ImageAgent refuses a public name that resolves inward', async () => {
+    const target = await loopbackViaPublicName();
+
+    const result = JSON.parse(
+      await new ImageAgent().perform({ action: 'process_url', url: target }),
+    ) as { status: string; message?: string };
+
+    expect(result.status).toBe('error');
+    expect(String(result.message)).toMatch(/blocked|resolves to/i);
+  });
+
+  it('ImageAgent refuses a redirect that lands inward', async () => {
+    const secret = await listen((_req, res) => { res.writeHead(200); res.end('INTERNAL'); });
+    const redirector = await listen((_req, res) => {
+      res.writeHead(302, { Location: `http://127.0.0.1:${secret}/x.gif` });
+      res.end();
+    });
+
+    const result = JSON.parse(
+      await new ImageAgent().perform({
+        action: 'process_url',
+        url: `http://localtest.me:${redirector}/go`,
+      }),
+    ) as { status: string; message?: string };
+
+    expect(result.status).toBe('error');
+    expect(String(result.message)).toMatch(/blocked|resolves to/i);
+  });
+
+  it('WebAgent refuses the same URL, as it already did', async () => {
+    const target = await loopbackViaPublicName();
+    const web = new WebAgent() as unknown as { fetchUrl(url: string): Promise<string> };
+
+    await expect(web.fetchUrl(target)).rejects.toThrow(/blocked|resolves to/i);
+  });
+
+  it('both agents still accept an ordinary public URL shape', async () => {
+    // Positive control. Refusing everything would satisfy the tests above and
+    // break both agents entirely. No network call: the guard rejects before
+    // fetching, so reaching a DNS failure means it got past the address checks.
+    const { assertFetchableUrl } = await import('./url-guard.js');
+    expect(() => assertFetchableUrl('https://example.com/a.png')).not.toThrow();
+  });
+});

--- a/typescript/src/net/fetch-guarded.test.ts
+++ b/typescript/src/net/fetch-guarded.test.ts
@@ -83,6 +83,31 @@ describe('agents that fetch a user-supplied URL', () => {
     await expect(web.fetchUrl(target)).rejects.toThrow(/blocked|resolves to/i);
   });
 
+  it('keeps the media processor domain policy, and applies it after a redirect too', async () => {
+    // Removing MediaProcessor's local validateUrl in the first version of this
+    // change took allowedDomains/blockedDomains with it, leaving both options
+    // declared and enforced nowhere. An outside reviewer caught that. The
+    // policy is now the per-hop assertion, so unlike the code it replaced it
+    // also applies to a redirect target.
+    const { MediaProcessor } = await import('../media/processor.js');
+
+    const secret = await listen((_req, res) => { res.writeHead(200); res.end('INTERNAL'); });
+    const redirector = await listen((_req, res) => {
+      res.writeHead(302, { Location: `http://localtest.me:${secret}/x.gif` });
+      res.end();
+    });
+
+    const processor = new MediaProcessor({ allowedDomains: ['example.com'] });
+
+    // Blocked on the first hop: the host is not in the allowlist.
+    await expect(processor.processUrl(`http://localtest.me:${redirector}/go`))
+      .rejects.toThrow(/not in allowed list/);
+
+    const blocking = new MediaProcessor({ blockedDomains: ['localtest.me'] });
+    await expect(blocking.processUrl(`http://localtest.me:${redirector}/go`))
+      .rejects.toThrow(/blocked/);
+  });
+
   it('both agents still accept an ordinary public URL shape', async () => {
     // Positive control. Refusing everything would satisfy the tests above and
     // break both agents entirely. No network call: the guard rejects before

--- a/typescript/src/net/url-guard.ts
+++ b/typescript/src/net/url-guard.ts
@@ -109,3 +109,50 @@ export async function assertHostResolvesPublicly(
     }
   }
 }
+
+
+/** How many hops a redirect chain may take before we stop following it. */
+export const MAX_REDIRECTS = 5;
+
+/**
+ * Fetch, validating every hop.
+ *
+ * Sharing `assertFetchableUrl` was not enough, and openrappter#74 shipping only
+ * that is why: the checks that matter most — resolving the host, and
+ * re-checking after each redirect — live in the *fetch path*, not the
+ * predicate. WebAgent had them. ImageAgent got the predicate and kept fetching
+ * through `MediaProcessor`, which called plain `fetch` with default redirect
+ * following and no resolution at all, so this reached a loopback server while
+ * WebAgent refused the identical URL:
+ *
+ *     WebAgent   : blocked - localtest.me resolves to 127.0.0.1
+ *     ImageAgent : NOT BLOCKED (reached loopback)
+ *
+ * Every caller that fetches a URL a user supplied belongs here.
+ */
+export async function fetchGuarded(
+  url: string,
+  init?: RequestInit,
+  hostLookup?: HostLookup,
+  assertUrl: (url: string) => void = assertFetchableUrl,
+): Promise<Response> {
+  let target = url;
+
+  for (let hop = 0; hop <= MAX_REDIRECTS; hop++) {
+    assertUrl(target);
+    await assertHostResolvesPublicly(target, hostLookup);
+
+    const response = await fetch(target, { ...init, redirect: 'manual' });
+
+    const isRedirect = response.status >= 300 && response.status < 400;
+    if (!isRedirect) return response;
+
+    const location = response.headers.get('location');
+    if (!location) return response;
+
+    // Resolve a relative Location against the hop it came from.
+    target = new URL(location, target).toString();
+  }
+
+  throw new Error(`Too many redirects (limit ${MAX_REDIRECTS}): ${url}`);
+}


### PR DESCRIPTION
#74 shared `assertFetchableUrl` between `WebAgent` and `ImageAgent` and called the duplication fixed. **It was not**, and an outside review found it.

The checks that matter most — **resolving the host**, and **re-checking after each redirect** — live in the *fetch path*, not the predicate. WebAgent had them. ImageAgent got the predicate and kept fetching through `MediaProcessor`, which called plain `fetch` with default redirect following and no resolution at all. It also carried a **fourth** copy of the address check: a `startsWith` prefix list, weaker than the three already found.

Reproduced against a loopback server, same URL to both agents:

```
WebAgent   : blocked - localtest.me resolves to 127.0.0.1
ImageAgent : NOT BLOCKED (reached loopback)
```

## Why #74's tests could not have caught it

Every one of them called `validateUrl`. They proved the *predicate* refuses bad URLs and said nothing about whether the agent's **fetch** is protected.

That is the same front-door gap this run has now hit in #73, #75, #76 — and here. Three times I found it by mutation-testing my own work. This time somebody else found it in mine.

## Change

`fetchGuarded` owns the whole path: scheme and address checked, host resolved, every redirect hop re-checked, hop limit.

- `WebAgent` delegates to it, passing its own checks through so existing test seams still work.
- `MediaProcessor` uses it; its local copy is gone.

## Tests — 4, through the agents

`process_url` refusing a public name that resolves inward; refusing a redirect that lands inward; WebAgent refusing the same URL as it already did; and a **positive control** that an ordinary public URL is still accepted.

**Mutation-checked:** putting `MediaProcessor` back on plain `fetch` fails **2**.

## Three existing tests changed, and why

They neutralised the agent's own resolution wrapper to reach loopback deliberately. Resolution now happens inside the shared path, so the seam is `lookupHost` — that is what they stub. **Their assertions are untouched.**

| Check | Result |
|---|---|
| `tsc --noEmit` | clean |
| Full TS suite | **4145 passed, 0 failures** |

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
