### PR TITLE
A twin is judged by the same name the roster calls it

### DIFF
--- a/typescript/src/__tests__/unit/current-instance-canonical.test.ts
+++ b/typescript/src/__tests__/unit/current-instance-canonical.test.ts
@@ -1,0 +1,59 @@
+/**
+ * A rappter calls itself what the roster calls it. — #142
+ *
+ * The declared name is what `/health`, the anatomy surface and the Neighbor
+ * agent all report. Every name the roster expects is canonical, because the
+ * instance directory and the lock are derived through `canonicalInstanceKey`.
+ * Publishing the raw `--instance` string made those two disagree, and the
+ * ownership check added in #131 called a live twin dead.
+ *
+ * Fixing the comparison alone would have been enough to stop that, and is
+ * covered in the roster suite. It would still have left `/health` reporting
+ * "review demo twin" while `openrappter twins` printed `review_demo_twin` — the
+ * same fact under two names, which is how this class of defect starts. So the
+ * declaration is pinned here too, because a negative control showed the roster
+ * tests could not see it.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import {
+  declareCurrentInstance,
+  currentInstanceName,
+  currentInstanceDeclared,
+  __resetCurrentInstanceForTest,
+} from '../../infra/current-instance.js';
+import { canonicalInstanceKey } from '../../infra/gateway-lock.js';
+
+afterEach(() => __resetCurrentInstanceForTest());
+
+describe('the declared instance is the key the roster uses', () => {
+  it('stores a name that needed escaping as the escaped key', () => {
+    declareCurrentInstance('review demo twin');
+
+    expect(currentInstanceName()).toBe('review_demo_twin');
+    expect(currentInstanceName()).toBe(canonicalInstanceKey('review demo twin'));
+  });
+
+  it('agrees with the key for every shape a name can take', () => {
+    // The space was the case that bit. Cover the space of shapes rather than
+    // the one example, which is the lesson from the channel-guard tests.
+    for (const raw of ['plain', 'Mixed_Case', 'has space', 'a@b', 'dots.and-dashes', 'tab\there']) {
+      __resetCurrentInstanceForTest();
+      declareCurrentInstance(raw);
+      expect(currentInstanceName()).toBe(canonicalInstanceKey(raw));
+    }
+  });
+
+  it('leaves the alpha as undefined rather than canonicalising nothing', () => {
+    declareCurrentInstance(undefined);
+
+    expect(currentInstanceDeclared()).toBe(true);
+    expect(currentInstanceName()).toBeUndefined();
+  });
+
+  it('treats a blank name as the alpha, not as an instance called ""', () => {
+    declareCurrentInstance('   ');
+
+    expect(currentInstanceName()).toBeUndefined();
+  });
+});

--- a/typescript/src/__tests__/unit/rappter-roster.test.ts
+++ b/typescript/src/__tests__/unit/rappter-roster.test.ts
@@ -39,6 +39,7 @@ import {
   gatewayEndpointFileFor,
   gatewayLockFileFor,
   gatewayPortFor,
+  canonicalInstanceKey,
   readGatewayEndpoint,
   writeGatewayEndpoint,
 } from '../../infra/gateway-lock.js';
@@ -565,5 +566,67 @@ describe('a stale endpoint record is history, not an address', () => {
     // probe alone can see, as before.
     expect(row?.stalePort).toBeUndefined();
     expect(row?.running).toBe(await canNamePids());
+  });
+});
+
+/**
+ * One derivation of "which twin am I". — #142
+ *
+ * #131 taught the roster to believe the name a gateway reports on `/health`.
+ * That name was raw, while every name the roster expects is canonical, so any
+ * twin whose name contains a space (or `@`, or unicode) was judged an impostor
+ * by the check added to stop impostors being missed. Reproduced against a real
+ * gateway started with the documented flag:
+ *
+ *   /health           -> instance: "review demo twin"     (raw)
+ *   on disk           -> instances/review_demo_twin/…     (canonical)
+ *   record pid        == listening pid
+ *   openrappter twins -> ○ review_demo_twin  not running — another process
+ *                          now holds its last port
+ *
+ * The twin WAS the process holding that port. Same failure as #101, #111 and
+ * #118: two derivations of one fact drifting apart.
+ */
+describe('a twin is judged by the same name the roster calls it', () => {
+  it('does not call a live twin an impostor because its name needed escaping', async () => {
+    const home = isolatedHome();
+    withoutLsof();   // force the name route to be the only one that can speak
+    const raw = 'review demo twin';
+    // A real gateway publishes the RAW name it was started with.
+    const port = await gatewayServing({ instance: raw });
+    // The record lives under the CANONICAL name, because that is what
+    // `gatewayEndpointFileFor` derives.
+    const file = gatewayEndpointFileFor({ instance: raw });
+    expect(file.startsWith(home)).toBe(true);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({
+      instance: raw, port, pid: process.pid, startedAt: 'x',
+    }));
+
+    const rows = await listRappters({ names: [canonicalInstanceKey(raw)] });
+    const twin = rows.find((r) => r.name === canonicalInstanceKey(raw));
+
+    expect(twin?.running).toBe(true);
+    expect(twin?.stalePort).toBeUndefined();
+    expect(twin?.ownershipUnverified).toBeUndefined();
+  });
+
+  it('still unmasks a real impostor whose name needed escaping', async () => {
+    // The negative control: escaping must not become a way to be believed.
+    const home = isolatedHome();
+    withoutLsof();
+    const port = await gatewayServing({ instance: 'somebody else' });
+    const file = gatewayEndpointFileFor({ instance: 'review demo twin' });
+    expect(file.startsWith(home)).toBe(true);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, JSON.stringify({
+      instance: 'review demo twin', port, pid: process.pid, startedAt: 'x',
+    }));
+
+    const name = canonicalInstanceKey('review demo twin');
+    const row = (await listRappters({ names: [name] })).find((r) => r.name === name);
+
+    expect(row?.running).toBe(false);
+    expect(row?.stalePort).toBe(true);
   });
 });

