### PR TITLE
fix(logging): the logger never redacted anything

### DIFF
--- a/typescript/src/cli/__tests__/commands.test.ts
+++ b/typescript/src/cli/__tests__/commands.test.ts
@@ -8,6 +8,7 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync, readdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { fileURLToPath } from 'url';
+import { redactSecrets } from '../../security/redact.js';
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -310,24 +311,8 @@ describe('Config Dot-notation Logic', () => {
 // Secret Redaction Logic Tests
 // ---------------------------------------------------------------------------
 describe('Config Secret Redaction', () => {
-  const SECRET_KEYS = ['token', 'password', 'key', 'secret', 'apiKey', 'api_key'];
-
-  function redactSecrets(obj: unknown, depth = 0): unknown {
-    if (depth > 10) return obj;
-    if (typeof obj !== 'object' || obj === null) return obj;
-    if (Array.isArray(obj)) return obj.map((v) => redactSecrets(v, depth + 1));
-
-    const result: Record<string, unknown> = {};
-    for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-      const isSecret = SECRET_KEYS.some((sk) => k.toLowerCase().includes(sk.toLowerCase()));
-      if (isSecret && typeof v === 'string' && v.length > 0) {
-        result[k] = '***REDACTED***';
-      } else {
-        result[k] = redactSecrets(v, depth + 1);
-      }
-    }
-    return result;
-  }
+  // Was a private re-implementation with its own word list, so it asserted
+  // nothing about the redactor that actually ships. Use the real one.
 
   it('should redact token fields', () => {
     const cfg = { token: 'secret123' };

--- a/typescript/src/cli/config.ts
+++ b/typescript/src/cli/config.ts
@@ -16,7 +16,8 @@ import { promises as fs } from 'fs';
 import { join } from 'path';
 import { homedir } from 'os';
 import { spawn } from 'child_process';
-import { isSecretKey } from '../security/secret-keys.js';
+export { redactSecrets } from '../security/redact.js';
+import { redactSecrets } from '../security/redact.js';
 
 const CONFIG_DIR = join(homedir(), '.openrappter');
 const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
@@ -49,26 +50,6 @@ export function setNestedValue(obj: Record<string, unknown>, path: string, value
     return curr[key];
   }, obj);
   target[last] = value;
-}
-
-/**
- * Recursively redact secret values in a config object for safe display.
- */
-export function redactSecrets(obj: unknown, depth = 0): unknown {
-  if (depth > 10) return obj;
-  if (typeof obj !== 'object' || obj === null) return obj;
-  if (Array.isArray(obj)) return obj.map((v) => redactSecrets(v, depth + 1));
-
-  const result: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
-    const isSecret = isSecretKey(k);
-    if (isSecret && typeof v === 'string' && v.length > 0) {
-      result[k] = '***REDACTED***';
-    } else {
-      result[k] = redactSecrets(v, depth + 1);
-    }
-  }
-  return result;
 }
 
 const DEFAULT_CONFIG: Record<string, unknown> = {

--- a/typescript/src/logging/logger-redaction.test.ts
+++ b/typescript/src/logging/logger-redaction.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect } from 'vitest';
+import { Logger, type LogEntry, type Transport } from './logger.js';
+
+// Values are built at runtime. A literal secret in this file would be
+// rewritten by scanning before it ever reached the code under test, and the
+// test would then pass for the wrong reason.
+const secret = (tag: string): string => ['S3CR3T', tag, 'v1'].join('-');
+
+function capture(): { entries: LogEntry[]; transport: Transport } {
+  const entries: LogEntry[] = [];
+  return { entries, transport: { write: (e) => entries.push(e) } };
+}
+
+function loggerWith(): { entries: LogEntry[]; log: Logger } {
+  const { entries, transport } = capture();
+  return { entries, log: new Logger({ level: 'debug', transports: [transport] }) };
+}
+
+describe('Logger redaction at the front door', () => {
+  // The redactor and its word list were already tested. Nothing tested that
+  // the logger calls them, and it did not.
+  it('redacts secrets passed to info()', () => {
+    const { entries, log } = loggerWith();
+    const value = secret('info');
+
+    log.info('provider configured', { apiKey: value, model: 'gpt-4o' });
+
+    const blob = JSON.stringify(entries);
+    expect(blob).not.toContain(value);
+    expect(entries[0].data?.apiKey).toBe('***REDACTED***');
+    expect(entries[0].data?.model).toBe('gpt-4o');
+  });
+
+  it('redacts secrets nested inside the data object', () => {
+    const { entries, log } = loggerWith();
+    const value = secret('nested');
+
+    log.info('connected', { transport: { privateKey: value, port: 18790 } });
+
+    expect(JSON.stringify(entries)).not.toContain(value);
+    const transport = entries[0].data?.transport as Record<string, unknown>;
+    expect(transport.privateKey).toBe('***REDACTED***');
+    expect(transport.port).toBe(18790);
+  });
+
+  it('redacts on the error path too, which takes a separate branch', () => {
+    const { entries, log } = loggerWith();
+    const value = secret('error');
+
+    log.error('call failed', new Error('boom'), { refresh_token: value });
+
+    expect(JSON.stringify(entries)).not.toContain(value);
+    expect(entries[0].data?.refresh_token).toBe('***REDACTED***');
+    expect(entries[0].error?.message).toBe('boom');
+  });
+
+  it('redacts through a child logger, which builds a new instance', () => {
+    const { entries, transport } = capture();
+    const value = secret('child');
+
+    new Logger({ level: 'debug', transports: [transport] })
+      .child('channel:imessage')
+      .warn('transport connection failed', { authToken: value, code: 'ECONNREFUSED' });
+
+    expect(JSON.stringify(entries)).not.toContain(value);
+    expect(entries[0].data?.code).toBe('ECONNREFUSED');
+    expect(entries[0].component).toBe('channel:imessage');
+  });
+
+  it('leaves ordinary diagnostic fields readable', () => {
+    // Without this, redacting everything would satisfy the tests above and
+    // make the logs useless.
+    const { entries, log } = loggerWith();
+
+    log.info('cycle complete', {
+      count: 3,
+      durationMs: 42,
+      host: '127.0.0.1',
+      keyCount: 7,
+      publicKey: 'ssh-ed25519 AAAA',
+    });
+
+    expect(entries[0].data).toMatchObject({
+      count: 3,
+      durationMs: 42,
+      host: '127.0.0.1',
+      keyCount: 7,
+      publicKey: 'ssh-ed25519 AAAA',
+    });
+  });
+
+  it('does not emit structures too deep to have been checked', () => {
+    const { entries, log } = loggerWith();
+    const value = secret('deep');
+
+    let node: Record<string, unknown> = { apiKey: value };
+    for (let i = 0; i < 15; i++) node = { child: node };
+
+    log.info('deep', node);
+
+    expect(JSON.stringify(entries)).not.toContain(value);
+  });
+});

--- a/typescript/src/logging/logger.ts
+++ b/typescript/src/logging/logger.ts
@@ -14,6 +14,7 @@
 import fs from 'fs';
 import path from 'path';
 import chalk from 'chalk';
+import { redactSecrets } from '../security/redact.js';
 
 // ── Log level ordering ────────────────────────────────────────────────────
 
@@ -228,6 +229,13 @@ export class JsonTransport implements Transport {
 
 // ── Logger ────────────────────────────────────────────────────────────────
 
+function redactData(
+  data?: Record<string, unknown>,
+): Record<string, unknown> | undefined {
+  if (!data) return data;
+  return redactSecrets(data) as Record<string, unknown>;
+}
+
 export class Logger {
   private level: LogLevel;
   private transports: Transport[];
@@ -340,7 +348,7 @@ export class Logger {
       timestamp: new Date().toISOString(),
       component: this.component,
       correlationId: this.correlationId,
-      data,
+      data: redactData(data),
     };
 
     this.dispatch(entry);
@@ -355,7 +363,7 @@ export class Logger {
       timestamp: new Date().toISOString(),
       component: this.component,
       correlationId: this.correlationId,
-      data,
+      data: redactData(data),
       error: {
         message: err.message,
         stack: err.stack,

--- a/typescript/src/security/redact.test.ts
+++ b/typescript/src/security/redact.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest';
+import { redactSecrets, TOO_DEEP } from './redact.js';
+
+const secret = (tag: string): string => ['S3CR3T', tag, 'v1'].join('-');
+
+describe('redactSecrets beyond a string value', () => {
+  it('covers an object held under a secret name', () => {
+    const value = secret('obj');
+    const out = redactSecrets({ apiKey: { raw: value } });
+    expect(JSON.stringify(out)).not.toContain(value);
+  });
+
+  it('covers an array held under a secret name', () => {
+    const value = secret('arr');
+    const out = redactSecrets({ apiKey: [value] });
+    expect(JSON.stringify(out)).not.toContain(value);
+  });
+
+  it('covers a non-string scalar held under a secret name', () => {
+    const out = redactSecrets({ apiKey: 1234567890 }) as Record<string, unknown>;
+    expect(out.apiKey).toBe('***REDACTED***');
+  });
+
+  it('leaves an absent or empty secret alone rather than inventing one', () => {
+    const out = redactSecrets({
+      apiKey: '', token: undefined, password: null,
+    }) as Record<string, unknown>;
+    expect(out.apiKey).toBe('');
+    expect(out.token).toBeUndefined();
+    expect(out.password).toBeNull();
+  });
+});
+
+describe('the depth limit', () => {
+  it('does not pass through a structure it never inspected', () => {
+    const value = secret('deep');
+    let node: Record<string, unknown> = { apiKey: value };
+    for (let i = 0; i < 12; i++) node = { child: node };
+
+    expect(JSON.stringify(redactSecrets(node))).not.toContain(value);
+  });
+
+  it('marks where it stopped instead of dropping the structure silently', () => {
+    let node: Record<string, unknown> = { leaf: 1 };
+    for (let i = 0; i < 12; i++) node = { child: node };
+
+    expect(JSON.stringify(redactSecrets(node))).toContain(TOO_DEEP);
+  });
+
+  it('still redacts everything within reach', () => {
+    const value = secret('shallow');
+    let node: Record<string, unknown> = { apiKey: value };
+    for (let i = 0; i < 8; i++) node = { child: node };
+
+    const blob = JSON.stringify(redactSecrets(node));
+    expect(blob).not.toContain(value);
+    expect(blob).not.toContain(TOO_DEEP);
+  });
+});

--- a/typescript/src/security/redact.ts
+++ b/typescript/src/security/redact.ts
@@ -1,0 +1,42 @@
+import { isSecretKey } from './secret-keys.js';
+
+export const REDACTED = '***REDACTED***';
+
+/**
+ * Structures below this depth are replaced wholesale rather than emitted.
+ * See the note in redactSecrets for why they cannot simply be passed through.
+ */
+export const MAX_REDACT_DEPTH = 10;
+
+export const TOO_DEEP = '[nested too deep to redact]';
+
+/**
+ * Recursively replace secret values so a structure is safe to print or persist.
+ *
+ * This is the only implementation. `config show` and the logger both call it,
+ * because a redactor that some writers bypass is not a redactor.
+ */
+export function redactSecrets(obj: unknown, depth = 0): unknown {
+  // Scalars carry no keys of their own; the caller already judged the key
+  // that pointed here, so they are safe to return at any depth.
+  if (typeof obj !== 'object' || obj === null) return obj;
+
+  // Past the limit we can no longer inspect keys. Returning the structure
+  // unread would let a secret nested deeper than the limit through untouched,
+  // so the structure itself is what has to go.
+  if (depth > MAX_REDACT_DEPTH) return TOO_DEEP;
+
+  if (Array.isArray(obj)) return obj.map((v) => redactSecrets(v, depth + 1));
+
+  const result: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj as Record<string, unknown>)) {
+    if (isSecretKey(k)) {
+      // A secret name covers everything beneath it, not just a string value.
+      // `apiKey: { raw: '...' }` and `apiKey: ['...']` are still the api key.
+      result[k] = v === undefined || v === null || v === '' ? v : REDACTED;
+      continue;
+    }
+    result[k] = redactSecrets(v, depth + 1);
+  }
+  return result;
+}


### PR DESCRIPTION
The same shape as the SSRF hole an outside reviewer found in #74: the shared helper was correct and well tested, and the front door never called it.

## The logger redacted nothing

`Logger.info/warn/error/fatal` accept `Record<string, unknown>` and passed it to the transports untouched. Measured directly, with the values assembled at runtime so no scanned literal could flatter the result:

```
leaked verbatim into the log: apiKey, authToken, password, privateKey
refresh_token leaked: true
model still readable: true
```

`FileTransport` persists entries to disk with rotation, so this was a leak with a lifetime.

**Scope, honestly:** exactly one caller passes a data payload today — `imessage-runtime`, with `count` and `code`. Nothing is known to have leaked in practice. This is a latent hole, not an active breach. It is worth closing because `Logger` is the general logging surface the codebase is meant to grow into, `data` accepts arbitrary nested objects, and after #76, #77 and #83 it was the one remaining door with no guard on it.

> A methodological note. My first reproduction appeared to show `authToken` being redacted, which would have implied a third redactor. It was an artifact: the literal secret I wrote into the scratch file was rewritten by secret scanning before the code ever ran. Reported as-is, that would have been a fabricated finding produced by my own instrumentation. Every value in these tests is now built at runtime for that reason.

## Two more holes, found while fixing that one

**A secret nested 11 levels deep survived untouched.** Past the depth limit the redactor returned the structure unread, so the keys inside were never examined:

```
nested 10 levels -> secret leaked: false
nested 11 levels -> secret leaked: true
nested 20 levels -> secret leaked: true
```

Emitting a structure nobody checked is the one thing a redactor must not do. The structure is now what gets replaced.

**A secret name only covered a string value.** Both of these printed in full:

```
{"apiKey":{"raw":"S3CR3T-obj-..."}}
{"apiKey":["S3CR3T-arr-..."]}
```

A secret name now covers whatever it holds.

## One implementation

`redactSecrets` moves to `src/security/redact.ts`, beside the word list it depends on. `cli/config.ts` re-exports it.

`cli/__tests__/commands.test.ts` carried a **private copy** of `redactSecrets` plus its own `SECRET_KEYS` list — including the substring rule #83 removed as wrong. It asserted nothing about shipped code and could not fail when that code changed. It now imports the real function.

## Mutations

116 tests across `redact`, `logger`, `secret-keys` and `cli` commands.

| mutation | result |
|---|---|
| logger stops calling the redactor *(the original bug)* | **5 failed** |
| depth limit returns the structure unread | **3 failed** |
| only string values redacted *(previous behaviour)* | **3 failed** |
| redact everything | **9 failed** |
| `token` deleted from the real word **and** fragment lists | **2 failed** in `commands.test.ts` |

That last row is the point of the test change: before it, the same mutation passed.

## Suite

`4190` passed / 19 skipped · `tsc --noEmit` clean.
