### PR TITLE
fix(agents): a file that fails to load leaves no trace

### DIFF
--- a/typescript/src/agents/AgentRegistry.ts
+++ b/typescript/src/agents/AgentRegistry.ts
@@ -63,6 +63,15 @@ export class AgentRegistry {
   private userAgentsDir: string;
   private agents: Map<string, BasicAgent> = new Map();
   private loaded = false;
+  /**
+   * Why a file on disk did not become an agent, keyed by path.
+   *
+   * A failed load used to be discarded, so a capability could disappear with
+   * no signal anywhere: the sweep is deliberately resilient, but resilient is
+   * not the same as silent. Keyed by path so a re-scan of a fixed file clears
+   * its own entry.
+   */
+  private loadFailures: Map<string, string> = new Map();
 
   constructor(
     agentsDir: string,
@@ -119,8 +128,9 @@ export class AgentRegistry {
               this.agents.set(instance.name, instance);
             }
           }
-        } catch {
-          // Skip agents that fail to load
+          this.loadFailures.delete(modulePath);
+        } catch (error) {
+          this.noteLoadFailure(path.join(this.agentsDir, file), error);
         }
       }
     } catch {
@@ -157,8 +167,9 @@ export class AgentRegistry {
               }
             }
           }
-        } catch {
-          // Skip agents that fail to load
+          this.loadFailures.delete(filePath);
+        } catch (error) {
+          this.noteLoadFailure(path.join(this.userAgentsDir, file), error);
         }
       }
     } catch {
@@ -182,7 +193,12 @@ export class AgentRegistry {
       const filePath = path.join(this.userAgentsDir, file);
       try {
         const found = await introspectPythonAgents(filePath);
-        if (!found.ok) continue; // a broken file is not a reason to fail the sweep
+        if (!found.ok) {
+          // A broken file is not a reason to fail the sweep, but it is a
+          // reason to be able to say which file and why.
+          this.loadFailures.set(filePath, found.error);
+          continue;
+        }
         for (const descriptor of found.agents) {
           // A re-dropped file must replace its own agent rather than being
           // ignored as a duplicate, or editing an agent would never take.
@@ -191,10 +207,26 @@ export class AgentRegistry {
           if (existing && !isOurs) continue;
           this.agents.set(descriptor.name, new PythonAgent(filePath, descriptor));
         }
-      } catch {
-        // Skip agents that fail to load
+        this.loadFailures.delete(filePath);
+      } catch (error) {
+        this.noteLoadFailure(filePath, error);
       }
     }
+  }
+
+  private noteLoadFailure(file: string, error: unknown): void {
+    this.loadFailures.set(file, error instanceof Error ? error.message : String(error));
+  }
+
+  /**
+   * Files that failed to become agents, and why.
+   *
+   * The sweep keeps going when a file is broken — one bad agent must not cost
+   * you the rest. This is how the failure stays visible instead of the
+   * capability just being absent.
+   */
+  getLoadFailures(): Array<{ file: string; reason: string }> {
+    return Array.from(this.loadFailures, ([file, reason]) => ({ file, reason }));
   }
 
   async getAgent(name: string): Promise<BasicAgent | undefined> {

--- a/typescript/src/agents/__tests__/load-failures.test.ts
+++ b/typescript/src/agents/__tests__/load-failures.test.ts
@@ -1,0 +1,92 @@
+/**
+ * A file that fails to become an agent must still be accounted for.
+ *
+ * The sweep is deliberately resilient — one broken file must not cost you
+ * every other agent. But every failure path discarded its error, so the only
+ * evidence was an absence: the capability was simply missing, with nothing
+ * anywhere saying which file or why.
+ */
+
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
+
+import { AgentRegistry } from '../AgentRegistry.js';
+
+let dir = '';
+let registry: AgentRegistry;
+
+function workingAgent(cls: string, name: string): string {
+  return `from agents.basic_agent import BasicAgent
+import json
+
+class ${cls}(BasicAgent):
+    def __init__(self):
+        self.name = '${name}'
+        self.metadata = {
+            "name": self.name,
+            "description": "works",
+            "parameters": {"type": "object", "properties": {}, "required": []}
+        }
+        super().__init__(name=self.name, metadata=self.metadata)
+
+    def perform(self, **kwargs):
+        return json.dumps({"status": "success", "result": "ran ${name}"})
+`;
+}
+
+beforeEach(async () => {
+  dir = await fs.mkdtemp(path.join(os.tmpdir(), 'openrappter-loadfail-'));
+  registry = new AgentRegistry(path.join(dir, '__no_builtins__'), dir);
+});
+
+afterEach(async () => {
+  await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('a file that cannot become an agent', () => {
+  it('is reported, with the file and a reason', async () => {
+    await fs.writeFile(path.join(dir, 'broken_agent.py'), 'this is not valid python(\n');
+
+    await registry.reloadUserAgents();
+
+    const failures = registry.getLoadFailures();
+    expect(failures).toHaveLength(1);
+    expect(failures[0].file).toContain('broken_agent.py');
+    expect(failures[0].reason.length).toBeGreaterThan(0);
+  });
+
+  it('does not cost the sweep the agents that do load', async () => {
+    // The whole reason the errors were swallowed. Keep that property.
+    await fs.writeFile(path.join(dir, 'broken_agent.py'), 'nope(\n');
+    await fs.writeFile(path.join(dir, 'good_agent.py'), workingAgent('GoodAgent', 'Good'));
+
+    await registry.reloadUserAgents();
+
+    const agents = await registry.getAllAgents();
+    expect([...agents.keys()]).toContain('Good');
+    expect(registry.getLoadFailures().map((f) => f.file).join()).toContain('broken_agent.py');
+  });
+
+  it('reports nothing when every file loads', async () => {
+    // Without this, always reporting a failure would satisfy the tests above.
+    await fs.writeFile(path.join(dir, 'good_agent.py'), workingAgent('GoodAgent', 'Good'));
+
+    await registry.reloadUserAgents();
+
+    expect(registry.getLoadFailures()).toEqual([]);
+  });
+
+  it('clears the entry once the file is fixed and rescanned', async () => {
+    const file = path.join(dir, 'later_agent.py');
+    await fs.writeFile(file, 'still broken(\n');
+    await registry.reloadUserAgents();
+    expect(registry.getLoadFailures()).toHaveLength(1);
+
+    await fs.writeFile(file, workingAgent('LaterAgent', 'Later'));
+    await registry.reloadUserAgents();
+
+    expect(registry.getLoadFailures()).toEqual([]);
+  });
+});


### PR DESCRIPTION
## A capability could disappear with nothing to show for it

Four places in `AgentRegistry` discarded the reason a file did not become an agent:

```ts
catch { /* Skip agents that fail to load */ }   // x3
if (!found.ok) continue;                        // the reason was right there
```

The resilience is correct — one broken file must not cost you every other agent. But **resilient and silent are not the same thing**. The only evidence of a failure was an absence: the agent was missing, and nothing anywhere said which file or why. `introspectPythonAgents` already returns `{ ok: false, error }`, and that error was thrown away.

Failures are now recorded per path and exposed via `getLoadFailures()`. Keyed by path, so re-scanning a fixed file clears its own entry instead of accumulating stale reports.

## Mutations

18 tests, run together with `hot-load.test.ts` so the resilience property is proven to survive.

| mutation | result |
|---|---|
| python failure discarded again *(the original bug)* | **3 failed** |
| accessor always returns empty | **3 failed** |
| every file recorded as failed | **2 failed** |

The last row is there because "always report a failure" would otherwise satisfy the other tests.

## Two harness errors, recorded because both produced wrong answers first

I do not want these buried, since in both cases my instrumentation looked exactly like a product bug:

1. The first fixture asserted through `registry.list()`, which does not exist — the real method is `listAgents()`. It reported *zero agents loaded* and looked like a catastrophic loader failure.
2. The second called `discoverAgents()`, which skips the user sweep entirely when the built-in directory is absent (`builtinFound` gates it). That is precisely why `hot-load.test.ts` drives `reloadUserAgents()` instead. Again it looked like nothing loaded.

Neither was a defect in the registry. This is the third time this run that a harness produced a confident false finding, after the secret-scanner rewriting a test literal in #85.

## Scope

`getLoadFailures()` is added but nothing consumes it yet — surfacing it in `openrappter doctor` or the gateway would be the natural follow-up, and belongs with the CLI registration decision in #88.

## Suite

`4210` passed / 19 skipped · `tsc --noEmit` clean.
