### PR TITLE
A twin tells its neighbours which twin it is

### DIFF
--- a/typescript/src/__tests__/unit/neighbor-speaks-as-itself.test.ts
+++ b/typescript/src/__tests__/unit/neighbor-speaks-as-itself.test.ts
@@ -1,0 +1,180 @@
+/**
+ * A twin says who it is. — #129
+ *
+ * `NeighborAgent` built its envelope with a literal `deviceRappid('kody-w',
+ * 'alpha')`, so every hatched twin told its neighbours it was the alpha.
+ * Measured on a real twin before the fix, read off the wire at the receiver
+ * rather than from the sender's own report:
+ *
+ *   $ openrappter hatch pebble          -> pebble is up on :19057 (pid 24359)
+ *   POST /twin  {"from_rappid":"rappid:@kody-w/alpha:f245acdb...",
+ *                "to_rappid":"rappid:@kody-w/capture:f6886e04...", ...}
+ *
+ * and on the /chat fallback, where the same value is the conversation key:
+ *
+ *   POST /chat  {"session_id":"rappid:@kody-w/alpha:f245acdb...", ...}
+ *
+ * — so two twins talking to one peer were writing into a single thread that
+ * belonged to neither of them.
+ *
+ * These tests drive the agent against a real listener and read what arrives,
+ * for the reason #127 exists: a test that asserts on what the sender believes
+ * it sent can pass while the wire says something else.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { createServer, type Server } from 'node:http';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, dirname } from 'node:path';
+import { vi } from 'vitest';
+import { NeighborAgent } from '../../agents/NeighborAgent.js';
+import {
+  declareCurrentInstance,
+  __resetCurrentInstanceForTest,
+} from '../../infra/current-instance.js';
+import { gatewayEndpointFileFor } from '../../infra/gateway-lock.js';
+import { deviceRappid } from '../../twin/send.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+const servers: Server[] = [];
+const homes: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(servers.splice(0).map((s) => new Promise<void>((r) => { s.close(() => r()); })));
+  for (const dir of homes.splice(0)) rmSync(dir, { recursive: true, force: true });
+  __resetCurrentInstanceForTest();
+  vi.unstubAllEnvs();
+});
+
+/** A neighbour that records the envelope it was handed. */
+async function neighbourNamed(name: string): Promise<{ received: Record<string, unknown>[] }> {
+  const received: Record<string, unknown>[] = [];
+  const port = await reserveTestPort();
+  const server = createServer((req, res) => {
+    let body = '';
+    req.on('data', (c) => { body += c; });
+    req.on('end', () => {
+      if (req.url === '/health') {
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ status: 'ok', version: 'peer', checks: { gateway: true } }));
+        return;
+      }
+      try { received.push({ url: req.url, ...JSON.parse(body) }); } catch { /* ignore */ }
+      res.writeHead(200, { 'content-type': 'application/json' });
+      // A /twin reply nests: send.ts reads `body.response.response`. A fixture
+      // that answers any other shape reports `said: ''` and the agent calls a
+      // delivered message an error — which is exactly what a hand-rolled stub
+      // did while this was being investigated.
+      res.end(JSON.stringify({ response: { response: 'heard' } }));
+    });
+  });
+  servers.push(server);
+  await new Promise<void>((resolve) => { server.listen(port, '127.0.0.1', resolve); });
+
+  // The roster resolves neighbours by name from a record, so give it one that
+  // points at this listener and names the pid actually holding it.
+  const file = gatewayEndpointFileFor({ instance: name });
+  mkdirSync(dirname(file), { recursive: true });
+  writeFileSync(file, JSON.stringify({
+    instance: name, port, pid: process.pid, startedAt: new Date().toISOString(),
+  }));
+  return { received };
+}
+
+function isolatedHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'neighbor-id-'));
+  homes.push(home);
+  vi.stubEnv('HOME', home);
+  return home;
+}
+
+describe('a rappter names itself to a neighbour', () => {
+  it('speaks as the twin it is, not as the alpha', async () => {
+    isolatedHome();
+    const peer = await neighbourNamed('peerling');
+    declareCurrentInstance('pebble');
+
+    const out = JSON.parse(await new NeighborAgent().perform({
+      action: 'say', to: 'peerling', text: 'hello',
+    }));
+    expect(out.status).toBe('success');
+
+    const envelope = peer.received.at(-1)!;
+    expect(envelope.from_rappid).toBe(deviceRappid('kody-w', 'pebble'));
+    // The precise failure: it must not be the alpha's.
+    expect(envelope.from_rappid).not.toBe(deviceRappid('kody-w', 'alpha'));
+    expect(envelope.to_rappid).toBe(deviceRappid('kody-w', 'peerling'));
+  });
+
+  it('speaks as the alpha when it is the alpha', async () => {
+    // The negative control for the case above. `undefined` is a real answer —
+    // the alpha declares it — and must not be confused with never declaring.
+    isolatedHome();
+    const peer = await neighbourNamed('peerling');
+    declareCurrentInstance(undefined);
+
+    const out = JSON.parse(await new NeighborAgent().perform({
+      action: 'say', to: 'peerling', text: 'hello',
+    }));
+    expect(out.status).toBe('success');
+    expect(peer.received.at(-1)!.from_rappid).toBe(deviceRappid('kody-w', 'alpha'));
+  });
+
+  it('refuses to name itself at all when nothing declared', async () => {
+    // A process that never went through gateway startup does not know which
+    // rappter it is. Defaulting to the alpha there is how the original defect
+    // read: a confident answer nobody had checked.
+    isolatedHome();
+    const peer = await neighbourNamed('peerling');
+
+    const out = JSON.parse(await new NeighborAgent().perform({
+      action: 'say', to: 'peerling', text: 'hello',
+    }));
+    expect(out.status).toBe('error');
+    expect(out.message).toMatch(/has not declared which rappter it is/);
+    // And it must not have sent anything while unable to say who it was.
+    expect(peer.received).toHaveLength(0);
+  });
+
+  it('carries the speaker into the /chat fallback, where it is the session key', async () => {
+    // sendTwin uses from_rappid as `session_id` when a peer has no /twin, so
+    // this is the path on which twins shared one thread. A peer that 404s
+    // /twin forces it.
+    isolatedHome();
+    const received: Record<string, unknown>[] = [];
+    const port = await reserveTestPort();
+    const server = createServer((req, res) => {
+      let body = '';
+      req.on('data', (c) => { body += c; });
+      req.on('end', () => {
+        if (req.url === '/health') {
+          res.writeHead(200, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ status: 'ok', checks: { gateway: true } }));
+          return;
+        }
+        if (req.url === '/twin') {
+          res.writeHead(404, { 'content-type': 'application/json' });
+          res.end(JSON.stringify({ error: 'no /twin here' }));
+          return;
+        }
+        try { received.push(JSON.parse(body)); } catch { /* ignore */ }
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({ response: 'heard' }));
+      });
+    });
+    servers.push(server);
+    await new Promise<void>((resolve) => { server.listen(port, '127.0.0.1', resolve); });
+    const file = gatewayEndpointFileFor({ instance: 'chatonly' });
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({
+      instance: 'chatonly', port, pid: process.pid, startedAt: 'x',
+    }));
+
+    declareCurrentInstance('pebble');
+    await new NeighborAgent().perform({ action: 'say', to: 'chatonly', text: 'hello' });
+
+    expect(received.at(-1)!.session_id).toBe(deviceRappid('kody-w', 'pebble'));
+    expect(received.at(-1)!.session_id).not.toBe(deviceRappid('kody-w', 'alpha'));
+  });
+});

