### PR TITLE
Distinguish ring not provisioned from ring provisioned and broken

### DIFF
--- a/.github/workflows/ring-dispatch.yml
+++ b/.github/workflows/ring-dispatch.yml
@@ -23,8 +23,27 @@ concurrency:
 jobs:
   dispatch:
     runs-on: ubuntu-latest
+    # "Not provisioned yet" and "provisioned and broken" are different facts and
+    # must not share a colour. Unset -> this job is SKIPPED, which GitHub shows
+    # as skipped rather than green: visibly not run, never falsely passing.
+    # Set -> it runs, and a missing token fails loudly below instead of dying on
+    # `gh: set the GH_TOKEN environment variable` with exit 4.
+    if: vars.RING_ENABLED == 'true'
     steps:
       - uses: actions/checkout@v4
+
+      - name: Refuse to dispatch without the credential
+        env:
+          RING_DISPATCH_TOKEN: ${{ secrets.RING_DISPATCH_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [ -z "${RING_DISPATCH_TOKEN}" ]; then
+            echo "::error::RING_ENABLED is true but RING_DISPATCH_TOKEN is not set." >&2
+            echo "Create a fine-grained PAT with contents:write on kody-w/openrappter-canary" >&2
+            echo "only, add it as the repository secret RING_DISPATCH_TOKEN, and re-run." >&2
+            exit 1
+          fi
+          echo "RING_DISPATCH_TOKEN present"
 
       - name: Record production latest so the ring can prove it did not move
         id: prod


### PR DESCRIPTION
**Closes #105.** Implemented from that issue's three-state table.

I merged #39, so this is my regression and I am reporting it against myself.

## What broke

`Ring — dispatch to canary` has failed on **every qualifying push** since #39 landed. `secrets.RING_DISPATCH_TOKEN` does not exist, so `GH_TOKEN` resolves to empty and `gh` dies with:

```
GH_TOKEN:
gh: To use GitHub CLI in a GitHub Actions workflow, set the GH_TOKEN environment variable.
##[error]Process completed with exit code 4
```

That message names `GH_TOKEN` — not the secret you actually have to create.

## Not the problem

All four ring repos exist. Checked, not assumed:

`openrappter-canary` · `openrappter-nightly` · `openrappter-alpha` · `openrappter-beta`

The design is sound. The only gap is a credential, and **a PAT can only be minted by the owner.**

## Why both obvious fixes are wrong

- **Leave it red** — correct today, but it fails forever on every push, and a permanently-red check is one people learn to scroll past. That is how five days of no-ops went unnoticed in this estate.
- **Exit 0 when the token is missing** — worse. A dispatch that silently does nothing while reporting success is the exact shape this repo keeps getting burned by.

## What this does instead

| `RING_ENABLED` | token | result |
|---|---|---|
| unset | — | job **skipped** — GitHub renders it as skipped, not green |
| `true` | missing | **fails loudly**, naming `RING_DISPATCH_TOKEN` and the scope to grant |
| `true` | present | dispatches as designed |

"Not provisioned yet" and "provisioned and broken" are different facts and should not share a colour.

## Verified both ways

```
empty token   -> exit 1, "::error::RING_ENABLED is true but RING_DISPATCH_TOKEN is not set."
token present -> exit 0, "RING_DISPATCH_TOKEN present"
```

## To enable (owner-only)

1. Mint a fine-grained PAT with `contents: write` on `kody-w/openrappter-canary` **only**
2. Add it as repository secret `RING_DISPATCH_TOKEN`
3. Set repository variable `RING_ENABLED=true`
