### PR TITLE
Roster tests bind their own listener instead of reading the developer's machine

### DIFF
--- a/typescript/src/__tests__/unit/rappter-roster.test.ts
+++ b/typescript/src/__tests__/unit/rappter-roster.test.ts
@@ -23,6 +23,10 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
+import { createServer, type Server } from 'node:http';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { reserveTestPort } from '../support/test-port.js';
 import {
   listRappters,
   plannedPortFor,
@@ -232,6 +236,48 @@ function isolatedHome(): string {
   return home;
 }
 
+const servers: Server[] = [];
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise<void>((r) => { s.close(() => r()); })));
+});
+
+/**
+ * A gateway this test owns. — #127
+ *
+ * The tests below used to write a record naming port 18790 and assert on what
+ * the roster concluded, without ever starting anything there. On the machine
+ * they were written on, the alpha daemon was listening — so they read the
+ * developer's machine and called it a result. Everywhere else, including every
+ * CI runner, `probe()` found nothing and both assertions inverted:
+ *
+ *   expected undefined to be true    rappter-roster.test.ts:346  (stalePort)
+ *   expected false to be true        rappter-roster.test.ts:377  (running)
+ *
+ * `main` was red for seven consecutive commits before anyone looked, because
+ * locally the same commit reported `19 passed (19)`.
+ *
+ * Binding our own listener makes the outcome depend on the code under test and
+ * nothing else. The pid answering is then `process.pid`, which is what lets a
+ * test say whether the roster can tell one owner from another.
+ */
+async function gatewayServing(): Promise<number> {
+  const port = await reserveTestPort();
+  const server = createServer((req, res) => {
+    if (req.url === '/health') {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        status: 'ok', version: 'test-fixture', checks: { gateway: true },
+      }));
+      return;
+    }
+    res.writeHead(404);
+    res.end();
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => { server.listen(port, '127.0.0.1', resolve); });
+  return port;
+}
+
 /**
  * Write an endpoint record, refusing to leave the sandbox.
  *
@@ -327,16 +373,36 @@ describe('a name with no endpoint record is not given someone else\'s port', () 
  * away: the record's own pid, and whoever is actually listening.
  */
 describe('a stale endpoint record is history, not an address', () => {
+  /**
+   * The dependency every guard in this block rests on. — #127
+   *
+   * `listenerPid` shells out to `lsof`. If a machine has no `lsof`, it returns
+   * `undefined`, and `impostor` in roster.ts requires `pid !== undefined` — so
+   * the guard does not merely stop working, it fails OPEN: a dead twin's record
+   * is certified as a live address, which is the exact bug #118 exists to
+   * prevent. That would be invisible, because everything else still passes.
+   *
+   * So measure it against a listener this test started, and say so out loud.
+   */
+  it('can name the pid holding a port, or every guard below fails open', async () => {
+    const port = await gatewayServing();
+    const { stdout } = await promisify(execFile)(
+      'lsof', ['-ti', `:${port}`, '-sTCP:LISTEN'], { timeout: 5_000 },
+    );
+    expect(Number.parseInt(stdout.trim().split(/\s+/)[0] ?? '', 10)).toBe(process.pid);
+  });
+
   it('does not report a name as running when another process holds its port', async () => {
     const home = isolatedHome();
-    // `ghost` recorded port 18790 under a pid that is not the alpha's. The
-    // alpha IS listening there, so the probe will find a healthy gateway —
-    // exactly the trap.
+    // `ghost` recorded a port under a pid that is not the one answering there.
+    // A healthy gateway IS serving it — this test started it — which is
+    // exactly the trap: liveness alone says "running".
+    const port = await gatewayServing();
     const file = gatewayEndpointFileFor({ instance: 'ghost' });
     expect(file.startsWith(home)).toBe(true);
     mkdirSync(dirname(file), { recursive: true });
     writeFileSync(file, JSON.stringify({
-      instance: 'ghost', port: 18_790, pid: 999_999, startedAt: 'x',
+      instance: 'ghost', port, pid: 999_999, startedAt: 'x',
     }));
 
     const rows = await listRappters({ names: ['ghost'] });
@@ -349,25 +415,36 @@ describe('a stale endpoint record is history, not an address', () => {
     expect(ghost?.version).toBeUndefined();
   });
 
-  it('still reports a live twin whose record matches the listener', async () => {
-    // The fix must not blind the roster to real twins. The alpha's own record
-    // names the pid that is actually serving 18790, so it stays visible.
-    isolatedHome();
-    const rows = await listRappters({ names: [] });
-    const alpha = rows.find((r) => r.isAlpha);
-    expect(alpha).toBeDefined();
-    // The alpha is exempt from the pid check by design: its port is a
-    // documented constant rather than a recorded claim.
-    expect(alpha?.stalePort).toBeUndefined();
+  it('reports a twin whose record names the pid that is answering', async () => {
+    // The negative control for the case above, and the property no test
+    // covered: the fix must not blind the roster to real twins. Same fixture,
+    // one field different — the recorded pid is the one actually listening.
+    const home = isolatedHome();
+    const port = await gatewayServing();
+    const file = gatewayEndpointFileFor({ instance: 'live-twin' });
+    expect(file.startsWith(home)).toBe(true);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({
+      instance: 'live-twin', port, pid: process.pid, startedAt: 'x',
+    }));
+
+    const rows = await listRappters({ names: ['live-twin'] });
+    const twin = rows.find((r) => r.name === 'live-twin');
+
+    expect(twin?.running).toBe(true);
+    expect(twin?.stalePort).toBeUndefined();
+    expect(twin?.pid).toBe(process.pid);
+    expect(twin?.version).toBe('test-fixture');
   });
 
   it('trusts a record with no pid, so an upgrade does not report twins as dead', async () => {
     const home = isolatedHome();
+    const port = await gatewayServing();
     const file = gatewayEndpointFileFor({ instance: 'older-build' });
     expect(file.startsWith(home)).toBe(true);
     mkdirSync(dirname(file), { recursive: true });
     // Records written before the pid field existed.
-    writeFileSync(file, JSON.stringify({ instance: 'older-build', port: 18_790 }));
+    writeFileSync(file, JSON.stringify({ instance: 'older-build', port }));
 
     const rows = await listRappters({ names: ['older-build'] });
     const row = rows.find((r) => r.name === 'older-build');


### PR DESCRIPTION
Closes #127.

Closes #127.

Two tests wrote an endpoint record naming port 18790 and asserted on what the
roster concluded, without starting anything there. They borrowed whatever was
already serving that port on the developer's machine -- here, the live alpha
daemon. Everywhere else, probe() found nothing and both assertions inverted:

  expected undefined to be true   rappter-roster.test.ts:346  (stalePort)
  expected false to be true       rappter-roster.test.ts:377  (running)

main was red for seven consecutive commits (63c97f4..3fed110, four hours)
while the same commits reported "19 passed (19)" locally. The tests written to
hold #118 in place could only ever run for one person on one machine.

Each test now starts a gateway on a port from reserveTestPort(), so the pid
answering is process.pid and the outcome depends on the code under test.

The middle test claimed to check "a live twin whose record matches the
listener" but only asserted the alpha's exemption -- it passed in CI while its
siblings failed, because it never touched the property it named. Replaced with
the real negative control: same fixture, recorded pid is the one listening,
expect running true and the fixture's version reported back.

Added a test for the dependency underneath all of them. listenerPid shells out
to lsof; if a machine has none it returns undefined, and `impostor` requires
`pid !== undefined`, so the guard fails OPEN -- a dead twin's record certified
as a live address, which is the bug #118 exists to prevent. lsof is not in the
ubuntu-24.04 runner manifest (0 matches; curl/jq/git appear 9 times), so this
is measured on CI rather than assumed.

Negative controls, needle asserted present before each edit:
  impostor = false            -> ghost test fails  (this is the lsof-blind case)
  running  = true             -> ghost test fails
Both restored. Full suite 4361 passed.

Opened as a PR, not pushed to main: the defect here is precisely that local
green was trusted over the shared signal.