--- a/typescript/src/agents/NeighborAgent.ts
+++ b/typescript/src/agents/NeighborAgent.ts
@@ -143,11 +143,39 @@ export class NeighborAgent extends BasicAgent {
 
     const { deviceRappid, sendTwin } = await import('../twin/send.js');
     const { canonicalInstanceKey } = await import('../infra/gateway-lock.js');
+    const { currentInstanceName, currentInstanceDeclared } = await import('../infra/current-instance.js');
     const slug = canonicalInstanceKey(to);
+
+    /**
+     * Say who is actually speaking. — #129
+     *
+     * This was `deviceRappid('kody-w', 'alpha')`, a literal, so a hatched twin
+     * told every neighbour it was the alpha. Measured from a real twin:
+     *
+     *   hatch pebble -> :19057;  pebble sends;  peer receives
+     *   from_rappid: rappid:@kody-w/alpha:f245acdb...
+     *
+     * It is not only a label. `sendTwin` uses the same value as `session_id`
+     * on the /chat fallback, so every twin on the device shared one
+     * conversation thread at every peer it spoke to.
+     *
+     * An undeclared process is not the alpha, it is a process that did not go
+     * through gateway startup. Defaulting there would restore the same
+     * confident-but-unchecked answer, so it refuses instead.
+     */
+    if (!currentInstanceDeclared()) {
+      return JSON.stringify({
+        status: 'error',
+        message:
+          'This process has not declared which rappter it is, so it cannot name '
+          + 'itself to a neighbour. Speaking as the alpha would be a guess.',
+      });
+    }
+    const me = canonicalInstanceKey(currentInstanceName() ?? 'alpha');
 
     const out = await sendTwin({
       to: url,
-      fromRappid: deviceRappid('kody-w', 'alpha'),
+      fromRappid: deviceRappid('kody-w', me),
       toRappid: deviceRappid('kody-w', slug),
       text,
     });

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1174,6 +1174,7 @@ program
       const webRoot = path.resolve(__dirname, '../ui/dist');
       const hasWebUI = fs.existsSync(path.join(webRoot, 'index.html'));
       const { acquireLock, releaseLock, gatewayLockFileFor, gatewayPortFor, writeGatewayEndpoint } = await import('./infra/gateway-lock.js');
+      const { declareCurrentInstance } = await import('./infra/current-instance.js');
       // Scope the lock AND the port to THIS instance, so an alpha and its
       // hatched twins can run side by side on one device. The alpha resolves to
       // the original path and the original port, so an existing install is
@@ -1185,6 +1186,9 @@ program
       // EADDRINUSE stack trace. #101
       const lockInstance = (options.instance as string | undefined)
         ?? process.env.OPENRAPPTER_INSTANCE;
+      // Publish it. Anything in this process that needs to say which rappter
+      // it is reads this one derivation rather than repeating it. #129
+      declareCurrentInstance(lockInstance);
       const explicitPort = options.port
         ? Number(options.port)
         : (process.env.OPENRAPPTER_PORT ? Number(process.env.OPENRAPPTER_PORT) : undefined);

--- a/typescript/src/infra/current-instance.ts
+++ b/typescript/src/infra/current-instance.ts
@@ -1,0 +1,56 @@
+/**
+ * Which rappter is this process? — #129
+ *
+ * A hatched twin ran the Neighbor agent and told the peer it was the alpha:
+ *
+ *   $ openrappter hatch pebble        -> pebble is up on :19057 (pid 24359)
+ *   (pebble sends)
+ *   POST /twin  {"from_rappid":"rappid:@kody-w/alpha:f245acdb...", ...}
+ *
+ * `NeighborAgent` had a literal `deviceRappid('kody-w', 'alpha')`, because the
+ * agent registry constructs agents with NO arguments — an agent cannot be told
+ * anything at construction, so it had nothing else to say.
+ *
+ * The value was never unknown. `index.ts` resolves it at startup from
+ * `--instance` or `OPENRAPPTER_INSTANCE` in order to pick the lock and the
+ * port. This module exists so that ONE derivation is published rather than a
+ * second one being invented somewhere else — the failure that produced #101
+ * (lock and port derived apart) and #118 (roster and sender derived apart) was
+ * exactly two derivations of one fact drifting.
+ *
+ * Undeclared is not the same as alpha. A process that never declared is a
+ * process that did not go through gateway startup, and guessing "alpha" there
+ * is how the original defect read: a confident answer nobody had checked.
+ * Callers are expected to handle `undefined` by refusing, not by defaulting.
+ */
+
+let current: string | undefined;
+let declared = false;
+
+/**
+ * Record which rappter this process is serving as. `undefined` means the
+ * alpha, which is a real answer — distinct from never having declared.
+ */
+export function declareCurrentInstance(instance: string | undefined): void {
+  current = instance && instance.trim() ? instance.trim() : undefined;
+  declared = true;
+}
+
+/** The declared instance name, or `undefined` for the alpha. */
+export function currentInstanceName(): string | undefined {
+  return current;
+}
+
+/**
+ * Has anything declared? False means this process is not a gateway, and no
+ * caller should assume which rappter it is.
+ */
+export function currentInstanceDeclared(): boolean {
+  return declared;
+}
+
+/** Test seam only: forget the declaration. */
+export function __resetCurrentInstanceForTest(): void {
+  current = undefined;
+  declared = false;
+}


### PR DESCRIPTION
Closes #129.

Closes #129.

NeighborAgent built its envelope with a literal:

    fromRappid: deviceRappid('kody-w', 'alpha')

so every hatched twin told every neighbour it was the alpha. Measured on a real
twin, read off the wire at the receiver rather than from the sender's report:

    $ openrappter hatch pebble     -> pebble is up on :19057 (pid 24359)
    POST /twin  {"from_rappid":"rappid:@kody-w/alpha:f245acdb...",
                 "to_rappid":"rappid:@kody-w/capture:f6886e04...", ...}

to_rappid was derived from the peer's name; from_rappid was a constant. Pointed
at the real alpha, the alpha answered a message claiming to come from its own
rappid -- "I'm the original on this device" -- without flinching.

It is not only a label. sendTwin uses the same value as the conversation key on
the /chat fallback (send.ts:130), so every twin on the device wrote into one
thread at every peer, and that thread belonged to the alpha:

    POST /chat  {"session_id":"rappid:@kody-w/alpha:f245acdb...", ...}

The value was never unknown -- index.ts resolves it at startup to pick the lock
and the port. The agent could not receive it because the registry constructs
agents with no arguments. So that one derivation is now published rather than a
second one invented: index.ts declares it, current-instance.ts holds it, the
agent reads it. Two derivations of one fact drifting apart is what produced
#101 (lock vs port) and #118 (roster vs sender).

Undeclared is not the same as alpha. A process that never went through gateway
startup does not know which rappter it is, and defaulting there would restore
the same confident-but-unchecked answer, so it refuses to send instead.

Live, after deploying (alpha respawned by launchd as 29799, pebble re-hatched):

    twin  -> from_rappid rappid:@kody-w/pebble:5a1f25b6...  (both wires)
    alpha -> from_rappid rappid:@kody-w/alpha:f245acdb...

Negative control, needle asserted present first: restoring the literal fails
"speaks as the twin it is" and the /chat-fallback test, while the alpha and
undeclared cases keep passing -- they are not affected by it, and should not be.

The four new tests drive the agent against a real listener and assert on what
ARRIVES, per #127: a test that asserts on what the sender believes it sent can
pass while the wire says something else. A hand-rolled stub during this
investigation reported a delivered message as an error because it answered the
wrong reply shape; the fixture now documents that /twin replies nest.

Full suite 4365 passed.
