### PR TITLE
fix(security): the Python redactor was flat where TypeScript recurses

### DIFF
--- a/python/openrappter/gateway/observability.py
+++ b/python/openrappter/gateway/observability.py
@@ -30,6 +30,7 @@ import threading
 import time
 from typing import Any, Dict, Optional
 
+from openrappter.security.redact import redact_secrets
 from openrappter.security.secret_keys import is_secret_key
 
 # Mutually-exclusive classification of a single RPC dispatch attempt.
@@ -170,7 +171,13 @@ def _redact_fields(fields: Optional[Dict[str, Any]]) -> Dict[str, Any]:
     for key, value in fields.items():
         if value is None:
             continue
-        safe[key] = "[REDACTED]" if is_secret_key(key) else value
+        if is_secret_key(key):
+            safe[key] = "[REDACTED]"
+            continue
+        # Unlike the TypeScript side, nothing here stops a caller passing a
+        # nested dict, so a mislabeled field one level down has to be caught
+        # at runtime or not at all.
+        safe[key] = redact_secrets(value, "[REDACTED]", 1)
     return safe
 
 

--- a/python/openrappter/security/redact.py
+++ b/python/openrappter/security/redact.py
@@ -1,0 +1,52 @@
+"""Recursively replace secret values so a structure is safe to print or persist.
+
+The TypeScript side is protected at two levels: `GatewayLogFields` forbids
+nested values, and every call site passes a literal object of scalars, so the
+compiler actually enforces flatness. Python has neither. `Dict[str, Any]`
+permits any shape and nothing checks it, which makes the runtime guard the
+only line of defence rather than a second one.
+
+Mirrors typescript/src/security/redact.ts. Kept in step by
+tests/test_redact.py, which runs the same cases through both runtimes.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from openrappter.security.secret_keys import is_secret_key
+
+REDACTED = "***REDACTED***"
+
+# Structures below this depth are replaced wholesale rather than emitted.
+MAX_REDACT_DEPTH = 10
+
+TOO_DEEP = "[nested too deep to redact]"
+
+
+def redact_secrets(value: Any, placeholder: str = REDACTED, depth: int = 0) -> Any:
+    """Return ``value`` with anything under a secret-looking name replaced."""
+    # Scalars carry no keys of their own; the caller already judged the key
+    # that pointed here, so they are safe to return at any depth.
+    if not isinstance(value, (dict, list, tuple)):
+        return value
+
+    # Past the limit we can no longer inspect keys. Returning the structure
+    # unread would let a secret nested deeper than the limit through
+    # untouched, so the structure itself is what has to go.
+    if depth > MAX_REDACT_DEPTH:
+        return TOO_DEEP
+
+    if isinstance(value, (list, tuple)):
+        return [redact_secrets(item, placeholder, depth + 1) for item in value]
+
+    safe: dict[str, Any] = {}
+    for key, item in value.items():
+        if is_secret_key(str(key)):
+            # A secret name covers everything beneath it, not just a string.
+            # `api_key: {"raw": ...}` and `api_key: [...]` are still the key.
+            empty = item is None or (isinstance(item, str) and item == "")
+            safe[key] = item if empty else placeholder
+            continue
+        safe[key] = redact_secrets(item, placeholder, depth + 1)
+    return safe

--- a/python/tests/test_redact.py
+++ b/python/tests/test_redact.py
@@ -1,0 +1,158 @@
+"""The Python redactor, and proof it agrees with the TypeScript one.
+
+The word list already had a cross-runtime test. The *walker* did not, which is
+how the two came to disagree: TypeScript recursed and Python did not, so a
+secret one level down was printed by one runtime and hidden by the other.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from openrappter.gateway.observability import _redact_fields
+from openrappter.security.redact import MAX_REDACT_DEPTH, TOO_DEEP, redact_secrets
+
+
+def secret(tag: str) -> str:
+    """Build the value at runtime; a literal would be rewritten by scanning."""
+    return "-".join(["S3CR3T", tag, "v1"])
+
+
+class TestGatewayFields:
+    def test_a_secret_nested_in_a_dict_does_not_reach_the_log(self):
+        value = secret("nested")
+        out = repr(_redact_fields({"context": {"api_key": value}, "status": 200}))
+        assert value not in out
+
+    def test_a_secret_inside_a_list_does_not_reach_the_log(self):
+        value = secret("listed")
+        out = repr(_redact_fields({"items": [{"api_key": value}]}))
+        assert value not in out
+
+    def test_flat_secrets_are_still_caught(self):
+        value = secret("flat")
+        out = _redact_fields({"api_key": value, "status": 200})
+        assert out["api_key"] == "[REDACTED]"
+
+    def test_ordinary_fields_stay_readable(self):
+        # Without this, redacting everything would satisfy the tests above.
+        out = _redact_fields(
+            {"host": "127.0.0.1", "port": 18790, "outcome": "success", "duration_ms": 4.2}
+        )
+        assert out == {
+            "host": "127.0.0.1",
+            "port": 18790,
+            "outcome": "success",
+            "duration_ms": 4.2,
+        }
+
+
+class TestDepthLimit:
+    def test_it_does_not_pass_through_a_structure_it_never_inspected(self):
+        value = secret("deep")
+        node = {"api_key": value}
+        for _ in range(MAX_REDACT_DEPTH + 4):
+            node = {"child": node}
+
+        assert value not in repr(redact_secrets(node))
+
+    def test_it_marks_where_it_stopped(self):
+        node = {"leaf": 1}
+        for _ in range(MAX_REDACT_DEPTH + 4):
+            node = {"child": node}
+
+        assert TOO_DEEP in repr(redact_secrets(node))
+
+    def test_everything_within_reach_is_still_redacted(self):
+        value = secret("shallow")
+        node = {"api_key": value}
+        for _ in range(5):
+            node = {"child": node}
+
+        rendered = repr(redact_secrets(node))
+        assert value not in rendered
+        assert TOO_DEEP not in rendered
+
+
+class TestSecretNameCoversWhatItHolds:
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {"api_key": {"raw": secret("obj")}},
+            {"api_key": [secret("arr")]},
+        ],
+        ids=["object value", "list value"],
+    )
+    def test_a_secret_name_covers_a_structured_value(self, payload):
+        rendered = repr(redact_secrets(payload))
+        assert "S3CR3T" not in rendered
+
+    def test_a_non_string_scalar_under_a_secret_name_is_redacted(self):
+        assert redact_secrets({"api_key": 1234567890})["api_key"] == "***REDACTED***"
+
+    def test_an_absent_secret_is_left_alone_rather_than_invented(self):
+        out = redact_secrets({"api_key": "", "token": None})
+        assert out["api_key"] == ""
+        assert out["token"] is None
+
+
+TS_REDACT = (
+    Path(__file__).resolve().parents[2] / "typescript" / "src" / "security" / "redact.ts"
+)
+
+
+class TestRuntimeAgreement:
+    """The two walkers must make the same decisions, not merely exist."""
+
+    def test_the_typescript_walker_shares_the_limit_and_the_marker(self):
+        source = TS_REDACT.read_text(encoding="utf-8")
+
+        match = re.search(r"MAX_REDACT_DEPTH = (\d+)", source)
+        assert match, "TypeScript no longer declares MAX_REDACT_DEPTH"
+        assert int(match.group(1)) == MAX_REDACT_DEPTH, (
+            "the runtimes would stop recursing at different depths"
+        )
+        assert f"'{TOO_DEEP}'" in source, "the runtimes would mark the cut differently"
+
+    @pytest.mark.skipif(
+        not (TS_REDACT.parents[2] / "node_modules" / ".bin" / "tsx").exists(),
+        reason="TypeScript toolchain not installed",
+    )
+    def test_both_runtimes_redact_the_same_cases(self, tmp_path):
+        cases = {
+            "flat": {"api_key": secret("a"), "port": 18790},
+            "nested": {"context": {"api_key": secret("b")}},
+            "in a list": {"items": [{"api_key": secret("c")}]},
+            "object value": {"api_key": {"raw": secret("d")}},
+            "readable": {"host": "127.0.0.1", "key_count": 7, "public_key": "ssh-x"},
+        }
+
+        ts_root = TS_REDACT.parents[2]
+        script = tmp_path / "agree.ts"
+        script.write_text(
+            "import { redactSecrets } from "
+            f"'{TS_REDACT.with_suffix('.js')}';\n"
+            "const cases = JSON.parse(process.argv[2]);\n"
+            "const out: Record<string, unknown> = {};\n"
+            "for (const [name, value] of Object.entries(cases)) "
+            "out[name] = redactSecrets(value);\n"
+            "console.log(JSON.stringify(out));\n",
+            encoding="utf-8",
+        )
+
+        result = subprocess.run(
+            [str(ts_root / "node_modules" / ".bin" / "tsx"), str(script), json.dumps(cases)],
+            capture_output=True,
+            text=True,
+            cwd=ts_root,
+        )
+        assert result.returncode == 0, result.stderr
+
+        typescript = json.loads(result.stdout)
+        python = {name: redact_secrets(value) for name, value in cases.items()}
+        assert typescript == python