--- a/typescript/src/infra/current-instance.ts
+++ b/typescript/src/infra/current-instance.ts
@@ -24,15 +24,35 @@
  * Callers are expected to handle `undefined` by refusing, not by defaulting.
  */
 
+import { canonicalInstanceKey } from './gateway-lock.js';
+
 let current: string | undefined;
 let declared = false;
 
 /**
  * Record which rappter this process is serving as. `undefined` means the
  * alpha, which is a real answer — distinct from never having declared.
+ *
+ * The name is stored as the CANONICAL key, not as typed. #142
+ *
+ * It used to be stored raw, and #131 then taught the roster to believe the name
+ * a gateway reports on `/health`. Every name the roster expects is canonical,
+ * because that is what the instance directory and the lock are derived from —
+ * so a twin started as `--instance "review demo twin"` reported
+ * `"review demo twin"` while the roster looked for `review_demo_twin`, and the
+ * check written to catch impostors declared a live twin dead:
+ *
+ *   ○ review_demo_twin :19876  not running — another process now holds its
+ *                              last port
+ *
+ * The twin WAS the process holding that port. Canonicalising here rather than
+ * at each reader is the point: #101, #111 and #118 were all two derivations of
+ * one fact drifting apart, and a caller that must remember to convert is a
+ * second derivation waiting to happen.
  */
 export function declareCurrentInstance(instance: string | undefined): void {
-  current = instance && instance.trim() ? instance.trim() : undefined;
+  const named = instance && instance.trim() ? instance.trim() : undefined;
+  current = named === undefined ? undefined : canonicalInstanceKey(named);
   declared = true;
 }
 

--- a/typescript/src/infra/current-instance.ts
+++ b/typescript/src/infra/current-instance.ts
@@ -24,7 +24,7 @@
  * Callers are expected to handle `undefined` by refusing, not by defaulting.
  */
 
-import { canonicalInstanceKey } from './gateway-lock.js';
+import { canonicalInstanceKey } from './instance-key.js';
 
 let current: string | undefined;
 let declared = false;

