### PR TITLE
fix(agents): warn when an agent file fails to load, like Python already does

### DIFF
--- a/typescript/src/agents/AgentRegistry.ts
+++ b/typescript/src/agents/AgentRegistry.ts
@@ -12,6 +12,7 @@ import { pathToFileURL } from 'url';
 import { BasicAgent } from './BasicAgent.js';
 import { PythonAgent, introspectPythonAgents } from './PythonAgent.js';
 import type { AgentInfo } from './types.js';
+import { logger } from '../logging/logger.js';
 
 /**
  * Subdirectories a conforming kernel never auto-loads.
@@ -57,6 +58,8 @@ async function walkAgentFiles(dir: string, prefix = ''): Promise<string[]> {
   }
   return out;
 }
+
+const registryLog = logger.child('agents');
 
 export class AgentRegistry {
   private agentsDir: string;
@@ -196,7 +199,7 @@ export class AgentRegistry {
         if (!found.ok) {
           // A broken file is not a reason to fail the sweep, but it is a
           // reason to be able to say which file and why.
-          this.loadFailures.set(filePath, found.error);
+          this.noteLoadFailure(filePath, found.error);
           continue;
         }
         for (const descriptor of found.agents) {
@@ -215,7 +218,11 @@ export class AgentRegistry {
   }
 
   private noteLoadFailure(file: string, error: unknown): void {
-    this.loadFailures.set(file, error instanceof Error ? error.message : String(error));
+    const reason = error instanceof Error ? error.message : String(error);
+    this.loadFailures.set(file, reason);
+    // Recording it is not the same as anyone seeing it. The Python registry
+    // has always warned here; this is the half that reaches an operator.
+    registryLog.warn('Agent file failed to load', { file, reason });
   }
 
   /**

--- a/typescript/src/agents/__tests__/load-failures.test.ts
+++ b/typescript/src/agents/__tests__/load-failures.test.ts
@@ -13,6 +13,7 @@ import os from 'os';
 import path from 'path';
 
 import { AgentRegistry } from '../AgentRegistry.js';
+import { logger, type LogEntry, type Transport } from '../../logging/logger.js';
 
 let dir = '';
 let registry: AgentRegistry;
@@ -43,6 +44,26 @@ beforeEach(async () => {
 
 afterEach(async () => {
   await fs.rm(dir, { recursive: true, force: true });
+});
+
+describe('the failure reaches an operator, not just an accessor', () => {
+  it('warns, the way the Python registry always has', async () => {
+    // getLoadFailures() only helps something that calls it, and nothing does.
+    const entries: LogEntry[] = [];
+    const capture: Transport = { write: (e) => entries.push(e) };
+    logger.addTransport(capture);
+    try {
+      await fs.writeFile(path.join(dir, 'broken_agent.py'), 'not python(\n');
+      await registry.reloadUserAgents();
+    } finally {
+      logger.removeTransport(capture);
+    }
+
+    const warning = entries.find((e) => e.level === 'warn' && e.component === 'agents');
+    expect(warning).toBeDefined();
+    expect(String(warning?.data?.file)).toContain('broken_agent.py');
+    expect(String(warning?.data?.reason).length).toBeGreaterThan(0);
+  });
 });
 
 describe('a file that cannot become an agent', () => {


### PR DESCRIPTION
Follow-up to #89, closing the half I flagged there.

#89 recorded load failures and exposed `getLoadFailures()`. Its own PR body noted that **nothing consumes it** — so in practice an operator still saw nothing when an agent silently vanished.

## Python is the precedent, not an invention

The Python registry has warned at every one of these points all along:

```python
logging.warning(f"Failed to load {file_path}: {e}")   # openrappter/cli.py
```

I went looking for the same swallow-the-error bug in Python and **did not find it** — Python was already correct. TypeScript was the outlier in both halves: it discarded the reason (fixed in #89), and it had no operator-visible signal (fixed here).

## The test found a gap in #89's own change

The `!found.ok` branch — the ordinary path for a malformed Python agent — set the failure map *directly* and never went through `noteLoadFailure`. So the most common real-world case would have recorded but not warned. It now shares the single path.

That is why the test asserts on the log output rather than the accessor: asserting on `getLoadFailures()` would have passed.

## Safe to log

Since #85 the logger redacts its `data` payload, so a path or error string containing something secret-looking is blanked rather than persisted by `FileTransport`.

## Mutations

| mutation | result |
|---|---|
| warning removed, accessor still records | **1 failed** |
| `!found.ok` bypasses the shared path again *(the bug above)* | **1 failed** |

## Suite

`4212` passed / 19 skipped · `tsc --noEmit` clean.