### PR DESCRIPTION
#85 made the TypeScript redactor recursive. Python kept a flat one, so from that commit the two runtimes disagreed about what a log line may contain — the same field hidden by one and printed by the other.

Measured, with values built at runtime so no scanned literal could flatter the result:

```
flat         leaked: False
nested       leaked: True
in a list    leaked: True
obj-valued   leaked: False
```

## Why the flat version was defensible in TypeScript and not here

The TypeScript side is protected twice over. `GatewayLogFields` is `Record<string, string | number | boolean | undefined>`, and I checked every call site — all of them pass a literal object of scalars, so the compiler genuinely enforces flatness. Recursion there would be dead code, which is why I left it alone.

Python's signature is `Dict[str, Any]` and nothing checks it, at compile time or otherwise. The docstring called the function "defense in depth" against "a mislabeled field" — but a mislabeled *nested* field is precisely the case it failed, and it is the only line of defence, not the second one.

**Scope, honestly:** no caller nests today — `host`, `port`, `transport`, `outcome`, `duration_ms`. Nothing is known to have leaked. This closes a latent gap, and more usefully stops the runtimes diverging.

## Also ported from #85

- A structure below the depth limit is **replaced** rather than emitted unread. Previously a secret nested past the limit was returned without its keys ever being examined.
- A secret name covers whatever it holds — `api_key: {"raw": ...}` and `api_key: [...]` are still the key.

## The walker had no cross-runtime test, which is how it drifted

The *word list* has had a cross-runtime agreement test since #77. The *walker* never did — so #85 could change one runtime's traversal and nothing noticed.

`tests/test_redact.py` now runs the same cases through both runtimes via `tsx` and compares the output, and separately pins the shared depth limit and marker.

## Mutations (13 tests)

| mutation | result |
|---|---|
| gateway stops recursing *(the original bug)* | **2 failed** |
| depth limit returns the structure unread | **2 failed** |
| secret name covers only string values | **4 failed** |
| TypeScript changes `MAX_REDACT_DEPTH` to 6 | **1 failed** |

The last row is the one that matters: the drift this PR fixes would now be caught the moment it reappears.

## Suites

`1177` Python passed / 4 skipped · TypeScript security `167` passed.
