### PR TITLE
fix(release): stop preflight failing on continued mac build env prefix

### DIFF
--- a/scripts/release-preflight.test.mjs
+++ b/scripts/release-preflight.test.mjs
@@ -448,7 +448,17 @@ test('macOS workflow validates the tag before checkout and never injects output 
     '^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-bar$',
   ));
   assert.doesNotMatch(workflow, /run:\s*VERSION=\$\{\{/);
-  assert.match(workflow, /VERSION="\$RELEASE_VERSION" bash scripts\/build-mac-app\.sh/);
+  // The guarded property is that the build reads the version from the quoted
+  // RELEASE_VERSION env var rather than an inlined ${{ }} expansion. It is not
+  // that the assignment and the command share a line: signing added
+  // REQUIRE_SIGNING and CODESIGN_IDENTITY as backslash-continued env prefixes,
+  // which broke this match and failed every Release run while the injection
+  // guard above still held. Cross newlines only through explicit `\`
+  // continuations, so this cannot drift into matching an unrelated block.
+  assert.match(
+    workflow,
+    /VERSION="\$RELEASE_VERSION"[^\n]*(?:\\\n[^\n]*)*bash scripts\/build-mac-app\.sh/,
+  );
 });
 
 test('registry publication reconciles exact artifacts and selects an explicit npm tag', () => {


### PR DESCRIPTION
## Problem

Every `Release` run has failed since **v1.11.0** ([run 31447657700](https://github.com/kody-w/openrappter/actions/runs/31447657700)). `Test deterministic preflight` was the **only** failing gate — 23 pass / 1 fail — and because it runs in `validate-tag`, every downstream job (build, install gates, quality gates, smoke-install, registry publication, GitHub Release) was **skipped**. No release could ship.

## Root cause

The assertion required the version assignment and the build command on a single line:

```js
assert.match(workflow, /VERSION="\$RELEASE_VERSION" bash scripts\/build-mac-app\.sh/);
```

Code signing later added `REQUIRE_SIGNING` and `CODESIGN_IDENTITY` as backslash-continued env prefixes in `release-bar.yml`:

```yaml
REQUIRE_SIGNING=1 \
VERSION="$RELEASE_VERSION" \
CODESIGN_IDENTITY="$CODESIGN_IDENTITY" \
  bash scripts/build-mac-app.sh
```

So the match broke on **formatting**. The property it guards was never violated — this is a stale assertion, not a security regression.

## Why the guard is unchanged in strength

The security property is that the build reads the version from the quoted env var rather than an inlined `${{ }}` expansion. That is still enforced:

- the sibling `assert.doesNotMatch(workflow, /run:\s*VERSION=\$\{\{/)` still holds
- `RELEASE_VERSION` comes from a job-level `env:`, and the tag is validated against a strict semver-plus-`-bar` pattern **before** checkout

The replacement crosses newlines **only** through explicit `\` continuations, so it cannot drift into matching an unrelated block.

Verified against negative controls — the new regex still rejects each of these:

| Mutation | Rejected |
| --- | --- |
| `VERSION=${{ needs.validate-tag.outputs.version }}` injection | yes |
| `VERSION` env line removed | yes |
| build script swapped to `scripts/other.sh` | yes |

## Verification

Ran the exact CI command from `release.yml` locally:

```
$ node --test scripts/release-preflight.test.mjs
tests 24
pass 24
fail 0
```

Was 23 pass / 1 fail before the change.

Found by the rapp-sentinel health check `eco_sweep` (red streak in `openrappter: Release`).
