### PR TITLE
The anatomy page says which rappter it belongs to

### DIFF
--- a/typescript/src/__tests__/unit/anatomy-names-its-rappter.test.ts
+++ b/typescript/src/__tests__/unit/anatomy-names-its-rappter.test.ts
@@ -1,0 +1,99 @@
+/**
+ * A twin's page is the twin's. — #138
+ *
+ * Every instance on a device derives its designation and called name from the
+ * DEVICE tail (`~/.openrappter/rappid.tail`), so a hatched twin's anatomy page
+ * was byte-identical to the alpha's. Measured on a live twin beside the alpha:
+ *
+ *   alpha  designation=openrappter-RM-0059  name=Rame  home=~/.openrappter
+ *   slate  designation=openrappter-RM-0059  name=Rame  home=~/.openrappter
+ *
+ * while the gateway knew exactly who was answering (`/health` → instance:
+ * alpha | slate), and the twin itself said so in words when asked over the
+ * same POST /chat the surgeon screen uses:
+ *
+ *   slate: "I'm Rame (openrappter-RM-0059), a hatched twin on this device."
+ *
+ * It knew its ROLE and wore the alpha's NAME.
+ *
+ * Whether a twin should have a designation of its own is a one-way door — the
+ * tail is minted once and never re-rolled — and belongs to the owner. Being
+ * able to tell WHICH rappter you are reading does not, so that is what these
+ * pin.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { readAnatomy } from '../../gateway/anatomy.js';
+import { renderAnatomyPage } from '../../gateway/anatomy-page.js';
+import {
+  declareCurrentInstance,
+  __resetCurrentInstanceForTest,
+} from '../../infra/current-instance.js';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+const homes: string[] = [];
+afterEach(() => {
+  for (const d of homes.splice(0)) rmSync(d, { recursive: true, force: true });
+  __resetCurrentInstanceForTest();
+});
+
+function sandboxHome(): string {
+  const home = mkdtempSync(join(tmpdir(), 'anatomy-home-'));
+  homes.push(home);
+  return home;
+}
+
+describe('the anatomy surface names the rappter it belongs to', () => {
+  it('carries the twin name a hatched twin is serving as', () => {
+    const home = sandboxHome();
+    declareCurrentInstance('slate');
+
+    expect(readAnatomy(home).vitals.instance).toBe('slate');
+  });
+
+  it('says alpha when it is the alpha', () => {
+    // The negative control. `undefined` is a real answer the alpha declares,
+    // and must not be confused with never having declared.
+    const home = sandboxHome();
+    declareCurrentInstance(undefined);
+
+    expect(readAnatomy(home).vitals.instance).toBe('alpha');
+  });
+
+  it('omits the field entirely when nothing declared, rather than guessing', () => {
+    // Guessing `alpha` here is the same collapse #129 and #131 were about:
+    // an unchecked default that reads exactly like a verified answer.
+    const home = sandboxHome();
+
+    expect(readAnatomy(home).vitals.instance).toBeUndefined();
+  });
+
+  it('marks a twin on the page, and stops claiming the designation is its own', () => {
+    const home = sandboxHome();
+    declareCurrentInstance('slate');
+
+    const page = renderAnatomyPage(readAnatomy(home));
+
+    expect(page).toContain('twin · slate');
+    // The tooltip must not tell a twin's viewer the designation came from its
+    // own rappid, because on a twin it did not.
+    expect(page).not.toContain('derived from its rappid; never changes');
+    expect(page).toContain('shared with the alpha');
+  });
+
+  it('leaves the alpha page unmarked and its claim intact', () => {
+    const home = sandboxHome();
+    declareCurrentInstance(undefined);
+
+    const page = renderAnatomyPage(readAnatomy(home));
+
+    // Assert on the rendered tag, not the class name: the stylesheet defines
+    // `.twintag` unconditionally, so searching for that string matches the CSS
+    // on every page and would pass for a reason that has nothing to do with
+    // what is being claimed.
+    expect(page).not.toContain('twin · ');
+    expect(page).toContain('derived from its rappid; never changes');
+  });
+});

--- a/typescript/src/gateway/anatomy-page.ts
+++ b/typescript/src/gateway/anatomy-page.ts
@@ -106,6 +106,27 @@ export function renderAnatomyPage(a: Anatomy): string {
   const title = a.vitals.name ?? 'openrappter';
   const designation = a.vitals.designation ?? '';
 
+  /**
+   * Say which rappter this page belongs to. — #138
+   *
+   * Every instance on a device derives its designation and called name from the
+   * DEVICE tail, so a hatched twin's page was byte-identical to the alpha's:
+   * same designation, same name, nothing to tell them apart. Measured live,
+   * alpha beside a twin called `slate`, both read `openrappter-RM-0059 / Rame`.
+   *
+   * Whether a twin should have a designation of its own is a one-way door and
+   * the owner's to decide. Being able to see WHICH rappter you are reading is
+   * not, so the page says it — and the tooltip stops asserting a derivation
+   * that is not true on a twin.
+   */
+  const isTwin = Boolean(a.vitals.instance) && a.vitals.instance !== 'alpha';
+  const instanceTag = isTwin
+    ? ` <span class="twintag" title="a hatched twin on this device">twin · ${esc(a.vitals.instance!)}</span>`
+    : '';
+  const twinNote = isTwin
+    ? 'derived from this device, and shared with the alpha — see issue #138'
+    : 'derived from its rappid; never changes';
+
   // ── Callout pins + leader lines ────────────────────────────────────────────
   const callouts = a.organs
     .filter(o => PINS[o.id])
