### PR TITLE
A neighbour is somebody else

### DIFF
--- a/typescript/src/__tests__/unit/neighbor-speaks-as-itself.test.ts
+++ b/typescript/src/__tests__/unit/neighbor-speaks-as-itself.test.ts
@@ -178,3 +178,60 @@ describe('a rappter names itself to a neighbour', () => {
     expect(received.at(-1)!.session_id).not.toBe(deviceRappid('kody-w', 'alpha'));
   });
 });
+
+describe('a neighbour is somebody else', () => {
+  it('leaves itself out of the list of who it can reach', async () => {
+    // Measured on a live twin before this: `ember` listed alpha, ember and
+    // brainstem, and a model that took the list at face value spent a full
+    // model turn answering itself "Nope, I'm not you." #140
+    isolatedHome();
+    await neighbourNamed('peerling');
+    await neighbourNamed('ember');
+    declareCurrentInstance('ember');
+
+    const out = JSON.parse(await new NeighborAgent().perform({ action: 'list' }));
+    const names = (out.reachable as Array<{ name: string }>).map((r) => r.name);
+
+    expect(names).toContain('peerling');
+    expect(names).not.toContain('ember');
+  });
+
+  it('still lists the others when it is the alpha', async () => {
+    // The negative control: excluding yourself must not empty the list.
+    isolatedHome();
+    await neighbourNamed('peerling');
+    declareCurrentInstance(undefined);
+
+    const out = JSON.parse(await new NeighborAgent().perform({ action: 'list' }));
+    const names = (out.reachable as Array<{ name: string }>).map((r) => r.name);
+
+    expect(names).toContain('peerling');
+    expect(names).not.toContain('alpha');
+  });
+
+  it('refuses to say something to itself', async () => {
+    isolatedHome();
+    const peer = await neighbourNamed('ember');
+    declareCurrentInstance('ember');
+
+    const out = JSON.parse(await new NeighborAgent().perform({
+      action: 'say', to: 'ember', text: 'are you me',
+    }));
+
+    expect(out.status).toBe('error');
+    expect(String(out.message)).toMatch(/is this rappter/);
+    expect(peer.received).toHaveLength(0);
+  });
+
+  it('does not exclude anything when it does not know which rappter it is', async () => {
+    // An undeclared process must not start dropping names on a guess — the
+    // same collapse #129 and #131 were both about.
+    isolatedHome();
+    await neighbourNamed('peerling');
+
+    const out = JSON.parse(await new NeighborAgent().perform({ action: 'list' }));
+    const names = (out.reachable as Array<{ name: string }>).map((r) => r.name);
+
+    expect(names).toContain('peerling');
+  });
+});

--- a/typescript/src/agents/NeighborAgent.ts
+++ b/typescript/src/agents/NeighborAgent.ts
@@ -104,8 +104,14 @@ export class NeighborAgent extends BasicAgent {
   private async list(): Promise<string> {
     const { listRappters } = await import('../infra/roster.js');
     const rows = await listRappters();
+    const me = await this.whoAmI();
     const reachable = rows
       .filter((r) => r.running)
+      // A neighbour is somebody else. This listed the caller among the
+      // rappters it could talk to, and a model that took the list at face
+      // value spent a whole turn in a mirror — measured on a twin called
+      // `ember`, which answered itself "Nope, I'm not you." #140
+      .filter((r) => r.name !== me)
       .map((r) => ({ name: r.name, port: r.port }));
 
     // The brainstem is a neighbour and is not a rappter, so the roster does not
@@ -116,6 +122,21 @@ export class NeighborAgent extends BasicAgent {
     }
 
     return JSON.stringify({ status: 'success', action: 'list', reachable });
+  }
+
+  /**
+   * Which rappter is asking, by the name the roster uses.
+   *
+   * Read from the one published derivation (#129) rather than re-derived, and
+   * `undefined` when nothing declared — a process that does not know which
+   * rappter it is must not start excluding names on a guess.
+   */
+  private async whoAmI(): Promise<string | undefined> {
+    const { currentInstanceName, currentInstanceDeclared } =
+      await import('../infra/current-instance.js');
+    if (!currentInstanceDeclared()) return undefined;
+    const { canonicalInstanceKey } = await import('../infra/gateway-lock.js');
+    return canonicalInstanceKey(currentInstanceName() ?? 'alpha');
   }
 
   private async say(kwargs: Record<string, unknown>): Promise<string> {
@@ -131,6 +152,20 @@ export class NeighborAgent extends BasicAgent {
         status: 'error',
         message: 'Address a neighbour by name, not by URL. Use `list` to see who is reachable.',
       });
+    }
+
+    // Talking to yourself completes, which is what makes it worth refusing: it
+    // spends a whole model turn and reads, in the logs, exactly like two
+    // rappters holding a conversation. #140
+    const self = await this.whoAmI();
+    if (self !== undefined) {
+      const { canonicalInstanceKey: key } = await import('../infra/gateway-lock.js');
+      if (key(to) === self) {
+        return JSON.stringify({
+          status: 'error',
+          message: `"${to}" is this rappter. Use \`list\` to see the neighbours it can reach.`,
+        });
+      }
     }
 
     const url = await this.resolve(to);


### PR DESCRIPTION
Closes #140.

Closes #140.

The Neighbor agent listed the caller among the rappters it could talk to.
Measured on a hatched twin called `ember` (:19013), driving its own tool:

    [Neighbor] {"action":"list","reachable":[
      {"name":"alpha","port":18790},
      {"name":"ember","port":19013},      <- itself
      {"name":"brainstem","port":7071}]}

Taking that at face value produced a self-dialogue. Asked to say something to
`ember`, `ember` did, and answered itself:

    [Neighbor] {"action":"say","to":"ember","wire":"twin",
     "said":"Nope, I'm not you.\n\n# Who I Am vs. Who You Are ..."}

It completes in ~9s, which is what makes it worth refusing rather than
harmless: no hang to notice, just a model turn spent in a mirror and a
transcript that reads like two rappters holding a conversation.

`resolve()` already knew which rappter it was -- `currentInstanceName()` is
read a few lines away to fill from_rappid (#129) -- so the information needed
to leave itself out was already in hand. An undeclared process excludes
nothing, because dropping names on a guess is the collapse #129 and #131 were
both about.

Four tests: absent from its own list, the others still listed when it is the
alpha, an explicit self-address refused without sending, and nothing excluded
when the instance is undeclared.

Negative controls, needles asserted present first:
  stop excluding self from the list  -> 2 failed | 6 passed
  stop refusing an explicit self-say -> 1 failed | 7 passed
Both produced assertion failures with a real summary line rather than a
collection error -- the distinction that made a control vacuous two ticks ago.

Recorded in the issue and NOT changed: while measuring this, the receiving
side answered the peer as though a person had written ("You're Kody"). That is
the architecture working. The stated goal is that a peer cannot tell whether it
is talking to a rappter, a brainstem, or a person, so a receiver treating every
caller alike is correct, and from_rappid is deliberately an unauthenticated
claim.

Full suite 4384 passed, tsc clean, 0 lint errors.
