### PR TITLE
Report what execute() actually said, not that it did not throw

### DIFF
--- a/typescript/src/__tests__/unit/report-storage-truth.test.ts
+++ b/typescript/src/__tests__/unit/report-storage-truth.test.ts
@@ -1,0 +1,83 @@
+/**
+ * A store is only stored if the store said so. — #136
+ *
+ * `ReportStorageAgent` returned `{status:'success', stored:true}`
+ * unconditionally. Agents in this codebase do not throw: `execute()` returns a
+ * JSON document and `MemoryAgent` reports failure as `{"status":"error"}`
+ * inside it — `No message provided to remember`, or any storage failure.
+ *
+ * So a productivity report that was never stored was announced as stored, with
+ * the contradicting reply sitting beside the claim in `memory_result`. The
+ * truth was in the document and the summary next to it said the opposite,
+ * which is worse than either alone: anything reading `stored` got the wrong
+ * answer while the evidence was right there.
+ *
+ * Same rule as #134, different caller. The absence of an exception is not
+ * evidence of anything.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { ReportStorageAgent } from '../../agents/ProductivityStackAgent.js';
+import { BasicAgent } from '../../agents/BasicAgent.js';
+
+class StubMemory extends BasicAgent {
+  public calls = 0;
+
+  constructor(private readonly reply: string) {
+    super('StubMemory', {
+      name: 'StubMemory',
+      description: 'test double',
+      parameters: { type: 'object', properties: {}, required: [] },
+    });
+  }
+
+  async execute(): Promise<string> {
+    this.calls += 1;
+    return this.reply;
+  }
+
+  async perform(): Promise<string> { return this.execute(); }
+}
+
+async function store(reply: string): Promise<Record<string, unknown>> {
+  const agent = new ReportStorageAgent(new StubMemory(reply));
+  return JSON.parse(await agent.perform({}));
+}
+
+describe('the productivity report says whether it was really stored', () => {
+  it('does not claim to have stored it when memory reported an error', async () => {
+    const out = await store(JSON.stringify({
+      status: 'error', message: 'No message provided to remember',
+    }));
+
+    expect(out.stored).toBe(false);
+    expect(out.status).toBe('error');
+    expect(String(out.error)).toMatch(/No message provided to remember/);
+    // The raw reply is still carried, so nothing is hidden — the summary just
+    // stops contradicting it.
+    expect(String(out.memory_result)).toContain('No message provided');
+  });
+
+  it('claims to have stored it when memory reported success', async () => {
+    // The negative control: the fix must not report every report as unstored.
+    const out = await store(JSON.stringify({ status: 'success', id: 'mem-1' }));
+
+    expect(out.stored).toBe(true);
+    expect(out.status).toBe('success');
+    expect(out.error).toBeUndefined();
+  });
+
+  it('does not claim to have stored it when memory answered with nonsense', async () => {
+    const out = await store('<html>gateway error</html>');
+
+    expect(out.stored).toBe(false);
+    expect(String(out.error)).toMatch(/unreadable reply/);
+  });
+
+  it('does not claim to have stored it when memory reported no status at all', async () => {
+    const out = await store(JSON.stringify({ id: 'mem-2' }));
+
+    expect(out.stored).toBe(false);
+    expect(String(out.error)).toMatch(/status "unknown"/);
+  });
+});

--- a/typescript/src/agents/ProductivityStackAgent.ts
+++ b/typescript/src/agents/ProductivityStackAgent.ts
@@ -45,7 +45,12 @@ class ReportAssemblerAgent extends BasicAgent {
   }
 }
 
-class ReportStorageAgent extends BasicAgent {
+/**
+ * Exported so the storage claim can be tested. #136 found it returning
+ * `stored: true` unconditionally, and it had no test because it was
+ * module-private and constructed internally.
+ */
+export class ReportStorageAgent extends BasicAgent {
   private memoryAgent: BasicAgent;
   constructor(memoryAgent?: BasicAgent) {
     const metadata: AgentMetadata = { name: 'ReportStorage', description: 'Stores the productivity report in memory.', parameters: { type: 'object', properties: {}, required: [] } };
@@ -57,7 +62,31 @@ class ReportStorageAgent extends BasicAgent {
     const reportSlush = upstream['report'] ?? {};
     const summary = (reportSlush['summary'] as string) || 'Productivity report (no summary)';
     const result = await this.memoryAgent.execute({ action: 'remember', message: `Productivity Report: ${summary}`, theme: 'productivity_report', tags: ['productivity', 'daily'], importance: 3 });
-    return JSON.stringify({ status: 'success', stored: true, memory_result: result });
+    /**
+     * Report what the store actually said. — #136
+     *
+     * This returned `{status:'success', stored:true}` unconditionally. Agents
+     * do not throw: `execute()` hands back a JSON document and `MemoryAgent`
+     * reports failure as `{"status":"error"}` inside it. So a report that was
+     * never stored was announced as stored, with the contradicting reply
+     * sitting right beside the claim in `memory_result` — and anything reading
+     * `stored` got the wrong answer.
+     */
+    let stored = false;
+    let storeError: string | undefined;
+    try {
+      const reply = JSON.parse(result) as { status?: string; message?: string };
+      if (reply.status === 'success') stored = true;
+      else storeError = reply.message ?? `memory reported status "${reply.status ?? 'unknown'}"`;
+    } catch {
+      storeError = `memory returned an unreadable reply: ${String(result).slice(0, 120)}`;
+    }
+    return JSON.stringify({
+      status: stored ? 'success' : 'error',
+      stored,
+      ...(storeError ? { error: storeError } : {}),
+      memory_result: result,
+    });
   }
 }
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -1804,8 +1804,26 @@ program
     try {
       const tipAgent = (await registry.getAgent('DailyTip'));
       if (tipAgent) {
-        await tipAgent.execute({ action: 'tip' });
-        log.success('Welcome notification sent — click it to open openrappter!');
+        /**
+         * Announce it only if it happened. — #136
+         *
+         * This was `await tipAgent.execute(…); log.success('Welcome
+         * notification sent…')`. Agents do not throw; `DailyTipAgent` reports
+         * failure as `{"status":"error"}` inside the string it returns. So the
+         * first sentence a new user read claimed a notification had been sent
+         * whether or not one had, and invited them to click something that may
+         * not exist.
+         */
+        const raw = await tipAgent.execute({ action: 'tip' });
+        let sent = false;
+        try {
+          sent = (JSON.parse(raw) as { status?: string }).status === 'success';
+        } catch { /* an unreadable reply is not a receipt */ }
+        if (sent) {
+          log.success('Welcome notification sent — click it to open openrappter!');
+        } else {
+          log.info('Welcome notification not sent (tips are still scheduled).');
+        }
       }
     } catch { /* non-critical */ }
 


### PR DESCRIPTION
Closes #136.

Closes #136.

Agents in this codebase do not throw. execute() returns a JSON document and
failure arrives as {"status":"error"} inside it, so `await x.execute(...)`
followed by a success claim is a claim nobody checked. #134 fixed one instance;
this is the audit of the rule.

48 call sites outside tests across 18 files. Scanning for a success claim in
the following statements with nothing inspecting the reply gives 7 candidates.
Five are demo harnesses in showcase-methods.ts driving MockAgents that always
return success, where the discarded calls are setup steps and the reported
value comes from a parsed result -- those are fine. Two are real.

1. src/index.ts -- the installer printed

       Welcome notification sent — click it to open openrappter!

   whether or not one was sent. DailyTipAgent returns {"status":"error"}
   without throwing ("No tip for day N", "Unknown action"). That sentence is
   the first thing a new user reads, and it invites them to click something
   that may not exist. It now says so plainly when nothing was sent, and still
   reports that tips remain scheduled.

2. ProductivityStackAgent ReportStorage returned {status:'success',
   stored:true} unconditionally, while passing the contradicting reply through
   as memory_result. The truth was in the document and the summary beside it
   said the opposite, which is worse than either alone -- anything reading
   `stored` got the wrong answer with the evidence right there. MemoryAgent
   returns errors without throwing. Confirmed in the built output before
   changing anything:

       ReportStorage present in dist: true
       unconditional claim in dist  : true

ReportStorageAgent was module-private and constructed internally, so it had no
test. Exporting it is part of the fix rather than incidental: the claim could
not be checked by anyone, which is how it survived.

Four tests: memory errors, memory succeeds, memory answers nonsense, memory
answers with no status at all.

Negative control, and the first attempt at it was VACUOUS -- replacing the
`if` left a dangling `else`, nothing compiled, and vitest reported "no tests"
while exiting 1, which reads exactly like a control that worked. Redone so it
compiles:

    stored = true unconditionally -> 2 failed | 2 passed
        expected true to be false   (the defect's own signature)

with the success and unreadable-reply cases correctly unaffected. Restored.

The installer path is covered by inspection and tsc, not by a test -- it is
inline in a large interactive command and extracting it is a bigger change than
this one. Saying so rather than implying otherwise.

Full suite 4375 passed, tsc clean, 0 lint errors.
