### PR TITLE
test: ask the CLI what it registers, instead of reading the source

### DIFF
--- a/typescript/src/__tests__/parity/cli-commands.test.ts
+++ b/typescript/src/__tests__/parity/cli-commands.test.ts
@@ -5,9 +5,13 @@ import { join } from 'path';
 /**
  * Parity Test: CLI Commands
  *
- * Validates the CLI command registration system structure by analyzing
- * the source files directly. This approach avoids import issues that
- * may occur during testing when some modules have unresolved dependencies.
+ * Checks the *shape* of the CLI source tree: that the command modules exist
+ * and export what index.ts re-exports.
+ *
+ * It deliberately does not tell you whether any of those commands is reachable.
+ * Reading the source cannot: twelve of these modules are fully implemented,
+ * exported, and never registered on the program, and every assertion here
+ * passes anyway. cli-registration.test.ts asks the CLI itself.
  */
 
 const CLI_DIR = join(__dirname, '../../cli');

--- a/typescript/src/__tests__/parity/cli-registration.test.ts
+++ b/typescript/src/__tests__/parity/cli-registration.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFileSync } from 'child_process';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+/**
+ * What the CLI actually exposes, asked of the CLI.
+ *
+ * The neighbouring cli-commands.test.ts reads the source files instead. That
+ * is why twelve fully implemented command modules under src/cli could sit
+ * unregistered without a single test going red: the files were present and
+ * exported, and nothing ever asked the program what it had registered.
+ */
+
+const ENTRY = join(__dirname, '../../index.ts');
+
+/** Commands the CLI is known to expose. Each is asserted individually. */
+const REGISTERED = [
+  'onboard',
+  'service',
+  'imessage',
+  'reset',
+  'bar',
+  'channel',
+  'call',
+  'twin',
+  'cron',
+];
+
+let commands: string[];
+
+function parseCommands(help: string): string[] {
+  const section = help.slice(help.indexOf('Commands:'));
+  return section
+    .split('\n')
+    .slice(1)
+    .map((line) => line.match(/^\s{2}([a-z][a-z-]*)/)?.[1])
+    .filter((name): name is string => Boolean(name));
+}
+
+beforeAll(() => {
+  // A throwaway HOME so nothing here can read or write the real config.
+  const home = mkdtempSync(join(tmpdir(), 'openrappter-cli-'));
+  const help = execFileSync(
+    'npx',
+    ['tsx', ENTRY, '--help'],
+    { encoding: 'utf-8', env: { ...process.env, HOME: home }, timeout: 120_000 },
+  );
+  commands = parseCommands(help);
+}, 180_000);
+
+describe('CLI command registration, observed from outside', () => {
+  it.each(REGISTERED)('registers %s', (name) => {
+    expect(commands).toContain(name);
+  });
+
+  it('parses a plausible command list at all', () => {
+    // Guards the parser above: if --help changed shape, every assertion in
+    // this file would pass vacuously against an empty list.
+    expect(commands.length).toBeGreaterThanOrEqual(REGISTERED.length);
+  });
+});


### PR DESCRIPTION
## Twelve command modules are never registered

`src/cli/` contains fully implemented, exported command modules for `agents`, `channels`, `config`, `doctor`, `gateway`, `login`, `memory`, `models`, `send`, `sessions`, `skills` and `update`. `src/index.ts` registers `registerCronCommand`, `registerTelephonyCommands` and `registerTwinCommands`, and nothing else.

```
$ openrappter --help
Commands:
  onboard  service  imessage  reset  bar  channel  call  twin  cron
```

## Why nothing went red

The test that covers this reads the source tree:

```ts
it('should have all expected command files', () => {
  const files = readdirSync(CLI_DIR);
  for (const expectedFile of expectedFiles) expect(files).toContain(expectedFile);
});
```

Its docstring claimed it "validates the CLI command registration system structure". It lists a directory. Every file is present, so it passes — and would keep passing if `index.ts` registered nothing at all.

## The replacement

`cli-registration.test.ts` spawns the CLI with a throwaway `HOME` and asserts each command appears in `--help`. Comment out `registerCronCommand(program)`:

| test | result |
|---|---|
| `cli-registration.test.ts` *(new)* | **2 failed** |
| `cli-commands.test.ts` *(existing)* | 26 passed |

That contrast is the entire argument for this change.

The old file is kept — checking module shape is fine — but its docstring now says what it actually does and points here.

## Deliberately not fixed

This pins what is registered **today**. It does not assert the twelve are absent, so wiring any of them up will not fail it.

Whether they should be wired is a product decision, and registering never-exercised modules wholesale would add surface like `config reset` that nothing has tested. Filed separately, with one finding worth repeating here: `typescript/skills/healthcheck/SKILL.md` instructs users to run `openrappter config validate`, which does not exist. It falls through to the chat default, answers conversationally, and **exits 0** — so a script gating on it passes while nothing is validated.

## Suite

`4200` passed / 19 skipped · `tsc --noEmit` clean.
