### PR TITLE
A record nothing can vouch for is not an address

### DIFF
--- a/typescript/src/__tests__/unit/rappter-roster.test.ts
+++ b/typescript/src/__tests__/unit/rappter-roster.test.ts
@@ -260,13 +260,19 @@ afterEach(async () => {
  * nothing else. The pid answering is then `process.pid`, which is what lets a
  * test say whether the roster can tell one owner from another.
  */
-async function gatewayServing(): Promise<number> {
+async function gatewayServing(options: { instance?: string } = {}): Promise<number> {
   const port = await reserveTestPort();
   const server = createServer((req, res) => {
     if (req.url === '/health') {
       res.writeHead(200, { 'content-type': 'application/json' });
       res.end(JSON.stringify({
-        status: 'ok', version: 'test-fixture', checks: { gateway: true },
+        status: 'ok',
+        version: 'test-fixture',
+        // A real gateway names itself here (#131). Omitting it models a build
+        // that predates the field, which is a case the roster must still
+        // handle — not a shortcut for the fixture.
+        ...(options.instance === undefined ? {} : { instance: options.instance }),
+        checks: { gateway: true },
       }));
       return;
     }
@@ -276,6 +282,38 @@ async function gatewayServing(): Promise<number> {
   servers.push(server);
   await new Promise<void>((resolve) => { server.listen(port, '127.0.0.1', resolve); });
   return port;
+}
+
+/**
+ * Make it impossible to name the process holding a port. — #131
+ *
+ * `listenerPid` shells out to `lsof`; emptying PATH makes that fail with
+ * ENOENT on any machine, which is precisely the situation on a host that has
+ * no `lsof` — several Linux container images, and the case an independent
+ * reviewer reproduced. Doing it inside the test means the guarantee is proved
+ * everywhere the suite runs, rather than only where somebody remembered to
+ * uninstall a binary.
+ */
+/**
+ * Can this host name the process holding a port at all?
+ *
+ * The three tests below exercise the PID route specifically, and that route
+ * needs `lsof`. Rather than assume (which is how port 18790 got hardcoded) or
+ * skip silently (which reads exactly like a passing test), they measure the
+ * host and assert what is correct FOR it: the pid comparison where it can be
+ * made, and the fail-closed refusal where it cannot.
+ */
+async function canNamePids(): Promise<boolean> {
+  try {
+    await promisify(execFile)('lsof', ['-v'], { timeout: 5_000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function withoutLsof(): void {
+  vi.stubEnv('PATH', '/nonexistent-for-this-test');
 }
 
 /**
@@ -374,22 +412,85 @@ describe('a name with no endpoint record is not given someone else\'s port', () 
  */
 describe('a stale endpoint record is history, not an address', () => {
   /**
-   * The dependency every guard in this block rests on. — #127
+   * The guard used to rest entirely on `lsof`. — #131
    *
-   * `listenerPid` shells out to `lsof`. If a machine has no `lsof`, it returns
-   * `undefined`, and `impostor` in roster.ts requires `pid !== undefined` — so
-   * the guard does not merely stop working, it fails OPEN: a dead twin's record
-   * is certified as a live address, which is the exact bug #118 exists to
-   * prevent. That would be invisible, because everything else still passes.
+   * `listenerPid` returned `undefined` both when nothing was listening and
+   * when it could not ask, and `impostor` required a pid — so on a host with
+   * no `lsof` the guard did not stop working, it failed OPEN and certified a
+   * record it had never checked. Measured before the fix, same commit, only
+   * `lsof` removed from PATH:
    *
-   * So measure it against a listener this test started, and say so out loud.
+   *     × does not report a name as running when another process holds its port
+   *         → expected true to be false        (ghost.running)
+   *         → expected undefined to be 38985   (ghost.pid)
+   *
+   * A listener that says its own name settles it without any external binary,
+   * and is better evidence besides: a pid proves only "the same process wrote
+   * this record", a name proves "you reached the rappter you asked for".
    */
-  it('can name the pid holding a port, or every guard below fails open', async () => {
+  it('unmasks an impostor with no way to name the process holding the port', async () => {
+    const home = isolatedHome();
+    withoutLsof();
+    // Somebody else's gateway is on this port, and it says so.
+    const port = await gatewayServing({ instance: 'someone-else' });
+    const file = gatewayEndpointFileFor({ instance: 'ghost' });
+    expect(file.startsWith(home)).toBe(true);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({
+      instance: 'ghost', port, pid: 999_999, startedAt: 'x',
+    }));
+
+    const ghost = (await listRappters({ names: ['ghost'] })).find((r) => r.name === 'ghost');
+
+    expect(ghost?.running).toBe(false);
+    expect(ghost?.stalePort).toBe(true);
+    expect(ghost?.pid).toBeUndefined();
+    expect(ghost?.version).toBeUndefined();
+  });
+
+  it('recognises its own name with no way to name the process holding the port', async () => {
+    // The negative control for the case above: the same conditions, and the
+    // listener is who the record says. It must stay reachable — a guard that
+    // refuses everything on a host without `lsof` is not a fix.
+    const home = isolatedHome();
+    withoutLsof();
+    const port = await gatewayServing({ instance: 'live-twin' });
+    const file = gatewayEndpointFileFor({ instance: 'live-twin' });
+    expect(file.startsWith(home)).toBe(true);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({
+      instance: 'live-twin', port, pid: 999_999, startedAt: 'x',
+    }));
+
+    const twin = (await listRappters({ names: ['live-twin'] })).find((r) => r.name === 'live-twin');
+
+    // The recorded pid is wrong and unverifiable, and it does not matter: the
+    // listener answered to the name.
+    expect(twin?.running).toBe(true);
+    expect(twin?.stalePort).toBeUndefined();
+    expect(twin?.ownershipUnverified).toBeUndefined();
+    expect(twin?.version).toBe('test-fixture');
+  });
+
+  it('refuses to certify a record nothing can vouch for', async () => {
+    // An older listener that does not name itself, on a host that cannot name
+    // the process either. Neither route can speak, so the record is not an
+    // address — "I could not check" is not "the record is fine".
+    const home = isolatedHome();
+    withoutLsof();
     const port = await gatewayServing();
-    const { stdout } = await promisify(execFile)(
-      'lsof', ['-ti', `:${port}`, '-sTCP:LISTEN'], { timeout: 5_000 },
-    );
-    expect(Number.parseInt(stdout.trim().split(/\s+/)[0] ?? '', 10)).toBe(process.pid);
+    const file = gatewayEndpointFileFor({ instance: 'unknowable' });
+    expect(file.startsWith(home)).toBe(true);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({ instance: 'unknowable', port, pid: 4242 }));
+
+    const row = (await listRappters({ names: ['unknowable'] })).find((r) => r.name === 'unknowable');
+
+    expect(row?.running).toBe(false);
+    expect(row?.ownershipUnverified).toBe(true);
+    // And it must not attribute a stranger's details to this name.
+    expect(row?.pid).toBeUndefined();
+    expect(row?.version).toBeUndefined();
   });
 
   it('does not report a name as running when another process holds its port', async () => {
@@ -408,8 +509,13 @@ describe('a stale endpoint record is history, not an address', () => {
     const rows = await listRappters({ names: ['ghost'] });
     const ghost = rows.find((r) => r.name === 'ghost');
 
+    // Either way it is refused; only the reason differs.
     expect(ghost?.running).toBe(false);
-    expect(ghost?.stalePort).toBe(true);
+    if (await canNamePids()) {
+      expect(ghost?.stalePort).toBe(true);
+    } else {
+      expect(ghost?.ownershipUnverified).toBe(true);
+    }
     // And it must not hand back the pid it has no claim to.
     expect(ghost?.pid).toBeUndefined();
     expect(ghost?.version).toBeUndefined();
@@ -431,10 +537,17 @@ describe('a stale endpoint record is history, not an address', () => {
     const rows = await listRappters({ names: ['live-twin'] });
     const twin = rows.find((r) => r.name === 'live-twin');
 
-    expect(twin?.running).toBe(true);
     expect(twin?.stalePort).toBeUndefined();
-    expect(twin?.pid).toBe(process.pid);
-    expect(twin?.version).toBe('test-fixture');
+    if (await canNamePids()) {
+      expect(twin?.running).toBe(true);
+      expect(twin?.pid).toBe(process.pid);
+      expect(twin?.version).toBe('test-fixture');
+    } else {
+      // This listener predates #131 and does not name itself, so on a host
+      // that cannot name the process either, nothing can vouch for it.
+      expect(twin?.running).toBe(false);
+      expect(twin?.ownershipUnverified).toBe(true);
+    }
   });
 
   it('trusts a record with no pid, so an upgrade does not report twins as dead', async () => {
@@ -451,6 +564,6 @@ describe('a stale endpoint record is history, not an address', () => {
     // No pid to compare, so no impostor claim — it is reported on what the
     // probe alone can see, as before.
     expect(row?.stalePort).toBeUndefined();
-    expect(row?.running).toBe(true);
+    expect(row?.running).toBe(await canNamePids());
   });
 });

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -38,6 +38,7 @@ import { VERSION } from '../version.js';
 import { buildChatEnvelope } from './chat-envelope.js';
 import { parseChatRequest } from './chat-request.js';
 import { buildTwinResponse, parseTwinEnvelope, sayText } from './twin-chat.js';
+import { currentInstanceDeclared, currentInstanceName } from '../infra/current-instance.js';
 import {
   GatewayMetrics,
   GatewayTimeoutError,
@@ -1422,6 +1423,23 @@ export class GatewayServer {
     return {
       status: this.wss ? 'ok' : 'error',
       version: VERSION,
+      /**
+       * Which rappter is answering. — #131
+       *
+       * The roster decided whether an endpoint record was still an address by
+       * comparing the recorded pid to the pid holding the port, obtained from
+       * `lsof`. Where `lsof` cannot answer, that comparison was skipped and the
+       * record was certified anyway — the guard failed OPEN, which is the
+       * defect #118 exists to prevent.
+       *
+       * A listener saying its own name is better evidence than a pid lookup:
+       * a pid proves only "the same process wrote this record", while a name
+       * proves "you have reached the rappter you asked for". It also needs no
+       * external binary, so it holds on platforms where `lsof` is absent.
+       *
+       * `alpha` is a real answer, not a default — see infra/current-instance.
+       */
+      instance: currentInstanceDeclared() ? (currentInstanceName() ?? 'alpha') : undefined,
       uptime: this.startedAt ? Math.floor((Date.now() - this.startedAt) / 1000) : 0,
       timestamp: new Date().toISOString(),
       checks: {

--- a/typescript/src/gateway/types.ts
+++ b/typescript/src/gateway/types.ts
@@ -268,6 +268,14 @@ export type GatewayEventType = (typeof GatewayEvents)[keyof typeof GatewayEvents
 export interface HealthResponse {
   status: 'ok' | 'degraded' | 'error';
   version: string;
+  /**
+   * Which rappter is answering — a twin's name, or `alpha`. #131
+   *
+   * Absent from builds predating this field, and from any process that has not
+   * declared. Consumers must treat absence as "unknown", never as "alpha":
+   * that collapse is the fail-open this field exists to close.
+   */
+  instance?: string;
   uptime: number;
   timestamp: string;
   checks: {

--- a/typescript/src/infra/roster.ts
+++ b/typescript/src/infra/roster.ts
@@ -60,6 +60,13 @@ export interface RappterStatus {
    */
   stalePort?: boolean;
   /**
+   * A healthy gateway answers here, but nothing could confirm it is this name:
+   * the listener does not report its instance (an older build) and the process
+   * holding the port could not be identified. The record is not certified —
+   * "I could not check" is not "the record is fine". #131
+   */
+  ownershipUnverified?: boolean;
+  /**
    * This name has no endpoint record, so it never successfully owned a port.
    * Its `port` is the one a new twin of that name WOULD try to claim, which is
    * a plan rather than an address — and may already belong to someone else.
@@ -150,19 +157,35 @@ export function urlForInstance(instance: string | undefined): string | undefined
  * 18790 it returns the daemon AND Microsoft Edge, which merely had the
  * dashboard open. That mistake has already been made once on this machine.
  */
-async function listenerPid(port: number): Promise<number | undefined> {
+/**
+ * Who is listening on this port, and did we manage to find out?
+ *
+ * `undefined` used to mean both "nothing is listening" and "I could not ask",
+ * and the caller treated the second as the first — so where `lsof` is absent
+ * the stale-record guard did not stop working, it failed OPEN and certified a
+ * record it had not checked. #131
+ */
+async function listenerPid(port: number): Promise<{ known: boolean; pid?: number }> {
   try {
     const { stdout } = await run('lsof', ['-ti', `:${port}`, '-sTCP:LISTEN'], { timeout: 5_000 });
     const pid = Number.parseInt(stdout.trim().split(/\s+/)[0] ?? '', 10);
-    return Number.isSafeInteger(pid) ? pid : undefined;
-  } catch {
-    return undefined;
+    return { known: true, pid: Number.isSafeInteger(pid) ? pid : undefined };
+  } catch (error) {
+    // `lsof` exits non-zero with no output when nothing is listening, which is
+    // a real answer. Anything else — not installed, not permitted, timed out —
+    // is not an answer at all.
+    const failed = error as { code?: number | string; stdout?: string };
+    const exitedCleanlyWithNothing = typeof failed?.code === 'number'
+      && !((failed.stdout ?? '').trim());
+    return exitedCleanlyWithNothing ? { known: true, pid: undefined } : { known: false };
   }
 }
 
 interface HealthShape {
   status?: string;
   version?: string;
+  /** Which rappter is answering. Absent on builds predating #131. */
+  instance?: string;
   metrics?: { uptimeSeconds?: number };
   checks?: { gateway?: boolean };
 }
@@ -229,10 +252,11 @@ export async function listRappters(options: {
       };
     }
 
-    const [health, pid] = await Promise.all([probe(port), listenerPid(port)]);
+    const [health, listener] = await Promise.all([probe(port), listenerPid(port)]);
+    const pid = listener.pid;
 
     /**
-     * A record is an address only while the pid that wrote it is the pid
+     * A record is an address only while the rappter that wrote it is the one
      * answering. #118
      *
      * `releaseLock` unlinks `gateway.pid` and never `endpoint.json`, so a dead
@@ -246,17 +270,43 @@ export async function listRappters(options: {
      *   hatch thicket -> "already running (pid 49019)", so it can never
      *                    be hatched again
      *
-     * The two numbers that tell them apart were already being fetched here and
-     * thrown away: the record's own pid, and whoever is actually listening.
+     * Two independent ways to check, best evidence first. #131
      *
-     * A record with no pid is from an older build; those are trusted, because
-     * refusing them would report working twins as dead on upgrade.
+     * 1. The listener says its own name. This proves you reached the rappter
+     *    you asked for, needs no external binary, and is the only check that
+     *    works where `lsof` does not.
+     * 2. The recorded pid matches the pid holding the port. Weaker — it proves
+     *    only that the same process wrote the record — and unavailable when
+     *    `lsof` cannot answer.
+     *
+     * If neither can speak, the record is UNVERIFIED. It is not certified,
+     * because "I could not check" is not "the record is fine": that collapse
+     * reported a stale record as running and handed back a stranger's pid.
+     *
+     * A record with no pid is from an older build; those are trusted on the
+     * pid route, because refusing them would report working twins as dead on
+     * upgrade. The name route has no such exemption — a listener that names a
+     * different rappter is an impostor whatever the record omits.
      */
     const recordedPid = instance === undefined ? undefined : recordFor(instance)?.pid;
-    const impostor = recordedPid !== undefined
+    const claimedName = typeof health?.instance === 'string' ? health.instance : undefined;
+    const expectedName = instance ?? 'alpha';
+
+    const namedImpostor = claimedName !== undefined && claimedName !== expectedName;
+    const pidImpostor = recordedPid !== undefined
+      && listener.known
       && pid !== undefined
       && recordedPid !== pid;
-    const running = health !== null && !impostor;
+    const impostor = namedImpostor || pidImpostor;
+
+    // Nothing could vouch for this record: the listener does not say who it is
+    // (an older build) and we could not name the process holding the port.
+    const unverified = !impostor
+      && health !== null
+      && claimedName === undefined
+      && !listener.known;
+
+    const running = health !== null && !impostor && !unverified;
 
     return {
       name: instance ?? 'alpha',
@@ -265,9 +315,11 @@ export async function listRappters(options: {
       running,
       // Do not hand back a pid this name has no claim to.
       ...(impostor ? { stalePort: true } : {}),
-      ...(pid !== undefined && !impostor ? { pid } : {}),
-      ...(health?.version && !impostor ? { version: health.version } : {}),
-      ...(typeof health?.metrics?.uptimeSeconds === 'number' && !impostor
+      // Something healthy answers, but nothing could confirm it is this name.
+      ...(unverified ? { ownershipUnverified: true } : {}),
+      ...(pid !== undefined && !impostor && !unverified ? { pid } : {}),
+      ...(health?.version && !impostor && !unverified ? { version: health.version } : {}),
+      ...(typeof health?.metrics?.uptimeSeconds === 'number' && !impostor && !unverified
         ? { uptimeSeconds: health.metrics.uptimeSeconds }
         : {}),
       // Something is holding the port, but it did not answer as a gateway.


### PR DESCRIPTION
Closes #131.

Closes #131.

`listenerPid` returned `undefined` both when nothing was listening and when it
could not ask, and `impostor` required a pid. So on a host with no `lsof` the
stale-record guard did not stop working -- it failed OPEN, certifying a record
it had never checked. That is the defect #118 exists to prevent, silently
reinstated wherever the binary is missing.

Measured on b47db49, same suite, only lsof removed from PATH:

    × does not report a name as running when another process holds its port
        → expected true to be false        (ghost.running)
        → expected undefined to be 38985   (ghost.pid)

Found by an independent reviewer of the b47db49 diff, who reproduced it that
way. b47db49 documented the gap in a comment and did not close it.

Consumers act on `running`: NeighborAgent.resolve() picks a peer by it and
returns 127.0.0.1:port, so a twin's message went to whoever held the port --
carrying, since #129, a truthful from_rappid to the wrong recipient. `hatch`
refuses a name that looks live, so a dead twin could never be hatched again.

Rather than only splitting "no listener" from "cannot ask", this adds the
better evidence that was missing: the gateway says which rappter it is on
/health. A pid proves "the same process wrote this record"; a name proves "you
reached the rappter you asked for". It needs no external binary, so it holds on
every platform. #129 had just given the process that self-knowledge.

Ownership is now decided by name first, pid second, and if neither can speak
the record is UNVERIFIED and not certified -- `ownershipUnverified`, distinct
from a proven `stalePort`.

Live, after deploy (alpha respawned by launchd as 44481):

    alpha  /health -> instance: alpha
    quartz /health -> instance: quartz
    (phantom record written against quartz's port)
    $ openrappter twins
      ○ phantom  :19613  not running — another process now holds its last port
      ● quartz   :19613  pid 44689  up 0m

The roster suite now passes with lsof AND with PATH emptied -- 22 both ways.
The three tests that exercise the pid route specifically measure the host and
assert what is correct for it, rather than assuming a binary (which is how port
18790 got hardcoded) or skipping silently (which reads like a pass).

Negative controls, needle asserted present before each, run against the
no-lsof suite:
  unverified = false                    -> 3 fail (the original collapse)
  namedImpostor = false                 -> 1 fail (name route removed)
  missing lsof treated as a clean answer-> 3 fail
All restored. Full suite 4367 passed, 0 lint errors.
