### PR TITLE
fix(security): redact jwt/bearer/pem, stop blanking keyCount and publicKey

### DIFF
--- a/python/openrappter/security/secret_keys.py
+++ b/python/openrappter/security/secret_keys.py
@@ -25,9 +25,20 @@ import re
 
 #: Whole words that make a field a secret.
 _SECRET_WORDS = frozenset({
-    "apikey", "auth", "authorization", "credential", "credentials", "cookie",
-    "key", "keys", "passphrase", "passwd", "password", "pat", "secret",
+    "apikey", "auth", "authorization", "bearer", "credential", "credentials",
+    "cookie", "jwt", "passphrase", "passwd", "password", "pat", "pem", "secret",
     "secrets", "signature", "token", "tokens",
+})
+
+#: Words that make a trailing ``key`` secret.
+#:
+#: ``key`` on its own is too blunt in both directions. As a whole word it
+#: blanked ``keyCount``, ``keyId`` and ``publicKey``; dropping it would let
+#: ``apiKey`` and ``privateKey`` through. So it counts when it is what the field
+#: *is* — the last word, qualified by something that makes it sensitive.
+_SECRET_KEY_QUALIFIERS = frozenset({
+    "access", "api", "app", "auth", "client", "encryption", "master", "private",
+    "secret", "session", "signing", "ssh", "token",
 })
 
 #: Fragments unambiguous even when glued to other text.
@@ -50,7 +61,16 @@ def _split_words(key: str) -> list:
 
 def is_secret_key(key: str) -> bool:
     """True when a field of this name must never be logged verbatim."""
-    if any(word in _SECRET_WORDS for word in _split_words(key)):
+    words = _split_words(key)
+    if any(word in _SECRET_WORDS for word in words):
         return True
+
+    if words and words[-1] in ("key", "keys"):
+        # A field named exactly ``key`` is a value, not a label for one.
+        if len(words) == 1:
+            return True
+        if any(word in _SECRET_KEY_QUALIFIERS for word in words[:-1]):
+            return True
+
     lowered = key.lower()
     return any(fragment in lowered for fragment in _SECRET_FRAGMENTS)

--- a/python/tests/test_secret_keys.py
+++ b/python/tests/test_secret_keys.py
@@ -28,12 +28,18 @@ SECRET_NAMES = [
     "credential", "credentials", "authorization",
     "api_key", "api-key", "ACCESS_TOKEN", "refresh_token", "passphrase",
     "authToken", "Cookie", "signature",
+    # Missed until an outside review checked.
+    "jwt", "bearerToken", "privatePem",
+    # A trailing `key` with a qualifier that makes it sensitive.
+    "accessKey", "encryptionKey", "masterKey", "sshKey", "key", "keys",
 ]
 
 BENIGN_NAMES = [
     "monkey", "keyword", "keyboard", "author",
     "name", "port", "host", "model", "sessionId", "requestId",
     "durationMs", "outcome",
+    # Blanked by the previous rule, which counted `key` anywhere in the name.
+    "keyCount", "keyId", "publicKey", "keyspace",
 ]
 
 
@@ -91,8 +97,14 @@ class TestRuntimeAgreement:
         )
         source = ts_path.read_text(encoding="utf-8")
 
-        from openrappter.security.secret_keys import _SECRET_WORDS, _SECRET_FRAGMENTS
+        from openrappter.security.secret_keys import (
+            _SECRET_FRAGMENTS,
+            _SECRET_KEY_QUALIFIERS,
+            _SECRET_WORDS,
+        )
 
+        for word in _SECRET_KEY_QUALIFIERS:
+            assert f"'{word}'" in source, f"TypeScript is missing the qualifier {word!r}"
         for word in _SECRET_WORDS:
             assert f"'{word}'" in source, f"TypeScript is missing the word {word!r}"
         for fragment in _SECRET_FRAGMENTS:

--- a/typescript/src/security/secret-keys.test.ts
+++ b/typescript/src/security/secret-keys.test.ts
@@ -25,6 +25,10 @@ describe('isSecretKey', () => {
     // Spelling variants.
     'api_key', 'ACCESS_TOKEN', 'refresh_token', 'passphrase', 'authToken',
     'api-key', 'Cookie', 'signature',
+    // Missed until an outside review checked: no jwt, bearer or pem.
+    'jwt', 'bearerToken', 'privatePem',
+    // A trailing `key` with a qualifier that makes it sensitive.
+    'accessKey', 'encryptionKey', 'masterKey', 'sshKey', 'key', 'keys',
   ])('treats %s as secret', (key) => {
     expect(isSecretKey(key)).toBe(true);
   });