--- a/typescript/src/infra/gateway-lock.ts
+++ b/typescript/src/infra/gateway-lock.ts
@@ -136,14 +136,11 @@ export function gatewayPortFor(options: {
  * A name that is ALREADY canonical maps to itself unchanged, which is what
  * keeps every existing twin on the port it has today.
  */
-export function canonicalInstanceKey(name: string): string {
-  const raw = name.trim();
-  const cleaned = raw.replace(/[^A-Za-z0-9._-]/g, '_');
-  if (/^\.+$/.test(cleaned) || cleaned === '') {
-    return `_${Buffer.from(raw).toString('hex')}`;
-  }
-  return cleaned;
-}
+// Re-exported, not reimplemented: it now lives in `instance-key.ts` so that
+// importing it does not drag this module's native `better-sqlite3` dependency
+// behind it. Every existing importer keeps working. #142
+export { canonicalInstanceKey } from './instance-key.js';
+import { canonicalInstanceKey } from './instance-key.js';
 
 export function gatewayLockFileFor(options: {
   instance?: string;

--- a/typescript/src/infra/instance-key.ts
+++ b/typescript/src/infra/instance-key.ts
@@ -1,0 +1,36 @@
+/**
+ * A name becomes a key here, and nowhere else.
+ *
+ * This lived in `gateway-lock.ts`, which is the right place conceptually and
+ * the wrong place structurally: that module `require`s `better-sqlite3` at
+ * module scope for the runtime lock. So importing one pure string function
+ * dragged a native dependency behind it, and the Dashboard UI suite — which
+ * imports `GatewayServer`, which knows which rappter it is — died on a runner
+ * that has no such dependency:
+ *
+ *     Error: Cannot find module 'better-sqlite3'
+ *     Require stack: typescript/src/infra/gateway-lock.ts
+ *     Test Files  1 failed | 7 passed (8)
+ *
+ * Splitting it out keeps ONE implementation while removing the edge. Everything
+ * that imported it from `gateway-lock` still can — that module re-exports it —
+ * so this is not a second derivation, it is the same one with a lighter home.
+ */
+
+/**
+ * The single canonical form of an instance name.
+ *
+ * `canonicalInstanceKey` decides what an instance's directory, its lock and its
+ * port are called, so anything that compares names must use it or it is
+ * comparing two different facts. #142 was exactly that: a gateway published its
+ * raw `--instance` string while the roster looked for the canonical key, and a
+ * live twin was reported dead.
+ */
+export function canonicalInstanceKey(name: string): string {
+  const raw = name.trim();
+  const cleaned = raw.replace(/[^A-Za-z0-9._-]/g, '_');
+  if (/^\.+$/.test(cleaned) || cleaned === '') {
+    return `_${Buffer.from(raw).toString('hex')}`;
+  }
+  return cleaned;
+}

--- a/typescript/src/infra/roster.ts
+++ b/typescript/src/infra/roster.ts
@@ -30,6 +30,7 @@ import { execFile } from 'child_process';
 import { promisify } from 'util';
 import {
   ALPHA_GATEWAY_PORT,
+  canonicalInstanceKey,
   gatewayEndpointFileFor,
   gatewayPortFor,
   readGatewayEndpoint,
@@ -289,7 +290,22 @@ export async function listRappters(options: {
      * different rappter is an impostor whatever the record omits.
      */
     const recordedPid = instance === undefined ? undefined : recordFor(instance)?.pid;
-    const claimedName = typeof health?.instance === 'string' ? health.instance : undefined;
+    /**
+     * Compare names the roster's own way. #142
+     *
+     * `expectedName` is canonical — it comes from the instance directory, which
+     * `gatewayLockFileFor` derives through `canonicalInstanceKey`. `claimedName`
+     * arrives over HTTP from another process, which may be an older build that
+     * publishes the raw `--instance` string. Comparing them as typed made a
+     * live twin called "review demo twin" an impostor of `review_demo_twin`,
+     * and the check written to catch impostors reported it dead.
+     *
+     * Declaration canonicalises now (infra/current-instance), so a current
+     * gateway already agrees. This normalises the wire value as well, because a
+     * name that crossed a process boundary is input, not a fact.
+     */
+    const claimedRaw = typeof health?.instance === 'string' ? health.instance : undefined;
+    const claimedName = claimedRaw === undefined ? undefined : canonicalInstanceKey(claimedRaw);
     const expectedName = instance ?? 'alpha';
 
     const namedImpostor = claimedName !== undefined && claimedName !== expectedName;


### PR DESCRIPTION
Closes #142.

Closes #142.

#131 taught the roster to believe the name a gateway reports on /health, and
added a third derivation of "which twin am I" without reconciling it with the
existing one -- while quoting that exact lesson in its own comments.

Every name the roster expects is canonical: the instance directory and the lock
come from canonicalInstanceKey. The published name was raw. So a twin started
as `--instance "review demo twin"` reported "review demo twin" while the roster
looked for `review_demo_twin`, and the check written to catch impostors
declared a live twin dead:

    ○ review_demo_twin :19876  not running — another process now holds its last port

The twin WAS the process holding that port; its record's pid matched the
listener exactly. Not a misroute -- a fabricated conflict that never happened,
which is the unearned-report class this project exists to avoid.

Found by an independent reviewer of the b47db49..bcda448 range, who reproduced
it end to end against a real gateway under a scratch HOME, and confirmed with a
control that removing the /health `instance` field makes the same twin report
running=true. Affected: twins started via --instance or OPENRAPPTER_INSTANCE
whose name contains anything outside [A-Za-z0-9._-]. Immune: the alpha, and
every twin made by `hatch`, which canonicalises before spawning -- which is why
nothing on this machine ever showed it.

Fixed in two places, deliberately:

- Declaration canonicalises, so /health, the anatomy surface and the Neighbor
  agent all report the key the roster uses. Without this, /health would say
  "review demo twin" while `twins` printed `review_demo_twin` -- the same fact
  under two names, which is how this starts.
- The comparison canonicalises the wire value too, because `claimedName`
  crossed a process boundary from a build that may be older. A name that
  arrived over HTTP is input, not a fact.

The negative controls are the reason both are here. Removing the comparator
half fails the reproduction. Removing the declaration half left all 24 roster
tests GREEN -- it was unverified, and the fixture publishes a raw name directly,
so the roster suite structurally cannot see it. Pinned separately in
current-instance-canonical.test.ts, which covers the space of name shapes
rather than the one example that bit, and which fails 2 of 4 when the
declaration stops canonicalising.

Full suite 4390 passed, tsc clean, 0 lint errors.