@@ -224,6 +245,10 @@ export function renderAnatomyPage(a: Anatomy): string {
        line-height: 1.06; margin: 22px 0 5px; color: var(--bone); }
   .sub { font-family: var(--mono); font-size: 13px; color: var(--muted); letter-spacing: 0.04em; }
   .designation { color: var(--bone); user-select: all; }
+  .twintag {
+    color: var(--bone); border: 1px solid currentColor; border-radius: 999px;
+    padding: 0 .45em; font-size: .8em; opacity: .85; white-space: nowrap;
+  }
 
   /* ── voice: the specimen can be heard, on-device only ── */
   .voicebar { display: flex; align-items: center; gap: 11px; margin-top: 14px; }
@@ -398,7 +423,7 @@ export function renderAnatomyPage(a: Anatomy): string {
   <div class="rule"></div>
 
   <h1>${esc(title)}</h1>
-  <div class="sub">${designation ? `<span class="designation" title="derived from its rappid; never changes">${esc(designation)}</span> · ` : ''}${a.vitals.liveness === 'awake'
+  <div class="sub">${designation ? `<span class="designation" title="${twinNote}">${esc(designation)}</span>${instanceTag} · ` : ''}${a.vitals.liveness === 'awake'
       ? 'read from this machine just now'
       : a.vitals.liveness === 'blocked'
         ? 'could not tell — nothing was learned about whether it is running'

--- a/typescript/src/gateway/anatomy.ts
+++ b/typescript/src/gateway/anatomy.ts
@@ -28,6 +28,7 @@
 
 import fs from 'fs';
 import { nameFor, mintTail, type OrganismName } from '../identity/name.js';
+import { currentInstanceDeclared, currentInstanceName } from '../infra/current-instance.js';
 import path from 'path';
 import os from 'os';
 
@@ -89,6 +90,24 @@ export interface VitalSigns {
   livenessReason: string;
   /** `openrappter-RX-4471` — formal identity, derived, never renamed. */
   designation?: string;
+  /**
+   * Which rappter on this device this page belongs to: a twin's name, or
+   * `alpha`. #138
+   *
+   * Every instance derives its designation and called name from the DEVICE
+   * tail (`~/.openrappter/rappid.tail`), so a twin's page was byte-identical
+   * to the alpha's — measured on a live twin:
+   *
+   *   alpha  designation=openrappter-RM-0059  name=Rame
+   *   slate  designation=openrappter-RM-0059  name=Rame
+   *
+   * Whether a twin should have a designation of its own is a one-way door and
+   * the owner's call. Being able to tell WHICH rappter you are reading is not.
+   *
+   * Absent when nothing has declared — never guessed as `alpha`, which is the
+   * collapse #129 and #131 were both about.
+   */
+  instance?: string;
   /** Chosen rung of the backend ladder, and why. */
   backend: string;
   backendReason: string;
@@ -487,6 +506,9 @@ export function readAnatomy(
     agentCount: liveAgents.length || agentFiles.length,
     name: soulName,
     designation: identity.designation,
+    // Which rappter is answering. Read from the one published derivation
+    // (#129) rather than re-derived here. #138
+    ...(currentInstanceDeclared() ? { instance: currentInstanceName() ?? 'alpha' } : {}),
     version: live.version ?? 'unknown',
     heartbeat: nextFire ? relativeTime(nextFire) : (live.awake ? 'no schedule' : 'none'),
   };


### PR DESCRIPTION
Closes #138 (the part that is not a one-way door).


Every instance on a device derives its designation and called name from the
DEVICE tail (~/.openrappter/rappid.tail), so a hatched twin's anatomy page was
byte-identical to the alpha's. Measured live, alpha beside a twin called slate:

    alpha  designation=openrappter-RM-0059  name=Rame  home=~/.openrappter
    slate  designation=openrappter-RM-0059  name=Rame  home=~/.openrappter

while the gateway knew exactly who was answering, since #131:

    alpha  instance=alpha
    slate  instance=slate

and the twin said so itself, asked over the same POST /chat the surgeon screen
uses:

    alpha : I'm openrappter-RM-0059, the alpha rappter on this device — the
            original, not a hatched twin.
    slate : I'm Rame (openrappter-RM-0059), a hatched twin on this device, and
            no — I'm not the alpha.

It knew its ROLE and wore the alpha's NAME, on the one surface a human reads.

Two problems live here and only one is mine. Whether a twin should have a
designation of its own is a one-way door -- the tail is "the GOD-layer secret
every public value derives from", minted once and never re-rolled (RAPP/1
6.2) -- and it is raised as a decision card in the tower rather than settled by
an autonomous tick. Being able to tell WHICH rappter you are reading is not a
judgement call, so that is what this does.

`vitals.instance` reads the one published derivation from #129 rather than
re-deriving; absent when nothing declared, never guessed as `alpha`, because
that collapse is what #129 and #131 were both about. The page marks a twin, and
its tooltip stops telling a twin's viewer that the designation came from its own
rappid -- on a twin it did not, and it now says where it did come from and
points at the open issue.

Five tests: the field on a twin, on the alpha, absent when undeclared, the page
marking a twin, and the alpha page left unmarked with its claim intact.

One test bug caught on the way: asserting the alpha page does not contain
"twintag" failed, because the stylesheet defines that class unconditionally. The
assertion was wrong, not the code -- a substring that also appears in CSS would
have passed or failed for reasons unrelated to the claim. It now asserts on the
rendered tag.

Negative control, needle asserted present first: dropping the field gives
"3 failed | 2 passed" with assertion failures -- a summary line, not a
collection error, which is the distinction that made a control vacuous last
time.

Full suite 4380 passed, tsc clean, 0 lint errors.