@@ -35,6 +39,10 @@ describe('isSecretKey', () => {
     // fields now that the gateway logger shares the same answer.
     'monkey', 'keyword', 'keyboard', 'author',
     'name', 'port', 'host', 'model', 'sessionId', 'requestId', 'durationMs', 'outcome',
+    // This file's own commit claimed keyCount stayed readable. It did not —
+    // `key` counted as a whole word anywhere in the name. An outside review
+    // caught the claim; these are the names it blanked.
+    'keyCount', 'keyId', 'publicKey', 'keyspace',
   ])('does not treat %s as secret', (key) => {
     expect(isSecretKey(key)).toBe(false);
   });

--- a/typescript/src/security/secret-keys.ts
+++ b/typescript/src/security/secret-keys.ts
@@ -19,9 +19,26 @@
 
 /** Whole words that make a field a secret. */
 const SECRET_WORDS = new Set([
-  'apikey', 'auth', 'authorization', 'credential', 'credentials', 'cookie',
-  'key', 'keys', 'passphrase', 'passwd', 'password', 'pat', 'secret',
+  'apikey', 'auth', 'authorization', 'bearer', 'credential', 'credentials',
+  'cookie', 'jwt', 'passphrase', 'passwd', 'password', 'pat', 'pem', 'secret',
   'secrets', 'signature', 'token', 'tokens',
+]);
+
+/**
+ * Words that make a trailing `key` secret.
+ *
+ * `key` on its own is too blunt in both directions. Treating it as a whole word
+ * blanked `keyCount`, `keyId` and `publicKey` — this file's own commit claimed
+ * `keyCount` stayed readable, and it did not, which an outside review caught.
+ * Dropping it entirely would let `apiKey` and `privateKey` through, which is
+ * the bug the word was added for.
+ *
+ * So `key` counts when it is what the field *is* — the last word, qualified by
+ * something that makes it sensitive — and not when it merely appears.
+ */
+const SECRET_KEY_QUALIFIERS = new Set([
+  'access', 'api', 'app', 'auth', 'client', 'encryption', 'master', 'private',
+  'secret', 'session', 'signing', 'ssh', 'token',
 ]);
 
 /** Fragments that are unambiguous even when glued to other text. */
@@ -41,7 +58,16 @@ function splitWords(key: string): string[] {
 }
 
 export function isSecretKey(key: string): boolean {
-  if (splitWords(key).some(word => SECRET_WORDS.has(word))) return true;
+  const words = splitWords(key);
+  if (words.some(word => SECRET_WORDS.has(word))) return true;
+
+  const last = words[words.length - 1];
+  if (last === 'key' || last === 'keys') {
+    // A field named exactly `key` is a value, not a label for one.
+    if (words.length === 1) return true;
+    if (words.slice(0, -1).some(word => SECRET_KEY_QUALIFIERS.has(word))) return true;
+  }
+
   const lowered = key.toLowerCase();
   return SECRET_FRAGMENTS.some(fragment => lowered.includes(fragment));
 }


### PR DESCRIPTION
Found by an outside review of #76 — not by the tests #76 shipped with.

#76 unified two divergent secret redactors. The unification was right; the word list it unified onto was wrong in **both** directions, and the PR description asserted a behaviour the code did not have.

### Missed — logged in the clear

`jwt`, `bearerToken`, `privatePem`

### Over-redacted — blanked when meant to be readable

`keyCount`, `keyId`, `publicKey`, `keyspace`

**This second half contradicts a claim in #76.** That PR's description stated `keyCount` stayed readable. It did not. `key` was matched as a whole word *anywhere* in the name, so `keyCount`, `keyId` and `publicKey` were all replaced with `[redacted]`. I have added a comment to #76 recording the correction, since merged history can't be rewritten.

That failure mode is worth naming: over-redaction is not the safe direction. It destroys the diagnostic value of a log while looking like diligence, and nothing fails when it happens.

### The rule now

A trailing `key`/`keys` is secret when the name is that word alone, or when it carries a qualifier — `api`, `access`, `secret`, `private`, `signing`, `encryption`, `master`, `ssh`, `session`, and so on. A *leading* `key` is a count or an identifier, not a credential. `publicKey` is public by construction.

Ported identically to Python. The cross-runtime agreement test now pins the **qualifier list** as well as the word list, so the runtimes cannot drift in either direction without a test failing.

### Mutations (secret-keys + logging, 83 tests)

| mutation | result |
|---|---|
| `SECRET_KEY_QUALIFIERS` emptied | **8 failed** — `apiKey`, `accessKey` leak |
| bare `key`/`keys` restored to word list | **3 failed** — `keyCount`, `publicKey` blanked |
| predicate always true | **17 failed** |
| qualifier deleted from the TS source | Python agreement test fails |

The second row is the direct evidence for the correction above: put the old rule back, and the names #76 promised were readable go dark.

### Suites

`4177` TS passed / 19 skipped · `1164` Python passed / 4 skipped · `tsc --noEmit` clean.