### PR TITLE
OpenRappter 1.12.0: Flight Recorder

### DIFF
--- a/.github/workflows/flight-recorder.yml
+++ b/.github/workflows/flight-recorder.yml
@@ -1,0 +1,94 @@
+name: Flight Recorder
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  gate:
+    name: Cross-runtime gate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: python/pyproject.toml
+
+      - name: Install TypeScript dependencies
+        working-directory: typescript
+        run: npm ci
+
+      - name: Install Python runtime and test dependencies
+        run: python -m pip install -e 'python[dev]'
+
+      - name: Install required conformance binaries
+        run: |
+          RSB_SHA=7846dfdd5e2c74ea2201e1b141269df359b4ce5a
+          KEYRING_SHA=89386724e9bf8b365ce3bd2847fbcc06365953d5
+          curl -fsSL \
+            "https://raw.githubusercontent.com/kody-w/rapp-secondbrain/$RSB_SHA/install.sh" \
+            -o "$RUNNER_TEMP/rsb-install.sh"
+          echo "6fbe9cf84a2b911384957743250e09bacb2c03a5be917974589255e89334d848  $RUNNER_TEMP/rsb-install.sh" \
+            | sha256sum -c -
+          RSB_REF="$RSB_SHA" bash "$RUNNER_TEMP/rsb-install.sh"
+
+          curl -fsSL \
+            "https://raw.githubusercontent.com/kody-w/rapp-keyring/$KEYRING_SHA/install.sh" \
+            -o "$RUNNER_TEMP/keyring-install.sh"
+          echo "a41a8e50f7a1a29212a402024bb65b8e9060e2b6f3bc4594b16d066ff666542c  $RUNNER_TEMP/keyring-install.sh" \
+            | sha256sum -c -
+          sed -i \
+            "s|https://raw.githubusercontent.com/\${REPO}/main|https://raw.githubusercontent.com/\${REPO}/$KEYRING_SHA|" \
+            "$RUNNER_TEMP/keyring-install.sh"
+          bash "$RUNNER_TEMP/keyring-install.sh"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+
+      - name: Run Flight Recorder acceptance gate
+        run: node tools/flight-recorder-gate.mjs
+
+  windows:
+    name: Native Windows storage
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: python/pyproject.toml
+
+      - name: Install TypeScript dependencies
+        working-directory: typescript
+        run: npm ci
+
+      - name: Install Python runtime and test dependencies
+        run: python -m pip install -e "python[dev]"
+
+      - name: Validate TypeScript Windows storage
+        working-directory: typescript
+        run: |
+          npx vitest run src/flight-recorder/windows-storage.test.ts
+          npm run build --silent
+
+      - name: Validate Python Windows storage
+        working-directory: python
+        run: python -m pytest tests/test_flight_recorder_windows.py -q

--- a/.github/workflows/flight-recorder.yml
+++ b/.github/workflows/flight-recorder.yml
@@ -87,7 +87,7 @@ jobs:
         working-directory: typescript
         run: |
           npx vitest run src/flight-recorder/windows-storage.test.ts
-          npm run build --silent
+          npm run build
 
       - name: Validate Python Windows storage
         working-directory: python

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,9 +65,98 @@ jobs:
 
           echo "version=${GITHUB_REF_NAME#v}" >> "$GITHUB_OUTPUT"
 
+  flight-recorder-gate:
+    name: Flight Recorder cross-runtime gate
+    needs: preflight
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: python/pyproject.toml
+
+      - name: Install TypeScript dependencies
+        working-directory: typescript
+        run: npm ci
+
+      - name: Install Python runtime and test dependencies
+        run: python -m pip install -e 'python[dev]'
+
+      - name: Install required conformance binaries
+        run: |
+          RSB_SHA=7846dfdd5e2c74ea2201e1b141269df359b4ce5a
+          KEYRING_SHA=89386724e9bf8b365ce3bd2847fbcc06365953d5
+          curl -fsSL \
+            "https://raw.githubusercontent.com/kody-w/rapp-secondbrain/$RSB_SHA/install.sh" \
+            -o "$RUNNER_TEMP/rsb-install.sh"
+          echo "6fbe9cf84a2b911384957743250e09bacb2c03a5be917974589255e89334d848  $RUNNER_TEMP/rsb-install.sh" \
+            | sha256sum -c -
+          RSB_REF="$RSB_SHA" bash "$RUNNER_TEMP/rsb-install.sh"
+
+          curl -fsSL \
+            "https://raw.githubusercontent.com/kody-w/rapp-keyring/$KEYRING_SHA/install.sh" \
+            -o "$RUNNER_TEMP/keyring-install.sh"
+          echo "a41a8e50f7a1a29212a402024bb65b8e9060e2b6f3bc4594b16d066ff666542c  $RUNNER_TEMP/keyring-install.sh" \
+            | sha256sum -c -
+          sed -i \
+            "s|https://raw.githubusercontent.com/\${REPO}/main|https://raw.githubusercontent.com/\${REPO}/$KEYRING_SHA|" \
+            "$RUNNER_TEMP/keyring-install.sh"
+          bash "$RUNNER_TEMP/keyring-install.sh"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          test -x "$HOME/.local/bin/rapp-keyring"
+          test -x "$HOME/.local/bin/rsb"
+
+      - name: Run the release acceptance gate
+        run: node tools/flight-recorder-gate.mjs
+
+  flight-recorder-windows:
+    name: Flight Recorder Windows storage gate
+    needs: preflight
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: typescript/package-lock.json
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: python/pyproject.toml
+
+      - name: Install TypeScript dependencies
+        working-directory: typescript
+        run: npm ci
+
+      - name: Install Python runtime and test dependencies
+        run: python -m pip install -e "python[dev]"
+
+      - name: Validate TypeScript Windows storage
+        working-directory: typescript
+        run: |
+          npx vitest run src/flight-recorder/windows-storage.test.ts
+          npm run build --silent
+
+      - name: Validate Python Windows storage
+        working-directory: python
+        run: python -m pytest tests/test_flight_recorder_windows.py -q
+
   build-artifacts:
     name: Build release artifacts once
-    needs: preflight
+    needs: [preflight, flight-recorder-gate, flight-recorder-windows]
     runs-on: ubuntu-latest
     env:
       RELEASE_VERSION: ${{ needs.preflight.outputs.version }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,7 +148,7 @@ jobs:
         working-directory: typescript
         run: |
           npx vitest run src/flight-recorder/windows-storage.test.ts
-          npm run build --silent
+          npm run build
 
       - name: Validate Python Windows storage
         working-directory: python

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,71 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   loopback request implicitly; protected JSON-RPC and `/chat` calls now enforce
   configured credentials consistently with WebSocket authentication.
 
+## [1.12.0] - 2026-08-11
+
+### Added
+
+- **Provider-neutral Flight Recorder** in TypeScript and Python — a local
+  SQLite WAL ledger records correlated trace, context, provider, tool, and
+  agent lifecycle events under `openrappter-event/1.0`.
+- **Privacy-safe defaults** — raw prompts, responses, tool arguments, and file
+  contents are omitted unless explicitly enabled. Opt-in IO is recursively
+  scrubbed for secret keys, secret-shaped values, sensitive paths, circular
+  values, unsafe numbers, and bounded by a post-redaction byte cap.
+- **Integrity-checked replay bundles** — versioned
+  `openrappter-flight-export/1.0` export/import with SHA-256 event hashes,
+  atomic tamper rejection, durable sequence continuity, and a committed
+  TypeScript/Python golden vector.
+- **Flight Recorder CLI** — `flight status`, `events`, `export`, `import`, and
+  confirmation-gated `clear`.
+- **Release-enforced cross-runtime gate** — behavior, mutation, privacy,
+  causality, retention, package, TypeScript, and Python validation now block
+  release artifact publication.
+
+### Changed
+
+- Provider responses may report the concrete model that actually answered;
+  `auto` remains a routing policy in metadata instead of being persisted as a
+  false model identity.
+- Retention prunes whole completed traces and preserves active traces rather
+  than leaving replay fragments without their start/context events. Nested and
+  resumed activity is evaluated by lifecycle depth in trace sequence order.
+- Replay exports read one uncapped SQLite snapshot, while interactive queries
+  retain their 10,000-event safety cap.
+- Trace sequence allocation reloads after cross-process SQLite conflicts, and
+  long-trace recovery uses one descending lookup rather than capped paging.
+  Lifecycle durations use monotonic clocks rather than wall time.
+- Absolute workspace paths are persisted as stable SHA-256 scope identifiers,
+  not raw filesystem paths.
+- Session identifiers are persisted as stable SHA-256 scope identifiers so
+  channel keys cannot leak phone numbers, email addresses, or chat GUIDs.
+  A private per-installation HMAC key prevents offline dictionary reversal.
+
+### Security
+
+- Persisted error metadata contains only safe class/code/status, message hash,
+  and message length. Raw provider response bodies remain opt-in payload data.
+- Flight databases, live WAL/SHM sidecars, and atomically replaced export
+  bundles use private filesystem modes. Custom database paths do not chmod
+  caller-owned parent directories.
+- Session/channel identifiers are normalized at the recorder boundary, and
+  Python query aliases reject unknown filters instead of silently exporting an
+  over-broad history.
+- Secret-shaped and excluded-path property names are replaced with
+  collision-safe markers before hashing or persistence; contents under
+  excluded filenames such as `.pem`, `.p12`, and service-account files are
+  removed.
+- Direct provider calls in telephony, Surgeon, LearnNew, Ouroboros, and
+  iMessage readiness checks now emit the same provider lifecycle evidence as
+  Assistant turns.
+- The Copilot CLI MCP child initializes its own recorder, streaming preserves
+  provider-reported model identity, and unknown fallback models remain
+  explicitly unattributed.
+- Copilot CLI child tools inherit the originating trace/parent scope and record
+  a tool-to-agent causal subtree rather than a disconnected child trace.
+- Standalone records evict sequence caches, and explicit recorder installation
+  remains synchronized with environment bootstrap.
+
 ## [1.10.0] - 2026-07-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 
 🌐 **[kody-w.github.io/openrappter](https://kody-w.github.io/openrappter)** — Website & docs
 
-[Skills Reference](./skills.md) | [Documentation](./docs) | [Architecture](./docs/architecture.html) | [v1.10.0 Release Notes](./docs/release-notes-1.10.0-evolution.html) | [RappterHub](https://github.com/rappterhub/rappterhub)
+[Skills Reference](./skills.md) | [Documentation](./docs) | [Architecture](./docs/architecture.html) | [Flight Recorder](./docs/flight-recorder.md) | [v1.12.0 Release Notes](./docs/release-notes-1.12.0-evolution.html) | [RappterHub](https://github.com/rappterhub/rappterhub)
 
 [TypeScript macOS iMessage assistant setup](./docs/typescript-imessage.md) ·
 [iMessage reliability contract](./docs/imessage-reliability.md)
@@ -82,6 +82,28 @@ Your agent will clone the repo, install dependencies, start the gateway and UI, 
 ## What Is openrappter
 
 A dual-runtime (Python + TypeScript) AI agent framework that uses **GitHub Copilot** as the cloud AI backbone. Copilot handles inference; your agent data (memory, config, state) stays local in `~/.openrappter/`.
+
+### Flight Recorder: one truthful local execution history
+
+Both runtimes keep a local, append-only SQLite event ledger for
+provider attempts, context assembly, tool calls, and agent execution. It gives
+every turn a correlated trace ID so a result can be explained and replayed
+instead of reconstructed from unrelated logs.
+
+Privacy is the default: raw prompts, responses, tool arguments, and file
+contents are **not persisted** unless `OPENRAPPTER_FLIGHT_RECORD_IO=1` is set.
+Metadata is recursively scrubbed for tokens, credentials, secret-shaped values,
+and sensitive paths such as `.env`, SSH keys, and cloud credential files.
+
+```bash
+openrappter flight status
+openrappter flight events --trace <trace-id>
+openrappter flight export --trace <trace-id> --output trace.json
+openrappter flight import trace.json
+```
+
+See [Flight Recorder](./docs/flight-recorder.md) for the event contract,
+privacy boundary, configuration, and replay/export format.
 
 ### Copilot Surgeon: the main interaction
 

--- a/contracts/flight-recorder-vector.json
+++ b/contracts/flight-recorder-vector.json
@@ -1,0 +1,45 @@
+{
+  "schema": "openrappter-event/1.0",
+  "id": "vector-alpha",
+  "sequence": 7,
+  "traceId": "trace-vector",
+  "parentId": null,
+  "sessionId": "session:e523e4096e6419b507b73af3",
+  "workspaceId": "workspace:9ae7af749ba270e5853be6ee",
+  "kind": "provider.attempt.completed",
+  "source": "parity-vector",
+  "status": "success",
+  "timestamp": "2026-08-11T12:34:56.789Z",
+  "durationMs": 12.5,
+  "providerId": "fixture",
+  "model": "gpt-test",
+  "agentName": "VectorAgent",
+  "toolName": "vector-tool",
+  "metadata": {
+    "unicode": "🦖 café",
+    "nested": {
+      "a": 1,
+      "b": [
+        true,
+        null,
+        2.5
+      ]
+    },
+    "numericEdges": [
+      1e-7,
+      2.5,
+      0,
+      "100000000000000000000n",
+      "1e+21n"
+    ],
+    "unicodeKeyOrder": {
+      "": "bmp-private-use",
+      "😀": "non-bmp"
+    }
+  },
+  "payload": {
+    "text": "hello",
+    "count": 3
+  },
+  "contentHash": "de428c9638474bb195bed10d8199559b949275465b1020f3c93c98ed2c362504"
+}

--- a/docs/flight-recorder.md
+++ b/docs/flight-recorder.md
@@ -1,0 +1,143 @@
+# Flight Recorder
+
+Flight Recorder is OpenRappter's local, provider-neutral execution ledger. It
+answers:
+
+> What context, provider, model, agent, tool, and result produced this outcome?
+
+It records a correlated event stream across an Assistant turn:
+
+```text
+trace.started
+  context.assembled
+  provider.attempt.started
+  provider.attempt.completed
+  tool.call.started
+    agent.execute.started
+    context.assembled
+    agent.execute.completed
+  tool.call.completed
+trace.completed
+```
+
+The default ledger is SQLite at `~/.openrappter/flight-recorder.db`. OpenRappter
+owns that directory and enforces mode `0700`; the database and live WAL/SHM
+sidecars are mode `0600`. A custom `OPENRAPPTER_FLIGHT_DB` keeps the mode of an
+existing caller-owned parent directory while the database and sidecars remain
+`0600`. The operational database is separate: a recorder failure cannot block
+an agent response.
+Recording is fail-open; inspection is not. A corrupt row makes
+`events`/`export`/`import` fail explicitly and updates recorder health instead
+of returning an empty history.
+
+TypeScript and Python pin their canonical hash behavior to the same committed
+`contracts/flight-recorder-vector.json` fixture, including UTF-16 object-key
+ordering, non-BMP Unicode, numeric edge cases, and exact one-to-three-digit
+fractional-second parsing.
+Exports read one uncapped SQLite snapshot; the 10,000-row limit applies only to
+interactive queries, so large active traces remain complete in replay bundles.
+Retention removes whole completed traces, never arbitrary rows from the middle
+of a replay. Activity is determined by unmatched lifecycle starts in trace
+sequence order, so nested traces and clock rollback cannot make an executing
+outer trace look completed. Active traces are preserved, so the configured
+event count is a target bound when trace integrity requires exceeding it.
+
+## Privacy boundary
+
+Summary events are enabled by default in the TypeScript and Python runtimes.
+
+Raw prompts, responses, tool arguments, tool results, and file contents are
+discarded unless explicitly enabled:
+
+```bash
+export OPENRAPPTER_FLIGHT_RECORD_IO=1
+```
+
+When IO recording is enabled, values are sanitized recursively before they
+reach SQLite:
+
+- token, secret, password, credential, authorization, cookie, private-key,
+  access-token, and refresh-token keys
+- GitHub tokens, AWS access keys, bearer tokens, credential-bearing URLs,
+  password connection strings, and PEM private keys
+- `.env*`, `.ssh`, `.aws/credentials`, `.copilot_token`, credential files, and
+  `.pem`, `.key`, or `.p12` paths
+- prototype-pollution keys and circular values
+- secret-shaped or excluded-path property names, replaced with deterministic
+  collision-safe markers; contents under excluded filenames are removed
+
+Payloads are capped at 16 KiB after redaction. Oversized values are replaced by
+an explicit truncation marker rather than silently clipped into invalid JSON.
+
+This is local-first, not secret-proof. If you enable raw IO, the resulting file
+is sensitive even after automated redaction. FileVault or equivalent
+full-disk encryption is still recommended.
+
+## Commands
+
+The `flight` command is the TypeScript CLI inspection surface. The Python
+runtime records the same event schema and exposes the equivalent
+`openrappter.flight_recorder` API.
+
+```bash
+# Health, event count, errors, database path
+openrappter flight status
+openrappter flight status --json
+
+# Privacy-safe summaries
+openrappter flight events --limit 50
+openrappter flight events --trace <trace-id> --json
+openrappter flight events --session <session-id>
+openrappter flight events --kind provider.attempt.failed
+
+# Versioned bundle for replay/evals
+openrappter flight export --trace <trace-id> --output trace.json
+openrappter flight import trace.json
+
+# Destructive and explicit
+openrappter flight clear --yes
+```
+
+Exported files atomically replace their destination at mode `0600`, including
+when an older file had broader permissions. They use:
+
+```json
+{
+  "schema": "openrappter-flight-export/1.0",
+  "exportedAt": "2026-08-11T00:00:00.000Z",
+  "events": []
+}
+```
+
+Every event carries `openrappter-event/1.0`, a trace-local sequence, a SHA-256
+integrity hash, and optional session/workspace/provider/agent/tool identities.
+Session identifiers are stored as stable `session:<hmac-sha256-prefix>` values so
+channel keys cannot persist phone numbers, email addresses, or chat GUIDs.
+They are keyed with a private per-installation HMAC secret stored beside the
+database at mode `0600`, preventing offline dictionary guesses from an export.
+Session filters accept the original identifier and normalize it before lookup.
+Absolute workspace paths are stored as stable `workspace:<sha256-prefix>`
+identifiers rather than persisted verbatim.
+`auto` is recorded as `metadata.modelPolicy`, not as the model identity: when
+the provider does not reveal the selected model, the `model` field stays absent
+rather than turning a routing policy into a false attribution.
+
+## Configuration
+
+| Variable | Default | Purpose |
+|---|---:|---|
+| `OPENRAPPTER_FLIGHT_RECORDER` | `1` outside tests | Set `0` to disable recording |
+| `OPENRAPPTER_FLIGHT_DB` | `~/.openrappter/flight-recorder.db` | Override database path |
+| `OPENRAPPTER_FLIGHT_RETENTION` | `10000` | Target retained events; active and newest replayable traces may exceed it |
+| `OPENRAPPTER_FLIGHT_RECORD_IO` | `0` | Opt into sanitized raw IO |
+| `OPENRAPPTER_FLIGHT_MAX_PAYLOAD` | `16384` | Post-redaction payload byte cap |
+| `OPENRAPPTER_FLIGHT_ID_KEY` | installation key | Optional 64-hex HMAC key override |
+
+## Runtime boundary
+
+Copilot CLI tools in the TypeScript runtime run in a child MCP process. The
+provider passes the active trace, parent, session, and workspace scope through
+the child environment; the MCP server then records a tool-to-agent subtree in
+the originating trace. Direct providers and in-process tool calls are likewise
+correlated, including telephony, Surgeon, LearnNew, Ouroboros, and readiness
+probes.

--- a/docs/index.html
+++ b/docs/index.html
@@ -112,7 +112,7 @@
         <a href="#" class="flex items-center gap-2 text-lg font-bold tracking-tight">
           <span class="text-2xl">🦖</span>
           <span class="text-[#fafafa]">openrappter</span>
-          <span class="text-[10px] font-mono bg-[#10b981]/10 text-[#10b981] px-1.5 py-0.5 rounded">v1.11.0</span>
+          <span class="text-[10px] font-mono bg-[#10b981]/10 text-[#10b981] px-1.5 py-0.5 rounded">v1.12.0</span>
         </a>
 
         <!-- Desktop links -->
@@ -122,7 +122,7 @@
           <a href="#agents" class="hover:text-[#fafafa] transition-colors duration-200">Agents</a>
           <a href="#pricing" class="hover:text-[#fafafa] transition-colors duration-200">Pricing</a>
           <a href="docs.html" class="hover:text-[#fafafa] transition-colors duration-200">Docs</a>
-          <a href="release-notes-1.11.0-evolution.html" class="hover:text-[#fafafa] transition-colors duration-200">Release Notes</a>
+          <a href="release-notes-1.12.0-evolution.html" class="hover:text-[#fafafa] transition-colors duration-200">Release Notes</a>
         </div>
 
         <!-- Desktop CTAs -->
@@ -152,7 +152,7 @@
         <a href="#agents" class="block text-[#a1a1aa] hover:text-[#fafafa] transition-colors duration-200">Agents</a>
         <a href="#pricing" class="block text-[#a1a1aa] hover:text-[#fafafa] transition-colors duration-200">Pricing</a>
         <a href="docs.html" class="block text-[#a1a1aa] hover:text-[#fafafa] transition-colors duration-200">Docs</a>
-        <a href="release-notes-1.11.0-evolution.html" class="block text-[#a1a1aa] hover:text-[#fafafa] transition-colors duration-200">Release Notes</a>
+        <a href="release-notes-1.12.0-evolution.html" class="block text-[#a1a1aa] hover:text-[#fafafa] transition-colors duration-200">Release Notes</a>
         <div class="pt-3 space-y-2 border-t border-[#27272a]">
           <a href="https://github.com/kody-w/openrappter/releases?q=bar" class="block text-center px-4 py-2 bg-[#10b981] text-[#09090b] text-sm font-semibold rounded-lg">Download for Mac</a>
           <a href="https://github.com/kody-w/openrappter" target="_blank" class="block text-center px-4 py-2 border border-[#27272a] text-[#a1a1aa] text-sm rounded-lg">View on GitHub</a>
@@ -358,7 +358,7 @@
 <span class="text-[#a1a1aa]">Detecting environment...
   Node.js 22.1.0 detected
   Installing openrappter...
-  Installed openrappter v1.11.0</span>
+  Installed openrappter v1.12.0</span>
 
 <span class="text-[#71717a]"># Persistent memory</span>
 <span class="text-[#10b981]">$</span> <span class="text-[#fafafa]">openrappter "remember I prefer async/await over promise chains"</span>
@@ -906,7 +906,7 @@
           <h4 class="text-sm font-semibold text-[#a1a1aa] mb-3">Resources</h4>
           <ul class="space-y-2 text-sm text-[#71717a]">
             <li><a href="changelog.html" class="hover:text-[#fafafa] transition-colors duration-200">Changelog</a></li>
-            <li><a href="release-notes-1.11.0-evolution.html" class="hover:text-[#fafafa] transition-colors duration-200">Evolution Release Notes</a></li>
+            <li><a href="release-notes-1.12.0-evolution.html" class="hover:text-[#fafafa] transition-colors duration-200">Flight Recorder Release Notes</a></li>
             <li><a href="https://rappter.com" target="_blank" class="hover:text-[#fafafa] transition-colors duration-200">rappter.com</a></li>
             <li><a href="https://rappter.beehiiv.com/" target="_blank" class="hover:text-[#fafafa] transition-colors duration-200">Newsletter</a></li>
           </ul>

--- a/docs/release-notes-1.12.0-evolution.html
+++ b/docs/release-notes-1.12.0-evolution.html
@@ -1,0 +1,496 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OpenRappter 1.12.0 — Flight Recorder</title>
+  <meta name="description" content="OpenRappter 1.12.0 adds a local, private, provider-neutral Flight Recorder with durable traces, integrity-checked exports, and TypeScript/Python parity." />
+  <link rel="icon" href="data:image/svg+xml,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'><text y='.9em' font-size='90'>🦖</text></svg>" />
+  <script>
+    (() => {
+      const param = new URLSearchParams(window.location.search).get("scoutTheme");
+      const theme =
+        param || (window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light");
+      document.documentElement.setAttribute("data-theme", theme);
+    })();
+  </script>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <style>
+    :root {
+      color-scheme: light;
+      --cp-bg: #f7f4ef;
+      --cp-bg-elevated: #fcfbf8;
+      --cp-surface: #ffffff;
+      --cp-surface-soft: #f5f5f5;
+      --cp-border: #dedede;
+      --cp-border-strong: #919191;
+      --cp-text: #242424;
+      --cp-text-muted: #5c5c5c;
+      --cp-text-soft: #6f6f6f;
+      --cp-accent: #b11f4b;
+      --cp-accent-hover: #9a1a41;
+      --cp-accent-soft: rgba(177, 31, 75, 0.08);
+      --cp-accent-fg: #ffffff;
+      --cp-success: #16a34a;
+      --cp-danger: #dc2626;
+      --cp-warning: #f59e0b;
+      --cp-link: #0078d4;
+      --cp-shadow: 0 18px 48px rgba(0, 0, 0, 0.12);
+      --cp-overlay: rgba(255, 255, 255, 0.8);
+      --cp-panel: rgba(255, 255, 255, 0.86);
+      --cp-panel-strong: rgba(255, 255, 255, 0.96);
+      --cp-sheen: rgba(255, 255, 255, 0.55);
+      --cp-highlight: rgba(177, 31, 75, 0.12);
+    }
+    html[data-theme="dark"] {
+      color-scheme: dark;
+      --cp-bg: #3d3b3a;
+      --cp-bg-elevated: #343231;
+      --cp-surface: #292929;
+      --cp-surface-soft: #2e2e2e;
+      --cp-border: #474747;
+      --cp-border-strong: #5f5f5f;
+      --cp-text: #dedede;
+      --cp-text-muted: #919191;
+      --cp-text-soft: #b0b0b0;
+      --cp-accent: #fd8ea1;
+      --cp-accent-hover: #fb7b91;
+      --cp-accent-soft: rgba(253, 142, 161, 0.14);
+      --cp-accent-fg: #1a1a1a;
+      --cp-success: #4ade80;
+      --cp-danger: #f87171;
+      --cp-warning: #fbbf24;
+      --cp-link: #4da6ff;
+      --cp-shadow: 0 18px 48px rgba(0, 0, 0, 0.32);
+      --cp-overlay: rgba(41, 41, 41, 0.88);
+      --cp-panel: rgba(41, 41, 41, 0.72);
+      --cp-panel-strong: rgba(41, 41, 41, 0.96);
+      --cp-sheen: rgba(255, 255, 255, 0.04);
+      --cp-highlight: rgba(253, 142, 161, 0.12);
+    }
+    * { box-sizing: border-box; }
+    html { scroll-behavior: smooth; background: var(--cp-bg); }
+    body {
+      margin: 0;
+      background: var(--cp-bg);
+      color: var(--cp-text);
+      font-family: "Segoe UI", Aptos, Calibri, -apple-system, BlinkMacSystemFont, sans-serif;
+    }
+    code, pre, .mono {
+      font-family: Consolas, "Courier New", Courier, monospace;
+    }
+    a { color: inherit; }
+    :focus-visible {
+      outline: 3px solid var(--cp-accent);
+      outline-offset: 3px;
+    }
+    .nav-shell {
+      background: var(--cp-overlay);
+      border-color: var(--cp-border);
+    }
+    .hero {
+      background:
+        linear-gradient(var(--cp-accent-soft), var(--cp-accent-soft)),
+        var(--cp-bg);
+      border-color: var(--cp-border);
+    }
+    .eyebrow, .accent { color: var(--cp-accent); }
+    .muted { color: var(--cp-text-muted); }
+    .soft { color: var(--cp-text-soft); }
+    .surface { background: var(--cp-surface); }
+    .surface-soft { background: var(--cp-surface-soft); }
+    .section-alt {
+      background: var(--cp-bg-elevated);
+      border-color: var(--cp-border);
+    }
+    .card {
+      background: var(--cp-surface);
+      border: 1px solid var(--cp-border);
+      border-radius: 16px;
+      box-shadow: 0 0 2px rgba(0,0,0,0.12), 0 1px 2px rgba(0,0,0,0.14);
+    }
+    .card:hover { border-color: var(--cp-border-strong); }
+    .chip {
+      background: var(--cp-accent-soft);
+      border: 1px solid var(--cp-accent);
+      border-radius: 0.625rem;
+      color: var(--cp-accent);
+    }
+    .button-primary {
+      background: var(--cp-accent);
+      border: 1px solid var(--cp-accent);
+      border-radius: 0.625rem;
+      color: var(--cp-accent-fg);
+    }
+    .button-primary:hover { background: var(--cp-accent-hover); }
+    .button-secondary {
+      background: var(--cp-surface);
+      border: 1px solid var(--cp-border-strong);
+      border-radius: 0.625rem;
+      color: var(--cp-text);
+    }
+    .button-secondary:hover { border-color: var(--cp-accent); }
+    .rule { border-color: var(--cp-border); }
+    .timeline-line { background: var(--cp-border); }
+    .timeline-dot {
+      background: var(--cp-accent);
+      border: 4px solid var(--cp-bg-elevated);
+    }
+    .command {
+      background: var(--cp-bg-elevated);
+      border: 1px solid var(--cp-border);
+      border-radius: 0.625rem;
+      color: var(--cp-text);
+    }
+    .prompt {
+      background: var(--cp-surface);
+      border: 1px solid var(--cp-border);
+      border-radius: 16px;
+    }
+    .prompt code { color: var(--cp-text-soft); }
+    .copy-button {
+      background: var(--cp-surface-soft);
+      border: 1px solid var(--cp-border);
+      border-radius: 0.625rem;
+      color: var(--cp-text-muted);
+    }
+    .copy-button:hover {
+      border-color: var(--cp-accent);
+      color: var(--cp-accent);
+    }
+    .success { color: var(--cp-success); }
+    .warning { color: var(--cp-warning); }
+    footer {
+      background: var(--cp-bg-elevated);
+      border-color: var(--cp-border);
+    }
+    @media (prefers-reduced-motion: reduce) {
+      html { scroll-behavior: auto; }
+    }
+  </style>
+</head>
+<body class="antialiased">
+  <nav class="nav-shell sticky top-0 z-50 border-b backdrop-blur-xl" aria-label="Release navigation">
+    <div class="mx-auto flex h-16 max-w-6xl items-center justify-between gap-4 px-4 sm:px-6">
+      <a href="./" class="logo flex min-w-0 items-center gap-2 font-bold">
+        <span aria-hidden="true" class="text-2xl">🦖</span>
+        <span class="truncate">openrappter</span>
+        <span class="chip mono px-2 py-1 text-[10px]">v1.12.0</span>
+      </a>
+      <div class="flex items-center gap-4 text-sm">
+        <a href="#truth" class="hidden sm:inline muted hover:accent">Truth</a>
+        <a href="#privacy" class="hidden sm:inline muted hover:accent">Privacy</a>
+        <a href="#prompts" class="muted hover:accent">10 prompts</a>
+        <a href="./docs.html" class="muted hover:accent">Docs</a>
+        <a href="https://github.com/kody-w/openrappter" class="muted hover:accent">GitHub</a>
+      </div>
+    </div>
+  </nav>
+
+  <header class="hero border-b">
+    <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6 sm:py-28">
+      <div class="grid items-end gap-12 lg:grid-cols-[1.35fr_.65fr]">
+        <div>
+          <p class="eyebrow mono mb-5 text-sm font-bold uppercase tracking-[0.24em]">
+            Flight Recorder · OpenRappter 1.12.0
+          </p>
+          <h1 class="max-w-4xl text-5xl font-black leading-[0.98] tracking-tight sm:text-7xl">
+            OpenRappter can now explain itself.
+          </h1>
+          <p class="muted mt-7 max-w-3xl text-lg leading-8 sm:text-xl">
+            A local, provider-neutral Flight Recorder captures the evidence behind an agent run:
+            what happened, in what order, across which lifecycle, and whether the record remained intact.
+            Truth you can inspect. Privacy you can control. History you can replay.
+          </p>
+          <div class="mt-9 flex flex-wrap gap-3">
+            <a href="#what-shipped" class="button-primary px-5 py-3 font-bold">See what shipped</a>
+            <a href="#prompts" class="button-secondary px-5 py-3 font-semibold">Copy a forensic prompt</a>
+          </div>
+        </div>
+        <aside class="card p-6" aria-label="Flight Recorder summary">
+          <p class="mono accent text-xs font-bold uppercase tracking-[0.18em]">The black box is local</p>
+          <dl class="mt-6 space-y-5">
+            <div>
+              <dt class="muted text-sm">Event contract</dt>
+              <dd class="mono mt-1 font-bold">openrappter-event/1.0</dd>
+            </div>
+            <div>
+              <dt class="muted text-sm">Portable export</dt>
+              <dd class="mono mt-1 font-bold">openrappter-flight-export/1.0</dd>
+            </div>
+            <div>
+              <dt class="muted text-sm">Raw inputs and outputs</dt>
+              <dd class="success mt-1 font-bold">OFF by default</dd>
+            </div>
+            <div>
+              <dt class="muted text-sm">Runtime coverage</dt>
+              <dd class="mt-1 font-bold">TypeScript + Python</dd>
+            </div>
+          </dl>
+        </aside>
+      </div>
+    </div>
+  </header>
+
+  <main>
+    <section id="what-shipped" class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
+      <div class="mb-12 max-w-3xl">
+        <p class="eyebrow mono mb-3 text-sm font-bold uppercase tracking-[0.2em]">What shipped</p>
+        <h2 class="text-4xl font-black tracking-tight sm:text-5xl">Observability without provider lock-in.</h2>
+        <p class="muted mt-5 text-lg leading-8">
+          The same durable event model records OpenRappter behavior whether a run uses one provider,
+          crosses a failover boundary, invokes tools, or moves through an agent lifecycle.
+        </p>
+      </div>
+      <div class="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+        <article class="card p-6">
+          <div class="mb-4 text-3xl" aria-hidden="true">🧭</div>
+          <h3 class="text-xl font-bold">Provider-neutral traces</h3>
+          <p class="muted mt-3 leading-7">Assistant, provider, tool, agent, and context lifecycle events share one local record, including provider failover decisions.</p>
+        </article>
+        <article class="card p-6">
+          <div class="mb-4 text-3xl" aria-hidden="true">🔢</div>
+          <h3 class="text-xl font-bold">Trace-local sequence</h3>
+          <p class="muted mt-3 leading-7">Every trace carries its own ordered sequence, so forensic reconstruction does not depend on wall-clock luck or provider-specific logs.</p>
+        </article>
+        <article class="card p-6">
+          <div class="mb-4 text-3xl" aria-hidden="true">💾</div>
+          <h3 class="text-xl font-bold">Durable continuity</h3>
+          <p class="muted mt-3 leading-7">SQLite WAL preserves the record across process restarts, keeping the story available after the process that created it is gone.</p>
+        </article>
+        <article class="card p-6">
+          <div class="mb-4 text-3xl" aria-hidden="true">🧾</div>
+          <h3 class="text-xl font-bold">Integrity you can verify</h3>
+          <p class="muted mt-3 leading-7">SHA-256 integrity turns exported evidence into something that can be checked, not merely trusted.</p>
+        </article>
+        <article class="card p-6">
+          <div class="mb-4 text-3xl" aria-hidden="true">📦</div>
+          <h3 class="text-xl font-bold">Atomic portability</h3>
+          <p class="muted mt-3 leading-7">Import and export are atomic, with a versioned flight-export envelope for moving a trace without creating a half-written record.</p>
+        </article>
+        <article class="card p-6">
+          <div class="mb-4 text-3xl" aria-hidden="true">🐍</div>
+          <h3 class="text-xl font-bold">Python parity</h3>
+          <p class="muted mt-3 leading-7">The Flight Recorder is implemented in both TypeScript and Python, preserving the project’s interchangeable-runtime promise.</p>
+        </article>
+      </div>
+    </section>
+
+    <section id="truth" class="section-alt border-y">
+      <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
+        <div class="grid gap-14 lg:grid-cols-[.75fr_1.25fr]">
+          <div>
+            <p class="eyebrow mono mb-3 text-sm font-bold uppercase tracking-[0.2em]">Truth</p>
+            <h2 class="text-4xl font-black tracking-tight">From “it failed” to a sequence you can inspect.</h2>
+            <p class="muted mt-5 text-lg leading-8">
+              Flight Recorder captures decisions around the execution—not just the final answer—so a run
+              can be reconstructed from local evidence.
+            </p>
+          </div>
+          <div class="relative pl-8">
+            <div class="timeline-line absolute bottom-3 left-[7px] top-3 w-px"></div>
+            <div class="space-y-8">
+              <article class="relative">
+                <span class="timeline-dot absolute -left-8 top-1 h-4 w-4 rounded-full"></span>
+                <p class="mono accent text-xs font-bold">0001 · CONTEXT</p>
+                <h3 class="mt-1 text-lg font-bold">The working context is assembled</h3>
+                <p class="muted mt-2">Context lifecycle instrumentation records the boundaries around what the agent received.</p>
+              </article>
+              <article class="relative">
+                <span class="timeline-dot absolute -left-8 top-1 h-4 w-4 rounded-full"></span>
+                <p class="mono accent text-xs font-bold">0002 · PROVIDER</p>
+                <h3 class="mt-1 text-lg font-bold">A provider decision is made</h3>
+                <p class="muted mt-2">Provider selection and failover decisions become explicit events rather than hidden control flow.</p>
+              </article>
+              <article class="relative">
+                <span class="timeline-dot absolute -left-8 top-1 h-4 w-4 rounded-full"></span>
+                <p class="mono accent text-xs font-bold">0003 · TOOL / AGENT</p>
+                <h3 class="mt-1 text-lg font-bold">Work crosses lifecycle boundaries</h3>
+                <p class="muted mt-2">Tool and agent starts, completions, and failures stay correlated inside the trace.</p>
+              </article>
+              <article class="relative">
+                <span class="timeline-dot absolute -left-8 top-1 h-4 w-4 rounded-full"></span>
+                <p class="mono accent text-xs font-bold">0004 · ASSISTANT</p>
+                <h3 class="mt-1 text-lg font-bold">The result closes the loop</h3>
+                <p class="muted mt-2">Assistant lifecycle evidence completes a replayable narrative without requiring a provider dashboard.</p>
+              </article>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="privacy" class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
+      <div class="grid gap-12 lg:grid-cols-2">
+        <div>
+          <p class="eyebrow mono mb-3 text-sm font-bold uppercase tracking-[0.2em]">Privacy</p>
+          <h2 class="text-4xl font-black tracking-tight">Useful evidence. Deliberate exposure.</h2>
+          <p class="muted mt-5 text-lg leading-8">
+            Flight Recorder is local-first and conservative by default. The event structure is recorded;
+            raw IO is off by default.
+          </p>
+        </div>
+        <div class="grid gap-4 sm:grid-cols-2">
+          <article class="card p-6">
+            <p class="mono success text-xs font-bold uppercase">Default</p>
+            <h3 class="mt-3 text-xl font-bold">Raw IO stays off</h3>
+            <p class="muted mt-3 leading-7">Inputs and outputs are not captured unless the operator explicitly opts in.</p>
+          </article>
+          <article class="card p-6">
+            <p class="mono accent text-xs font-bold uppercase">When opted in</p>
+            <h3 class="mt-3 text-xl font-bold">Redaction is recursive</h3>
+            <p class="muted mt-3 leading-7">Secret and path redaction walks nested data rather than protecting only top-level fields.</p>
+          </article>
+          <article class="card p-6">
+            <p class="mono accent text-xs font-bold uppercase">Scoped identity</p>
+            <h3 class="mt-3 text-xl font-bold">Sessions and paths are hashed</h3>
+            <p class="muted mt-3 leading-7">Exports preserve correlation without publishing channel handles or absolute workspace paths.</p>
+          </article>
+          <article class="card p-6">
+            <p class="mono accent text-xs font-bold uppercase">Local storage</p>
+            <h3 class="mt-3 text-xl font-bold">Private file modes</h3>
+            <p class="muted mt-3 leading-7">The default directory is <code>0700</code>; the database, WAL/SHM sidecars, and atomic exports are <code>0600</code>.</p>
+          </article>
+        </div>
+      </div>
+    </section>
+
+    <section class="section-alt border-y">
+      <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
+        <div class="mb-12 max-w-3xl">
+          <p class="eyebrow mono mb-3 text-sm font-bold uppercase tracking-[0.2em]">Operate it</p>
+          <h2 class="text-4xl font-black tracking-tight">Four CLI verbs. One inspectable record.</h2>
+          <p class="muted mt-5 text-lg leading-8">Check health, inspect events, carry evidence out, or deliberately clear local history.</p>
+        </div>
+        <div class="grid gap-4 md:grid-cols-2">
+          <div class="command p-5"><code><span class="accent">$</span> openrappter flight status</code><p class="muted mt-2 text-sm">Inspect recorder state and local continuity.</p></div>
+          <div class="command p-5"><code><span class="accent">$</span> openrappter flight events</code><p class="muted mt-2 text-sm">Read the ordered events behind recent traces.</p></div>
+          <div class="command p-5"><code><span class="accent">$</span> openrappter flight export</code><p class="muted mt-2 text-sm">Create an integrity-checked portable export.</p></div>
+          <div class="command p-5"><code><span class="accent">$</span> openrappter flight clear</code><p class="muted mt-2 text-sm">Explicitly remove the local recorder history.</p></div>
+        </div>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
+      <div class="grid gap-8 lg:grid-cols-[1.25fr_.75fr]">
+        <article class="card p-7 sm:p-9">
+          <p class="eyebrow mono mb-3 text-sm font-bold uppercase tracking-[0.2em]">Acceptance gate</p>
+          <h2 class="text-3xl font-black tracking-tight">Evidence for the evidence system.</h2>
+          <p class="muted mt-4 leading-7">
+            Release acceptance covers behavior, mutation, and parity suites—not a hand-curated happy path.
+          </p>
+          <ul class="mt-7 grid gap-3 sm:grid-cols-2">
+            <li class="surface-soft rounded-[0.625rem] p-4"><strong>mutation tests</strong><br /><span class="muted text-sm">Recorder fault resistance</span></li>
+            <li class="surface-soft rounded-[0.625rem] p-4"><strong>npm test</strong><br /><span class="muted text-sm">Full TypeScript suite, minus two proven environment-only baseline tests</span></li>
+            <li class="surface-soft rounded-[0.625rem] p-4"><strong>pytest</strong><br /><span class="muted text-sm">Full Python suite</span></li>
+            <li class="surface-soft rounded-[0.625rem] p-4"><strong>builds + lint</strong><br /><span class="muted text-sm">Both delivery surfaces checked</span></li>
+            <li class="surface-soft rounded-[0.625rem] p-4 sm:col-span-2"><strong>cold-start CLI smoke</strong><br /><span class="muted text-sm">The shipped command starts from a clean process boundary</span></li>
+          </ul>
+        </article>
+        <aside class="card p-7 sm:p-9">
+          <p class="mono warning mb-3 text-sm font-bold uppercase tracking-[0.2em]">Explicit limitation</p>
+          <h2 class="text-2xl font-black">One process boundary is not yet bridged.</h2>
+          <p class="muted mt-4 leading-7">
+            Copilot CLI child MCP cross-process trace correlation remains an explicit limitation.
+            The recorder does not pretend that child-process evidence is correlated when that propagation
+            boundary has not been completed.
+          </p>
+          <p class="mt-5 font-bold">A truthful gap is better than a fictional trace.</p>
+        </aside>
+      </div>
+    </section>
+
+    <section id="prompts" class="section-alt border-y">
+      <div class="mx-auto max-w-6xl px-4 py-20 sm:px-6">
+        <div class="mb-12 max-w-3xl">
+          <p class="eyebrow mono mb-3 text-sm font-bold uppercase tracking-[0.2em]">Try the recorder</p>
+          <h2 class="text-4xl font-black tracking-tight sm:text-5xl">10 copy-paste prompts for evidence-led agents.</h2>
+          <p class="muted mt-5 text-lg leading-8">Each prompt asks OpenRappter to reason from its local Flight Recorder instead of guessing from the final output.</p>
+        </div>
+        <div class="space-y-5">
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">1. Forensic trace reconstruction</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Use the Flight Recorder to reconstruct the most recent failed run as an ordered forensic timeline. Identify the first anomalous event, every downstream consequence, the provider/tool/agent boundaries involved, and the smallest evidence-supported root cause. Separate recorded fact from inference.</code>
+          </article>
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">2. Provider comparison</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Compare recent traces across providers. Show differences in lifecycle shape, failover decisions, tool usage, latency signals available in the events, and final outcomes. Do not rank a provider unless the local evidence supports the conclusion.</code>
+          </article>
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">3. Privacy audit</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Audit my Flight Recorder privacy posture. Confirm whether raw IO capture is enabled, inspect exported nested fields for secret and path redaction, verify absolute workspace paths are hashed, and report any value that could identify a person, credential, or local filesystem location.</code>
+          </article>
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">4. Evidence replay</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Replay the evidence from this exported flight trace as a human-readable narrative. Preserve trace-local sequence, mark assistant/provider/tool/agent/context transitions, verify SHA-256 integrity first, and flag any gap where the export cannot prove what happened.</code>
+          </article>
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">5. Failed-agent diagnosis</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Find the latest agent lifecycle that ended in failure. Trace its parent context, tool calls, provider decisions, and assistant response. Propose a fix only after citing the exact event sequence that supports it, then list the regression trace we should expect after the fix.</code>
+          </article>
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">6. Context-budget investigation</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Investigate whether context growth contributed to recent failures or provider failover. Compare context lifecycle events across successful and failed traces, identify where the working set expanded, and recommend the smallest safe compaction point without claiming token data the recorder did not capture.</code>
+          </article>
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">7. Failover decision review</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Review every provider failover decision in the latest trace. Explain the triggering evidence, the selected fallback, and the resulting outcome. Highlight any failover that was unnecessary, late, or impossible to validate from the recorded events.</code>
+          </article>
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">8. Restart continuity proof</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Prove whether Flight Recorder continuity survived the last process restart. Use trace-local sequence and persisted SQLite history to show the final event before shutdown and the first event after startup. Report discontinuities without filling them in.</code>
+          </article>
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">9. Tool behavior audit</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Audit tool lifecycle events across the last ten traces. Group repeated failures, orphaned starts, slow completions, and provider-specific patterns. Produce a prioritized remediation list where every item links back to recorded evidence.</code>
+          </article>
+          <article class="prompt p-6">
+            <div class="flex items-start justify-between gap-4"><h3 class="text-xl font-bold">10. Export handoff packet</h3><button class="copy-button shrink-0 px-3 py-2 text-xs font-bold" type="button">Copy</button></div>
+            <code class="mt-4 block whitespace-pre-wrap leading-7">Prepare a privacy-safe incident handoff from this Flight Recorder export. Verify the export schema and SHA-256 integrity, summarize the trace, include the minimum relevant event sequence, confirm recursive redaction, and state the Copilot CLI child MCP cross-process correlation limitation.</code>
+          </article>
+        </div>
+        <p id="copyStatus" class="muted mt-5 min-h-6 text-center text-sm" aria-live="polite"></p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-5xl px-4 py-20 text-center sm:px-6">
+      <p class="eyebrow mono mb-4 text-sm font-bold uppercase tracking-[0.2em]">OpenRappter 1.12.0</p>
+      <h2 class="text-4xl font-black tracking-tight sm:text-5xl">Not just observable. Accountable.</h2>
+      <p class="muted mx-auto mt-5 max-w-2xl text-lg leading-8">
+        Local truth, privacy-first capture, portable evidence, and the same contract across providers and runtimes.
+      </p>
+      <div class="mt-9 flex flex-wrap justify-center gap-3">
+        <a href="./docs.html" class="button-primary px-6 py-3 font-bold">Read the docs</a>
+        <a href="https://github.com/kody-w/openrappter" class="button-secondary px-6 py-3 font-semibold">View on GitHub</a>
+      </div>
+    </section>
+  </main>
+
+  <footer class="border-t py-10">
+    <div class="mx-auto flex max-w-6xl flex-col items-center justify-between gap-3 px-4 text-center text-sm sm:flex-row sm:px-6 sm:text-left">
+      <p class="muted">OpenRappter 1.12.0 · Flight Recorder · Local-first · Apache-2.0</p>
+      <a href="./" class="accent font-semibold">Back to openrappter</a>
+    </div>
+  </footer>
+
+  <script>
+    const status = document.getElementById("copyStatus");
+    document.querySelectorAll(".prompt").forEach((prompt) => {
+      const button = prompt.querySelector(".copy-button");
+      const code = prompt.querySelector("code");
+      button.addEventListener("click", async () => {
+        try {
+          await navigator.clipboard.writeText(code.textContent.trim());
+          button.textContent = "Copied";
+          status.textContent = `${prompt.querySelector("h3").textContent} copied to clipboard.`;
+          window.setTimeout(() => {
+            button.textContent = "Copy";
+          }, 1600);
+        } catch {
+          status.textContent = "Clipboard access was unavailable. Select the prompt text to copy it.";
+        }
+      });
+    });
+  </script>
+</body>
+</html>

--- a/python/openrappter/__init__.py
+++ b/python/openrappter/__init__.py
@@ -1,3 +1,48 @@
 """openrappter - Local-first AI agent powered by GitHub Copilot SDK"""
 
-__version__ = "1.10.0"
+from openrappter.flight_recorder import (
+    FLIGHT_EVENT_SCHEMA,
+    FLIGHT_EXPORT_SCHEMA,
+    FlightRecorder,
+    FlightRecorderCorruptionError,
+    FlightRecorderUnhealthyError,
+    SQLiteFlightLedger,
+    compute_flight_event_hash,
+    ensure_flight_recorder_from_env,
+    get_flight_recorder,
+    normalize_flight_model_id,
+    normalize_flight_session_id,
+    normalize_flight_workspace_id,
+    sanitize_flight_metadata,
+    sanitize_flight_payload,
+    sanitize_flight_value,
+    set_flight_recorder,
+    summarize_flight_error,
+    verify_flight_event_hash,
+    with_flight_trace,
+)
+
+__version__ = "1.12.0"
+
+__all__ = [
+    "__version__",
+    "FLIGHT_EVENT_SCHEMA",
+    "FLIGHT_EXPORT_SCHEMA",
+    "FlightRecorder",
+    "FlightRecorderCorruptionError",
+    "FlightRecorderUnhealthyError",
+    "SQLiteFlightLedger",
+    "compute_flight_event_hash",
+    "ensure_flight_recorder_from_env",
+    "get_flight_recorder",
+    "normalize_flight_model_id",
+    "normalize_flight_session_id",
+    "normalize_flight_workspace_id",
+    "sanitize_flight_metadata",
+    "sanitize_flight_payload",
+    "sanitize_flight_value",
+    "set_flight_recorder",
+    "summarize_flight_error",
+    "verify_flight_event_hash",
+    "with_flight_trace",
+]

--- a/python/openrappter/agents/basic_agent.py
+++ b/python/openrappter/agents/basic_agent.py
@@ -31,10 +31,12 @@ Single File Agent Pattern:
 """
 
 import copy
+import contextvars
 import hashlib
 import json
 import logging
 import re
+import time
 from datetime import datetime
 from collections import Counter
 
@@ -52,9 +54,13 @@ class BasicAgent:
     def __init__(self, name, metadata):
         self.name = name
         self.metadata = metadata
-        self.context = {}
+        self._invocation_state = contextvars.ContextVar(
+            f"openrappter_agent_{id(self)}",
+            default=None,
+        )
+        self._last_context = {}
+        self._last_user_guid = None
         self._storage_manager = None
-        self._user_guid = None
         self.slosh_filter = None
         self.slosh_preferences = None
         self.breadcrumbs = []
@@ -65,6 +71,38 @@ class BasicAgent:
         self.on_slosh_debug = None
         self.auto_suppress_threshold = -3
         self.signal_decay = 0.9
+
+    @property
+    def context(self):
+        state = self._invocation_state.get()
+        return (
+            state["context"]
+            if state is not None
+            else self._last_context
+        )
+
+    @context.setter
+    def context(self, value):
+        state = self._invocation_state.get()
+        if state is not None:
+            state["context"] = value
+        self._last_context = value
+
+    @property
+    def _user_guid(self):
+        state = self._invocation_state.get()
+        return (
+            state["user_guid"]
+            if state is not None
+            else self._last_user_guid
+        )
+
+    @_user_guid.setter
+    def _user_guid(self, value):
+        state = self._invocation_state.get()
+        if state is not None:
+            state["user_guid"] = value
+        self._last_user_guid = value
     
     @property
     def storage_manager(self):
@@ -87,6 +125,79 @@ class BasicAgent:
         so downstream agents are aware of upstream results without an LLM
         interpreting between calls.
         """
+        from openrappter.flight_recorder import (
+            ensure_flight_recorder_from_env,
+            summarize_flight_error,
+        )
+        from openrappter.result_status import agent_result_is_error
+
+        recorder = ensure_flight_recorder_from_env()
+
+        def operation():
+            started = time.monotonic()
+            started_event = recorder.record({
+                'kind': 'agent.execute.started',
+                'source': 'basic-agent',
+                'status': 'started',
+                'agentName': self.name,
+            })
+
+            def within_agent():
+                try:
+                    result = self._execute_within_trace(recorder, **kwargs)
+                    failed = agent_result_is_error(result)
+                    structured_result = result
+                    if isinstance(result, str):
+                        try:
+                            structured_result = json.loads(result)
+                        except (json.JSONDecodeError, TypeError):
+                            pass
+                    recorder.record({
+                        'kind': (
+                            'agent.execute.failed'
+                            if failed
+                            else 'agent.execute.completed'
+                        ),
+                        'source': 'basic-agent',
+                        'status': 'error' if failed else 'success',
+                        'agentName': self.name,
+                        'durationMs': (time.monotonic() - started) * 1000,
+                        'metadata': {
+                            'resultLength': len(result) if isinstance(result, str) else 0,
+                            **({'resultStatus': 'error'} if failed else {}),
+                        },
+                        'payload': {'result': structured_result},
+                    })
+                    return result
+                except Exception as exc:
+                    recorder.record({
+                        'kind': 'agent.execute.failed',
+                        'source': 'basic-agent',
+                        'status': 'error',
+                        'agentName': self.name,
+                        'durationMs': (time.monotonic() - started) * 1000,
+                        'metadata': summarize_flight_error(exc),
+                        'payload': {'error': exc},
+                    })
+                    raise
+
+            return recorder.with_parent(
+                started_event.get('id') if started_event is not None else None,
+                within_agent,
+            )
+
+        token = self._invocation_state.set(
+            {"context": {}, "user_guid": None}
+        )
+        try:
+            if recorder.current_trace():
+                return operation()
+            return recorder.run_trace({}, operation)
+        finally:
+            self._invocation_state.reset(token)
+
+    def _execute_within_trace(self, recorder, **kwargs):
+        """Execute the existing sloshing pipeline inside a correlated trace."""
         self._user_guid = kwargs.get('user_guid')
         query = self._resolve_slosh_query(kwargs)
 
@@ -136,6 +247,16 @@ class BasicAgent:
             self.context['upstream_slush'] = upstream
 
         kwargs['_context'] = self.context
+        recorder.record({
+            'kind': 'context.assembled',
+            'source': 'basic-agent',
+            'status': 'info',
+            'agentName': self.name,
+            'metadata': {
+                'categories': sorted(self.context.keys()),
+                'queryType': type(query).__name__,
+            },
+        })
 
         result = self.perform(**kwargs)
 

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -42,6 +42,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 
 from openrappter import __version__
+from openrappter.result_status import agent_result_is_error
 
 
 def _http_json(url, headers, payload=None, timeout=60):
@@ -516,6 +517,7 @@ def copilot_session():
     _copilot_cache["token"] = data.get("token")
     _copilot_cache["endpoint"] = (data.get("endpoints") or {}).get("api", "https://api.githubcopilot.com")
     _copilot_cache["expires_at"] = data.get("expires_at") or 0
+    _copilot_cache["direct_capi"] = False
     return _copilot_cache
 
 
@@ -577,7 +579,7 @@ def login_status():
 
 
 def llm_chat(messages, tools):
-    """Return ``(message, served_model)``.
+    """Return ``(message, served_model, requested_model)``.
 
     The API response names the model that actually served the request, which is
     the only authoritative answer to PARITY §2.4's first question. Discarding it
@@ -619,7 +621,7 @@ def llm_chat(messages, tools):
         raise RuntimeError(f"Copilot chat failed: HTTP {status}")
     # The server names what served the request; prefer it over what we asked for.
     served = data.get("model") if isinstance(data, dict) else None
-    return data["choices"][0]["message"], (served or model)
+    return data["choices"][0]["message"], served, model
 
 
 # ── The frozen /chat envelope (rapp-runtime-parity/1.0 §2.4) ─────────────────
@@ -695,6 +697,35 @@ def build_chat_envelope(content, session_id, agent_logs=None, model=None,
 
 
 def run_chat(user_input, history, session_id, trusted_context=None):
+    """Run one Brainstem turn inside the shared Flight Recorder contract."""
+    from openrappter.flight_recorder import ensure_flight_recorder_from_env
+
+    recorder = ensure_flight_recorder_from_env()
+    operation = lambda: _run_chat_within_trace(
+        user_input,
+        history,
+        session_id,
+        trusted_context,
+        recorder,
+    )
+    if recorder.current_trace():
+        return operation()
+    return recorder.run_trace(
+        {
+            "sessionId": session_id,
+            "workspaceId": str(Path.cwd()),
+        },
+        operation,
+    )
+
+
+def _run_chat_within_trace(
+    user_input,
+    history,
+    session_id,
+    trusted_context,
+    recorder,
+):
     """The kernel's /chat tool loop: soul + agents-as-tools + tool_call rounds."""
     agents = load_agents()
     trusted = dict(trusted_context) if isinstance(trusted_context, dict) else None
@@ -755,12 +786,132 @@ def run_chat(user_input, history, session_id, trusted_context=None):
         messages.append({"role": "user", "content": memory_data_message})
     messages.extend(h for h in history if isinstance(h, dict) and h.get("role") in ("user", "assistant"))
     messages.append({"role": "user", "content": user_input})
+    recorder.record(
+        {
+            "kind": "context.assembled",
+            "source": "python-brainstem",
+            "status": "info",
+            "metadata": {
+                "sourceNames": [
+                    "soul",
+                    "memory",
+                    "history",
+                    "tools",
+                ],
+                "categoryNames": [
+                    "system",
+                    "memory",
+                    "conversation",
+                    "tools",
+                ],
+                "systemChars": len(system_prompt),
+                "historyLength": len(messages),
+                "toolCount": len(tools),
+                "memoryIncluded": bool(memory_data_message),
+            },
+            "payload": {
+                "messages": messages,
+                "tools": tools,
+            },
+        }
+    )
 
     agent_logs = []
     served_model = None
+    requested_model = MODEL
     last_content = ""
     for _ in range(MAX_TOOL_ROUNDS):
-        reply, served_model = llm_chat(messages, tools)
+        policy_session = copilot_session()
+        requested_model = (
+            os.environ.get("OPENRAPPTER_CAPI_MODEL", "gpt-4o")
+            if policy_session and policy_session.get("direct_capi")
+            else MODEL
+        )
+        provider_started_at = time.monotonic()
+        provider_started = recorder.record(
+            {
+                "kind": "provider.attempt.started",
+                "source": "python-brainstem",
+                "status": "started",
+                "providerId": BACKEND_KIND or "copilot",
+                "metadata": {
+                    "messageCount": len(messages),
+                    "toolCount": len(tools),
+                    "modelPolicy": requested_model,
+                },
+                "payload": {
+                    "messages": messages,
+                    "tools": tools,
+                },
+            }
+        )
+        try:
+            chat_result = recorder.with_parent(
+                provider_started.get("id") if provider_started else None,
+                lambda: llm_chat(messages, tools),
+            )
+            if len(chat_result) == 3:
+                reply, served_model, requested_model = chat_result
+            else:
+                reply, served_model = chat_result
+                requested_model = MODEL
+        except Exception as exc:
+            from openrappter.flight_recorder import summarize_flight_error
+
+            recorder.record(
+                {
+                    "kind": "provider.attempt.failed",
+                    "source": "python-brainstem",
+                    "status": "error",
+                    "parentId": (
+                        provider_started.get("id")
+                        if provider_started
+                        else None
+                    ),
+                    "providerId": BACKEND_KIND or "copilot",
+                    "durationMs": (
+                        time.monotonic() - provider_started_at
+                    )
+                    * 1000,
+                    "metadata": {
+                        "modelPolicy": requested_model,
+                        **summarize_flight_error(exc),
+                    },
+                    "payload": {
+                        "messages": messages,
+                        "tools": tools,
+                        "error": exc,
+                    },
+                }
+            )
+            raise
+        provider_completed = recorder.record(
+            {
+                "kind": "provider.attempt.completed",
+                "source": "python-brainstem",
+                "status": "success",
+                "parentId": (
+                    provider_started.get("id")
+                    if provider_started
+                    else None
+                ),
+                "providerId": BACKEND_KIND or "copilot",
+                **({"model": served_model} if served_model else {}),
+                "durationMs": (
+                    time.monotonic() - provider_started_at
+                )
+                * 1000,
+                "metadata": {
+                    "modelPolicy": requested_model,
+                    "hadToolCalls": bool(reply.get("tool_calls")),
+                },
+                "payload": {
+                    "messages": messages,
+                    "tools": tools,
+                    "response": reply,
+                },
+            }
+        )
         if isinstance(reply.get("content"), str) and reply["content"]:
             last_content = reply["content"]
         calls = reply.get("tool_calls")
@@ -768,6 +919,7 @@ def run_chat(user_input, history, session_id, trusted_context=None):
             return build_chat_envelope(
                 reply.get("content", ""), session_id, agent_logs,
                 model=served_model,
+                requested_model=requested_model,
             )
         messages.append(reply)
         for call in calls:
@@ -780,23 +932,181 @@ def run_chat(user_input, history, session_id, trusted_context=None):
             kwargs.pop("_trusted_context", None)
             kwargs.pop("_transport_event_id", None)
             agent = agents.get(name)
+            tool_started_at = time.monotonic()
+            tool_started = recorder.record(
+                {
+                    "kind": "tool.call.started",
+                    "source": "python-brainstem",
+                    "status": "started",
+                    "parentId": (
+                        provider_completed.get("id")
+                        if provider_completed
+                        else None
+                    ),
+                    "toolName": name,
+                    "metadata": {
+                        "argumentKeys": sorted(kwargs),
+                    },
+                    "payload": {"arguments": kwargs},
+                }
+            )
             if agent is None:
                 # PARITY §2.3 fixes these strings: tooling (Flight Recorder,
                 # rapp-god) reads agent_logs, so the shape is contract, not
                 # cosmetics. We were emitting a JSON error blob instead.
                 result = f"Agent '{name}' not found."
                 log_line = result
+                failed = True
             else:
                 try:
                     if trusted and name in ("ManageMemory", "ContextMemory"):
                         # Reserved runtime context always wins over model arguments.
                         kwargs["_trusted_context"] = trusted
                         kwargs["_transport_event_id"] = trusted.get("transport_event_id")
-                    result = str(agent.perform(**kwargs))
+                    from openrappter.agents.basic_agent import BasicAgent
+
+                    execute = (
+                        agent.execute
+                        if isinstance(agent, BasicAgent)
+                        else None
+                    )
+
+                    def invoke_agent():
+                        if callable(execute):
+                            return execute(**kwargs)
+                        agent_started_at = time.monotonic()
+                        agent_started = recorder.record(
+                            {
+                                "kind": "agent.execute.started",
+                                "source": "python-brainstem-legacy",
+                                "status": "started",
+                                "agentName": name,
+                            }
+                        )
+
+                        def perform_legacy():
+                            try:
+                                legacy_result = str(agent.perform(**kwargs))
+                                try:
+                                    legacy_failed = (
+                                        str(
+                                            json.loads(legacy_result).get(
+                                                "status",
+                                                "",
+                                            )
+                                        ).lower()
+                                        == "error"
+                                    )
+                                except (
+                                    AttributeError,
+                                    TypeError,
+                                    ValueError,
+                                ):
+                                    legacy_failed = False
+                                recorder.record(
+                                    {
+                                        "kind": (
+                                            "agent.execute.failed"
+                                            if legacy_failed
+                                            else "agent.execute.completed"
+                                        ),
+                                        "source": "python-brainstem-legacy",
+                                        "status": (
+                                            "error"
+                                            if legacy_failed
+                                            else "success"
+                                        ),
+                                        "agentName": name,
+                                        "durationMs": (
+                                            time.monotonic()
+                                            - agent_started_at
+                                        )
+                                        * 1000,
+                                        "metadata": {
+                                            "resultLength": len(
+                                                legacy_result
+                                            ),
+                                        },
+                                    }
+                                )
+                                return legacy_result
+                            except Exception as legacy_error:
+                                from openrappter.flight_recorder import (
+                                    summarize_flight_error,
+                                )
+
+                                recorder.record(
+                                    {
+                                        "kind": "agent.execute.failed",
+                                        "source": "python-brainstem-legacy",
+                                        "status": "error",
+                                        "agentName": name,
+                                        "durationMs": (
+                                            time.monotonic()
+                                            - agent_started_at
+                                        )
+                                        * 1000,
+                                        "metadata": (
+                                            summarize_flight_error(
+                                                legacy_error
+                                            )
+                                        ),
+                                    }
+                                )
+                                raise
+
+                        return recorder.with_parent(
+                            (
+                                agent_started.get("id")
+                                if agent_started
+                                else None
+                            ),
+                            perform_legacy,
+                        )
+
+                    result = str(
+                        recorder.with_parent(
+                            tool_started.get("id")
+                            if tool_started
+                            else None,
+                            invoke_agent,
+                        )
+                    )
                     log_line = result
+                    failed = agent_result_is_error(result)
                 except Exception as e:  # noqa: BLE001
                     result = f"Error: {e}"
                     log_line = f"ERROR: {e}"
+                    failed = True
+            structured_result = result
+            if isinstance(result, str):
+                try:
+                    structured_result = json.loads(result)
+                except (TypeError, ValueError):
+                    pass
+            recorder.record(
+                {
+                    "kind": (
+                        "tool.call.failed"
+                        if failed
+                        else "tool.call.completed"
+                    ),
+                    "source": "python-brainstem",
+                    "status": "error" if failed else "success",
+                    "parentId": (
+                        tool_started.get("id")
+                        if tool_started
+                        else None
+                    ),
+                    "toolName": name,
+                    "durationMs": (
+                        time.monotonic() - tool_started_at
+                    )
+                    * 1000,
+                    "metadata": {"resultLength": len(result)},
+                    "payload": {"result": structured_result},
+                }
+            )
             agent_logs.append(f"[{name}] {log_line}")
             # §2.3 fixes the tool message shape, including `name`, which we omitted.
             messages.append({
@@ -810,7 +1120,11 @@ def run_chat(user_input, history, session_id, trusted_context=None):
     # requested; the last assistant `content` is the reply." A synthetic
     # "Tool loop limit reached." discards an answer the model actually gave.
     return build_chat_envelope(
-        last_content, session_id, agent_logs, model=served_model,
+        last_content,
+        session_id,
+        agent_logs,
+        model=served_model,
+        requested_model=requested_model,
     )
 
 
@@ -910,7 +1224,11 @@ class BrainstemHandler(BaseHTTPRequestHandler):
             history_value = data.get("conversation_history", data.get("history"))
             history = history_value if isinstance(history_value, list) else []
             provided_session_id = data.get("session_id") or data.get("sessionId")
-            session_id = provided_session_id or str(uuid.uuid4())
+            session_id = (
+                str(provided_session_id)
+                if provided_session_id is not None
+                else str(uuid.uuid4())
+            )
             raw_idempotency_key = (
                 data.get("idempotency_key") or data.get("idempotencyKey")
             )

--- a/python/openrappter/channels/bridge.py
+++ b/python/openrappter/channels/bridge.py
@@ -14,12 +14,28 @@ other's internals: the channel only knows about ``IncomingMessage``/
 from __future__ import annotations
 
 import logging
+import time
+import json
 from typing import Callable, List, Optional
 
 from openrappter.channels.base import BaseChannel, IncomingMessage, OutgoingMessage
+from openrappter.flight_recorder import (
+    sanitize_flight_value,
+    summarize_flight_error,
+)
 from openrappter.providers.types import ChatOptions, ProviderError, ProviderMessage
 
 logger = logging.getLogger(__name__)
+
+
+def _structured_content(value):
+    parsed = value
+    if isinstance(value, str):
+        try:
+            parsed = json.loads(value)
+        except (TypeError, ValueError):
+            pass
+    return sanitize_flight_value(parsed)
 
 
 class ChannelDispatchError(Exception):
@@ -80,20 +96,124 @@ class ProviderChannelBridge:
         return messages
 
     def _on_incoming(self, incoming: IncomingMessage) -> None:
-        messages = self._build_messages(incoming)
-        try:
-            response = self.provider.chat(messages, self.chat_options)
-        except ProviderError as exc:
-            # Re-raised as a channel-domain error rather than swallowed, so
-            # the channel transport (e.g. WebhookChannel's HTTP response)
-            # can surface a bounded, explicit failure to the caller instead
-            # of silently answering with an empty/garbled message.
-            raise ChannelDispatchError(str(exc)) from exc
+        from openrappter.flight_recorder import ensure_flight_recorder_from_env
 
-        outgoing = OutgoingMessage(
-            channel_id=incoming.channel_id,
-            conversation_id=incoming.conversation_id,
-            content=response.content or "",
-            request_generation=incoming.request_generation,
+        recorder = ensure_flight_recorder_from_env()
+        operation = lambda: self._dispatch_incoming(incoming, recorder)
+        if recorder.current_trace():
+            return operation()
+        return recorder.run_trace(
+            {
+                "sessionId": incoming.conversation_id,
+                "workspaceId": f"channel:{incoming.channel_id}",
+            },
+            operation,
         )
-        self.channel.send(incoming.conversation_id, outgoing)
+
+    def _dispatch_incoming(self, incoming: IncomingMessage, recorder) -> None:
+        messages = self._build_messages(incoming)
+        provider_id = str(
+            getattr(self.provider, "id", None)
+            or getattr(self.provider, "name", None)
+            or self.provider.__class__.__name__
+        )
+        configured_model = (
+            getattr(self.chat_options, "model", None)
+            or getattr(self.provider, "model", None)
+        )
+        model_policy = (
+            configured_model.strip()
+            if isinstance(configured_model, str) and configured_model.strip()
+            else None
+        )
+        started = time.monotonic()
+        started_event = recorder.record({
+            "kind": "provider.attempt.started",
+            "source": "provider-channel-bridge",
+            "status": "started",
+            "providerId": provider_id,
+            "metadata": {
+                "messageCount": len(messages),
+                "channelType": self.channel.type,
+                **({"modelPolicy": model_policy} if model_policy else {}),
+            },
+            "payload": lambda: {
+                "messages": [
+                    {
+                        "role": message.role,
+                        "content": _structured_content(message.content),
+                    }
+                    for message in messages
+                ]
+            },
+        })
+
+        def within_provider():
+            try:
+                response = self.provider.chat(messages, self.chat_options)
+            except Exception as exc:
+                recorder.record({
+                    "kind": "provider.attempt.failed",
+                    "source": "provider-channel-bridge",
+                    "status": "error",
+                    "providerId": provider_id,
+                    "durationMs": (time.monotonic() - started) * 1000,
+                    "metadata": {
+                        **summarize_flight_error(exc),
+                        **({"modelPolicy": model_policy} if model_policy else {}),
+                    },
+                    "payload": lambda: {
+                        "messages": [
+                            {
+                                "role": message.role,
+                                "content": _structured_content(
+                                    message.content
+                                ),
+                            }
+                            for message in messages
+                        ],
+                        "error": exc,
+                    },
+                })
+                # Re-raised as a channel-domain error rather than swallowed, so
+                # the channel transport (e.g. WebhookChannel's HTTP response)
+                # can surface a bounded, explicit failure to the caller instead
+                # of silently answering with an empty/garbled message.
+                if isinstance(exc, ProviderError):
+                    raise ChannelDispatchError(str(exc)) from exc
+                raise
+
+            recorder.record({
+                "kind": "provider.attempt.completed",
+                "source": "provider-channel-bridge",
+                "status": "success",
+                "providerId": provider_id,
+                **({"model": response.model} if response.model else {}),
+                "durationMs": (time.monotonic() - started) * 1000,
+                "metadata": {
+                    "hadContent": bool(response.content),
+                    "finishReason": response.finish_reason,
+                    "usage": response.usage,
+                    **({"modelPolicy": model_policy} if model_policy else {}),
+                },
+                "payload": lambda: {
+                    "response": {
+                        "content": _structured_content(response.content),
+                        "model": response.model,
+                        "finishReason": response.finish_reason,
+                        "usage": response.usage,
+                    }
+                },
+            })
+            outgoing = OutgoingMessage(
+                channel_id=incoming.channel_id,
+                conversation_id=incoming.conversation_id,
+                content=response.content or "",
+                request_generation=incoming.request_generation,
+            )
+            self.channel.send(incoming.conversation_id, outgoing)
+
+        return recorder.with_parent(
+            started_event.get("id") if started_event is not None else None,
+            within_provider,
+        )

--- a/python/openrappter/cli.py
+++ b/python/openrappter/cli.py
@@ -30,11 +30,13 @@ import subprocess
 import sys
 import re
 import logging
+import time
 from pathlib import Path
 from datetime import datetime
 from typing import Optional
 
 from openrappter import __version__
+from openrappter.result_status import agent_result_is_error
 
 # Package root for agent discovery
 PACKAGE_ROOT = Path(__file__).parent
@@ -249,6 +251,8 @@ class CopilotProvider:
     """
     
     def __init__(self):
+        self.id = "github-copilot"
+        self.model = "gpt-4.1"
         self._client = None
         self._session = None
         self._sdk_available = None
@@ -302,7 +306,7 @@ class CopilotProvider:
         client = await self._ensure_client()
         
         session_config = {
-            "model": "gpt-4.1",  # Fast and capable
+            "model": self.model,  # Fast and capable
         }
         
         # Convert our tool format to Copilot SDK format
@@ -387,7 +391,12 @@ class CopilotProvider:
                 try:
                     await asyncio.wait_for(done.wait(), timeout=60)
                 except asyncio.TimeoutError:
-                    pass
+                    await session.destroy()
+                    return {
+                        "content": None,
+                        "tool_calls": None,
+                        "error": "Copilot request timed out after 60 seconds",
+                    }
                 
                 await session.destroy()
                 
@@ -463,6 +472,22 @@ Be helpful, concise, and use the appropriate tool when needed.
         Process a user message, potentially calling agents via tool calling.
         Returns the response string.
         """
+        from openrappter.flight_recorder import ensure_flight_recorder_from_env
+
+        recorder = ensure_flight_recorder_from_env()
+        operation = lambda: self._process_message_within_trace(user_message)
+        if recorder.current_trace():
+            return operation()
+        return recorder.run_trace(
+            {
+                "sessionId": "python-cli",
+                "workspaceId": str(Path.cwd()),
+            },
+            operation,
+        )
+
+    def _process_message_within_trace(self, user_message: str) -> str:
+        """Process one message after its Flight Recorder trace is established."""
         # Add to conversation history
         self.conversation_history.append({
             "role": "user",
@@ -473,29 +498,177 @@ Be helpful, concise, and use the appropriate tool when needed.
         tools = self.registry.get_agent_metadata_tools()
         
         # Call Copilot with tools
-        response = self.copilot.chat(
-            message=user_message,
-            system_prompt=self.get_system_prompt(),
-            tools=tools if tools else None
+        from openrappter.flight_recorder import (
+            ensure_flight_recorder_from_env,
+            summarize_flight_error,
         )
+
+        recorder = ensure_flight_recorder_from_env()
+        started = time.monotonic()
+        system_prompt = self.get_system_prompt()
+        provider_messages = [
+            {"role": "system", "content": system_prompt},
+            {"role": "user", "content": user_message},
+        ]
+        model_policy = (
+            self.copilot.model.strip()
+            if isinstance(self.copilot.model, str)
+            and self.copilot.model.strip()
+            else None
+        )
+        recorder.record({
+            "kind": "context.assembled",
+            "source": "python-cli-assistant",
+            "status": "info",
+            "metadata": {
+                "sourceNames": ["system", "history", "tools"],
+                "categoryNames": [
+                    "system",
+                    "conversation",
+                    "tools",
+                ],
+                "systemChars": len(system_prompt),
+                "historyLength": len(self.conversation_history),
+                "toolCount": len(tools),
+            },
+            "payload": {
+                "messages": provider_messages,
+                "tools": tools,
+            },
+        })
+        started_event = recorder.record({
+            "kind": "provider.attempt.started",
+            "source": "python-cli-assistant",
+            "status": "started",
+            "providerId": self.copilot.id,
+            "metadata": {
+                "messageCount": len(provider_messages),
+                "toolCount": len(tools),
+                **({"modelPolicy": model_policy} if model_policy else {}),
+            },
+            "payload": {
+                "messages": provider_messages,
+                "tools": tools,
+            },
+        })
+        provider_parent_id = (
+            started_event.get("id") if started_event is not None else None
+        )
+        try:
+            response = self.copilot.chat(
+                message=user_message,
+                system_prompt=system_prompt,
+                tools=tools if tools else None
+            )
+        except Exception as exc:
+            recorder.record({
+                "kind": "provider.attempt.failed",
+                "source": "python-cli-assistant",
+                "status": "error",
+                **({"parentId": provider_parent_id} if provider_parent_id else {}),
+                "providerId": self.copilot.id,
+                "durationMs": (time.monotonic() - started) * 1000,
+                "metadata": {
+                    **summarize_flight_error(exc),
+                    **({"modelPolicy": model_policy} if model_policy else {}),
+                },
+                "payload": {
+                    "messages": provider_messages,
+                    "tools": tools,
+                    "error": exc,
+                },
+            })
+            raise
+
+        if response.get("error"):
+            failed_event = recorder.record({
+                "kind": "provider.attempt.failed",
+                "source": "python-cli-assistant",
+                "status": "error",
+                **({"parentId": provider_parent_id} if provider_parent_id else {}),
+                "providerId": self.copilot.id,
+                **(
+                    {"model": response.get("model")}
+                    if response.get("model")
+                    else {}
+                ),
+                "durationMs": (time.monotonic() - started) * 1000,
+                "metadata": {
+                    **summarize_flight_error(response.get("error")),
+                    **({"modelPolicy": model_policy} if model_policy else {}),
+                },
+                "payload": {
+                    "messages": provider_messages,
+                    "tools": tools,
+                    "response": response,
+                },
+            })
+            provider_completed_id = (
+                failed_event.get("id")
+                if failed_event is not None
+                else provider_parent_id
+            )
+        else:
+            completed_event = recorder.record({
+                "kind": "provider.attempt.completed",
+                "source": "python-cli-assistant",
+                "status": "success",
+                **({"parentId": provider_parent_id} if provider_parent_id else {}),
+                "providerId": self.copilot.id,
+                **(
+                    {"model": response.get("model")}
+                    if response.get("model")
+                    else {}
+                ),
+                "durationMs": (time.monotonic() - started) * 1000,
+                "metadata": {
+                    "hadContent": bool(response.get("content")),
+                    "hadToolCalls": bool(response.get("tool_calls")),
+                    **({"modelPolicy": model_policy} if model_policy else {}),
+                },
+                "payload": {
+                    "messages": provider_messages,
+                    "tools": tools,
+                    "response": response,
+                },
+            })
+            provider_completed_id = (
+                completed_event.get("id")
+                if completed_event is not None
+                else provider_parent_id
+            )
         
         # Handle errors
         if response.get('error'):
             # Fallback to direct agent execution for simple queries
-            return self._fallback_response(user_message)
+            return self._fallback_response(
+                user_message,
+                recorder,
+                provider_completed_id,
+            )
         
         # Check for tool calls
         if response.get('tool_calls'):
             tool_call = response['tool_calls'][0]
             agent_name = tool_call['name']
             
+            parse_success = True
             try:
                 arguments = json.loads(tool_call['arguments']) if tool_call['arguments'] else {}
             except json.JSONDecodeError:
                 arguments = {}
+                parse_success = False
             
-            # Execute the agent
-            result = self._execute_agent(agent_name, arguments, user_message)
+            result = self._run_agent_tool(
+                recorder,
+                agent_name,
+                arguments,
+                user_message,
+                provider_completed_id,
+                parse_success=parse_success,
+                argument_text=tool_call.get("arguments") or "",
+                route="provider-tool-call",
+            )
             
             # Add agent execution to history
             self.conversation_history.append({
@@ -546,8 +719,92 @@ Be helpful, concise, and use the appropriate tool when needed.
                 "status": "error",
                 "message": f"Error executing {agent_name}: {str(e)}"
             })
-    
-    def _fallback_response(self, message: str) -> str:
+
+    def _run_agent_tool(
+        self,
+        recorder,
+        agent_name: str,
+        arguments: dict,
+        original_query: str,
+        parent_id: Optional[str],
+        *,
+        parse_success: bool,
+        argument_text: str,
+        route: str,
+        route_score: Optional[int] = None,
+    ) -> str:
+        from openrappter.flight_recorder import sanitize_flight_value
+
+        tool_started_at = time.monotonic()
+        route_metadata = {
+            "route": route,
+            **({"routeScore": route_score} if route_score is not None else {}),
+        }
+        tool_started = recorder.record({
+            "kind": "tool.call.started",
+            "source": "python-cli-assistant",
+            "status": "started",
+            **({"parentId": parent_id} if parent_id else {}),
+            "toolName": agent_name,
+            "metadata": {
+                "parseSuccess": parse_success,
+                "argumentChars": len(argument_text),
+                **route_metadata,
+            },
+            "payload": {
+                "arguments": (
+                    arguments
+                    if parse_success
+                    else sanitize_flight_value(argument_text)
+                )
+            },
+        })
+        tool_parent_id = (
+            tool_started.get("id") if tool_started is not None else None
+        )
+        result = recorder.with_parent(
+            tool_parent_id,
+            lambda: self._execute_agent(agent_name, arguments, original_query),
+        )
+        failed = agent_result_is_error(result)
+        try:
+            parsed_result = json.loads(result)
+        except (json.JSONDecodeError, TypeError):
+            parsed_result = sanitize_flight_value(result)
+        recorder.record({
+            "kind": (
+                "tool.call.failed"
+                if failed
+                else "tool.call.completed"
+            ),
+            "source": "python-cli-assistant",
+            "status": "error" if failed else "success",
+            **({"parentId": tool_parent_id} if tool_parent_id else {}),
+            "toolName": agent_name,
+            "durationMs": (time.monotonic() - tool_started_at) * 1000,
+            "metadata": {
+                "parseSuccess": parse_success,
+                "resultLength": len(result),
+                **({"resultStatus": "error"} if failed else {}),
+                **route_metadata,
+            },
+            "payload": {
+                "arguments": (
+                    arguments
+                    if parse_success
+                    else sanitize_flight_value(argument_text)
+                ),
+                "result": sanitize_flight_value(parsed_result),
+            },
+        })
+        return result
+
+    def _fallback_response(
+        self,
+        message: str,
+        recorder,
+        parent_id: Optional[str],
+    ) -> str:
         """Fallback when Copilot is unavailable - use smart agent matching."""
         msg_lower = message.lower()
         
@@ -598,9 +855,21 @@ Be helpful, concise, and use the appropriate tool when needed.
                         if prefix in msg_lower:
                             desc = message[msg_lower.find(prefix) + len(prefix):].strip()
                             break
-                    return agent.execute(description=desc, query=message)
+                    arguments = {"description": desc, "query": message}
                 else:
-                    return agent.execute(query=message)
+                    arguments = {"query": message}
+                argument_text = json.dumps(arguments, separators=(",", ":"))
+                return self._run_agent_tool(
+                    recorder,
+                    best_match,
+                    arguments,
+                    message,
+                    parent_id,
+                    parse_success=True,
+                    argument_text=argument_text,
+                    route="provider-error-fallback",
+                    route_score=best_score,
+                )
         
         # Default response
         return json.dumps({

--- a/python/openrappter/flight_recorder.py
+++ b/python/openrappter/flight_recorder.py
@@ -1,0 +1,5135 @@
+"""Privacy-safe, provider-neutral Flight Recorder v1 for the Python runtime."""
+
+from __future__ import annotations
+
+import contextvars
+import atexit
+import asyncio
+import errno
+import hashlib
+import hmac
+import inspect
+import json
+import math
+import os
+import re
+import sqlite3
+import stat as stat_module
+import subprocess
+import sys
+import threading
+import time
+import uuid
+import weakref
+from contextlib import contextmanager
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Iterator, Mapping, Optional, Sequence
+from urllib.parse import parse_qsl, unquote, urlparse
+
+FLIGHT_EVENT_SCHEMA = "openrappter-event/1.0"
+FLIGHT_EXPORT_SCHEMA = "openrappter-flight-export/1.0"
+DEFAULT_RETENTION_EVENTS = 10_000
+DEFAULT_MAX_PAYLOAD_BYTES = 16 * 1024
+MAX_SANITIZE_STRING_BYTES = 64 * 1024
+MAX_EMBEDDED_JSON_PARSE_CHARS = MAX_SANITIZE_STRING_BYTES * 4
+MAX_EMBEDDED_JSON_DEPTH = 4
+MAX_SANITIZE_NODES = 10_000
+MAX_SANITIZE_BYTES = 256 * 1024
+TRAVERSAL_LIMIT = "[truncated:budget]"
+BUSY_TIMEOUT_MS = 5_000
+RUNTIME_BUSY_TIMEOUT_MS = 25
+MAX_BUSY_RETRIES = 4
+MAX_QUERY_LIMIT = 10_000
+MAX_QUERY_OFFSET = 1_000_000
+MAX_KIND_FILTERS = 100
+JS_MAX_SAFE_INTEGER = 9_007_199_254_740_991
+QUERY_KEYS = frozenset(
+    {
+        "traceId",
+        "sessionId",
+        "workspaceId",
+        "kind",
+        "source",
+        "providerId",
+        "agentName",
+        "toolName",
+        "status",
+        "since",
+        "until",
+        "order",
+        "limit",
+        "offset",
+    }
+)
+QUERY_ALIASES = {
+    "trace_id": "traceId",
+    "session_id": "sessionId",
+    "workspace_id": "workspaceId",
+    "provider_id": "providerId",
+    "agent_name": "agentName",
+    "tool_name": "toolName",
+}
+
+REDACTED = "[redacted]"
+EXCLUDED_PATH = "[excluded-path]"
+CIRCULAR = "[circular]"
+UNSERIALIZABLE = "[unserializable]"
+
+DEFAULT_REDACTED_KEYS = frozenset(
+    {
+        "token",
+        "secret",
+        "password",
+        "credential",
+        "authorization",
+        "api_key",
+        "apiKey",
+        "apikey",
+        "private_key",
+        "privateKey",
+        "privatekey",
+        "cookie",
+        "session_token",
+        "sessionToken",
+        "sessiontoken",
+        "access_token",
+        "accessToken",
+        "accesstoken",
+        "refresh_token",
+        "refreshToken",
+        "refreshtoken",
+        "identityKey",
+        "identity_key",
+        "OPENRAPPTER_FLIGHT_ID_KEY",
+        "__proto__",
+        "constructor",
+        "prototype",
+    }
+)
+
+DEFAULT_EXCLUDED_PATH_PATTERNS = (
+    re.compile(r"(?:^|[\\/])\.env(?:\.[^\\/]+)?(?:$|[\\/])", re.I),
+    re.compile(
+        r"(?:^|[\\/])(?:\.git-credentials|credentials?|"
+        r"application_default_credentials|service[-_.]?account|"
+        r"client[-_.]?secret)(?:\.[^\\/]*)?$",
+        re.I,
+    ),
+    re.compile(r"\.(?:pem|key|p12)(?:$|[?#])", re.I),
+    re.compile(r"(?:^|[\\/])\.ssh(?:[\\/]|$)", re.I),
+    re.compile(r"(?:^|[\\/])\.aws[\\/]credentials(?:$|[\\/])", re.I),
+    re.compile(r"(?:^|[\\/])\.copilot_token(?:$|[\\/])", re.I),
+    re.compile(
+        r"\.identity-key(?:\.\d+\.[0-9a-f-]+\.tmp)?(?:$|[?#])",
+        re.I,
+    ),
+)
+
+_PROCESS_OWNER_PATHS: set[Path] = set()
+_RECORDER_INSTANCES: "weakref.WeakSet[FlightRecorder]" = weakref.WeakSet()
+
+
+@atexit.register
+def _cleanup_process_owner_paths() -> None:
+    for owner_path in list(_PROCESS_OWNER_PATHS):
+        try:
+            owner_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+
+SECRET_VALUE_PATTERNS = (
+    re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{16,})\b", re.I | re.ASCII),
+    re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", re.ASCII),
+    re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{8,}", re.I | re.ASCII),
+    re.compile(r"\b[a-z][a-z0-9+.-]*://[^/\s:@]*:[^@\s/]+@", re.I | re.ASCII),
+    re.compile(r"\b(?:password|pwd)\s*=\s*[^;\s]+", re.I | re.ASCII),
+    re.compile(
+        r"\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|"
+        r"client[_-]?secret|credential)\s*[:=]\s*[\"']?"
+        r"[A-Za-z0-9._~+/=-]{8,}",
+        re.I | re.ASCII,
+    ),
+    re.compile(
+        r"[?&](?:token|secret|password|credential|authorization|"
+        r"api[_-]?key|access[_-]?token|refresh[_-]?token|"
+        r"client[_-]?secret)=",
+        re.I | re.ASCII,
+    ),
+    re.compile(
+        r"(?:^|[{,\s])[\"']?(?:password|pwd|token|secret|credential|"
+        r"authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|"
+        r"client[_-]?secret)[\"']?\s*[:=]",
+        re.I,
+    ),
+    re.compile(r"-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----", re.I),
+)
+
+EVENT_STATUSES = frozenset({"started", "success", "error", "decision", "info"})
+EVENT_KEYS = frozenset(
+    {
+        "schema",
+        "id",
+        "sequence",
+        "kind",
+        "source",
+        "status",
+        "traceId",
+        "parentId",
+        "sessionId",
+        "workspaceId",
+        "providerId",
+        "model",
+        "agentName",
+        "toolName",
+        "timestamp",
+        "durationMs",
+        "metadata",
+        "payload",
+        "contentHash",
+    }
+)
+
+_MISSING = object()
+
+
+class FlightRecorderError(RuntimeError):
+    """Base Flight Recorder error."""
+
+
+class FlightRecorderCorruptionError(FlightRecorderError):
+    """Raised when persisted or imported event integrity is invalid."""
+
+
+class FlightRecorderUnhealthyError(FlightRecorderError):
+    """Raised when explicit inspection targets an unhealthy recorder."""
+
+
+def _json_text(value: Any, *, sort_keys: bool = False) -> str:
+    return json.dumps(
+        value,
+        ensure_ascii=False,
+        allow_nan=False,
+        separators=(",", ":"),
+        sort_keys=sort_keys,
+    )
+
+
+def _reject_json_constant(value: str) -> None:
+    raise ValueError(f"Non-standard JSON constant: {value}")
+
+
+def _strict_json_loads(value: str) -> Any:
+    return json.loads(value, parse_constant=_reject_json_constant)
+
+
+def _ecmascript_number(value: int | float) -> str:
+    """Serialize a finite safe number like ECMAScript JSON.stringify."""
+    if isinstance(value, bool):
+        raise TypeError("Booleans are not numbers.")
+    if isinstance(value, int):
+        if abs(value) > JS_MAX_SAFE_INTEGER:
+            raise ValueError("Integer exceeds the JavaScript safe integer domain.")
+        return str(value)
+    if not math.isfinite(value):
+        raise ValueError("Non-finite numbers are not canonical JSON numbers.")
+    if value == 0:
+        return "0"
+
+    negative = value < 0
+    absolute = abs(value)
+    shortest = repr(absolute).lower()
+    mantissa, exponent_text = (
+        shortest.split("e", 1) if "e" in shortest else (shortest, "0")
+    )
+    exponent = int(exponent_text)
+    integer_part, fractional_part = (
+        mantissa.split(".", 1) if "." in mantissa else (mantissa, "")
+    )
+    raw_digits = integer_part + fractional_part
+    leading_zeros = len(raw_digits) - len(raw_digits.lstrip("0"))
+    digits = raw_digits.lstrip("0") or "0"
+    decimal_position = len(integer_part) + exponent - leading_zeros
+
+    if absolute >= 1e21 or absolute < 1e-6:
+        scientific_exponent = decimal_position - 1
+        significant = digits.rstrip("0") or "0"
+        coefficient = significant[0]
+        if len(significant) > 1:
+            coefficient += f".{significant[1:]}"
+        exponent_sign = "+" if scientific_exponent >= 0 else "-"
+        rendered = f"{coefficient}e{exponent_sign}{abs(scientific_exponent)}"
+    elif decimal_position <= 0:
+        rendered = f"0.{'0' * -decimal_position}{digits}".rstrip("0")
+    elif decimal_position >= len(digits):
+        rendered = digits + ("0" * (decimal_position - len(digits)))
+    else:
+        rendered = (
+            f"{digits[:decimal_position]}.{digits[decimal_position:]}"
+        ).rstrip("0").rstrip(".")
+
+    return f"-{rendered}" if negative else rendered
+
+
+def _canonical(value: Any) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        return _json_text(value)
+    if isinstance(value, int):
+        return _ecmascript_number(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return "null"
+        return _ecmascript_number(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_canonical(item) for item in value) + "]"
+    if isinstance(value, Mapping):
+        keys = list(value)
+        if any(not isinstance(key, str) for key in keys):
+            raise TypeError("Flight event object keys must be strings.")
+        entries = []
+        for key in sorted(keys, key=lambda item: item.encode("utf-16-be")):
+            entries.append(f"{_json_text(key)}:{_canonical(value[key])}")
+        return "{" + ",".join(entries) + "}"
+    raise TypeError(f"Value of type {type(value).__name__} is not JSON-compatible.")
+
+
+def _portable_json(value: Any) -> str:
+    if value is None:
+        return "null"
+    if value is True:
+        return "true"
+    if value is False:
+        return "false"
+    if isinstance(value, str):
+        return _json_text(value)
+    if isinstance(value, int):
+        return _ecmascript_number(value)
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return "null"
+        return _ecmascript_number(value)
+    if isinstance(value, (list, tuple)):
+        return "[" + ",".join(_portable_json(item) for item in value) + "]"
+    if isinstance(value, Mapping):
+        entries = []
+        for key, entry_value in value.items():
+            if not isinstance(key, str):
+                raise TypeError("JSON object keys must be strings.")
+            entries.append(
+                f"{_json_text(key)}:{_portable_json(entry_value)}"
+            )
+        return "{" + ",".join(entries) + "}"
+    raise TypeError(
+        f"Value of type {type(value).__name__} is not JSON-compatible."
+    )
+
+
+def compute_flight_event_hash(event: Mapping[str, Any]) -> str:
+    """Return SHA-256 over the canonical event body, excluding ``contentHash``."""
+    body = dict(event)
+    body.pop("contentHash", None)
+    return hashlib.sha256(_canonical(body).encode("utf-8")).hexdigest()
+
+
+def verify_flight_event_hash(event: Mapping[str, Any]) -> bool:
+    content_hash = event.get("contentHash")
+    return (
+        isinstance(content_hash, str)
+        and re.fullmatch(r"[0-9a-f]{64}", content_hash) is not None
+        and compute_flight_event_hash(event) == content_hash
+    )
+
+
+def _exportable_event(event: Mapping[str, Any]) -> Dict[str, Any]:
+    exported = dict(event)
+    metadata = dict(exported.get("metadata") or {})
+    changed = False
+    for key in ("ownerPid", "ownerId", "ownerIncarnation"):
+        if key in metadata:
+            metadata.pop(key)
+            changed = True
+    if not changed:
+        return exported
+    exported["metadata"] = metadata
+    exported["contentHash"] = compute_flight_event_hash(exported)
+    return exported
+
+
+def _normalize_unicode_scalars(value: str) -> str:
+    return "".join(
+        "\ufffd" if 0xD800 <= ord(character) <= 0xDFFF else character
+        for character in value
+    )
+
+
+def _decode_percent_fixed(value: str) -> str:
+    current = value
+    for _pass in range(32):
+        decoded = unquote(current)
+        if decoded == current:
+            return decoded
+        current = decoded
+    return REDACTED
+
+
+def normalize_flight_workspace_id(value: Optional[str]) -> Optional[str]:
+    """Hash absolute filesystem paths while preserving already-opaque IDs."""
+    if not value:
+        return value
+    normalized_value = _normalize_unicode_scalars(value)
+    if re.fullmatch(r"workspace:[0-9a-f]{24}", normalized_value):
+        return normalized_value
+    candidates = [normalized_value]
+    try:
+        decoded = _decode_percent_fixed(normalized_value)
+        if decoded == REDACTED:
+            digest = hashlib.sha256(
+                normalized_value.encode("utf-8")
+            ).hexdigest()[:24]
+            return f"workspace:{digest}"
+        if decoded != normalized_value:
+            candidates.append(decoded)
+    except (TypeError, ValueError):
+        pass
+
+    def is_path_like(candidate: str) -> bool:
+        if (
+            re.match(
+                r"^[A-Za-z][A-Za-z0-9+.-]*://",
+                candidate,
+            )
+            or re.match(r"^(?:file|workspace):", candidate, re.I)
+        ):
+            return True
+        if (
+            candidate.startswith("/")
+            or re.match(r"^[A-Za-z]:[\\/]", candidate)
+            or candidate.startswith("\\\\")
+        ):
+            return True
+        namespaced = re.match(
+            r"^[A-Za-z][A-Za-z0-9+.-]*:(.*)$",
+            candidate,
+            re.S,
+        )
+        if namespaced is None or "://" in candidate:
+            return False
+        suffix = namespaced.group(1)
+        return (
+            suffix.startswith("/")
+            or re.match(r"^[A-Za-z]:[\\/]", suffix) is not None
+            or suffix.startswith("\\\\")
+        )
+
+    path_like = any(is_path_like(candidate) for candidate in candidates)
+    if not path_like:
+        return normalized_value
+    digest = hashlib.sha256(
+        normalized_value.encode("utf-8")
+    ).hexdigest()[:24]
+    return f"workspace:{digest}"
+
+
+def normalize_flight_session_id(
+    value: Optional[str],
+    identity_key: str,
+    redacted_values: Sequence[str] = (),
+) -> Optional[str]:
+    """Hash conversation IDs so counterparty identity is never persisted."""
+    if not value:
+        return value
+    normalized_value = _normalize_unicode_scalars(value)
+    exact_secret = any(
+        candidate
+        and (
+            (
+                re.fullmatch(r"[0-9a-fA-F]{64}", candidate)
+                is not None
+                and candidate.lower() == normalized_value.lower()
+            )
+            or (
+                re.fullmatch(r"[0-9a-fA-F]{64}", candidate)
+                is None
+                and candidate == normalized_value
+            )
+        )
+        for candidate in redacted_values
+    )
+    if (
+        re.fullmatch(r"session:[0-9a-f]{24}", normalized_value)
+        and not exact_secret
+    ):
+        return normalized_value
+    if re.fullmatch(r"[0-9a-fA-F]{64}", identity_key) is None:
+        raise ValueError(
+            "Flight Recorder identity key must be 32-byte hexadecimal."
+        )
+    digest = hmac.new(
+        bytes.fromhex(identity_key),
+        normalized_value.encode("utf-8"),
+        hashlib.sha256,
+    ).hexdigest()[:24]
+    return f"session:{digest}"
+
+
+def _harden_private_path(path: Path, *, directory: bool = False) -> None:
+    if os.name != "nt":
+        os.chmod(path, 0o700 if directory else 0o600)
+        return
+    user = os.environ.get("USERNAME")
+    if not user:
+        raise ValueError(
+            "USERNAME is required to harden Flight Recorder ACLs."
+        )
+    security_type = (
+        "System.Security.AccessControl.DirectorySecurity"
+        if directory
+        else "System.Security.AccessControl.FileSecurity"
+    )
+    inheritance = (
+        "[System.Security.AccessControl.InheritanceFlags]'ContainerInherit,ObjectInherit'"
+        if directory
+        else "[System.Security.AccessControl.InheritanceFlags]::None"
+    )
+    command = f"""
+$ErrorActionPreference = 'Stop'
+try {{
+  $identity = New-Object System.Security.Principal.NTAccount($env:HF_USER)
+  $sid = $identity.Translate([System.Security.Principal.SecurityIdentifier])
+  $acl = New-Object {security_type}
+  $acl.SetOwner($sid)
+  $acl.SetAccessRuleProtection($true, $false)
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($sid, 'FullControl', {inheritance}, [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow)
+  $acl.AddAccessRule($rule)
+  Set-Acl -LiteralPath $env:HF_TARGET -AclObject $acl -ErrorAction Stop
+
+  $actual = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
+  $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
+  $rules = @($actual.Access)
+  if (-not $actual.AreAccessRulesProtected -or $ownerSid.Value -ne $sid.Value -or $rules.Count -ne 1) {{
+    throw 'Flight Recorder ACL verification failed.'
+  }}
+  $ruleSid = $rules[0].IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
+  $fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
+  if ($ruleSid.Value -ne $sid.Value -or $rules[0].IsInherited -or $rules[0].AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or (($rules[0].FileSystemRights -band $fullControl) -ne $fullControl)) {{
+    throw 'Flight Recorder ACL rule verification failed.'
+  }}
+}} catch {{
+  [Console]::Error.WriteLine($_.Exception.ToString())
+  exit 1
+}}
+"""
+    subprocess.run(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            command,
+        ],
+        check=True,
+        capture_output=True,
+        env={**os.environ, "HF_TARGET": str(path), "HF_USER": user},
+    )
+
+
+def _assert_private_directory(directory: Path) -> None:
+    current = directory.absolute()
+    while True:
+        linked = current.lstat()
+        if (
+            _is_reparse_or_symlink(linked)
+            and (
+                os.name == "nt"
+                or not hasattr(os, "getuid")
+                or linked.st_uid != 0
+            )
+        ):
+            raise FlightRecorderError(
+                "Flight Recorder storage parent must not use a "
+                f"user-controlled symlink/reparse point: {current}"
+            )
+        if current.parent == current:
+            break
+        current = current.parent
+    if os.name == "nt":
+        user = os.environ.get("USERNAME")
+        if not user:
+            raise ValueError(
+                "USERNAME is required to validate Flight Recorder ACLs."
+            )
+        command = r"""
+$ErrorActionPreference = 'Stop'
+try {
+  $identity = New-Object System.Security.Principal.NTAccount($env:HF_USER)
+  $sid = $identity.Translate([System.Security.Principal.SecurityIdentifier])
+  $allowed = @($sid.Value, 'S-1-5-18', 'S-1-5-32-544')
+  $writeRights = [System.Security.AccessControl.FileSystemRights]::Write `
+    -bor [System.Security.AccessControl.FileSystemRights]::Modify `
+    -bor [System.Security.AccessControl.FileSystemRights]::FullControl `
+    -bor [System.Security.AccessControl.FileSystemRights]::CreateFiles `
+    -bor [System.Security.AccessControl.FileSystemRights]::CreateDirectories `
+    -bor [System.Security.AccessControl.FileSystemRights]::Delete `
+    -bor [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles `
+    -bor [System.Security.AccessControl.FileSystemRights]::ChangePermissions `
+    -bor [System.Security.AccessControl.FileSystemRights]::TakeOwnership
+  $acl = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
+  $ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+  if ($allowed -notcontains $ownerSid.Value) {
+    throw "Flight Recorder storage parent has untrusted owner $($ownerSid.Value)."
+  }
+  foreach ($rule in @($acl.Access)) {
+    if ($rule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow) { continue }
+    $ruleSid = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
+    if ($allowed -contains $ruleSid.Value) { continue }
+    if (($rule.FileSystemRights -band $writeRights) -ne 0) {
+      throw "Flight Recorder storage parent grants write access to $($ruleSid.Value)."
+    }
+  }
+} catch {
+  [Console]::Error.WriteLine($_.Exception.ToString())
+  exit 1
+}
+"""
+        subprocess.run(
+            [
+                "powershell.exe",
+                "-NoProfile",
+                "-NonInteractive",
+                "-Command",
+                command,
+            ],
+            check=True,
+            capture_output=True,
+            env={
+                **os.environ,
+                "HF_TARGET": str(directory),
+                "HF_USER": user,
+            },
+        )
+        return
+    status = directory.lstat()
+    if (
+        _is_reparse_or_symlink(status)
+        or not stat_module.S_ISDIR(status.st_mode)
+    ):
+        raise FlightRecorderError(
+            f"Flight Recorder storage parent must be a directory: {directory}"
+        )
+    if hasattr(os, "getuid") and status.st_uid != os.getuid():
+        raise FlightRecorderError(
+            "Flight Recorder storage parent must be owned by the "
+            f"current user: {directory}"
+        )
+    if stat_module.S_IMODE(status.st_mode) & 0o022:
+        raise FlightRecorderError(
+            "Flight Recorder storage parent must not be group/world "
+            f"writable: {directory}"
+        )
+
+
+def _prepare_managed_database_directory(directory: Path) -> None:
+    existing = directory
+    while not os.path.lexists(existing):
+        if existing.parent == existing:
+            break
+        existing = existing.parent
+    _assert_private_directory(existing)
+    directory.mkdir(parents=True, exist_ok=True, mode=0o700)
+    _assert_private_directory(directory)
+    _harden_private_path(directory, directory=True)
+
+
+def _sync_directory(directory: Path) -> None:
+    if os.name == "nt":
+        return
+    descriptor = os.open(directory, os.O_RDONLY)
+    try:
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+
+
+def _write_all(descriptor: int, data: bytes) -> None:
+    view = memoryview(data)
+    written = 0
+    while written < len(view):
+        count = os.write(descriptor, view[written:])
+        if count <= 0:
+            raise OSError("Flight Recorder key write made no progress.")
+        written += count
+
+
+def _read_all(descriptor: int, expected_size: int) -> bytes:
+    chunks: list[bytes] = []
+    remaining = max(0, expected_size)
+    while remaining > 0:
+        chunk = os.read(descriptor, remaining)
+        if not chunk:
+            break
+        chunks.append(chunk)
+        remaining -= len(chunk)
+    return b"".join(chunks)
+
+
+def _is_reparse_or_symlink(path_stat: os.stat_result) -> bool:
+    return (
+        stat_module.S_ISLNK(path_stat.st_mode)
+        or bool(
+            getattr(path_stat, "st_file_attributes", 0)
+            & getattr(stat_module, "FILE_ATTRIBUTE_REPARSE_POINT", 0)
+        )
+    )
+
+
+def _prepare_private_database_files(
+    database: str,
+) -> list[tuple[Path, int, int]]:
+    identities: list[tuple[Path, int, int]] = []
+    for candidate in (
+        Path(database),
+        Path(f"{database}-wal"),
+        Path(f"{database}-shm"),
+    ):
+        try:
+            existing = candidate.lstat()
+            if (
+                _is_reparse_or_symlink(existing)
+                or not stat_module.S_ISREG(existing.st_mode)
+            ):
+                raise FlightRecorderError(
+                    "Flight Recorder storage must be a regular file: "
+                    f"{candidate}"
+                )
+        except FileNotFoundError:
+            pass
+        descriptor = os.open(
+            candidate,
+            os.O_CREAT
+            | os.O_RDWR
+            | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+        )
+        try:
+            opened = os.fstat(descriptor)
+            linked = candidate.lstat()
+            if (
+                not stat_module.S_ISREG(opened.st_mode)
+                or _is_reparse_or_symlink(linked)
+                or not stat_module.S_ISREG(linked.st_mode)
+                or opened.st_dev != linked.st_dev
+                or opened.st_ino != linked.st_ino
+            ):
+                raise FlightRecorderError(
+                    "Flight Recorder storage changed during private open: "
+                    f"{candidate}"
+                )
+            _harden_private_path(candidate)
+            verified = candidate.lstat()
+            if (
+                _is_reparse_or_symlink(verified)
+                or verified.st_dev != opened.st_dev
+                or verified.st_ino != opened.st_ino
+            ):
+                raise FlightRecorderError(
+                    "Flight Recorder storage identity changed: "
+                    f"{candidate}"
+                )
+            identities.append(
+                (candidate, opened.st_dev, opened.st_ino)
+            )
+        finally:
+            os.close(descriptor)
+    return identities
+
+
+def _verify_private_database_files(
+    identities: Sequence[tuple[Path, int, int]],
+) -> None:
+    for candidate, device, inode in identities:
+        current = candidate.lstat()
+        if (
+            _is_reparse_or_symlink(current)
+            or not stat_module.S_ISREG(current.st_mode)
+            or current.st_dev != device
+            or current.st_ino != inode
+        ):
+            raise FlightRecorderError(
+                f"Flight Recorder storage identity changed: {candidate}"
+            )
+
+
+def _recorder_owner_directory(database_path: str) -> Path:
+    return Path(f"{database_path}.owners").expanduser()
+
+
+def _recorder_reset_lock(database_path: str) -> Path:
+    return Path(f"{database_path}.reset-lock").expanduser()
+
+
+def _prepare_recorder_owner_directory(directory: Path) -> None:
+    if os.path.lexists(directory):
+        before = directory.lstat()
+        if (
+            _is_reparse_or_symlink(before)
+            or not stat_module.S_ISDIR(before.st_mode)
+        ):
+            raise FlightRecorderError(
+                "Flight Recorder owner storage must be a regular "
+                f"directory: {directory}"
+            )
+        _assert_private_directory(directory)
+    else:
+        _assert_private_directory(directory.parent)
+        directory.mkdir(mode=0o700)
+        before = directory.lstat()
+        _assert_private_directory(directory)
+    _harden_private_path(directory, directory=True)
+    after = directory.lstat()
+    if (
+        _is_reparse_or_symlink(after)
+        or not stat_module.S_ISDIR(after.st_mode)
+        or before.st_dev != after.st_dev
+        or before.st_ino != after.st_ino
+    ):
+        raise FlightRecorderError(
+            f"Flight Recorder owner storage identity changed: {directory}"
+        )
+
+
+def _reset_barrier_is_active(reset_lock: Path) -> bool:
+    try:
+        observed = reset_lock.stat()
+        raw = reset_lock.read_text(encoding="utf-8").strip()
+        try:
+            parsed = json.loads(raw)
+            pid = int(parsed["pid"])
+            incarnation = parsed.get("incarnation")
+        except (json.JSONDecodeError, KeyError, TypeError):
+            pid = int(raw)
+            incarnation = None
+    except FileNotFoundError:
+        return False
+    except (OSError, ValueError):
+        raise FlightRecorderError(
+            "Flight Recorder reset barrier cannot be inspected."
+        )
+    if _process_matches_incarnation(pid, incarnation):
+        return True
+    try:
+        current = reset_lock.stat()
+    except FileNotFoundError:
+        return False
+    if (
+        current.st_dev != observed.st_dev
+        or current.st_ino != observed.st_ino
+        or current.st_mtime_ns != observed.st_mtime_ns
+        or current.st_size != observed.st_size
+    ):
+        return True
+    try:
+        reset_lock.unlink()
+    except FileNotFoundError:
+        return False
+    _sync_directory(reset_lock.parent)
+    return False
+
+
+def _register_recorder_owner(database_path: str, owner_id: str) -> Path:
+    reset_lock = _recorder_reset_lock(database_path)
+    if _reset_barrier_is_active(reset_lock):
+        raise FlightRecorderError("Flight Recorder reset is in progress.")
+    directory = _recorder_owner_directory(database_path)
+    _prepare_recorder_owner_directory(directory)
+    owner_path = directory / f"{owner_id}.json"
+    temporary = Path(
+        f"{owner_path}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+    )
+    descriptor = os.open(
+        temporary,
+        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+        0o600,
+    )
+    try:
+        _harden_private_path(temporary)
+        owner_record = {"ownerId": owner_id, "pid": os.getpid()}
+        incarnation = _current_process_incarnation()
+        if incarnation:
+            owner_record["incarnation"] = incarnation
+        os.write(
+            descriptor,
+            f"{json.dumps(owner_record)}\n".encode("utf-8"),
+        )
+        os.fsync(descriptor)
+    finally:
+        os.close(descriptor)
+    try:
+        os.link(temporary, owner_path)
+        _sync_directory(directory)
+    finally:
+        temporary.unlink(missing_ok=True)
+        _sync_directory(directory)
+    if _reset_barrier_is_active(reset_lock):
+        owner_path.unlink(missing_ok=True)
+        _sync_directory(directory)
+        raise FlightRecorderError("Flight Recorder reset is in progress.")
+    _PROCESS_OWNER_PATHS.add(owner_path)
+    return owner_path
+
+
+def _unregister_recorder_owner(owner_path: Optional[Path]) -> None:
+    if owner_path is None:
+        return
+    _PROCESS_OWNER_PATHS.discard(owner_path)
+    try:
+        owner_path.unlink(missing_ok=True)
+        _sync_directory(owner_path.parent)
+    except OSError:
+        pass
+
+
+def _load_or_create_identity_key(
+    database_path: str,
+    explicit_key: Optional[str] = None,
+    allow_unconfigured_create: bool = True,
+) -> str:
+    explicit = (explicit_key or "").strip()
+    environment = os.environ.get(
+        "OPENRAPPTER_FLIGHT_ID_KEY",
+        "",
+    ).strip()
+    if (
+        explicit
+        and environment
+        and explicit.lower() != environment.lower()
+    ):
+        raise ValueError(
+            "Configured Flight Recorder identity keys do not match."
+        )
+    configured = explicit or environment
+    if configured:
+        if re.fullmatch(r"[0-9a-fA-F]{64}", configured) is None:
+            raise ValueError(
+                "OPENRAPPTER_FLIGHT_ID_KEY must be 32-byte hexadecimal."
+            )
+
+    key_path = Path(f"{database_path}.identity-key").expanduser()
+    for _attempt in range(3):
+        try:
+            observed = key_path.lstat()
+            if (
+                _is_reparse_or_symlink(observed)
+                or not stat_module.S_ISREG(observed.st_mode)
+            ):
+                raise ValueError(
+                    "Flight Recorder identity key must be a regular file."
+                )
+            descriptor = os.open(
+                key_path,
+                os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+            )
+            try:
+                opened = os.fstat(descriptor)
+                current = key_path.lstat()
+                if (
+                    _is_reparse_or_symlink(current)
+                    or opened.st_dev != current.st_dev
+                    or opened.st_ino != current.st_ino
+                ):
+                    raise ValueError(
+                        "Flight Recorder identity key changed during "
+                        "private open."
+                    )
+                existing = _read_all(
+                    descriptor,
+                    opened.st_size,
+                ).decode("utf-8").strip()
+            finally:
+                os.close(descriptor)
+            if re.fullmatch(r"[0-9a-fA-F]{64}", existing):
+                if (
+                    configured
+                    and existing.lower() != configured.lower()
+                ):
+                    raise ValueError(
+                        "Configured Flight Recorder identity key does "
+                        "not match the persisted key."
+                    )
+                _harden_private_path(key_path)
+                return existing.lower()
+            if existing:
+                raise ValueError("Flight Recorder identity key is invalid.")
+            current = key_path.lstat()
+            if (
+                current.st_dev != observed.st_dev
+                or current.st_ino != observed.st_ino
+                or current.st_mtime_ns != observed.st_mtime_ns
+                or current.st_size != observed.st_size
+            ):
+                continue
+            key_path.unlink()
+        except FileNotFoundError:
+            pass
+
+        if not configured and not allow_unconfigured_create:
+            raise ValueError(
+                "Flight Recorder identity key is missing for a "
+                "non-empty ledger."
+            )
+        key = configured.lower() if configured else os.urandom(32).hex()
+        temporary = Path(
+            f"{key_path}.{os.getpid()}.{uuid.uuid4().hex}.tmp"
+        )
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            _harden_private_path(temporary)
+            _write_all(descriptor, f"{key}\n".encode("utf-8"))
+            os.fsync(descriptor)
+        finally:
+            os.close(descriptor)
+        try:
+            published = False
+            try:
+                verification = os.open(
+                    temporary,
+                    os.O_RDONLY | getattr(os, "O_NOFOLLOW", 0),
+                )
+                try:
+                    verified = _read_all(
+                        verification,
+                        os.fstat(verification).st_size,
+                    ).decode("utf-8")
+                finally:
+                    os.close(verification)
+                if verified != f"{key}\n":
+                    raise ValueError(
+                        "Flight Recorder identity key temporary "
+                        "publication is incomplete."
+                    )
+                os.link(temporary, key_path)
+                _harden_private_path(key_path)
+                _sync_directory(key_path.parent)
+                published = True
+                return key
+            except FileExistsError:
+                continue
+        finally:
+            temporary.unlink(missing_ok=True)
+            if published:
+                _sync_directory(key_path.parent)
+    raise ValueError("Flight Recorder identity key could not be created.")
+
+
+def normalize_flight_model_id(value: Optional[str]) -> Optional[str]:
+    """Remove routing policies from persisted model attribution."""
+    if value is None:
+        return None
+    model = value.strip()
+    if not model or model.lower() == "auto":
+        return None
+    return model
+
+
+def _private_identifier(
+    value: Optional[str],
+    privacy: Optional[Mapping[str, Any]],
+    prefix: str,
+    field_key: Optional[str] = None,
+) -> Optional[str]:
+    if value is None:
+        return None
+    key = field_key or prefix
+    if not isinstance(value, str):
+        raise TypeError(f"{key} must be a string.")
+    value = _normalize_unicode_scalars(value)
+    if key == "kind" and value in {
+        "trace.started",
+        "trace.completed",
+        "trace.failed",
+    }:
+        return value
+    configured_values = _privacy_value(
+        privacy,
+        "redactedValues",
+        "redacted_values",
+        default=(),
+    ) or ()
+    exact_secret = any(
+        isinstance(candidate, str)
+        and candidate
+        and (
+            (
+                re.fullmatch(r"[0-9a-fA-F]{64}", candidate)
+                is not None
+                and candidate.lower() == value.lower()
+            )
+            or (
+                re.fullmatch(r"[0-9a-fA-F]{64}", candidate)
+                is None
+                and candidate == value
+            )
+        )
+        for candidate in configured_values
+    )
+    if exact_secret:
+        digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
+        return f"{prefix}:{digest}"
+    if _is_canonical_private_identifier(value, prefix):
+        return value
+    if sanitize_flight_value(
+        value,
+        {
+            "redactedValues": _privacy_value(
+                privacy,
+                "redactedValues",
+                "redacted_values",
+                default=(),
+            )
+            or ()
+        },
+    ) != value:
+        digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
+        return f"{prefix}:{digest}"
+    if key == "kind":
+        if sanitize_flight_value(
+            value,
+            {
+                "redactedValues": _privacy_value(
+                    privacy,
+                    "redactedValues",
+                    "redacted_values",
+                    default=(),
+                )
+                or ()
+            },
+        ) == value:
+            return value
+        digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
+        return f"{prefix}:{digest}"
+    policy_keys = (
+        ("id", "parentId")
+        if key in {"id", "parentId"}
+        else (key,)
+    )
+    if (
+        all(
+            sanitize_flight_metadata(
+                {policy_key: value},
+                privacy,
+            ).get(policy_key)
+            == value
+            for policy_key in policy_keys
+        )
+        and sanitize_flight_value(value, privacy) == value
+    ):
+        return value
+    digest = hashlib.sha256(value.encode("utf-8")).hexdigest()[:24]
+    return f"{prefix}:{digest}"
+
+
+def _is_canonical_private_identifier(
+    value: str,
+    prefix: str,
+) -> bool:
+    return (
+        re.fullmatch(
+            rf"{re.escape(prefix)}:[0-9a-f]{{24}}",
+            value,
+        )
+        is not None
+    )
+
+
+def _privacy_value(privacy: Optional[Mapping[str, Any]], *names: str, default: Any = None) -> Any:
+    if not privacy:
+        return default
+    for name in names:
+        if name in privacy:
+            return privacy[name]
+    return default
+
+
+def _normalized_key(key: str) -> str:
+    return re.sub(r"[^a-z0-9]", "", key.lower())
+
+
+def _is_prototype_pollution_key(key: str) -> bool:
+    if key == "__proto__":
+        return True
+    return _normalized_key(key) in {"constructor", "prototype"}
+
+
+def _is_sensitive_key(key: str, privacy: Optional[Mapping[str, Any]]) -> bool:
+    if _is_prototype_pollution_key(key):
+        return True
+    normalized = _normalized_key(key)
+    words = re.sub(r"([a-z0-9])([A-Z])", r"\1 \2", key).lower()
+    words = [word for word in re.split(r"[^a-z0-9]+", words) if word]
+    if any(
+        word in {"token", "secret", "authorization"}
+        or word.startswith(("password", "credential", "cookie"))
+        for word in words
+    ):
+        return True
+    if any(
+        candidate in normalized
+        for candidate in (
+            "apikey",
+            "privatekey",
+            "sessiontoken",
+            "accesstoken",
+            "refreshtoken",
+            "identitykey",
+        )
+    ):
+        return True
+    configured = _privacy_value(privacy, "redactedKeys", "redacted_keys", default=()) or ()
+    return any(_normalized_key(str(candidate)) == normalized for candidate in configured)
+
+
+def is_excluded_flight_path(value: str, privacy: Optional[Mapping[str, Any]] = None) -> bool:
+    patterns = list(DEFAULT_EXCLUDED_PATH_PATTERNS)
+    patterns.extend(
+        _privacy_value(privacy, "excludedPathPatterns", "excluded_path_patterns", default=()) or ()
+    )
+    decoded_value = _decode_percent_fixed(value)
+    candidates = {
+        value,
+        re.sub(r"[?#].*$", "", value),
+        decoded_value,
+        re.sub(r"[?#].*$", "", decoded_value),
+    }
+    if re.match(r"^[a-z][a-z0-9+.-]*:", value, re.I):
+        try:
+            parsed = urlparse(value)
+            pathname = _decode_percent_fixed(parsed.path)
+            candidates.add(pathname)
+            candidates.add(re.sub(r"[?#].*$", "", pathname))
+        except (TypeError, ValueError):
+            try:
+                candidates.add(
+                    _decode_percent_fixed(
+                        re.sub(
+                            r"^[a-z][a-z0-9+.-]*://",
+                            "",
+                            value,
+                            flags=re.I,
+                        )
+                    )
+                )
+            except (TypeError, ValueError):
+                pass
+    for candidate in candidates:
+        if candidate == REDACTED:
+            return True
+        for pattern in patterns:
+            if hasattr(pattern, "search") and pattern.search(candidate):
+                return True
+            if isinstance(pattern, str) and re.search(pattern, candidate, re.I):
+                return True
+    return False
+
+
+def _flight_path_string(value: Any) -> Optional[str]:
+    if isinstance(value, str):
+        return value
+    if isinstance(value, os.PathLike):
+        try:
+            return os.fsdecode(os.fspath(value))
+        except (TypeError, ValueError, OSError):
+            return None
+    return None
+
+
+def _is_file_locator_key(key: str) -> bool:
+    normalized = _normalized_key(_decode_percent_fixed(key))
+    return normalized in {
+        "path",
+        "sourcepath",
+        "file",
+        "filename",
+        "filepath",
+        "name",
+        "uri",
+        "url",
+    } or normalized.endswith(
+        ("path", "uri", "url", "filename")
+    )
+
+
+def _contains_excluded_file_locator(
+    value: Any,
+    privacy: Optional[Mapping[str, Any]],
+    ancestors: Optional[set[int]] = None,
+    depth: int = 0,
+) -> bool:
+    if (
+        value is None
+        or isinstance(value, (str, bytes, bytearray, memoryview))
+    ):
+        return False
+    if depth > 16:
+        return True
+    ancestors = ancestors or set()
+    identity = id(value)
+    if identity in ancestors:
+        return False
+    ancestors.add(identity)
+    try:
+        if isinstance(value, Mapping):
+            for key, entry_value in value.items():
+                if (
+                    _is_file_locator_key(str(key))
+                    and _flight_path_string(entry_value) is not None
+                    and is_excluded_flight_path(
+                        _flight_path_string(entry_value),
+                        privacy,
+                    )
+                ):
+                    return True
+                if _contains_excluded_file_locator(
+                    entry_value,
+                    privacy,
+                    ancestors,
+                    depth + 1,
+                ):
+                    return True
+            return False
+        if isinstance(value, (list, tuple, set, frozenset)):
+            return any(
+                _contains_excluded_file_locator(
+                    entry,
+                    privacy,
+                    ancestors,
+                    depth + 1,
+                )
+                for entry in value
+            )
+        return False
+    finally:
+        ancestors.discard(identity)
+
+
+def _is_safe_file_metadata_field(
+    key: str,
+    value: Any,
+    privacy: Optional[Mapping[str, Any]],
+) -> bool:
+    normalized = _normalized_key(key)
+    if normalized in {"size", "length"}:
+        return (
+            isinstance(value, (int, float))
+            and not isinstance(value, bool)
+            and math.isfinite(value)
+            and value >= 0
+        )
+    if normalized in {"language", "mime", "mimetype", "extension"}:
+        return (
+            isinstance(value, str)
+            and len(value) <= 256
+            and _sanitize_string(value, privacy) == value
+        )
+    return False
+
+
+def _oversized_string_marker(value: str) -> Optional[str]:
+    byte_count = len(value.encode("utf-8"))
+    return (
+        f"[truncated:{byte_count}]"
+        if byte_count > MAX_SANITIZE_STRING_BYTES
+        else None
+    )
+
+
+def _collect_embedded_json_ranges(
+    value: str,
+) -> list[Dict[str, Any]]:
+    completed: list[Dict[str, Any]] = []
+    stack: list[tuple[str, int]] = []
+    string_start: Optional[int] = None
+    escaped = False
+
+    for index, character in enumerate(value):
+        if string_start is not None:
+            if escaped:
+                escaped = False
+            elif character == "\\":
+                escaped = True
+            elif character == '"':
+                completed.append(
+                    {
+                        "kind": "string",
+                        "start": string_start,
+                        "end": index,
+                        "children": [],
+                    }
+                )
+                string_start = None
+            continue
+
+        if character == '"':
+            string_start = index
+            continue
+        if character in "{[":
+            stack.append((character, index))
+            continue
+        if character not in "}]":
+            continue
+        expected = "{" if character == "}" else "["
+        if not stack or stack[-1][0] != expected:
+            continue
+        _opening, start = stack.pop()
+        completed.append(
+            {
+                "kind": "container",
+                "start": start,
+                "end": index,
+                "children": [],
+            }
+        )
+
+    completed.sort(
+        key=lambda item: (item["start"], -item["end"])
+    )
+    roots: list[Dict[str, Any]] = []
+    parents: list[Dict[str, Any]] = []
+    for item in completed:
+        while parents and not (
+            parents[-1]["start"] < item["start"]
+            and item["end"] < parents[-1]["end"]
+        ):
+            parents.pop()
+        if parents:
+            parents[-1]["children"].append(item)
+        else:
+            roots.append(item)
+        parents.append(item)
+    return roots
+
+
+def _sanitize_embedded_json(
+    value: str,
+    privacy: Optional[Mapping[str, Any]],
+    depth: int = 0,
+    budget: Optional[Dict[str, Any]] = None,
+) -> str:
+    oversized = _oversized_string_marker(value)
+    if oversized is not None:
+        return oversized
+    if depth > MAX_EMBEDDED_JSON_DEPTH:
+        return REDACTED
+    if budget is None:
+        budget = {
+            "remaining": min(
+                MAX_EMBEDDED_JSON_PARSE_CHARS,
+                max(len(value) * 4, 1024),
+            ),
+            "exhausted": False,
+        }
+
+    ranges = _collect_embedded_json_ranges(value)
+
+    def render_range(item: Mapping[str, Any]) -> str:
+        candidate = value[item["start"]:item["end"] + 1]
+        budget["remaining"] -= len(candidate)
+        if budget["remaining"] < 0:
+            budget["exhausted"] = True
+            return ""
+        try:
+            parsed = _strict_json_loads(candidate)
+        except (TypeError, ValueError):
+            parsed = _MISSING
+        if (
+            item["kind"] == "container"
+            and isinstance(parsed, (dict, list))
+        ):
+            return _portable_json(
+                _sanitize_recursive(parsed, privacy, set())
+            )
+        if (
+            item["kind"] == "string"
+            and isinstance(parsed, str)
+        ):
+            nested = _sanitize_embedded_json(
+                parsed,
+                privacy,
+                depth + 1,
+                budget,
+            )
+            return _portable_json(
+                _sanitize_scalar_string(nested, privacy)
+            )
+
+        rendered: list[str] = []
+        cursor = item["start"]
+        for child in item["children"]:
+            rendered.append(value[cursor:child["start"]])
+            rendered.append(render_range(child))
+            cursor = child["end"] + 1
+        rendered.append(value[cursor:item["end"] + 1])
+        return "".join(rendered)
+
+    output: list[str] = []
+    cursor = 0
+    for item in ranges:
+        output.append(value[cursor:item["start"]])
+        output.append(render_range(item))
+        cursor = item["end"] + 1
+    output.append(value[cursor:])
+    if budget["exhausted"]:
+        return f"[truncated:{len(value.encode('utf-8'))}]"
+    return "".join(output)
+
+
+def _sanitize_string(value: str, privacy: Optional[Mapping[str, Any]]) -> str:
+    value = _normalize_unicode_scalars(value)
+    oversized = _oversized_string_marker(value)
+    if oversized is not None:
+        return oversized
+    return _sanitize_scalar_string(
+        _sanitize_embedded_json(value, privacy),
+        privacy,
+    )
+
+
+def _sanitize_scalar_string(
+    value: str,
+    privacy: Optional[Mapping[str, Any]],
+) -> str:
+    if _is_secret_shaped_string(value, privacy):
+        return REDACTED
+    if is_excluded_flight_path(value, privacy):
+        return EXCLUDED_PATH
+    return value
+
+
+def _is_secret_shaped_string(
+    value: str,
+    privacy: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    configured = _privacy_value(
+        privacy,
+        "redactedValues",
+        "redacted_values",
+        default=(),
+    ) or ()
+    for candidate_value in {
+        value,
+        _decode_percent_fixed(value),
+    }:
+        if candidate_value == REDACTED:
+            return True
+        uri_secret = False
+        if "?" in candidate_value:
+            try:
+                uri_secret = any(
+                    _is_sensitive_key(
+                        _decode_percent_fixed(key),
+                        privacy,
+                    )
+                    for key, _entry_value in parse_qsl(
+                        urlparse(candidate_value).query,
+                        keep_blank_values=True,
+                    )
+                )
+            except (TypeError, ValueError):
+                uri_secret = False
+        try:
+            fragment_secret = any(
+                _is_sensitive_key(
+                    _decode_percent_fixed(key),
+                    privacy,
+                )
+                for key, _entry_value in parse_qsl(
+                    _decode_percent_fixed(
+                        urlparse(candidate_value).fragment
+                    ),
+                    keep_blank_values=True,
+                )
+            )
+        except (TypeError, ValueError):
+            fragment_secret = False
+        if uri_secret or fragment_secret or any(
+            isinstance(candidate, str)
+            and candidate
+            and (
+                (
+                    re.fullmatch(r"[0-9a-fA-F]{64}", candidate)
+                    is not None
+                    and candidate.lower() in candidate_value.lower()
+                )
+                or (
+                    re.fullmatch(r"[0-9a-fA-F]{64}", candidate)
+                    is None
+                    and candidate in candidate_value
+                )
+            )
+            for candidate in configured
+        ) or any(
+            pattern.search(candidate_value)
+            for pattern in SECRET_VALUE_PATTERNS
+        ):
+            return True
+    return False
+
+
+def _is_secret_shaped_key(
+    value: str,
+    privacy: Optional[Mapping[str, Any]] = None,
+) -> bool:
+    configured = _privacy_value(
+        privacy,
+        "redactedValues",
+        "redacted_values",
+        default=(),
+    ) or ()
+    return any(
+        isinstance(candidate, str)
+        and candidate
+        and (
+            (
+                re.fullmatch(r"[0-9a-fA-F]{64}", candidate)
+                is not None
+                and candidate.lower() in value.lower()
+            )
+            or (
+                re.fullmatch(r"[0-9a-fA-F]{64}", candidate)
+                is None
+                and candidate in value
+            )
+        )
+        for candidate in configured
+    ) or any(
+        pattern.search(value)
+        for pattern in SECRET_VALUE_PATTERNS
+    )
+
+
+def _unsafe_property_key_marker(
+    key: str,
+    privacy: Optional[Mapping[str, Any]],
+) -> Optional[str]:
+    if key == REDACTED:
+        return REDACTED
+    if _is_prototype_pollution_key(key):
+        return REDACTED
+    if _is_secret_shaped_key(key, privacy):
+        return REDACTED
+    path_like = (
+        "/" in key
+        or "\\" in key
+        or key.startswith(".")
+        or re.search(r"\.[a-z0-9]+$", key, re.I) is not None
+        or re.fullmatch(
+            r"(?:application_default_credentials|client[-_.]?secret)",
+            key,
+            re.I,
+        )
+        is not None
+    )
+    if path_like and is_excluded_flight_path(key, privacy):
+        return EXCLUDED_PATH
+    if _is_sensitive_key(key, privacy):
+        return None
+    return None
+
+
+def _planned_mapping_entries(
+    value: Mapping[Any, Any],
+    privacy: Optional[Mapping[str, Any]],
+) -> list[tuple[Any, str, str]]:
+    entries = [
+        (
+            original,
+            str(original),
+            _decode_percent_fixed(
+                _normalize_unicode_scalars(str(original))
+            ),
+        )
+        for original in value
+    ]
+    entries.sort(
+        key=lambda entry: entry[1].encode(
+            "utf-16-be",
+            errors="surrogatepass",
+        )
+    )
+    reserved = {
+        string_key
+        for _original, _raw_key, string_key in entries
+        if _unsafe_property_key_marker(string_key, privacy) is None
+    }
+    assigned: set[str] = set()
+    planned: list[tuple[Any, str, str]] = []
+    for original, _raw_key, string_key in entries:
+        marker = _unsafe_property_key_marker(string_key, privacy)
+        if marker is None and string_key not in assigned:
+            sanitized_key = string_key
+        else:
+            base = marker or string_key
+            sanitized_key = base
+            suffix = 2
+            while sanitized_key in reserved or sanitized_key in assigned:
+                sanitized_key = f"{base}#{suffix}"
+                suffix += 1
+        assigned.add(sanitized_key)
+        planned.append((original, string_key, sanitized_key))
+    return planned
+
+
+def _stable_sort_key(value: Any) -> bytes:
+    try:
+        serialized = _canonical(value)
+    except (TypeError, ValueError):
+        serialized = str(value)
+    return serialized.encode("utf-16-be", errors="surrogatepass")
+
+
+def _sanitize_recursive(
+    value: Any,
+    privacy: Optional[Mapping[str, Any]],
+    ancestors: set[int],
+) -> Any:
+    if value is None or isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        oversized = _oversized_string_marker(value)
+        if oversized is not None:
+            return oversized
+        stripped = value.strip()
+        if (
+            stripped.startswith("{")
+            and stripped.endswith("}")
+        ) or (
+            stripped.startswith("[")
+            and stripped.endswith("]")
+        ):
+            try:
+                parsed = _strict_json_loads(value)
+            except (TypeError, ValueError):
+                pass
+            else:
+                if isinstance(parsed, (dict, list)):
+                    return _sanitize_recursive(
+                        parsed,
+                        privacy,
+                        ancestors,
+                    )
+        return _sanitize_string(value, privacy)
+    if isinstance(value, int):
+        return value if abs(value) <= JS_MAX_SAFE_INTEGER else f"{value}n"
+    if isinstance(value, float):
+        if not math.isfinite(value):
+            return None
+        if value.is_integer() and abs(value) > JS_MAX_SAFE_INTEGER:
+            return f"{_ecmascript_number(value)}n"
+        return value
+    if isinstance(value, (bytes, bytearray, memoryview)):
+        return list(bytes(value))
+    if isinstance(value, (datetime, date)):
+        if isinstance(value, datetime) and value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.isoformat().replace("+00:00", "Z")
+    if isinstance(value, re.Pattern):
+        return f"/{value.pattern}/"
+    path_string = _flight_path_string(value)
+    if path_string is not None:
+        return _sanitize_string(path_string, privacy)
+    if callable(value):
+        return UNSERIALIZABLE
+
+    identity = id(value)
+    if identity in ancestors:
+        return CIRCULAR
+    ancestors.add(identity)
+    try:
+        if isinstance(value, Mapping):
+            result: Dict[str, Any] = {}
+            excluded_file_object = _contains_excluded_file_locator(
+                value,
+                privacy,
+            )
+            for key, string_key, sanitized_key in _planned_mapping_entries(
+                value, privacy
+            ):
+                if (
+                    _unsafe_property_key_marker(string_key, privacy)
+                    == EXCLUDED_PATH
+                ):
+                    result[sanitized_key] = EXCLUDED_PATH
+                elif _is_sensitive_key(string_key, privacy):
+                    result[sanitized_key] = REDACTED
+                elif (
+                    _is_file_locator_key(string_key)
+                    and _flight_path_string(value[key]) is not None
+                    and is_excluded_flight_path(
+                        _flight_path_string(value[key]),
+                        privacy,
+                    )
+                ):
+                    result[sanitized_key] = EXCLUDED_PATH
+                elif (
+                    excluded_file_object
+                    and not _is_safe_file_metadata_field(
+                        string_key,
+                        value[key],
+                        privacy,
+                    )
+                    and not _is_file_locator_key(string_key)
+                    and not _contains_excluded_file_locator(
+                        value[key],
+                        privacy,
+                    )
+                ):
+                    result[sanitized_key] = EXCLUDED_PATH
+                else:
+                    try:
+                        result[sanitized_key] = _sanitize_recursive(
+                            value[key], privacy, ancestors
+                        )
+                    except Exception:
+                        result[sanitized_key] = UNSERIALIZABLE
+            return result
+        if isinstance(value, (list, tuple)):
+            return [_sanitize_recursive(item, privacy, ancestors) for item in value]
+        if isinstance(value, (set, frozenset)):
+            entries = [_sanitize_recursive(item, privacy, ancestors) for item in value]
+            return sorted(entries, key=_stable_sort_key)
+        if isinstance(value, BaseException):
+            result = {
+                "name": value.__class__.__name__,
+                "message": _sanitize_string(str(value), privacy),
+            }
+            if hasattr(value, "code"):
+                result["code"] = _sanitize_recursive(value.code, privacy, ancestors)
+            if value.__cause__ is not None:
+                result["cause"] = _sanitize_recursive(value.__cause__, privacy, ancestors)
+            return result
+        attributes = vars(value)
+        return _sanitize_recursive(attributes, privacy, ancestors)
+    finally:
+        ancestors.remove(identity)
+
+
+_SNAPSHOT_LIMIT = object()
+
+
+def _snapshot_for_sanitization(
+    value: Any,
+    *,
+    max_nodes: int,
+    max_bytes: int,
+) -> Any:
+    seen: Dict[int, Any] = {}
+    nodes = 0
+    byte_count = 0
+
+    def visit(current: Any) -> Any:
+        nonlocal nodes, byte_count
+        nodes += 1
+        if nodes > max_nodes:
+            raise RuntimeError(_SNAPSHOT_LIMIT)
+        if isinstance(current, str):
+            current = _normalize_unicode_scalars(current)
+            byte_count += len(current.encode("utf-8"))
+            if byte_count > max_bytes:
+                raise RuntimeError(_SNAPSHOT_LIMIT)
+            return current
+        if current is None or isinstance(
+            current,
+            (bool, int, float),
+        ):
+            return current
+        if isinstance(current, (bytes, bytearray, memoryview)):
+            byte_count += len(current)
+            if byte_count > max_bytes:
+                raise RuntimeError(_SNAPSHOT_LIMIT)
+            return bytes(current)
+        if isinstance(current, (datetime, date, re.Pattern)):
+            return current
+        path_string = _flight_path_string(current)
+        if path_string is not None:
+            return path_string
+
+        identity = id(current)
+        if identity in seen:
+            return seen[identity]
+
+        if isinstance(current, Mapping):
+            clone: Dict[Any, Any] = {}
+            seen[identity] = clone
+            try:
+                entries = list(current.items())
+            except Exception:
+                return UNSERIALIZABLE
+            if nodes + len(entries) > max_nodes:
+                raise RuntimeError(_SNAPSHOT_LIMIT)
+            for key, entry_value in entries:
+                nodes += 1
+                raw_key_text = str(key)
+                normalized_key_text = _normalize_unicode_scalars(
+                    raw_key_text
+                )
+                byte_count += len(normalized_key_text.encode("utf-8"))
+                if nodes > max_nodes or byte_count > max_bytes:
+                    raise RuntimeError(_SNAPSHOT_LIMIT)
+                snapshot_key = (
+                    raw_key_text
+                    if isinstance(key, str)
+                    else visit(key)
+                )
+                snapshot_value = visit(entry_value)
+                try:
+                    clone[snapshot_key] = snapshot_value
+                except TypeError:
+                    clone[raw_key_text] = snapshot_value
+            return clone
+        if isinstance(current, (list, tuple)):
+            if nodes + len(current) > max_nodes:
+                raise RuntimeError(_SNAPSHOT_LIMIT)
+            clone_list: list[Any] = []
+            seen[identity] = clone_list
+            for entry in current:
+                clone_list.append(visit(entry))
+            return clone_list
+        if isinstance(current, (set, frozenset)):
+            if nodes + len(current) > max_nodes:
+                raise RuntimeError(_SNAPSHOT_LIMIT)
+            clone_set: list[Any] = []
+            seen[identity] = clone_set
+            for entry in current:
+                clone_set.append(visit(entry))
+            clone_set.sort(key=_stable_sort_key)
+            return clone_set
+        if isinstance(current, BaseException):
+            clone_error: Dict[str, Any] = {}
+            seen[identity] = clone_error
+            for key, getter in (
+                ("name", lambda: current.__class__.__name__),
+                ("message", lambda: str(current)),
+                ("code", lambda: getattr(current, "code", None)),
+                ("cause", lambda: current.__cause__),
+            ):
+                try:
+                    entry = getter()
+                    if entry is not None:
+                        clone_error[key] = visit(entry)
+                except Exception:
+                    clone_error[key] = UNSERIALIZABLE
+            return clone_error
+        if callable(current):
+            return UNSERIALIZABLE
+        try:
+            attributes = vars(current)
+        except Exception:
+            return UNSERIALIZABLE
+        clone_object: Dict[str, Any] = {}
+        seen[identity] = clone_object
+        for key, entry_value in list(attributes.items()):
+            nodes += 1
+            key_text = str(key)
+            byte_count += len(
+                _normalize_unicode_scalars(key_text).encode("utf-8")
+            )
+            if nodes > max_nodes or byte_count > max_bytes:
+                raise RuntimeError(_SNAPSHOT_LIMIT)
+            clone_object[key_text] = visit(entry_value)
+        return clone_object
+
+    return visit(value)
+
+
+def _within_sanitize_budget(
+    value: Any,
+    *,
+    max_nodes: int,
+    max_bytes: int,
+) -> bool:
+    stack: list[tuple[Any, bool]] = [(value, False)]
+    ancestors: set[int] = set()
+    nodes = 0
+    byte_count = 0
+
+    while stack:
+        current, exiting = stack.pop()
+        if exiting:
+            ancestors.discard(id(current))
+            continue
+        nodes += 1
+        if nodes > max_nodes:
+            return False
+        if isinstance(current, str):
+            byte_count += len(current.encode("utf-8"))
+            if byte_count > max_bytes:
+                return False
+            continue
+        if current is None or isinstance(
+            current,
+            (bool, int, float),
+        ):
+            continue
+        if isinstance(current, (bytes, bytearray, memoryview)):
+            byte_count += len(current)
+            if byte_count > max_bytes:
+                return False
+            continue
+
+        identity = id(current)
+        if identity in ancestors:
+            continue
+        ancestors.add(identity)
+        stack.append((current, True))
+
+        if isinstance(current, Mapping):
+            try:
+                if len(current) + nodes > max_nodes:
+                    return False
+                for key, entry_value in current.items():
+                    key_text = str(key)
+                    nodes += 1
+                    byte_count += len(key_text.encode("utf-8"))
+                    if nodes > max_nodes or byte_count > max_bytes:
+                        return False
+                    stack.append((entry_value, False))
+            except Exception:
+                return True
+            continue
+        if isinstance(current, (list, tuple, set, frozenset)):
+            if len(current) + nodes > max_nodes:
+                return False
+            stack.extend((entry, False) for entry in current)
+            continue
+        if isinstance(current, BaseException):
+            try:
+                error_name = current.__class__.__name__
+            except Exception:
+                error_name = UNSERIALIZABLE
+            try:
+                error_message = str(current)
+            except Exception:
+                error_message = UNSERIALIZABLE
+            try:
+                error_code = getattr(current, "code", None)
+            except Exception:
+                error_code = UNSERIALIZABLE
+            try:
+                error_cause = current.__cause__
+            except Exception:
+                error_cause = UNSERIALIZABLE
+            stack.extend(
+                (
+                    (error_name, False),
+                    (error_message, False),
+                    (error_code, False),
+                    (error_cause, False),
+                )
+            )
+            continue
+        path_string = _flight_path_string(current)
+        if path_string is not None:
+            stack.append((path_string, False))
+            continue
+        try:
+            attributes = vars(current)
+        except Exception:
+            return True
+        stack.append((attributes, False))
+    return True
+
+
+def _sanitize_bounded_value(
+    value: Any,
+    privacy: Optional[Mapping[str, Any]],
+    *,
+    max_nodes: int,
+    max_bytes: int,
+) -> Any:
+    try:
+        snapshot = _snapshot_for_sanitization(
+            value,
+            max_nodes=max_nodes,
+            max_bytes=max_bytes,
+        )
+        if not _within_sanitize_budget(
+            snapshot,
+            max_nodes=max_nodes,
+            max_bytes=max_bytes,
+        ):
+            return TRAVERSAL_LIMIT
+        return _sanitize_recursive(snapshot, privacy, set())
+    except RuntimeError as exc:
+        if exc.args and exc.args[0] is _SNAPSHOT_LIMIT:
+            return TRAVERSAL_LIMIT
+        return UNSERIALIZABLE
+    except Exception:
+        return UNSERIALIZABLE
+
+
+def sanitize_flight_value(value: Any, privacy: Optional[Mapping[str, Any]] = None) -> Any:
+    return _sanitize_bounded_value(
+        value,
+        privacy,
+        max_nodes=MAX_SANITIZE_NODES,
+        max_bytes=MAX_SANITIZE_BYTES,
+    )
+
+
+def sanitize_flight_metadata(
+    metadata: Optional[Mapping[str, Any]],
+    privacy: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    if metadata is None:
+        return {}
+    sanitized = sanitize_flight_value(metadata, privacy)
+    if isinstance(sanitized, dict):
+        return sanitized
+    return {"value": sanitized}
+
+
+def _safe_error_property(error: Any, key: str) -> Any:
+    if isinstance(error, Mapping):
+        try:
+            return error.get(key)
+        except Exception:
+            return None
+    try:
+        return getattr(error, key)
+    except Exception:
+        return None
+
+
+def summarize_flight_error(error: Any) -> Dict[str, Any]:
+    """Return stable, non-reversible error metadata without the raw message."""
+    try:
+        if isinstance(error, str):
+            raw_message = error
+            error_name = "Error"
+        else:
+            message = _safe_error_property(error, "message")
+            raw_message = (
+                message
+                if isinstance(message, str)
+                else str(error)
+                if isinstance(error, BaseException)
+                else ""
+            )
+            name = _safe_error_property(error, "name")
+            if not isinstance(name, str) and isinstance(error, BaseException):
+                name = error.__class__.__name__
+            error_name = (
+                name
+                if isinstance(name, str)
+                and re.fullmatch(r"[A-Za-z][A-Za-z0-9_.:-]{0,63}", name)
+                and not any(pattern.search(name) for pattern in SECRET_VALUE_PATTERNS)
+                and not is_excluded_flight_path(name)
+                else "Error"
+            )
+
+        summary: Dict[str, Any] = {
+            "errorName": error_name,
+            "messageHash": hashlib.sha256(raw_message.encode("utf-8")).hexdigest(),
+            "messageChars": len(raw_message.encode("utf-16-le")) // 2,
+        }
+
+        code = _safe_error_property(error, "code")
+        if isinstance(code, bool):
+            summary["errorCode"] = code
+        elif (
+            isinstance(code, (int, float))
+            and not isinstance(code, bool)
+            and math.isfinite(code)
+            and len(str(code)) <= 32
+        ):
+            summary["errorCode"] = code
+        elif (
+            isinstance(code, str)
+            and re.fullmatch(r"[A-Za-z0-9_.:-]{1,64}", code)
+            and not any(pattern.search(code) for pattern in SECRET_VALUE_PATTERNS)
+            and not is_excluded_flight_path(code)
+        ):
+            summary["errorCode"] = code
+
+        for key in ("status", "statusCode"):
+            status = _safe_error_property(error, key)
+            if (
+                isinstance(status, (int, float))
+                and not isinstance(status, bool)
+                and math.isfinite(status)
+                and float(status).is_integer()
+                and 100 <= status <= 599
+            ):
+                summary["httpStatus"] = int(status)
+                break
+        return summary
+    except Exception:
+        return {
+            "errorName": "Error",
+            "messageHash": hashlib.sha256(b"").hexdigest(),
+            "messageChars": 0,
+        }
+
+
+def sanitize_flight_payload(
+    payload: Any,
+    privacy: Optional[Mapping[str, Any]] = None,
+) -> Any:
+    if _privacy_value(privacy, "recordIO", "record_io", default=False) is not True:
+        return None
+    configured = _privacy_value(
+        privacy,
+        "maxPayloadBytes",
+        "max_payload_bytes",
+        default=DEFAULT_MAX_PAYLOAD_BYTES,
+    )
+    if isinstance(configured, bool) or not isinstance(configured, (int, float)):
+        configured = DEFAULT_MAX_PAYLOAD_BYTES
+    if not math.isfinite(configured) or configured < 0:
+        configured = DEFAULT_MAX_PAYLOAD_BYTES
+    max_payload_bytes = int(configured)
+    if max_payload_bytes < 4:
+        return f"[truncated:{max_payload_bytes}]"
+    resolved = payload() if callable(payload) else payload
+    sanitized = _sanitize_bounded_value(
+        resolved,
+        privacy,
+        max_nodes=max(
+            64,
+            min(
+                MAX_SANITIZE_NODES,
+                max_payload_bytes * 2 + 64,
+            ),
+        ),
+        max_bytes=max(
+            MAX_SANITIZE_STRING_BYTES,
+            min(
+                MAX_SANITIZE_BYTES,
+                max_payload_bytes * 4 + 1_024,
+            ),
+        ),
+    )
+    try:
+        serialized = _portable_json(sanitized)
+    except (TypeError, ValueError):
+        return UNSERIALIZABLE
+    byte_count = len(serialized.encode("utf-8"))
+    if byte_count <= max_payload_bytes:
+        return sanitized
+    return f"[truncated:{byte_count}]"
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _assert_string(value: Any, label: str) -> None:
+    if not isinstance(value, str):
+        raise FlightRecorderCorruptionError(f"{label} must be a string.")
+    if any(0xD800 <= ord(character) <= 0xDFFF for character in value):
+        raise FlightRecorderCorruptionError(
+            f"{label} must contain valid Unicode scalar values."
+        )
+
+
+def _assert_non_negative_integer(value: Any, label: str) -> None:
+    if (
+        isinstance(value, bool)
+        or not isinstance(value, int)
+        or value < 0
+        or value > JS_MAX_SAFE_INTEGER
+    ):
+        raise FlightRecorderCorruptionError(
+            f"{label} must be a non-negative integer within the JavaScript safe integer domain."
+        )
+
+
+def _parse_iso_timestamp_ms(value: Any, label: str) -> int:
+    _assert_string(value, label)
+    match = re.fullmatch(
+        r"([0-9]{4})-([0-9]{2})-([0-9]{2})T([0-9]{2}):([0-9]{2}):([0-9]{2})(?:\.([0-9]{1,3}))?(?:Z|([+-])([0-9]{2}):([0-9]{2}))",
+        value,
+    )
+    if match is None:
+        raise FlightRecorderCorruptionError(f"{label} must be a parseable ISO timestamp.")
+    year = int(match.group(1))
+    month = int(match.group(2))
+    day = int(match.group(3))
+    hour = int(match.group(4))
+    minute = int(match.group(5))
+    second = int(match.group(6))
+    fraction = match.group(7) or ""
+    offset_sign = match.group(8)
+    offset_hour = int(match.group(9) or 0)
+    offset_minute = int(match.group(10) or 0)
+    leap_year = year % 4 == 0 and (year % 100 != 0 or year % 400 == 0)
+    days_in_month = (
+        31,
+        29 if leap_year else 28,
+        31,
+        30,
+        31,
+        30,
+        31,
+        31,
+        30,
+        31,
+        30,
+        31,
+    )
+    if (
+        year < 1
+        or month < 1
+        or month > 12
+        or day < 1
+        or day > days_in_month[month - 1]
+        or hour > 23
+        or minute > 59
+        or second > 59
+        or offset_hour > 14
+        or offset_minute > 59
+        or (offset_hour == 14 and offset_minute != 0)
+    ):
+        raise FlightRecorderCorruptionError(
+            f"{label} must be a parseable ISO timestamp."
+        )
+    fraction_ms = int((fraction[:3]).ljust(3, "0") or "0")
+    offset_minutes = (offset_hour * 60 + offset_minute) * (
+        -1 if offset_sign == "-" else 1
+    )
+    return (
+        _days_from_civil(year, month, day) * 86_400_000
+        + hour * 3_600_000
+        + minute * 60_000
+        + second * 1_000
+        + fraction_ms
+        - offset_minutes * 60_000
+    )
+
+
+def _days_from_civil(year: int, month: int, day: int) -> int:
+    adjusted_year = year - (1 if month <= 2 else 0)
+    era = adjusted_year // 400
+    year_of_era = adjusted_year - era * 400
+    shifted_month = month + (-3 if month > 2 else 9)
+    day_of_year = (153 * shifted_month + 2) // 5 + day - 1
+    day_of_era = (
+        year_of_era * 365
+        + year_of_era // 4
+        - year_of_era // 100
+        + day_of_year
+    )
+    return era * 146_097 + day_of_era - 719_468
+
+
+def _assert_iso_timestamp(value: Any, label: str) -> None:
+    _parse_iso_timestamp_ms(value, label)
+
+
+def _timestamp_ms(value: Any, label: str) -> int:
+    return _parse_iso_timestamp_ms(value, label)
+
+
+def _trace_lifecycle_fields(
+    event_json: str,
+) -> tuple[
+    Optional[str],
+    Optional[str],
+    Optional[int],
+    Optional[str],
+]:
+    try:
+        event = json.loads(event_json)
+        metadata = event.get("metadata") or {}
+        owner_pid = metadata.get("ownerPid")
+        normalized_owner = (
+            isinstance(owner_pid, int)
+            and not isinstance(owner_pid, bool)
+            and owner_pid > 0
+        )
+        return (
+            event.get("id") if isinstance(event.get("id"), str) else None,
+            (
+                event.get("parentId")
+                if isinstance(event.get("parentId"), str)
+                else None
+            ),
+            owner_pid if normalized_owner else None,
+            (
+                metadata.get("ownerIncarnation")
+                if isinstance(metadata.get("ownerIncarnation"), str)
+                else None
+            ),
+        )
+    except (AttributeError, TypeError, json.JSONDecodeError):
+        pass
+    return None, None, None, None
+
+
+def _process_is_alive(pid: int) -> bool:
+    if os.name == "nt":
+        import ctypes
+        from ctypes import wintypes
+
+        process_query_limited_information = 0x1000
+        kernel32 = ctypes.WinDLL("kernel32", use_last_error=True)
+        open_process = kernel32.OpenProcess
+        open_process.argtypes = [
+            wintypes.DWORD,
+            wintypes.BOOL,
+            wintypes.DWORD,
+        ]
+        open_process.restype = wintypes.HANDLE
+        close_handle = kernel32.CloseHandle
+        close_handle.argtypes = [wintypes.HANDLE]
+        close_handle.restype = wintypes.BOOL
+
+        ctypes.set_last_error(0)
+        handle = open_process(
+            process_query_limited_information,
+            False,
+            pid,
+        )
+        if handle:
+            close_handle(handle)
+            return True
+        error = ctypes.get_last_error()
+        if error in {87, 1168}:
+            return False
+        # Access denial and ambiguous API failures must fail closed so an
+        # active owner is never reclaimed merely because it cannot be queried.
+        return True
+    try:
+        os.kill(pid, 0)
+        return True
+    except PermissionError:
+        return True
+    except ProcessLookupError:
+        return False
+    except OSError as exc:
+        if exc.errno == errno.ESRCH:
+            return False
+        if getattr(exc, "winerror", None) in {
+            87,
+            1168,
+        }:
+            return False
+        raise
+
+
+def _read_process_incarnation(pid: int) -> Optional[str]:
+    try:
+        if sys.platform.startswith("linux"):
+            stat = Path(f"/proc/{pid}/stat").read_text(
+                encoding="utf-8"
+            )
+            fields = stat[stat.rfind(")") + 2 :].split()
+            return f"linux:{fields[19]}" if len(fields) > 19 else None
+        if os.name == "nt":
+            return "win:" + subprocess.check_output(
+                [
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    (
+                        f"(Get-Process -Id {pid}).StartTime."
+                        "ToUniversalTime().ToFileTimeUtc()"
+                    ),
+                ],
+                text=True,
+            ).strip()
+        started = subprocess.check_output(
+            ["ps", "-o", "lstart=", "-p", str(pid)],
+            text=True,
+            env={**os.environ, "LC_ALL": "C", "TZ": "UTC"},
+        ).strip()
+        return f"ps-c-utc:{started}" if started else None
+    except (OSError, subprocess.SubprocessError, IndexError):
+        return None
+
+
+_CURRENT_PROCESS_PID = os.getpid()
+_CURRENT_PROCESS_INCARNATION = _read_process_incarnation(
+    _CURRENT_PROCESS_PID
+)
+
+
+def _current_process_incarnation() -> Optional[str]:
+    global _CURRENT_PROCESS_PID, _CURRENT_PROCESS_INCARNATION
+    current_pid = os.getpid()
+    if current_pid != _CURRENT_PROCESS_PID:
+        _CURRENT_PROCESS_PID = current_pid
+        _CURRENT_PROCESS_INCARNATION = (
+            _read_process_incarnation(current_pid)
+        )
+    return _CURRENT_PROCESS_INCARNATION
+
+
+def _process_matches_incarnation(
+    pid: int,
+    incarnation: Optional[str],
+) -> bool:
+    if not _process_is_alive(pid):
+        return False
+    if not incarnation:
+        return True
+    current = (
+        _current_process_incarnation()
+        if pid == os.getpid()
+        else _read_process_incarnation(pid)
+    )
+    return current is None or current == incarnation
+
+
+def _rows_have_live_trace(rows: list[tuple[Any, ...]]) -> bool:
+    starts = _unmatched_trace_starts(rows)
+    return any(
+        owner_pid is not None
+        and _process_matches_incarnation(owner_pid, incarnation)
+        for owner_pid, incarnation in starts.values()
+    )
+
+
+def _unmatched_trace_starts(
+    rows: list[tuple[Any, ...]],
+) -> Dict[str, tuple[Optional[int], Optional[str]]]:
+    starts: Dict[str, tuple[Optional[int], Optional[str]]] = {}
+    for row in rows:
+        kind = row[4]
+        event_json = row[5]
+        (
+            event_id,
+            parent_id,
+            owner_pid,
+            owner_incarnation,
+        ) = _trace_lifecycle_fields(event_json)
+        if kind == "trace.started" and event_id is not None:
+            starts[event_id] = (owner_pid, owner_incarnation)
+        elif kind in {"trace.completed", "trace.failed"} and parent_id:
+            starts.pop(parent_id, None)
+    return starts
+
+
+def _normalize_flight_query(
+    query: Optional[Mapping[str, Any]] = None,
+    filters: Optional[Mapping[str, Any]] = None,
+    identity_key: Optional[str] = None,
+    privacy: Optional[Mapping[str, Any]] = None,
+) -> Dict[str, Any]:
+    normalized: Dict[str, Any] = {}
+    for source in (query or {}, filters or {}):
+        if not isinstance(source, Mapping):
+            raise TypeError("Flight event query must be a mapping.")
+        for key, value in source.items():
+            if key in normalized:
+                raise TypeError(f'Flight event query contains duplicate filter "{key}".')
+            normalized[key] = value
+    for alias, canonical in QUERY_ALIASES.items():
+        if alias not in normalized:
+            continue
+        if canonical in normalized:
+            raise TypeError(
+                f'Flight event query contains both "{canonical}" and "{alias}".'
+            )
+        normalized[canonical] = normalized.pop(alias)
+    unexpected = set(normalized) - QUERY_KEYS
+    if unexpected:
+        raise TypeError(
+            f'Flight event query contains unexpected filter "{sorted(unexpected)[0]}".'
+        )
+    if "sessionId" in normalized:
+        _assert_string(normalized["sessionId"], "sessionId")
+        if identity_key is not None:
+            normalized["sessionId"] = normalize_flight_session_id(
+                normalized["sessionId"],
+                identity_key,
+                _privacy_value(
+                    privacy,
+                    "redactedValues",
+                    "redacted_values",
+                    default=(),
+                )
+                or (),
+            )
+    if "traceId" in normalized:
+        _assert_string(normalized["traceId"], "traceId")
+        if not _is_canonical_private_identifier(
+            normalized["traceId"],
+            "trace",
+        ):
+            normalized["traceId"] = _private_identifier(
+                normalized["traceId"],
+                privacy,
+                "trace",
+                "traceId",
+            )
+    if "workspaceId" in normalized:
+        _assert_string(normalized["workspaceId"], "workspaceId")
+        normalized["workspaceId"] = normalize_flight_workspace_id(
+            _private_identifier(
+                normalized["workspaceId"],
+                privacy,
+                "workspace",
+                "workspaceId",
+            )
+        )
+    for key, prefix in (
+        ("source", "source"),
+        ("providerId", "provider"),
+        ("agentName", "agent"),
+        ("toolName", "tool"),
+    ):
+        if key in normalized:
+            _assert_string(normalized[key], key)
+            normalized[key] = _private_identifier(
+                normalized[key],
+                privacy,
+                prefix,
+                key,
+            )
+    return normalized
+
+
+def _assert_json_value(value: Any, label: str, seen: Optional[set[int]] = None) -> None:
+    if isinstance(value, str):
+        _assert_string(value, label)
+        return
+    if value is None or isinstance(value, bool):
+        return
+    if isinstance(value, int):
+        if abs(value) <= JS_MAX_SAFE_INTEGER:
+            return
+        raise FlightRecorderCorruptionError(
+            f"{label} must not contain integers outside the JavaScript safe integer domain."
+        )
+    if isinstance(value, float):
+        if (
+            math.isfinite(value)
+            and not (
+                value.is_integer()
+                and abs(value) > JS_MAX_SAFE_INTEGER
+            )
+        ):
+            return
+        raise FlightRecorderCorruptionError(
+            f"{label} must contain only finite numbers and JavaScript-safe integral values."
+        )
+    if not isinstance(value, (list, dict)):
+        raise FlightRecorderCorruptionError(f"{label} must contain only JSON-compatible values.")
+    if seen is None:
+        seen = set()
+    identity = id(value)
+    if identity in seen:
+        raise FlightRecorderCorruptionError(f"{label} must not contain circular references.")
+    seen.add(identity)
+    try:
+        if isinstance(value, list):
+            for index, item in enumerate(value):
+                _assert_json_value(item, f"{label}[{index}]", seen)
+        else:
+            for key, item in value.items():
+                if not isinstance(key, str):
+                    raise FlightRecorderCorruptionError(f"{label} keys must be strings.")
+                _assert_string(key, f"{label} key")
+                _assert_json_value(item, f"{label}.{key}", seen)
+    finally:
+        seen.remove(identity)
+
+
+def validate_flight_event(value: Any, label: str = "event") -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        raise FlightRecorderCorruptionError(f"{label} must be an object.")
+    unexpected = set(value) - EVENT_KEYS
+    if unexpected:
+        raise FlightRecorderCorruptionError(
+            f'{label} contains unexpected field "{sorted(unexpected)[0]}".'
+        )
+    if value.get("schema") != FLIGHT_EVENT_SCHEMA:
+        raise FlightRecorderCorruptionError(
+            f'{label}.schema must be "{FLIGHT_EVENT_SCHEMA}".'
+        )
+    for key in ("id", "kind", "source", "traceId", "timestamp", "contentHash"):
+        _assert_string(value.get(key), f"{label}.{key}")
+    _assert_non_negative_integer(value.get("sequence"), f"{label}.sequence")
+    if value.get("status") not in EVENT_STATUSES:
+        raise FlightRecorderCorruptionError(f"{label}.status is invalid.")
+    if value.get("parentId", _MISSING) is _MISSING:
+        raise FlightRecorderCorruptionError(f"{label}.parentId is required.")
+    if value["parentId"] is not None:
+        _assert_string(value["parentId"], f"{label}.parentId")
+    _assert_iso_timestamp(value["timestamp"], f"{label}.timestamp")
+    for key in ("sessionId", "workspaceId", "providerId", "model", "agentName", "toolName"):
+        if key in value:
+            _assert_string(value[key], f"{label}.{key}")
+    if (
+        "model" in value
+        and normalize_flight_model_id(value["model"]) != value["model"]
+    ):
+        raise FlightRecorderCorruptionError(
+            f"{label}.model must be a concrete normalized model ID."
+        )
+    for key in (
+        "id",
+        "kind",
+        "source",
+        "traceId",
+        "parentId",
+        "providerId",
+        "workspaceId",
+        "model",
+        "agentName",
+        "toolName",
+    ):
+        field = value.get(key)
+        if (
+            isinstance(field, str)
+            and sanitize_flight_value(field) != field
+        ):
+            raise FlightRecorderCorruptionError(
+                f"{label}.{key} violates Flight Recorder privacy."
+            )
+    if "durationMs" in value:
+        duration = value["durationMs"]
+        if (
+            isinstance(duration, bool)
+            or not isinstance(duration, (int, float))
+            or not math.isfinite(duration)
+            or duration < 0
+            or (
+                isinstance(duration, int)
+                and duration > JS_MAX_SAFE_INTEGER
+            )
+            or (
+                isinstance(duration, float)
+                and duration.is_integer()
+                and duration > JS_MAX_SAFE_INTEGER
+            )
+        ):
+            raise FlightRecorderCorruptionError(
+                f"{label}.durationMs must be a finite non-negative number."
+            )
+    if not isinstance(value.get("metadata"), dict):
+        raise FlightRecorderCorruptionError(f"{label}.metadata must be an object.")
+    _assert_json_value(value["metadata"], f"{label}.metadata")
+    if (
+        "sessionId" in value
+        and re.fullmatch(r"session:[0-9a-f]{24}", value["sessionId"])
+        is None
+    ):
+        raise FlightRecorderCorruptionError(
+            f"{label}.sessionId must be an opaque session identifier."
+        )
+    if (
+        "workspaceId" in value
+        and normalize_flight_workspace_id(value["workspaceId"])
+        != value["workspaceId"]
+    ):
+        raise FlightRecorderCorruptionError(
+            f"{label}.workspaceId must not contain a raw path."
+        )
+    if sanitize_flight_metadata(value["metadata"]) != value["metadata"]:
+        raise FlightRecorderCorruptionError(
+            f"{label}.metadata violates Flight Recorder privacy."
+        )
+    if "payload" in value:
+        _assert_json_value(value["payload"], f"{label}.payload")
+        if (
+            sanitize_flight_payload(
+                value["payload"],
+                {
+                    "recordIO": True,
+                    "maxPayloadBytes": JS_MAX_SAFE_INTEGER,
+                },
+            )
+            != value["payload"]
+        ):
+            raise FlightRecorderCorruptionError(
+                f"{label}.payload violates Flight Recorder privacy."
+            )
+    if not verify_flight_event_hash(value):
+        raise FlightRecorderCorruptionError(f"Flight event integrity check failed for {label}.")
+    return value
+
+
+class SQLiteFlightLedger:
+    """SQLite append ledger with integrity validation at every boundary."""
+
+    def __init__(
+        self,
+        options: Optional[Mapping[str, Any]] = None,
+        *,
+        database_path: Optional[str | os.PathLike[str]] = None,
+        in_memory: Optional[bool] = None,
+    ) -> None:
+        options = dict(options or {})
+        self.database_path = str(
+            database_path
+            if database_path is not None
+            else options.get("databasePath", options.get("database_path", "openrappter-flight.db"))
+        )
+        self.in_memory = bool(
+            in_memory
+            if in_memory is not None
+            else options.get("inMemory", options.get("in_memory", False))
+        )
+        self._db: Optional[sqlite3.Connection] = None
+        self._state = "created"
+        self._lock = threading.RLock()
+
+    def initialize(self) -> None:
+        with self._lock:
+            if self._state == "closed":
+                raise FlightRecorderError("Flight ledger is closed and cannot be initialized.")
+            if self._state == "initialized":
+                return
+            database = ":memory:" if self.in_memory else self.database_path
+            prepared_files = (
+                []
+                if self.in_memory
+                else (
+                    _assert_private_directory(
+                        Path(database).expanduser().parent
+                    )
+                    or _prepare_private_database_files(database)
+                )
+            )
+            db = sqlite3.connect(
+                database,
+                timeout=BUSY_TIMEOUT_MS / 1000,
+                check_same_thread=False,
+                isolation_level=None,
+            )
+            try:
+                if prepared_files:
+                    _verify_private_database_files(prepared_files)
+                db.execute(f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}")
+                db.execute("PRAGMA foreign_keys = ON")
+                db.execute("PRAGMA secure_delete = ON")
+                if not self.in_memory:
+                    db.execute("PRAGMA journal_mode = WAL")
+                    db.execute("PRAGMA synchronous = FULL")
+                    _verify_private_database_files(prepared_files)
+                table_exists = db.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'flight_events'"
+                ).fetchone()
+                if table_exists is None:
+                    self._create_table(db)
+                    self._create_indexes(db)
+                else:
+                    columns = {
+                        row[1]: row
+                        for row in db.execute(
+                            "PRAGMA table_info(flight_events)"
+                        ).fetchall()
+                    }
+                    timestamp_column = columns.get("timestamp_ms")
+                    if timestamp_column is None or timestamp_column[3] != 1:
+                        self._migrate_timestamp_ms(
+                            db,
+                            source_has_timestamp_ms=timestamp_column is not None,
+                        )
+                    else:
+                        self._create_indexes(db)
+                db.execute(
+                    """
+                    CREATE TABLE IF NOT EXISTS flight_metadata (
+                        key TEXT PRIMARY KEY,
+                        value TEXT NOT NULL
+                    )
+                    """
+                )
+                if not self.in_memory:
+                    probe_id = (
+                        "__openrappter_sidecar_probe__:"
+                        f"{uuid.uuid4()}"
+                    )
+                    db.execute("BEGIN IMMEDIATE")
+                    try:
+                        db.execute(
+                            """
+                            INSERT INTO flight_events (
+                                id, sequence, trace_id, timestamp,
+                                timestamp_ms, kind, source, status,
+                                session_id, workspace_id, provider_id,
+                                agent_name, tool_name, event_json
+                            ) VALUES (
+                                ?, 0, ?, '1970-01-01T00:00:00.000Z',
+                                0, 'sidecar.probe', 'flight-recorder',
+                                'info', NULL, NULL, NULL, NULL, NULL, '{}'
+                            )
+                            """,
+                            (probe_id, probe_id),
+                        )
+                        db.execute(
+                            "DELETE FROM flight_events WHERE id = ?",
+                            (probe_id,),
+                        )
+                        db.execute("COMMIT")
+                    except Exception:
+                        db.execute("ROLLBACK")
+                        raise
+                    candidates = (
+                        Path(database),
+                        Path(f"{database}-wal"),
+                        Path(f"{database}-shm"),
+                    )
+                    missing = [
+                        str(candidate)
+                        for candidate in candidates
+                        if not candidate.exists()
+                    ]
+                    if missing:
+                        raise FlightRecorderError(
+                            "Flight Recorder private SQLite files were "
+                            f"not materialized: {', '.join(missing)}"
+                        )
+                    for candidate in candidates:
+                        _harden_private_path(candidate)
+                    _verify_private_database_files(prepared_files)
+            except Exception:
+                db.close()
+                raise
+            self._db = db
+            self._state = "initialized"
+
+    @staticmethod
+    def _create_table(db: sqlite3.Connection) -> None:
+        db.execute(
+            """
+            CREATE TABLE flight_events (
+                id TEXT PRIMARY KEY,
+                sequence INTEGER NOT NULL,
+                trace_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                timestamp_ms INTEGER NOT NULL,
+                kind TEXT NOT NULL,
+                source TEXT NOT NULL,
+                status TEXT NOT NULL,
+                session_id TEXT,
+                workspace_id TEXT,
+                provider_id TEXT,
+                agent_name TEXT,
+                tool_name TEXT,
+                event_json TEXT NOT NULL,
+                UNIQUE (trace_id, sequence)
+            )
+            """
+        )
+
+    @staticmethod
+    def _create_indexes(db: sqlite3.Connection) -> None:
+        statements = (
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_sequence_timestamp "
+            "ON flight_events(sequence, timestamp_ms)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_trace ON flight_events(trace_id)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_session ON flight_events(session_id)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_workspace ON flight_events(workspace_id)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_kind ON flight_events(kind)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_source ON flight_events(source)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_provider ON flight_events(provider_id)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_agent ON flight_events(agent_name)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_tool ON flight_events(tool_name)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_status ON flight_events(status)",
+            "CREATE INDEX IF NOT EXISTS idx_flight_events_timestamp ON flight_events(timestamp_ms)",
+        )
+        for statement in statements:
+            db.execute(statement)
+
+    @classmethod
+    def _migrate_timestamp_ms(
+        cls,
+        db: sqlite3.Connection,
+        *,
+        source_has_timestamp_ms: bool,
+    ) -> None:
+        db.execute("BEGIN IMMEDIATE")
+        try:
+            db.execute("ALTER TABLE flight_events RENAME TO flight_events_legacy")
+            cls._create_table(db)
+            source_columns = (
+                "rowid, id, sequence, trace_id, timestamp, timestamp_ms, kind, "
+                "source, status, session_id, workspace_id, provider_id, "
+                "agent_name, tool_name, event_json"
+                if source_has_timestamp_ms
+                else
+                "rowid, id, sequence, trace_id, timestamp, kind, source, status, "
+                "session_id, workspace_id, provider_id, agent_name, tool_name, event_json"
+            )
+            rows = db.execute(
+                f"SELECT {source_columns} FROM flight_events_legacy ORDER BY rowid"
+            ).fetchall()
+            insert_sql = """
+                INSERT INTO flight_events (
+                    rowid, id, sequence, trace_id, timestamp, timestamp_ms,
+                    kind, source, status, session_id, workspace_id, provider_id,
+                    agent_name, tool_name, event_json
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """
+            for row in rows:
+                if source_has_timestamp_ms:
+                    (
+                        rowid,
+                        event_id,
+                        sequence,
+                        trace_id,
+                        timestamp,
+                        _old_timestamp_ms,
+                        kind,
+                        source,
+                        status,
+                        session_id,
+                        workspace_id,
+                        provider_id,
+                        agent_name,
+                        tool_name,
+                        event_json,
+                    ) = row
+                else:
+                    (
+                        rowid,
+                        event_id,
+                        sequence,
+                        trace_id,
+                        timestamp,
+                        kind,
+                        source,
+                        status,
+                        session_id,
+                        workspace_id,
+                        provider_id,
+                        agent_name,
+                        tool_name,
+                        event_json,
+                    ) = row
+                db.execute(
+                    insert_sql,
+                    (
+                        rowid,
+                        event_id,
+                        sequence,
+                        trace_id,
+                        timestamp,
+                        _timestamp_ms(timestamp, f'flight event row "{event_id}".timestamp'),
+                        kind,
+                        source,
+                        status,
+                        session_id,
+                        workspace_id,
+                        provider_id,
+                        agent_name,
+                        tool_name,
+                        event_json,
+                    ),
+                )
+            db.execute("DROP TABLE flight_events_legacy")
+            cls._create_indexes(db)
+            db.execute("COMMIT")
+        except Exception:
+            db.execute("ROLLBACK")
+            raise
+
+    def close(self) -> None:
+        with self._lock:
+            if self._state == "closed":
+                return
+            if self._db is not None:
+                self._db.close()
+            self._db = None
+            self._state = "closed"
+
+    def _ensure_db(self) -> sqlite3.Connection:
+        if self._state == "closed":
+            raise FlightRecorderError("Flight ledger is closed.")
+        if self._state != "initialized" or self._db is None:
+            raise FlightRecorderError("Flight ledger is not initialized. Call initialize() first.")
+        return self._db
+
+    @staticmethod
+    def _parameters(event: Mapping[str, Any], serialized: str) -> tuple[Any, ...]:
+        return (
+            event["id"],
+            event["sequence"],
+            event["traceId"],
+            event["timestamp"],
+            _timestamp_ms(event["timestamp"], "event.timestamp"),
+            event["kind"],
+            event["source"],
+            event["status"],
+            event.get("sessionId"),
+            event.get("workspaceId"),
+            event.get("providerId"),
+            event.get("agentName"),
+            event.get("toolName"),
+            serialized,
+        )
+
+    @staticmethod
+    def _insert_sql(replace: bool) -> str:
+        values = """id, sequence, trace_id, timestamp, timestamp_ms, kind, source, status,
+            session_id, workspace_id, provider_id, agent_name, tool_name, event_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)"""
+        if not replace:
+            return f"INSERT INTO flight_events ({values} ON CONFLICT(id) DO NOTHING"
+        return f"""INSERT INTO flight_events ({values}
+            ON CONFLICT(id) DO UPDATE SET
+                sequence=excluded.sequence, trace_id=excluded.trace_id,
+                timestamp=excluded.timestamp, timestamp_ms=excluded.timestamp_ms,
+                kind=excluded.kind,
+                source=excluded.source, status=excluded.status,
+                session_id=excluded.session_id, workspace_id=excluded.workspace_id,
+                provider_id=excluded.provider_id, agent_name=excluded.agent_name,
+                tool_name=excluded.tool_name, event_json=excluded.event_json"""
+
+    def append(self, event: Mapping[str, Any]) -> None:
+        validated = validate_flight_event(dict(event), "event")
+        serialized = _portable_json(validated)
+        with self._lock:
+            db = self._ensure_db()
+            db.execute(
+                f"PRAGMA busy_timeout = {RUNTIME_BUSY_TIMEOUT_MS}"
+            )
+            try:
+                db.execute(
+                    self._insert_sql(False),
+                    self._parameters(validated, serialized),
+                )
+            finally:
+                db.execute(
+                    f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}"
+                )
+
+    def query(self, query: Optional[Mapping[str, Any]] = None, **filters: Any) -> list[Dict[str, Any]]:
+        query_data = _normalize_flight_query(query, filters)
+        with self._lock:
+            return self._select_events(
+                self._ensure_db(),
+                query_data,
+                public_query=True,
+            )
+
+    @classmethod
+    def _select_events(
+        cls,
+        db: sqlite3.Connection,
+        query_data: Mapping[str, Any],
+        *,
+        public_query: bool,
+    ) -> list[Dict[str, Any]]:
+        columns = {
+            "traceId": "trace_id",
+            "sessionId": "session_id",
+            "workspaceId": "workspace_id",
+            "source": "source",
+            "providerId": "provider_id",
+            "agentName": "agent_name",
+            "toolName": "tool_name",
+            "status": "status",
+        }
+        for key in columns:
+            if key in query_data:
+                _assert_string(query_data[key], key)
+        kinds = query_data.get("kind", _MISSING)
+        if kinds is not _MISSING:
+            kinds = kinds if isinstance(kinds, (list, tuple)) else [kinds]
+            if len(kinds) > MAX_KIND_FILTERS:
+                raise ValueError(f"kind filter may contain at most {MAX_KIND_FILTERS} values.")
+            for kind in kinds:
+                _assert_string(kind, "kind")
+            kinds = set(kinds)
+        since_ms = (
+            _timestamp_ms(query_data["since"], "since")
+            if "since" in query_data
+            else None
+        )
+        until_ms = (
+            _timestamp_ms(query_data["until"], "until")
+            if "until" in query_data
+            else None
+        )
+        limit = query_data.get("limit", _MISSING)
+        offset = query_data.get("offset", 0)
+        if limit is not _MISSING:
+            _assert_non_negative_integer(limit, "limit")
+        _assert_non_negative_integer(offset, "offset")
+        if public_query:
+            limit = (
+                MAX_QUERY_LIMIT
+                if limit is _MISSING
+                else min(limit, MAX_QUERY_LIMIT)
+            )
+            offset = min(offset, MAX_QUERY_OFFSET)
+        order = query_data.get("order", "asc")
+        if order not in {"asc", "desc"}:
+            raise ValueError('order must be "asc" or "desc".')
+
+        rows = db.execute(
+            """
+            SELECT rowid, id, sequence, trace_id, timestamp, timestamp_ms,
+                   kind, source, status, session_id, workspace_id,
+                   provider_id, agent_name, tool_name, event_json
+            FROM flight_events
+            """
+        ).fetchall()
+        validated = [
+            (row, cls._row_to_event(row))
+            for row in rows
+        ]
+
+        filtered: list[tuple[tuple[Any, ...], Dict[str, Any]]] = []
+        for row, event in validated:
+            if any(
+                key in query_data
+                and event.get(key) != query_data[key]
+                for key in columns
+            ):
+                continue
+            if kinds is not _MISSING and event["kind"] not in kinds:
+                continue
+            if since_ms is not None and row[5] < since_ms:
+                continue
+            if until_ms is not None and row[5] > until_ms:
+                continue
+            filtered.append((row, event))
+
+        if "traceId" in query_data:
+            filtered.sort(
+                key=lambda item: (
+                    item[1]["sequence"],
+                    item[0][5],
+                    item[0][0],
+                ),
+                reverse=order == "desc",
+            )
+        else:
+            filtered.sort(
+                key=lambda item: (
+                    item[0][5],
+                    item[0][0],
+                ),
+                reverse=order == "desc",
+            )
+        if limit == 0:
+            return []
+        end = None if limit is _MISSING else offset + limit
+        return [
+            event
+            for _row, event in filtered[offset:end]
+        ]
+
+    @staticmethod
+    def _row_to_event(row: tuple[Any, ...]) -> Dict[str, Any]:
+        (
+            _rowid,
+            row_id,
+            sequence,
+            trace_id,
+            timestamp,
+            timestamp_ms,
+            kind,
+            source,
+            status,
+            session_id,
+            workspace_id,
+            provider_id,
+            agent_name,
+            tool_name,
+            event_json,
+        ) = row
+        try:
+            parsed = json.loads(event_json)
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise FlightRecorderCorruptionError(
+                f'Corrupt flight event row "{row_id}": event_json is not valid JSON: {exc}'
+            ) from exc
+        event = validate_flight_event(parsed, f'flight event row "{row_id}"')
+        indexed = {
+            "id": row_id,
+            "sequence": sequence,
+            "traceId": trace_id,
+            "timestamp": timestamp,
+            "kind": kind,
+            "source": source,
+            "status": status,
+            "sessionId": session_id,
+            "workspaceId": workspace_id,
+            "providerId": provider_id,
+            "agentName": agent_name,
+            "toolName": tool_name,
+        }
+        mismatches = [
+            key
+            for key, indexed_value in indexed.items()
+            if indexed_value != event.get(key)
+        ]
+        expected_timestamp_ms = _timestamp_ms(
+            event["timestamp"], f'flight event row "{row_id}".timestamp'
+        )
+        if timestamp_ms != expected_timestamp_ms:
+            mismatches.append("timestamp_ms does not match timestamp")
+        if mismatches:
+            raise FlightRecorderCorruptionError(
+                f'Corrupt flight event row "{row_id}": '
+                + ", ".join(f"{key} does not match event_json" for key in mismatches)
+                + "."
+            )
+        return event
+
+    def count(self) -> int:
+        with self._lock:
+            row = self._ensure_db().execute(
+                "SELECT COUNT(*) FROM flight_events"
+            ).fetchone()
+        return int(row[0])
+
+    def last_sequence(self, trace_id: str) -> int:
+        _assert_string(trace_id, "traceId")
+        with self._lock:
+            row = self._ensure_db().execute(
+                """
+                SELECT rowid, id, sequence, trace_id, timestamp,
+                       timestamp_ms, kind, source, status, session_id,
+                       workspace_id, provider_id, agent_name, tool_name,
+                       event_json
+                FROM flight_events
+                WHERE trace_id = ?
+                ORDER BY sequence DESC, rowid DESC
+                LIMIT 1
+                """,
+                (trace_id,),
+            ).fetchone()
+        return self._row_to_event(row)["sequence"] if row else 0
+
+    def bind_identity_key(self, identity_key: str) -> None:
+        if re.fullmatch(r"[0-9a-fA-F]{64}", identity_key) is None:
+            raise ValueError(
+                "Flight Recorder identity key must be 32-byte hexadecimal."
+            )
+        fingerprint = hashlib.sha256(
+            (
+                "openrappter-flight-identity/1:"
+                f"{identity_key.lower()}"
+            ).encode("utf-8")
+        ).hexdigest()
+        with self._transaction() as db:
+            row = db.execute(
+                "SELECT value FROM flight_metadata "
+                "WHERE key = 'identity-key-fingerprint'"
+            ).fetchone()
+            if row is not None and row[0] != fingerprint:
+                raise FlightRecorderError(
+                    "Flight Recorder identity key does not match "
+                    "the ledger fingerprint."
+                )
+            if row is None:
+                db.execute(
+                    "INSERT INTO flight_metadata (key, value) "
+                    "VALUES ('identity-key-fingerprint', ?)",
+                    (fingerprint,),
+                )
+
+    def prune(self, keep: int) -> int:
+        _assert_non_negative_integer(keep, "keep")
+        with self._transaction() as db:
+            before = int(
+                db.execute("SELECT COUNT(*) FROM flight_events").fetchone()[0]
+            )
+            if before <= keep:
+                return 0
+            rows = db.execute(
+                """
+                SELECT rowid, id, sequence, trace_id, timestamp,
+                       timestamp_ms, kind, source, status, session_id,
+                       workspace_id, provider_id, agent_name, tool_name,
+                       event_json
+                FROM flight_events
+                ORDER BY trace_id, sequence, rowid
+                """
+            ).fetchall()
+
+            traces: Dict[str, Dict[str, Any]] = {}
+            for row in rows:
+                event = self._row_to_event(row)
+                row_id = row[0]
+                timestamp = row[5]
+                trace_id = event["traceId"]
+                kind = event["kind"]
+                trace = traces.setdefault(
+                    trace_id,
+                    {
+                        "traceId": trace_id,
+                        "rowCount": 0,
+                        "lifecycle": "atomic",
+                        "lifecycleDepth": 0,
+                        "sawLifecycleStart": False,
+                        "malformedLifecycle": False,
+                        "lifecycleStarts": {},
+                        "latestTimestamp": timestamp,
+                        "latestRowId": row_id,
+                    },
+                )
+                trace["rowCount"] += 1
+                if kind == "trace.started":
+                    trace["sawLifecycleStart"] = True
+                    event_id = event["id"]
+                    owner_pid = event["metadata"].get("ownerPid")
+                    owner_incarnation = event["metadata"].get(
+                        "ownerIncarnation"
+                    )
+                    if event_id is None:
+                        trace["malformedLifecycle"] = True
+                    else:
+                        trace["lifecycleStarts"][event_id] = (
+                            owner_pid,
+                            owner_incarnation,
+                        )
+                        trace["lifecycleDepth"] = len(
+                            trace["lifecycleStarts"]
+                        )
+                elif kind in {"trace.completed", "trace.failed"}:
+                    parent_id = event.get("parentId")
+                    if (
+                        parent_id is not None
+                        and parent_id in trace["lifecycleStarts"]
+                    ):
+                        trace["lifecycleStarts"].pop(parent_id)
+                        trace["lifecycleDepth"] = len(
+                            trace["lifecycleStarts"]
+                        )
+                    else:
+                        trace["malformedLifecycle"] = True
+                if (
+                    timestamp > trace["latestTimestamp"]
+                    or (
+                        timestamp == trace["latestTimestamp"]
+                        and row_id > trace["latestRowId"]
+                    )
+                ):
+                    trace["latestTimestamp"] = timestamp
+                    trace["latestRowId"] = row_id
+
+            retention_traces = list(traces.values())
+            for trace in retention_traces:
+                if (
+                    trace["lifecycleDepth"] > 0
+                    and any(
+                        owner_pid is not None
+                        and _process_matches_incarnation(
+                            owner_pid,
+                            owner_incarnation,
+                        )
+                        for owner_pid, owner_incarnation in trace[
+                            "lifecycleStarts"
+                        ].values()
+                    )
+                ):
+                    trace["lifecycle"] = "active"
+                elif (
+                    not trace["sawLifecycleStart"]
+                    and not trace["malformedLifecycle"]
+                ):
+                    trace["lifecycle"] = "atomic"
+                elif (
+                    trace["sawLifecycleStart"]
+                    and not trace["malformedLifecycle"]
+                ):
+                    trace["lifecycle"] = "completed"
+                else:
+                    trace["lifecycle"] = "malformed"
+            active = [
+                trace
+                for trace in retention_traces
+                if trace["lifecycle"] == "active"
+            ]
+            candidates = sorted(
+                (
+                    trace
+                    for trace in retention_traces
+                    if trace["lifecycle"] != "active"
+                ),
+                key=lambda trace: (
+                    trace["latestTimestamp"],
+                    trace["latestRowId"],
+                ),
+                reverse=True,
+            )
+            retained_trace_ids = {trace["traceId"] for trace in active}
+            retained_rows = sum(trace["rowCount"] for trace in active)
+            newest_completed = next(
+                (
+                    trace
+                    for trace in candidates
+                    if trace["lifecycle"] == "completed"
+                ),
+                None,
+            ) if keep > 0 else None
+            if newest_completed is not None:
+                retained_trace_ids.add(newest_completed["traceId"])
+                retained_rows += newest_completed["rowCount"]
+
+            for trace in candidates:
+                if trace["traceId"] in retained_trace_ids:
+                    continue
+                if retained_rows + trace["rowCount"] > keep:
+                    break
+                retained_trace_ids.add(trace["traceId"])
+                retained_rows += trace["rowCount"]
+
+            if keep > 0 and not active and not retained_trace_ids and candidates:
+                retained_trace_ids.add(candidates[0]["traceId"])
+
+            deleted = 0
+            for trace in retention_traces:
+                if trace["traceId"] not in retained_trace_ids:
+                    cursor = db.execute(
+                        "DELETE FROM flight_events WHERE trace_id = ?",
+                        (trace["traceId"],),
+                    )
+                    deleted += cursor.rowcount
+        if deleted > 0:
+            self._purge_deleted_pages(vacuum=False)
+        return deleted
+
+    def prune_runtime(self, keep: int) -> int:
+        with self._lock:
+            db = self._ensure_db()
+            db.execute(
+                f"PRAGMA busy_timeout = {RUNTIME_BUSY_TIMEOUT_MS}"
+            )
+            try:
+                return self.prune(keep)
+            finally:
+                db.execute(
+                    f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}"
+                )
+
+    def export(self, query: Optional[Mapping[str, Any]] = None) -> Dict[str, Any]:
+        query_data = _normalize_flight_query(query)
+        with self._transaction(immediate=False) as db:
+            events = self._select_events(
+                db,
+                query_data,
+                public_query=False,
+            )
+            return {
+                "schema": FLIGHT_EXPORT_SCHEMA,
+                "exportedAt": _iso_now(),
+                "events": [_exportable_event(event) for event in events],
+            }
+
+    @staticmethod
+    def _validate_export(data: Any) -> list[Dict[str, Any]]:
+        if not isinstance(data, dict):
+            raise FlightRecorderCorruptionError("Flight export must be an object.")
+        unexpected = set(data) - {"schema", "exportedAt", "events"}
+        if unexpected:
+            raise FlightRecorderCorruptionError(
+                f'flight export contains unexpected field "{sorted(unexpected)[0]}".'
+            )
+        if data.get("schema") != FLIGHT_EXPORT_SCHEMA:
+            raise FlightRecorderCorruptionError(
+                f'Flight export schema must be "{FLIGHT_EXPORT_SCHEMA}".'
+            )
+        _assert_iso_timestamp(data.get("exportedAt"), "flight export exportedAt")
+        if not isinstance(data.get("events"), list):
+            raise FlightRecorderCorruptionError("Flight export events must be an array.")
+        validated = []
+        event_ids: set[str] = set()
+        for index, event in enumerate(data["events"]):
+            metadata = event.get("metadata") if isinstance(event, dict) else None
+            if isinstance(metadata, dict) and (
+                "ownerPid" in metadata
+                or "ownerId" in metadata
+                or "ownerIncarnation" in metadata
+            ):
+                raise FlightRecorderCorruptionError(
+                    f"flight export events[{index}] must not claim live trace ownership."
+                )
+            validated_event = validate_flight_event(
+                    event,
+                    f"flight export events[{index}]",
+                )
+            if validated_event["id"] in event_ids:
+                raise FlightRecorderCorruptionError(
+                    f'flight export contains duplicate event ID "{validated_event["id"]}".'
+                )
+            event_ids.add(validated_event["id"])
+            validated.append(validated_event)
+        return validated
+
+    def import_(self, data: Mapping[str, Any], *, replace: bool = False) -> int:
+        events = self._validate_export(data)
+        with self._transaction() as db:
+            existing_rows = db.execute(
+                """
+                SELECT rowid, id, sequence, trace_id, timestamp,
+                       timestamp_ms, kind, source, status, session_id,
+                       workspace_id, provider_id, agent_name, tool_name,
+                       event_json
+                FROM flight_events
+                """
+            ).fetchall()
+            existing_by_id: Dict[str, Dict[str, Any]] = {}
+            existing_by_trace: Dict[str, list[Dict[str, Any]]] = {}
+            for row in existing_rows:
+                existing = self._row_to_event(row)
+                existing_by_id[existing["id"]] = existing
+                existing_by_trace.setdefault(
+                    existing["traceId"],
+                    [],
+                ).append(existing)
+            live_trace_ids: set[str] = set()
+            live_start_ids: set[str] = set()
+            for trace_id, trace_events in existing_by_trace.items():
+                unmatched: Dict[
+                    str,
+                    tuple[Optional[int], Optional[str]],
+                ] = {}
+                for existing in sorted(
+                    trace_events,
+                    key=lambda item: item["sequence"],
+                ):
+                    if existing["kind"] == "trace.started":
+                        metadata = existing.get("metadata") or {}
+                        owner_pid = metadata.get("ownerPid")
+                        unmatched[existing["id"]] = (
+                            owner_pid
+                            if isinstance(owner_pid, int)
+                            and not isinstance(owner_pid, bool)
+                            and owner_pid > 0
+                            else None,
+                            metadata.get("ownerIncarnation")
+                            if isinstance(
+                                metadata.get("ownerIncarnation"),
+                                str,
+                            )
+                            else None,
+                        )
+                    elif (
+                        existing["kind"]
+                        in {"trace.completed", "trace.failed"}
+                        and existing.get("parentId")
+                    ):
+                        unmatched.pop(existing["parentId"], None)
+                for start_id, owner in unmatched.items():
+                    if (
+                        owner[0] is not None
+                        and _process_matches_incarnation(
+                            owner[0],
+                            owner[1],
+                        )
+                    ):
+                        live_trace_ids.add(trace_id)
+                        live_start_ids.add(start_id)
+            persisted_events = []
+            for event in events:
+                existing = existing_by_id.get(event["id"])
+                if existing is not None and not replace:
+                    if (
+                        _exportable_event(existing).get(
+                            "contentHash"
+                        )
+                        != event.get("contentHash")
+                    ):
+                        raise FlightRecorderCorruptionError(
+                            f'Flight event ID "{event["id"]}" conflicts '
+                            "with existing content."
+                        )
+                    continue
+                if existing is not None:
+                    existing_trace_id = existing.get("traceId")
+                    if (
+                        isinstance(existing_trace_id, str)
+                        and existing_trace_id != event["traceId"]
+                        and existing_trace_id in live_trace_ids
+                    ):
+                        raise FlightRecorderCorruptionError(
+                            f'Cannot move event "{event["id"]}" out of '
+                            f'live trace "{existing_trace_id}".'
+                        )
+                if event["traceId"] in live_trace_ids:
+                    exact = (
+                        existing is not None
+                        and _exportable_event(existing).get(
+                            "contentHash"
+                        )
+                        == event.get("contentHash")
+                    )
+                    if not exact:
+                        raise FlightRecorderCorruptionError(
+                            f'Cannot import event "{event["id"]}" into '
+                            f'live trace "{event["traceId"]}".'
+                        )
+                persisted = event
+                if replace and existing is not None:
+                        owner_pid = (existing.get("metadata") or {}).get(
+                            "ownerPid"
+                        )
+                        owner_incarnation = (
+                            existing.get("metadata") or {}
+                        ).get("ownerIncarnation")
+                        if (
+                            existing.get("kind") == "trace.started"
+                            and isinstance(owner_pid, int)
+                            and not isinstance(owner_pid, bool)
+                            and owner_pid > 0
+                            and _process_matches_incarnation(
+                                owner_pid,
+                                (
+                                    owner_incarnation
+                                    if isinstance(
+                                        owner_incarnation,
+                                        str,
+                                    )
+                                    else None
+                                ),
+                            )
+                            and existing.get("id") in live_start_ids
+                        ):
+                            if (
+                                event["kind"] != "trace.started"
+                                or event["traceId"] != existing.get("traceId")
+                                or event["sequence"]
+                                != existing.get("sequence")
+                                or _exportable_event(existing).get(
+                                    "contentHash"
+                                )
+                                != event.get("contentHash")
+                            ):
+                                raise FlightRecorderCorruptionError(
+                                    f'Cannot replace live trace start "{event["id"]}" '
+                                    "with different portable content."
+                                )
+                            persisted = dict(event)
+                            metadata = dict(event.get("metadata") or {})
+                            metadata["ownerPid"] = owner_pid
+                            if isinstance(owner_incarnation, str):
+                                metadata["ownerIncarnation"] = (
+                                    owner_incarnation
+                                )
+                            if "ownerId" in (existing.get("metadata") or {}):
+                                metadata["ownerId"] = existing["metadata"][
+                                    "ownerId"
+                                ]
+                            persisted["metadata"] = metadata
+                            persisted["contentHash"] = (
+                                compute_flight_event_hash(persisted)
+                            )
+                persisted_events.append(persisted)
+            if replace:
+                for event in persisted_events:
+                    db.execute(
+                        "DELETE FROM flight_events WHERE id = ?",
+                        (event["id"],),
+                    )
+            imported = 0
+            sql = self._insert_sql(False)
+            for event in persisted_events:
+                cursor = db.execute(
+                    sql,
+                    self._parameters(event, _portable_json(event)),
+                )
+                imported += cursor.rowcount
+        if replace and imported > 0:
+            self._purge_deleted_pages(vacuum=False)
+        return imported
+
+    import_bundle = import_
+    import_data = import_
+
+    def clear(self) -> None:
+        with self._transaction() as db:
+            rows = db.execute(
+                """
+                SELECT rowid, id, sequence, trace_id, timestamp,
+                       timestamp_ms, kind, source, status, session_id,
+                       workspace_id, provider_id, agent_name, tool_name,
+                       event_json
+                FROM flight_events
+                ORDER BY trace_id, sequence, rowid
+                """
+            ).fetchall()
+            owners: Dict[
+                str,
+                Dict[str, tuple[Optional[int], Optional[str]]],
+            ] = {}
+            for row in rows:
+                event = self._row_to_event(row)
+                trace_id = event["traceId"]
+                kind = event["kind"]
+                if kind not in {
+                    "trace.started",
+                    "trace.completed",
+                    "trace.failed",
+                }:
+                    continue
+                starts = owners.setdefault(trace_id, {})
+                if kind == "trace.started":
+                    event_id = event["id"]
+                    owner_pid = event["metadata"].get("ownerPid")
+                    owner_incarnation = event["metadata"].get(
+                        "ownerIncarnation"
+                    )
+                    if event_id is not None:
+                        starts[event_id] = (
+                            owner_pid,
+                            owner_incarnation,
+                        )
+                else:
+                    parent_id = event.get("parentId")
+                    if parent_id is not None:
+                        starts.pop(parent_id, None)
+            if any(
+                any(
+                    owner_pid is not None
+                    and _process_matches_incarnation(
+                        owner_pid,
+                        owner_incarnation,
+                    )
+                    for owner_pid, owner_incarnation in starts.values()
+                )
+                for starts in owners.values()
+            ):
+                raise FlightRecorderError(
+                    "Flight ledger cannot clear while active traces exist."
+                )
+            db.execute("DELETE FROM flight_events")
+        self._purge_deleted_pages(vacuum=True)
+
+    def release_event_ownership(self, event_id: str) -> None:
+        with self._lock:
+            db = self._ensure_db()
+            db.execute(
+                f"PRAGMA busy_timeout = {RUNTIME_BUSY_TIMEOUT_MS}"
+            )
+            try:
+                db.execute("BEGIN IMMEDIATE")
+                try:
+                    row = db.execute(
+                        """
+                        SELECT rowid, id, sequence, trace_id, timestamp,
+                               timestamp_ms, kind, source, status,
+                               session_id, workspace_id, provider_id,
+                               agent_name, tool_name, event_json
+                        FROM flight_events
+                        WHERE id = ?
+                        """,
+                        (event_id,),
+                    ).fetchone()
+                    if row is not None:
+                        event = self._row_to_event(row)
+                        metadata = dict(event.get("metadata") or {})
+                        if (
+                            "ownerPid" in metadata
+                            or "ownerId" in metadata
+                            or "ownerIncarnation" in metadata
+                        ):
+                            metadata.pop("ownerPid", None)
+                            metadata.pop("ownerId", None)
+                            metadata.pop("ownerIncarnation", None)
+                            event["metadata"] = metadata
+                            event["contentHash"] = (
+                                compute_flight_event_hash(event)
+                            )
+                            db.execute(
+                                "UPDATE flight_events "
+                                "SET event_json = ? WHERE id = ?",
+                                (_portable_json(event), event_id),
+                            )
+                    db.execute("COMMIT")
+                except Exception:
+                    db.execute("ROLLBACK")
+                    raise
+            finally:
+                db.execute(
+                    f"PRAGMA busy_timeout = {BUSY_TIMEOUT_MS}"
+                )
+
+    def _purge_deleted_pages(self, *, vacuum: bool) -> None:
+        with self._lock:
+            db = self._ensure_db()
+            self._checkpoint_wal(db)
+            if vacuum:
+                db.execute("VACUUM")
+                self._checkpoint_wal(db)
+
+    @staticmethod
+    def _checkpoint_wal(db: sqlite3.Connection) -> None:
+        for attempt in range(MAX_BUSY_RETRIES + 1):
+            row = db.execute("PRAGMA wal_checkpoint(TRUNCATE)").fetchone()
+            if row is not None and int(row[0]) == 0:
+                return
+            if attempt < MAX_BUSY_RETRIES:
+                time.sleep(0.025 * (attempt + 1))
+        raise FlightRecorderError(
+            "WAL checkpoint did not complete; deleted data may remain."
+        )
+
+    @contextmanager
+    def _transaction(
+        self,
+        *,
+        immediate: bool = True,
+    ) -> Iterator[sqlite3.Connection]:
+        with self._lock:
+            db = self._ensure_db()
+            db.execute("BEGIN IMMEDIATE" if immediate else "BEGIN")
+            try:
+                yield db
+            except Exception:
+                db.execute("ROLLBACK")
+                raise
+            else:
+                db.execute("COMMIT")
+
+
+class FlightRecorder:
+    """Fail-open runtime facade around a Flight Recorder ledger."""
+
+    def __init__(
+        self,
+        options: Optional[Mapping[str, Any]] = None,
+        ledger: Optional[Any] = None,
+        *,
+        enabled: Optional[bool] = None,
+        database_path: Optional[str | os.PathLike[str]] = None,
+        in_memory: Optional[bool] = None,
+        privacy: Optional[Mapping[str, Any]] = None,
+        retention_events: Optional[int] = None,
+        identity_key: Optional[str] = None,
+    ) -> None:
+        options = dict(options or {})
+        self.enabled = bool(
+            enabled if enabled is not None else options.get("enabled", True)
+        )
+        configured_database_path = (
+            database_path
+            if database_path is not None
+            else options.get("databasePath", options.get("database_path"))
+        )
+        self._manages_database_parent = configured_database_path is None
+        self.database_path = str(
+            configured_database_path
+            if configured_database_path is not None
+            else Path.home() / ".openrappter" / "flight-recorder.db"
+        )
+        self.in_memory = bool(
+            in_memory
+            if in_memory is not None
+            else options.get("inMemory", options.get("in_memory", False))
+        )
+        self.privacy = dict(
+            privacy if privacy is not None else options.get("privacy", {})
+        )
+        self.retention_events = (
+            retention_events
+            if retention_events is not None
+            else options.get(
+                "retentionEvents",
+                options.get("retention_events", DEFAULT_RETENTION_EVENTS),
+            )
+        )
+        self._ledger = ledger
+        self._identity_key = (
+            identity_key
+            if identity_key is not None
+            else options.get("identityKey", options.get("identity_key"))
+        )
+        self._initialized = False
+        self._error_count = 0
+        self._last_error: Optional[str] = None
+        self._initialization_error: Optional[str] = None
+        self._trace_context: contextvars.ContextVar[Optional[Dict[str, Any]]] = (
+            contextvars.ContextVar("openrappter_flight_trace", default=None)
+        )
+        self._sequence_by_trace: Dict[str, int] = {}
+        self._sequence_lock = threading.RLock()
+        self._sequence_in_flight: set[str] = set()
+        self._initialization_condition = threading.Condition(threading.RLock())
+        self._initializing = False
+        self._next_initialization_attempt_at = 0.0
+        self._initialization_waiters = 0
+        self._closing = False
+        self._clearing = False
+        self._last_clear_result = True
+        self._last_clear_error: Optional[BaseException] = None
+        self._active_trace_operations = 0
+        self._closed = False
+        self._owner_id = str(uuid.uuid4())
+        self._owner_path: Optional[Path] = None
+        self._retained_event_count = 0
+        self._next_retention_check_count = 0
+        _RECORDER_INSTANCES.add(self)
+
+    def _note_error(self, error: BaseException) -> None:
+        self._error_count += 1
+        try:
+            error_name = error.__class__.__name__
+        except Exception:
+            error_name = "UnknownError"
+        try:
+            message = str(error)
+        except Exception:
+            message = "[unavailable]"
+        self._last_error = f"{error_name}: {message}"
+
+    def initialize(self) -> None:
+        if (
+            not self.enabled
+            or self._closed
+            or self._closing
+            or time.monotonic() < self._next_initialization_attempt_at
+        ):
+            return
+        with self._initialization_condition:
+            while self._initializing or self._closing:
+                self._initialization_waiters += 1
+                try:
+                    self._initialization_condition.wait()
+                finally:
+                    self._initialization_waiters -= 1
+            if time.monotonic() < self._next_initialization_attempt_at:
+                return
+            if self._closed or self._closing or self._initialized:
+                return
+            self._initializing = True
+        try:
+            creates_ledger = self._ledger is None
+            if self._ledger is None:
+                if not self.in_memory:
+                    directory = Path(self.database_path).expanduser().parent
+                    if self._manages_database_parent:
+                        _prepare_managed_database_directory(directory)
+                    else:
+                        directory.mkdir(
+                            parents=True,
+                            exist_ok=True,
+                            mode=0o700,
+                        )
+                        _assert_private_directory(directory)
+                    self._owner_path = _register_recorder_owner(
+                        self.database_path,
+                        self._owner_id,
+                    )
+                self._ledger = SQLiteFlightLedger(
+                    database_path=str(Path(self.database_path).expanduser()),
+                    in_memory=self.in_memory,
+                )
+            if self.in_memory or not creates_ledger:
+                self._identity_key = (
+                    self._identity_key
+                    or os.urandom(32).hex()
+                )
+            self._ledger.initialize()
+            if self._closed:
+                self._ledger.close()
+                return
+            self._retained_event_count = self._ledger.count()
+            if not self.in_memory and creates_ledger:
+                self._identity_key = _load_or_create_identity_key(
+                    self.database_path,
+                    self._identity_key,
+                    self._retained_event_count == 0,
+                )
+            if (
+                not self._identity_key
+                or re.fullmatch(
+                    r"[0-9a-fA-F]{64}",
+                    self._identity_key,
+                )
+                is None
+            ):
+                raise ValueError(
+                    "Flight Recorder identity key must be 32-byte hexadecimal."
+                )
+            bind_identity_key = getattr(
+                self._ledger,
+                "bind_identity_key",
+                None,
+            )
+            if callable(bind_identity_key):
+                bind_identity_key(self._identity_key)
+            redacted_values = list(
+                _privacy_value(
+                    self.privacy,
+                    "redactedValues",
+                    "redacted_values",
+                    default=(),
+                )
+                or ()
+            )
+            if self._identity_key not in redacted_values:
+                redacted_values.append(self._identity_key)
+            self.privacy["redactedValues"] = redacted_values
+            self._next_retention_check_count = self.retention_events + 1
+            if not self.in_memory and creates_ledger:
+                database = Path(self.database_path).expanduser()
+                if database.exists():
+                    _harden_private_path(database)
+            self._initialized = True
+            self._next_initialization_attempt_at = 0.0
+            self._last_error = None
+            self._initialization_error = None
+        except Exception as exc:
+            if creates_ledger and self._ledger is not None:
+                try:
+                    self._ledger.close()
+                except Exception:
+                    pass
+                self._ledger = None
+            _unregister_recorder_owner(self._owner_path)
+            self._owner_path = None
+            self._initialized = False
+            self._note_error(exc)
+            self._next_initialization_attempt_at = time.monotonic() + 1.0
+            self._initialization_error = self._last_error
+        finally:
+            with self._initialization_condition:
+                self._initializing = False
+                self._initialization_condition.notify_all()
+
+    def close(self) -> None:
+        if self.current_trace():
+            raise FlightRecorderError(
+                "Flight Recorder cannot close from inside an active trace."
+            )
+        try:
+            asyncio.get_running_loop()
+            running_loop = True
+        except RuntimeError:
+            running_loop = False
+        if running_loop:
+            raise FlightRecorderError(
+                "Flight Recorder close would block the active "
+                "event loop; use 'await recorder.aclose()'."
+            )
+        with self._initialization_condition:
+            if self._closing:
+                while self._closing:
+                    self._initialization_waiters += 1
+                    try:
+                        self._initialization_condition.wait()
+                    finally:
+                        self._initialization_waiters -= 1
+                return
+            if self._closed:
+                return
+            self._closing = True
+            while (
+                self._initializing
+                or self._active_trace_operations > 0
+                or self._clearing
+            ):
+                self._initialization_waiters += 1
+                try:
+                    self._initialization_condition.wait()
+                finally:
+                    self._initialization_waiters -= 1
+            self._closed = True
+        try:
+            with self._sequence_lock:
+                if self._ledger is not None:
+                    self._ledger.close()
+                self._sequence_by_trace.clear()
+                self._sequence_in_flight.clear()
+                self._retained_event_count = 0
+                self._next_retention_check_count = 0
+                _unregister_recorder_owner(self._owner_path)
+                self._owner_path = None
+        except Exception as exc:
+            self._note_error(exc)
+        finally:
+            with self._initialization_condition:
+                self._initialized = False
+                self._initializing = False
+                self._closing = False
+                self._initialization_condition.notify_all()
+
+    async def aclose(self) -> None:
+        if self.current_trace():
+            raise FlightRecorderError(
+                "Flight Recorder cannot close from inside an active trace."
+            )
+        await asyncio.to_thread(self.close)
+
+    def current_trace(self) -> Optional[Dict[str, Any]]:
+        context = self._current_trace_state()
+        if not context:
+            return None
+        return {
+            key: value
+            for key, value in context.items()
+            if key != "_generation"
+        }
+
+    def _current_trace_state(self) -> Optional[Dict[str, Any]]:
+        context = self._trace_context.get()
+        if not context:
+            return None
+        generation = context.get("_generation")
+        if isinstance(generation, dict) and not generation.get(
+            "active",
+            False,
+        ):
+            return None
+        return context
+
+    def _raise_unhealthy_inspection(self) -> None:
+        if not self.enabled:
+            raise FlightRecorderUnhealthyError("Flight Recorder is disabled.")
+        if self._closed:
+            raise FlightRecorderUnhealthyError("Flight Recorder is closed.")
+        if self.enabled and self._initialization_error is not None:
+            raise FlightRecorderUnhealthyError(
+                f"Flight Recorder is unhealthy: {self._initialization_error}"
+            )
+        if not self._initialized or self._ledger is None:
+            raise FlightRecorderUnhealthyError(
+                "Flight Recorder is unavailable."
+            )
+
+    def with_parent(self, parent_id: Optional[str], operation: Callable[[], Any]) -> Any:
+        current = self._current_trace_state()
+        if current is None:
+            return operation()
+        parent_context = {
+            **current,
+            "parentId": parent_id,
+        }
+        token = self._trace_context.set(parent_context)
+        try:
+            result = operation()
+        except BaseException:
+            self._trace_context.reset(token)
+            raise
+        if inspect.isawaitable(result):
+            self._trace_context.reset(token)
+
+            async def await_result():
+                async_token = self._trace_context.set(parent_context)
+                try:
+                    return await result
+                finally:
+                    self._trace_context.reset(async_token)
+
+            return await_result()
+        self._trace_context.reset(token)
+        return result
+
+    @contextmanager
+    def trace(self, context: Optional[Mapping[str, Any]] = None) -> Iterator[Dict[str, Any]]:
+        context = dict(context or {})
+        inherited = self.current_trace()
+        trace_id = _private_identifier(
+            context.get("traceId")
+            or (inherited or {}).get("traceId")
+            or str(uuid.uuid4()),
+            self.privacy,
+            "trace",
+            "traceId",
+        )
+        trace_context = {
+            "traceId": trace_id,
+            "parentId": context.get(
+                "parentId", (inherited or {}).get("parentId")
+            ),
+        }
+        generation = {"active": True}
+        trace_context["_generation"] = generation
+        for key in ("sessionId", "workspaceId"):
+            value = context.get(key, (inherited or {}).get(key))
+            if value is not None:
+                if key == "workspaceId":
+                    value = normalize_flight_workspace_id(
+                        _private_identifier(
+                            value,
+                            self.privacy,
+                            "workspace",
+                            "workspaceId",
+                        )
+                    )
+                trace_context[key] = value
+        token = self._trace_context.set(trace_context)
+        try:
+            yield {
+                key: value
+                for key, value in trace_context.items()
+                if key != "_generation"
+            }
+        finally:
+            generation["active"] = False
+            self._trace_context.reset(token)
+
+    def run_trace(
+        self,
+        context: Optional[Mapping[str, Any]],
+        operation: Callable[[], Any],
+    ) -> Any:
+        inherited = self.current_trace()
+        context_data = dict(context or {})
+        inherited_trace_id = (inherited or {}).get("traceId")
+        trace_id = (
+            inherited_trace_id
+            if inherited_trace_id is not None
+            else _private_identifier(
+                context_data.get("traceId")
+                or str(uuid.uuid4()),
+                self.privacy,
+                "trace",
+                "traceId",
+            )
+        )
+        generation = {"active": True}
+        trace_state: Dict[str, Any] = {
+            "traceId": trace_id,
+            "parentId": context_data.get(
+                "parentId",
+                (inherited or {}).get("parentId"),
+            ),
+            "_generation": generation,
+        }
+        session_id = context_data.get(
+            "sessionId",
+            (inherited or {}).get("sessionId"),
+        )
+        if session_id is not None:
+            if not isinstance(session_id, str):
+                session_id = str(session_id)
+            trace_state["sessionId"] = (
+                normalize_flight_session_id(
+                    session_id,
+                    self._identity_key,
+                    _privacy_value(
+                        self.privacy,
+                        "redactedValues",
+                        "redacted_values",
+                        default=(),
+                    )
+                    or (),
+                )
+                if self._identity_key
+                else session_id
+            )
+        workspace_id = context_data.get(
+            "workspaceId",
+            (inherited or {}).get("workspaceId"),
+        )
+        if workspace_id is not None:
+            trace_state["workspaceId"] = normalize_flight_workspace_id(
+                _private_identifier(
+                    workspace_id,
+                    self.privacy,
+                    "workspace",
+                    "workspaceId",
+                )
+            )
+
+        with self._initialization_condition:
+            if (
+                not inherited
+                and (self._closed or self._closing or self._clearing)
+            ):
+                return operation()
+            self._active_trace_operations += 1
+
+        finished = False
+
+        def finish_trace() -> None:
+            nonlocal finished
+            if finished:
+                return
+            finished = True
+            generation["active"] = False
+            with self._sequence_lock:
+                self._sequence_by_trace.pop(trace_id, None)
+            with self._initialization_condition:
+                self._active_trace_operations -= 1
+                self._initialization_condition.notify_all()
+
+        started = time.monotonic()
+        root_token = self._trace_context.set(trace_state)
+        try:
+            root = self.record(
+                {
+                    "kind": "trace.started",
+                    "source": "runtime",
+                    "status": "started",
+                    "metadata": {"nested": bool(inherited)},
+                }
+            )
+        finally:
+            self._trace_context.reset(root_token)
+        operation_state = {
+            **trace_state,
+            "parentId": root.get("id") if root is not None else None,
+        }
+
+        def record_failure(exc: BaseException) -> None:
+            if root is None:
+                return
+            terminal = self.record(
+                {
+                    "kind": "trace.failed",
+                    "source": "runtime",
+                    "status": "error",
+                    "durationMs": (
+                        time.monotonic() - started
+                    )
+                    * 1000,
+                    "metadata": summarize_flight_error(exc),
+                    "payload": {"error": exc},
+                }
+            )
+            if terminal is None:
+                self._release_start_ownership(root["id"])
+
+        def record_success() -> None:
+            if root is None:
+                return
+            terminal = self.record(
+                {
+                    "kind": "trace.completed",
+                    "source": "runtime",
+                    "status": "success",
+                    "durationMs": (
+                        time.monotonic() - started
+                    )
+                    * 1000,
+                }
+            )
+            if terminal is None:
+                self._release_start_ownership(root["id"])
+
+        operation_token = self._trace_context.set(operation_state)
+        try:
+            try:
+                result = operation()
+            except BaseException as exc:
+                record_failure(exc)
+                raise
+        except BaseException:
+            finish_trace()
+            raise
+        finally:
+            self._trace_context.reset(operation_token)
+
+        if inspect.isawaitable(result):
+            async def await_result():
+                token = self._trace_context.set(operation_state)
+                try:
+                    try:
+                        value = await result
+                    except BaseException as exc:
+                        record_failure(exc)
+                        raise
+                    record_success()
+                    return value
+                finally:
+                    self._trace_context.reset(token)
+                    finish_trace()
+
+            return await_result()
+
+        token = self._trace_context.set(operation_state)
+        try:
+            record_success()
+            return result
+        finally:
+            self._trace_context.reset(token)
+            finish_trace()
+
+    def _last_sequence(self, trace_id: str) -> int:
+        latest_sequence = getattr(
+            self._ledger,
+            "last_sequence",
+            None,
+        )
+        if callable(latest_sequence):
+            return int(latest_sequence(trace_id))
+        latest = self._ledger.query(
+            {"traceId": trace_id, "order": "desc", "limit": 1}
+        )
+        return latest[0]["sequence"] if latest else 0
+
+    def _release_start_ownership(self, event_id: str) -> None:
+        try:
+            release = getattr(
+                self._ledger,
+                "release_event_ownership",
+                None,
+            )
+            if callable(release):
+                release(event_id)
+        except Exception as exc:
+            self._note_error(exc)
+
+    def _enforce_retention(self, force: bool = False) -> None:
+        high_water = self.retention_events
+        if (
+            high_water < 0
+            or self._retained_event_count <= high_water
+            or (
+                not force
+                and self._retained_event_count < self._next_retention_check_count
+            )
+        ):
+            return
+        batch = max(1, math.ceil(high_water * 0.1))
+        target = max(0, high_water - batch) if high_water > 100 else high_water
+        prune_runtime = getattr(
+            self._ledger,
+            "prune_runtime",
+            None,
+        )
+        deleted = (
+            prune_runtime(target)
+            if callable(prune_runtime)
+            else self._ledger.prune(target)
+        )
+        self._retained_event_count = max(
+            0, self._retained_event_count - deleted
+        )
+        self._next_retention_check_count = (
+            self._retained_event_count + batch
+            if self._retained_event_count > high_water
+            else high_water + 1
+        )
+
+    def record(
+        self,
+        event_input: Optional[Mapping[str, Any]] = None,
+        **kwargs: Any,
+    ) -> Optional[Dict[str, Any]]:
+        if (
+            not self.enabled
+            or self._closed
+            or (
+                (self._closing or self._clearing)
+                and not self.current_trace()
+            )
+        ):
+            return None
+        if not self._initialized or self._ledger is None:
+            self.initialize()
+            if not self._initialized or self._ledger is None:
+                return None
+        data = dict(event_input or {})
+        data.update(kwargs)
+        aliases = {
+            "trace_id": "traceId",
+            "parent_id": "parentId",
+            "session_id": "sessionId",
+            "workspace_id": "workspaceId",
+            "provider_id": "providerId",
+            "agent_name": "agentName",
+            "tool_name": "toolName",
+            "duration_ms": "durationMs",
+        }
+        for old, new in aliases.items():
+            if old in data and new not in data:
+                data[new] = data.pop(old)
+        context = self.current_trace() or {}
+        trace_id = _private_identifier(
+            data.get("traceId")
+            or context.get("traceId")
+            or str(uuid.uuid4()),
+            self.privacy,
+            "trace",
+            "traceId",
+        )
+        try:
+            with self._sequence_lock:
+                if self._clearing and not context:
+                    return None
+                self._sequence_in_flight.add(trace_id)
+                try:
+                    conflict_attempt = 0
+                    while not self._closed:
+                        previous = self._sequence_by_trace.get(trace_id)
+                        if previous is None:
+                            previous = self._last_sequence(trace_id)
+                        sequence = previous + 1
+                        event: Dict[str, Any] = {
+                            "schema": FLIGHT_EVENT_SCHEMA,
+                            "id": _private_identifier(
+                                str(uuid.uuid4()),
+                                self.privacy,
+                                "event",
+                                "id",
+                            ),
+                            "sequence": sequence,
+                            "traceId": trace_id,
+                            "parentId": _private_identifier(
+                                data.get(
+                                    "parentId",
+                                    context.get("parentId"),
+                                ),
+                                self.privacy,
+                                "event",
+                                "parentId",
+                            ),
+                            "kind": _private_identifier(
+                                data["kind"],
+                                self.privacy,
+                                "kind",
+                                "kind",
+                            ),
+                            "source": _private_identifier(
+                                data["source"],
+                                self.privacy,
+                                "source",
+                                "source",
+                            ),
+                            "status": data.get("status", "info"),
+                            "timestamp": data.get("timestamp", _iso_now()),
+                            "metadata": sanitize_flight_metadata(
+                                data.get("metadata"), self.privacy
+                            ),
+                        }
+                        event["metadata"].pop("ownerPid", None)
+                        event["metadata"].pop("ownerId", None)
+                        event["metadata"].pop("ownerIncarnation", None)
+                        if (
+                            data["kind"] == "trace.started"
+                            and data["source"] == "runtime"
+                        ):
+                            event["metadata"]["ownerPid"] = os.getpid()
+                            incarnation = _current_process_incarnation()
+                            if incarnation:
+                                event["metadata"][
+                                    "ownerIncarnation"
+                                ] = incarnation
+                        for key in (
+                            "sessionId",
+                            "workspaceId",
+                            "providerId",
+                            "model",
+                            "agentName",
+                            "toolName",
+                            "durationMs",
+                        ):
+                            value = data.get(key, context.get(key))
+                            if key == "model":
+                                value = (
+                                    normalize_flight_model_id(value)
+                                    if sanitize_flight_metadata(
+                                        {"model": value},
+                                        self.privacy,
+                                    ).get("model")
+                                    == value
+                                    and sanitize_flight_value(
+                                        value, self.privacy
+                                    ) == value
+                                    else None
+                                )
+                            if value is not None:
+                                if key == "sessionId":
+                                    value = normalize_flight_session_id(
+                                        value,
+                                        self._identity_key,
+                                        _privacy_value(
+                                            self.privacy,
+                                            "redactedValues",
+                                            "redacted_values",
+                                            default=(),
+                                        )
+                                        or (),
+                                    )
+                                elif key == "workspaceId":
+                                    value = normalize_flight_workspace_id(
+                                        _private_identifier(
+                                            value,
+                                            self.privacy,
+                                            "workspace",
+                                            "workspaceId",
+                                        )
+                                    )
+                                elif key in {
+                                    "providerId",
+                                    "agentName",
+                                    "toolName",
+                                }:
+                                    value = _private_identifier(
+                                        value,
+                                        self.privacy,
+                                        {
+                                            "providerId": "provider",
+                                            "agentName": "agent",
+                                            "toolName": "tool",
+                                        }[key],
+                                        key,
+                                    )
+                                event[key] = value
+                        if _privacy_value(
+                            self.privacy, "recordIO", "record_io", default=False
+                        ) is True:
+                            event["payload"] = sanitize_flight_payload(
+                                data.get("payload"), self.privacy
+                            )
+                        event["contentHash"] = compute_flight_event_hash(event)
+                        try:
+                            self._ledger.append(event)
+                        except sqlite3.IntegrityError as exc:
+                            if "trace_id, flight_events.sequence" not in str(exc):
+                                raise
+                            self._sequence_by_trace.pop(trace_id, None)
+                            conflict_attempt += 1
+                            time.sleep(min(conflict_attempt / 1000, 0.01))
+                            continue
+                        self._sequence_by_trace[trace_id] = sequence
+                        try:
+                            self._retained_event_count = self._ledger.count()
+                            self._enforce_retention(
+                                data["kind"] in {"trace.completed", "trace.failed"}
+                            )
+                        except Exception as exc:
+                            # The append is already durable; preserve its ID and
+                            # sequence while surfacing maintenance health.
+                            self._note_error(exc)
+                        return event
+                finally:
+                    self._sequence_in_flight.discard(trace_id)
+                    if not context or context.get("traceId") != trace_id:
+                        self._sequence_by_trace.pop(trace_id, None)
+        except Exception as exc:
+            self._note_error(exc)
+            return None
+        return None
+
+    def query(self, query: Optional[Mapping[str, Any]] = None, **filters: Any) -> list[Dict[str, Any]]:
+        if not self._initialized or self._ledger is None:
+            self._raise_unhealthy_inspection()
+            return []
+        try:
+            normalized_query = _normalize_flight_query(
+                query,
+                filters,
+                self._identity_key,
+                self.privacy,
+            )
+            return self._ledger.query(normalized_query)
+        except Exception as exc:
+            self._note_error(exc)
+            raise
+
+    def count(self) -> int:
+        if not self.enabled or self._closed:
+            self._raise_unhealthy_inspection()
+        if not self._initialized or self._ledger is None:
+            self._raise_unhealthy_inspection()
+        try:
+            return self._ledger.count()
+        except Exception as exc:
+            self._note_error(exc)
+            raise
+
+    def prune(self, keep: int) -> int:
+        if not self.enabled or self._closed:
+            self._raise_unhealthy_inspection()
+        if not self._initialized or self._ledger is None:
+            self._raise_unhealthy_inspection()
+        try:
+            with self._sequence_lock:
+                deleted = self._ledger.prune(keep)
+                self._retained_event_count = max(
+                    0, self._retained_event_count - deleted
+                )
+                return deleted
+        except Exception as exc:
+            self._note_error(exc)
+            raise
+
+    def export(self, query: Optional[Mapping[str, Any]] = None) -> Optional[Dict[str, Any]]:
+        if not self._initialized or self._ledger is None:
+            self._raise_unhealthy_inspection()
+            return None
+        try:
+            normalized_query = _normalize_flight_query(
+                query,
+                identity_key=self._identity_key,
+                privacy=self.privacy,
+            )
+            return self._ledger.export(normalized_query)
+        except Exception as exc:
+            self._note_error(exc)
+            raise
+
+    def export_trace(self, trace_id: str) -> Optional[Dict[str, Any]]:
+        return self.export({"traceId": trace_id})
+
+    def import_(self, data: Mapping[str, Any], *, replace: bool = False) -> int:
+        if not self._initialized or self._ledger is None:
+            self._raise_unhealthy_inspection()
+            return 0
+        try:
+            with self._sequence_lock:
+                if self._closing or self._closed:
+                    raise FlightRecorderError(
+                        "Flight Recorder close is in progress."
+                    )
+                if self._clearing and not self.current_trace():
+                    raise FlightRecorderError(
+                        "Flight Recorder clear is in progress."
+                    )
+                for event in data.get("events", []):
+                    for key, prefix in (
+                        ("id", "event"),
+                        ("kind", "kind"),
+                        ("source", "source"),
+                        ("traceId", "trace"),
+                        ("parentId", "event"),
+                        ("providerId", "provider"),
+                        ("agentName", "agent"),
+                        ("toolName", "tool"),
+                    ):
+                        value = event.get(key)
+                        if (
+                            isinstance(value, str)
+                            and _private_identifier(
+                                value,
+                                self.privacy,
+                                prefix,
+                                key,
+                            )
+                            != value
+                        ):
+                            raise FlightRecorderCorruptionError(
+                                f"Flight Recorder import {key} violates active privacy policy."
+                            )
+                    session_id = event.get("sessionId")
+                    if (
+                        isinstance(session_id, str)
+                        and normalize_flight_session_id(
+                            session_id,
+                            self._identity_key,
+                            _privacy_value(
+                                self.privacy,
+                                "redactedValues",
+                                "redacted_values",
+                                default=(),
+                            )
+                            or (),
+                        )
+                        != session_id
+                    ):
+                        raise FlightRecorderCorruptionError(
+                            "Flight Recorder import sessionId violates "
+                            "active privacy policy."
+                        )
+                    workspace_id = event.get("workspaceId")
+                    if (
+                        isinstance(workspace_id, str)
+                        and normalize_flight_workspace_id(
+                            _private_identifier(
+                                workspace_id,
+                                self.privacy,
+                                "workspace",
+                                "workspaceId",
+                            )
+                        )
+                        != workspace_id
+                    ):
+                        raise FlightRecorderCorruptionError(
+                            "Flight Recorder import workspaceId violates active privacy policy."
+                        )
+                    model = event.get("model")
+                    if (
+                        isinstance(model, str)
+                        and (
+                            sanitize_flight_metadata(
+                                {"model": model},
+                                self.privacy,
+                            ).get("model")
+                            != model
+                            or sanitize_flight_value(
+                                model,
+                                self.privacy,
+                            )
+                            != model
+                        )
+                    ):
+                        raise FlightRecorderCorruptionError(
+                            "Flight Recorder import model violates active privacy policy."
+                        )
+                    if (
+                        sanitize_flight_metadata(
+                            event.get("metadata"),
+                            self.privacy,
+                        )
+                        != event.get("metadata")
+                    ):
+                        raise FlightRecorderCorruptionError(
+                            "Flight Recorder import metadata violates active privacy policy."
+                        )
+                    if "payload" in event:
+                        if (
+                            _privacy_value(
+                                self.privacy,
+                                "recordIO",
+                                "record_io",
+                                default=False,
+                            )
+                            is not True
+                        ):
+                            raise FlightRecorderCorruptionError(
+                                "Flight Recorder import contains payload IO while recordIO is disabled."
+                            )
+                        payload_privacy = {
+                            **self.privacy,
+                            "recordIO": True,
+                        }
+                        if (
+                            sanitize_flight_payload(
+                                event["payload"],
+                                payload_privacy,
+                            )
+                            != event["payload"]
+                        ):
+                            raise FlightRecorderCorruptionError(
+                                "Flight Recorder import payload violates active privacy policy."
+                            )
+                imported = self._ledger.import_(data, replace=replace)
+                self._sequence_by_trace.clear()
+                self._retained_event_count = self._ledger.count()
+                self._next_retention_check_count = self.retention_events + 1
+                return imported
+        except Exception as exc:
+            self._note_error(exc)
+            raise
+
+    import_bundle = import_
+    import_data = import_
+
+    def clear(self) -> bool:
+        if not self._initialized or self._ledger is None:
+            self._raise_unhealthy_inspection()
+            return False
+        if self.current_trace():
+            raise FlightRecorderError(
+                "Flight Recorder cannot clear from inside an active trace."
+            )
+        try:
+            asyncio.get_running_loop()
+            running_loop = True
+        except RuntimeError:
+            running_loop = False
+        if running_loop:
+            raise FlightRecorderError(
+                "Flight Recorder clear would block the active "
+                "event loop; use 'await recorder.aclear()'."
+            )
+        with self._initialization_condition:
+            if self._closing or self._closed:
+                raise FlightRecorderError(
+                    "Flight Recorder close is in progress."
+                )
+            if self._clearing:
+                while self._clearing:
+                    self._initialization_waiters += 1
+                    try:
+                        self._initialization_condition.wait()
+                    finally:
+                        self._initialization_waiters -= 1
+                if self._last_clear_error is not None:
+                    raise self._last_clear_error
+                return self._last_clear_result
+            self._clearing = True
+            self._last_clear_error = None
+            while self._active_trace_operations > 0:
+                self._initialization_waiters += 1
+                try:
+                    self._initialization_condition.wait()
+                finally:
+                    self._initialization_waiters -= 1
+        try:
+            with self._sequence_lock:
+                self._ledger.clear()
+                self._sequence_by_trace.clear()
+                self._retained_event_count = 0
+                self._next_retention_check_count = self.retention_events + 1
+                self._last_clear_result = True
+                return True
+        except Exception as exc:
+            self._note_error(exc)
+            self._last_clear_error = exc
+            raise
+        finally:
+            with self._initialization_condition:
+                self._clearing = False
+                self._initialization_condition.notify_all()
+
+    async def aclear(self) -> bool:
+        if self.current_trace():
+            raise FlightRecorderError(
+                "Flight Recorder cannot clear from inside an active trace."
+            )
+        return await asyncio.to_thread(self.clear)
+
+    def health(self) -> Dict[str, Any]:
+        event_count = 0
+        if self.enabled and self._initialized and not self._closed:
+            try:
+                event_count = self.count()
+            except Exception as exc:
+                self._note_error(exc)
+        health = {
+            "enabled": self.enabled,
+            "initialized": self._initialized,
+            "eventCount": event_count,
+            "errorCount": self._error_count,
+            "databasePath": ":memory:" if self.in_memory else self.database_path,
+        }
+        if self._last_error is not None:
+            health["lastError"] = self._last_error
+        return health
+
+    def _mark_forked_child(self) -> None:
+        self._owner_path = None
+        self._ledger = None
+        self._initialized = False
+        self._closed = True
+        self._closing = False
+        self._clearing = False
+        self._sequence_by_trace = {}
+        self._sequence_in_flight = set()
+        self._sequence_lock = threading.RLock()
+        self._initialization_condition = threading.Condition(
+            threading.RLock()
+        )
+        self._trace_context = contextvars.ContextVar(
+            "openrappter_flight_trace",
+            default=None,
+        )
+
+
+_global_lock = threading.RLock()
+_global_recorder = FlightRecorder(enabled=False)
+_environment_configured = False
+_explicit_global = False
+
+
+def _reset_flight_recorder_after_fork() -> None:
+    global _global_lock, _global_recorder
+    global _environment_configured, _explicit_global
+    _PROCESS_OWNER_PATHS.clear()
+    for recorder in list(_RECORDER_INSTANCES):
+        recorder._mark_forked_child()
+    _global_recorder = FlightRecorder(enabled=False)
+    _global_lock = threading.RLock()
+    _environment_configured = False
+    _explicit_global = False
+
+
+if hasattr(os, "register_at_fork"):
+    os.register_at_fork(after_in_child=_reset_flight_recorder_after_fork)
+
+
+def get_flight_recorder() -> FlightRecorder:
+    return _global_recorder
+
+
+def set_flight_recorder(recorder: FlightRecorder) -> FlightRecorder:
+    global _global_recorder, _explicit_global
+    with _global_lock:
+        previous = _global_recorder
+        _global_recorder = recorder
+        _explicit_global = True
+        return previous
+
+
+def ensure_flight_recorder_from_env(
+    env: Optional[Mapping[str, str]] = None,
+) -> FlightRecorder:
+    global _global_recorder, _environment_configured
+    with _global_lock:
+        if _explicit_global or _environment_configured:
+            return _global_recorder
+        source = os.environ if env is None else env
+        configured = source.get("OPENRAPPTER_FLIGHT_RECORDER")
+        under_pytest = "pytest" in sys.modules or "PYTEST_CURRENT_TEST" in source
+        enabled = configured == "1" or (configured != "0" and not under_pytest)
+        try:
+            retention = int(
+                source.get(
+                    "OPENRAPPTER_FLIGHT_RETENTION",
+                    str(DEFAULT_RETENTION_EVENTS),
+                )
+            )
+            if retention < 0:
+                raise ValueError
+        except ValueError:
+            retention = DEFAULT_RETENTION_EVENTS
+        max_payload: Optional[int]
+        try:
+            raw_max = source.get("OPENRAPPTER_FLIGHT_MAX_PAYLOAD")
+            max_payload = int(raw_max) if raw_max is not None else None
+        except ValueError:
+            max_payload = None
+        database_override = source.get("OPENRAPPTER_FLIGHT_DB", "").strip()
+        recorder = FlightRecorder(
+            enabled=enabled,
+            database_path=database_override or None,
+            retention_events=retention,
+            privacy={
+                "recordIO": source.get("OPENRAPPTER_FLIGHT_RECORD_IO") == "1",
+                "maxPayloadBytes": max_payload,
+            },
+        )
+        recorder.initialize()
+        _global_recorder = recorder
+        _environment_configured = True
+        return recorder
+
+
+def reset_flight_recorder_environment_for_tests() -> None:
+    global _global_recorder, _environment_configured, _explicit_global
+    with _global_lock:
+        try:
+            _global_recorder.close()
+        finally:
+            _global_recorder = FlightRecorder(enabled=False)
+            _environment_configured = False
+            _explicit_global = False
+
+
+def with_flight_trace(
+    context: Optional[Mapping[str, Any]],
+    operation: Callable[[], Any],
+) -> Any:
+    return get_flight_recorder().run_trace(context, operation)
+
+
+__all__ = [
+    "DEFAULT_EXCLUDED_PATH_PATTERNS",
+    "DEFAULT_REDACTED_KEYS",
+    "FLIGHT_EVENT_SCHEMA",
+    "FLIGHT_EXPORT_SCHEMA",
+    "FlightRecorder",
+    "FlightRecorderCorruptionError",
+    "FlightRecorderError",
+    "FlightRecorderUnhealthyError",
+    "SQLiteFlightLedger",
+    "compute_flight_event_hash",
+    "ensure_flight_recorder_from_env",
+    "get_flight_recorder",
+    "is_excluded_flight_path",
+    "normalize_flight_model_id",
+    "normalize_flight_session_id",
+    "normalize_flight_workspace_id",
+    "reset_flight_recorder_environment_for_tests",
+    "sanitize_flight_metadata",
+    "sanitize_flight_payload",
+    "sanitize_flight_value",
+    "set_flight_recorder",
+    "summarize_flight_error",
+    "verify_flight_event_hash",
+    "with_flight_trace",
+]

--- a/python/openrappter/flight_recorder.py
+++ b/python/openrappter/flight_recorder.py
@@ -492,6 +492,11 @@ def _harden_private_path(path: Path, *, directory: bool = False) -> None:
         if directory
         else "System.Security.AccessControl.FileSecurity"
     )
+    io_type = (
+        "System.IO.DirectoryInfo"
+        if directory
+        else "System.IO.FileInfo"
+    )
     inheritance = (
         "[System.Security.AccessControl.InheritanceFlags]'ContainerInherit,ObjectInherit'"
         if directory
@@ -507,9 +512,10 @@ try {{
   $acl.SetAccessRuleProtection($true, $false)
   $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($sid, 'FullControl', {inheritance}, [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow)
   $acl.AddAccessRule($rule)
-  Set-Acl -LiteralPath $env:HF_TARGET -AclObject $acl -ErrorAction Stop
+  $item = New-Object {io_type}($env:HF_TARGET)
+  $item.SetAccessControl($acl)
 
-  $actual = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
+  $actual = $item.GetAccessControl()
   $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
   $rules = @($actual.Access)
   $allowedOwners = @($sid.Value, 'S-1-5-18', 'S-1-5-32-544')
@@ -580,7 +586,8 @@ try {
     -bor [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles `
     -bor [System.Security.AccessControl.FileSystemRights]::ChangePermissions `
     -bor [System.Security.AccessControl.FileSystemRights]::TakeOwnership
-  $acl = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
+  $item = New-Object System.IO.DirectoryInfo($env:HF_TARGET)
+  $acl = $item.GetAccessControl()
   $ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
   if ($allowed -notcontains $ownerSid.Value) {
     throw "Flight Recorder storage parent has untrusted owner $($ownerSid.Value)."

--- a/python/openrappter/flight_recorder.py
+++ b/python/openrappter/flight_recorder.py
@@ -512,7 +512,8 @@ try {{
   $actual = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
   $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
   $rules = @($actual.Access)
-  if (-not $actual.AreAccessRulesProtected -or $ownerSid.Value -ne $sid.Value -or $rules.Count -ne 1) {{
+  $allowedOwners = @($sid.Value, 'S-1-5-18', 'S-1-5-32-544')
+  if (-not $actual.AreAccessRulesProtected -or $allowedOwners -notcontains $ownerSid.Value -or $rules.Count -ne 1) {{
     throw 'Flight Recorder ACL verification failed.'
   }}
   $ruleSid = $rules[0].IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])

--- a/python/openrappter/flight_recorder.py
+++ b/python/openrappter/flight_recorder.py
@@ -605,22 +605,29 @@ try {
   exit 1
 }
 """
-        subprocess.run(
-            [
-                "powershell.exe",
-                "-NoProfile",
-                "-NonInteractive",
-                "-Command",
-                command,
-            ],
-            check=True,
-            capture_output=True,
-            env={
-                **os.environ,
-                "HF_TARGET": str(directory),
-                "HF_USER": user,
-            },
-        )
+        try:
+            subprocess.run(
+                [
+                    "powershell.exe",
+                    "-NoProfile",
+                    "-NonInteractive",
+                    "-Command",
+                    command,
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "HF_TARGET": str(directory),
+                    "HF_USER": user,
+                },
+            )
+        except subprocess.CalledProcessError as exc:
+            raise FlightRecorderError(
+                (exc.stderr or "").strip()
+                or "Flight Recorder ACL validation failed."
+            ) from exc
         return
     status = directory.lstat()
     if (

--- a/python/openrappter/flight_recorder.py
+++ b/python/openrappter/flight_recorder.py
@@ -576,7 +576,7 @@ $ErrorActionPreference = 'Stop'
 try {
   $identity = New-Object System.Security.Principal.NTAccount($env:HF_USER)
   $sid = $identity.Translate([System.Security.Principal.SecurityIdentifier])
-  $allowed = @($sid.Value, 'S-1-5-18', 'S-1-5-32-544')
+  $allowed = @($sid.Value, 'S-1-3-4', 'S-1-5-18', 'S-1-5-32-544')
   $writeRights = [System.Security.AccessControl.FileSystemRights]::Write `
     -bor [System.Security.AccessControl.FileSystemRights]::Modify `
     -bor [System.Security.AccessControl.FileSystemRights]::FullControl `

--- a/python/openrappter/flight_recorder.py
+++ b/python/openrappter/flight_recorder.py
@@ -4560,6 +4560,7 @@ class FlightRecorder:
                 self._sequence_in_flight.add(trace_id)
                 try:
                     conflict_attempt = 0
+                    busy_attempt = 0
                     while not self._closed:
                         previous = self._sequence_by_trace.get(trace_id)
                         if previous is None:
@@ -4691,6 +4692,21 @@ class FlightRecorder:
                             self._sequence_by_trace.pop(trace_id, None)
                             conflict_attempt += 1
                             time.sleep(min(conflict_attempt / 1000, 0.01))
+                            continue
+                        except sqlite3.OperationalError as exc:
+                            if (
+                                busy_attempt >= 10
+                                or not re.search(
+                                    r"(?:locked|busy)",
+                                    str(exc),
+                                    re.I,
+                                )
+                            ):
+                                raise
+                            busy_attempt += 1
+                            time.sleep(
+                                min(busy_attempt / 1000, 0.01)
+                            )
                             continue
                         self._sequence_by_trace[trace_id] = sequence
                         try:

--- a/python/openrappter/providers/openai_compatible.py
+++ b/python/openrappter/providers/openai_compatible.py
@@ -148,7 +148,7 @@ class OpenAICompatibleProvider:
 
         return ProviderResponse(
             content=message.get("content"),
-            model=data.get("model") or payload["model"],
+            model=data.get("model") or "",
             finish_reason=choices[0].get("finish_reason"),
             usage={
                 "input_tokens": int(usage.get("prompt_tokens", 0) or 0),

--- a/python/openrappter/result_status.py
+++ b/python/openrappter/result_status.py
@@ -1,0 +1,16 @@
+import json
+from typing import Any
+
+
+def agent_result_is_error(result: Any) -> bool:
+    if not isinstance(result, str):
+        return False
+    try:
+        parsed = json.loads(result)
+    except (TypeError, ValueError):
+        return False
+    return (
+        isinstance(parsed, dict)
+        and isinstance(parsed.get("status"), str)
+        and parsed["status"].lower() == "error"
+    )

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "openrappter"
-version = "1.10.0"
+version = "1.12.0"
 description = "🦖 Local-first AI agent powered by GitHub Copilot SDK — no API keys required"
 readme = {text = "openrappter - Local-first AI agent powered by GitHub Copilot SDK", content-type = "text/plain"}
 license = "Apache-2.0"

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -12,7 +12,7 @@ from unittest.mock import patch, MagicMock
 class TestVersion:
     def test_package_version(self):
         from openrappter import __version__
-        assert __version__ == "1.10.0"
+        assert __version__ == "1.12.0"
 
     def test_cli_version_matches(self):
         """Verify cli.py version matches package version."""

--- a/python/tests/test_flight_recorder.py
+++ b/python/tests/test_flight_recorder.py
@@ -1,0 +1,4796 @@
+"""Python parity and mutation controls for Flight Recorder v1."""
+
+from __future__ import annotations
+
+import copy
+import hashlib
+import json
+import os
+import re
+import shutil
+import sqlite3
+import stat
+import threading
+import time
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from collections.abc import Mapping
+from pathlib import Path
+
+import pytest
+
+from openrappter.agents.basic_agent import BasicAgent
+from openrappter.channels.base import BaseChannel, IncomingMessage, OutgoingMessage
+from openrappter.channels.bridge import ChannelDispatchError, ProviderChannelBridge
+from openrappter.cli import Assistant, CopilotProvider
+from openrappter.flight_recorder import (
+    FLIGHT_EVENT_SCHEMA,
+    FLIGHT_EXPORT_SCHEMA,
+    JS_MAX_SAFE_INTEGER,
+    FlightRecorder,
+    FlightRecorderCorruptionError,
+    FlightRecorderError,
+    FlightRecorderUnhealthyError,
+    SQLiteFlightLedger,
+    compute_flight_event_hash,
+    ensure_flight_recorder_from_env,
+    get_flight_recorder,
+    normalize_flight_model_id,
+    normalize_flight_session_id,
+    normalize_flight_workspace_id,
+    reset_flight_recorder_environment_for_tests,
+    sanitize_flight_payload,
+    sanitize_flight_value,
+    set_flight_recorder,
+    summarize_flight_error,
+    verify_flight_event_hash,
+    _process_is_alive,
+    _load_or_create_identity_key,
+    _current_process_incarnation,
+    _reset_flight_recorder_after_fork,
+    _reset_barrier_is_active,
+    _canonical,
+)
+from openrappter.providers.types import ChatOptions, ProviderError, ProviderResponse
+
+TEST_IDENTITY_KEY = "33" * 32
+
+
+@pytest.fixture(autouse=True)
+def isolated_global_recorder():
+    reset_flight_recorder_environment_for_tests()
+    yield
+    reset_flight_recorder_environment_for_tests()
+
+
+@pytest.fixture
+def work_dir():
+    path = Path.cwd() / f".flight-recorder-pytest-{uuid.uuid4().hex}"
+    path.mkdir(mode=0o700)
+    try:
+        yield path
+    finally:
+        shutil.rmtree(path, ignore_errors=True)
+
+
+def in_memory_recorder(**kwargs):
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=TEST_IDENTITY_KEY,
+        **kwargs,
+    )
+    recorder.initialize()
+    return recorder
+
+
+def ledger_event(
+    event_id,
+    trace_id,
+    sequence,
+    timestamp,
+    *,
+    kind="agent.execute.completed",
+    parent_id=None,
+    metadata=None,
+):
+    status = (
+        "started"
+        if kind == "trace.started"
+        else "error"
+        if kind == "trace.failed"
+        else "success"
+    )
+    event = {
+        "schema": FLIGHT_EVENT_SCHEMA,
+        "id": event_id,
+        "sequence": sequence,
+        "traceId": trace_id,
+        "parentId": parent_id,
+        "kind": kind,
+        "source": "test",
+        "status": status,
+        "timestamp": timestamp,
+        "metadata": (
+            {"ownerPid": os.getpid()}
+            if metadata is None and kind == "trace.started"
+            else (metadata or {})
+        ),
+    }
+    event["contentHash"] = compute_flight_event_hash(event)
+    return event
+
+
+def recorded_trace(
+    trace_id,
+    prefix,
+    started_second,
+    *,
+    middle_kinds=(),
+    terminal="trace.completed",
+):
+    kinds = ["trace.started", *middle_kinds]
+    if terminal is not None:
+        kinds.append(terminal)
+    return [
+        ledger_event(
+            f"{prefix}-{index}",
+            trace_id,
+            index + 1,
+            f"2026-01-01T00:00:{started_second + index:02d}.000Z",
+            kind=kind,
+            parent_id=None if index == 0 else f"{prefix}-0",
+        )
+        for index, kind in enumerate(kinds)
+    ]
+
+
+def test_event_shape_redaction_and_mutation_controls():
+    recorder = in_memory_recorder(privacy={"recordIO": True})
+    secret = f"ghp_{'z' * 32}"
+    insecure_control = {"recentEdit": {"patch": f'const x = "{secret}"'}}
+    assert secret in json.dumps(insecure_control)
+
+    recorder.run_trace(
+        {"traceId": "trace-a", "sessionId": "session-a", "workspaceId": "/repo"},
+        lambda: recorder.record(
+            {
+                "kind": "context.assembled",
+                "source": "test",
+                "metadata": {"apiKey": secret, "ordinary": True},
+                "payload": insecure_control,
+            }
+        ),
+    )
+    bundle = recorder.export_trace("trace-a")
+    assert bundle["schema"] == FLIGHT_EXPORT_SCHEMA
+    assert [event["sequence"] for event in bundle["events"]] == [1, 2, 3]
+    assert [event["kind"] for event in bundle["events"]] == [
+        "trace.started",
+        "context.assembled",
+        "trace.completed",
+    ]
+    root, context, terminal = bundle["events"]
+    assert root["parentId"] is None
+    assert context["parentId"] == root["id"]
+    assert terminal["parentId"] == root["id"]
+    assert context["schema"] == FLIGHT_EVENT_SCHEMA
+    assert context["sessionId"] == normalize_flight_session_id(
+        "session-a",
+        TEST_IDENTITY_KEY,
+    )
+    assert context["workspaceId"] == normalize_flight_workspace_id("/repo")
+    assert context["metadata"]["apiKey"] == "[redacted]"
+    assert secret not in json.dumps(bundle)
+    assert "/repo" not in json.dumps(bundle)
+    assert "[redacted]" in json.dumps(context["payload"])
+    assert all(verify_flight_event_hash(event) for event in bundle["events"])
+    assert [
+        event["sequence"]
+        for event in recorder.query({"traceId": "trace-a", "order": "desc"})
+    ] == [3, 2, 1]
+
+    trace_mutation = {**context, "traceId": "trace-b"}
+    payload_mutation = {**context, "payload": {"value": 2}}
+    assert not verify_flight_event_hash(trace_mutation)
+    assert compute_flight_event_hash(payload_mutation) != context["contentHash"]
+    assert not verify_flight_event_hash(payload_mutation)
+
+
+def test_counterparty_session_identifiers_are_hashed_but_queryable():
+    recorder = in_memory_recorder()
+    handle = "imessage:iMessage;-;+15551234567"
+
+    recorder.run_trace(
+        {"traceId": "private-session", "sessionId": handle},
+        lambda: None,
+    )
+
+    events = recorder.query({"sessionId": handle})
+    assert len(events) == 2
+    assert {
+        event["sessionId"] for event in events
+    } == {normalize_flight_session_id(handle, TEST_IDENTITY_KEY)}
+    assert "+15551234567" not in json.dumps(events)
+
+
+def test_python_query_aliases_are_strict_and_never_fall_back_to_broad_results():
+    recorder = in_memory_recorder()
+    recorder.run_trace(
+        {"traceId": "alice-trace", "sessionId": "alice@example.com"},
+        lambda: None,
+    )
+    recorder.run_trace(
+        {"traceId": "bob-trace", "sessionId": "bob@example.com"},
+        lambda: None,
+    )
+
+    alice = recorder.query(session_id="alice@example.com")
+    assert {event["traceId"] for event in alice} == {"alice-trace"}
+    exported = recorder.export({"session_id": "alice@example.com"})
+    assert {event["traceId"] for event in exported["events"]} == {"alice-trace"}
+    with pytest.raises(TypeError, match="unexpected filter"):
+        recorder.query(unknown_filter="alice@example.com")
+    with pytest.raises(TypeError, match="both"):
+        recorder.query(
+            {
+                "sessionId": "alice@example.com",
+                "session_id": "alice@example.com",
+            }
+        )
+    with pytest.raises(TypeError, match="unexpected filter"):
+        recorder._ledger.query({"unknown_filter": True})
+
+
+def test_matches_committed_typescript_python_golden_hash_vector():
+    vector_path = Path(__file__).parents[2] / "contracts" / "flight-recorder-vector.json"
+    vector = json.loads(vector_path.read_text(encoding="utf-8"))
+    if vector["contentHash"] == "PENDING":
+        pytest.skip("cross-runtime hash vector is awaiting its committed expected hash")
+    assert compute_flight_event_hash(vector) == vector["contentHash"]
+    assert verify_flight_event_hash(vector)
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    try:
+        assert ledger.import_({
+            "schema": FLIGHT_EXPORT_SCHEMA,
+            "exportedAt": "2026-08-11T12:35:00.000Z",
+            "events": [vector],
+        }) == 1
+        assert ledger.query({"traceId": vector["traceId"]}) == [vector]
+    finally:
+        ledger.close()
+
+
+def test_ownership_cleanup_never_heals_corrupt_rows():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    start = ledger_event(
+        "corrupt-ownership",
+        "corrupt-ownership",
+        1,
+        "2026-01-01T00:00:00.000Z",
+        kind="trace.started",
+    )
+    ledger.append(start)
+    row = ledger._db.execute(
+        "SELECT event_json FROM flight_events WHERE id = ?",
+        (start["id"],),
+    ).fetchone()
+    tampered = json.loads(row[0])
+    tampered["metadata"]["tampered"] = True
+    ledger._db.execute(
+        "UPDATE flight_events SET event_json = ? WHERE id = ?",
+        (json.dumps(tampered), start["id"]),
+    )
+
+    with pytest.raises(FlightRecorderCorruptionError, match="integrity"):
+        ledger.release_event_ownership(start["id"])
+    with pytest.raises(FlightRecorderCorruptionError, match="integrity"):
+        ledger.query()
+
+
+def test_export_is_uncapped_while_public_query_remains_bounded():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    events = [
+        ledger_event(
+            f"uncapped-export-{index}",
+            f"uncapped-trace-{index}",
+            1,
+            "2026-01-01T00:00:00.000Z",
+        )
+        for index in range(10_001)
+    ]
+    assert ledger.import_(
+        {
+            "schema": FLIGHT_EXPORT_SCHEMA,
+            "exportedAt": "2026-01-01T00:00:00.000Z",
+            "events": events,
+        }
+    ) == 10_001
+
+    assert len(ledger.query()) == 10_000
+    assert len(ledger.export()["events"]) == 10_001
+
+
+def test_recursive_sanitizer_is_deterministic_circular_and_capped():
+    shared = {"label": "shared"}
+    value = {
+        "TOKEN": "not-secret-shaped",
+        "files": ["/repo/.env.local", "/repo/src/main.py"],
+        "first": shared,
+        "second": shared,
+        "set": {"b", "a"},
+        "nan": float("nan"),
+    }
+    value["self"] = value
+    sanitized = sanitize_flight_value(value)
+    assert sanitized == {
+        "TOKEN": "[redacted]",
+        "files": ["[excluded-path]", "/repo/src/main.py"],
+        "first": {"label": "shared"},
+        "nan": None,
+        "second": {"label": "shared"},
+        "self": "[circular]",
+        "set": ["a", "b"],
+    }
+    assert sanitize_flight_value(value) == sanitized
+    assert sanitize_flight_value(
+        "HTTP 401: Authorization: Bearer header.payload.signature response denied"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        "provider failed: client_secret=abcdefgh12345678 while connecting"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        "redis://:supersecret@host/0"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        "-----BEGIN DSA PRIVATE KEY-----\nZmFrZQ=="
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        "https://example.test/path?token=ordinary-secret-value"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        "https://example.test/path?session_token=ordinary-secret-value"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        "https://example.test/path?%74oken=ordinary-secret-value"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        "/callback?session_token=ordinary-secret-value"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        "//host/path?%74oken=ordinary-secret-value"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        "https://example.test/cb#token=ordinary-secret-value"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        '{"password":"ordinary-secret",'
+        '"nested":[{"token":"other-secret"}]}'
+    ) == {
+        "password": "[redacted]",
+        "nested": [{"token": "[redacted]"}],
+    }
+    assert sanitize_flight_value(
+        '{"password":"ordinary-private-value", trailing}'
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        '{"value":9007199254740993}'
+    ) == {"value": "9007199254740993n"}
+    assert sanitize_flight_value(
+        'prefix {"a":1.0,"b":1e-7}'
+    ) == 'prefix {"a":1,"b":1e-7}'
+    assert sanitize_flight_value(
+        '{"password"\u00a0:\u00a0"unicode-space-secret", trailing}'
+    ) == "[redacted]"
+    escaped = (
+        'HTTP 400 body="{\\"password\\":'
+        '\\"escaped-secret\\"}"'
+    )
+    sanitized_escaped = sanitize_flight_value(escaped)
+    assert "escaped-secret" not in sanitized_escaped
+    assert "[redacted]" in sanitized_escaped
+    unicode_escaped = (
+        r'"\u007b\"password\":\"unicode-secret\"\u007d"'
+    )
+    sanitized_unicode = sanitize_flight_value(unicode_escaped)
+    assert "unicode-secret" not in sanitized_unicode
+    assert "[redacted]" in sanitized_unicode
+    double_encoded = json.dumps(unicode_escaped)
+    sanitized_double = sanitize_flight_value(double_encoded)
+    assert "unicode-secret" not in sanitized_double
+    assert "[redacted]" in sanitized_double
+    primitive_secret = (
+        r'"\u0067\u0068\u0070_aaaaaaaaaaaaaaaaaaaa"'
+    )
+    sanitized_primitive = sanitize_flight_value(primitive_secret)
+    assert "aaaaaaaaaaaaaaaaaaaa" not in sanitized_primitive
+    assert "[redacted]" in sanitized_primitive
+    unmatched = "{" * 8_000
+    assert sanitize_flight_value(unmatched) == unmatched
+    assert sanitize_flight_value("{" * 70_000) == (
+        "[truncated:70000]"
+    )
+    invoked = False
+
+    def disabled_payload():
+        nonlocal invoked
+        invoked = True
+        raise AssertionError("disabled payload should remain lazy")
+
+    assert sanitize_flight_payload(
+        disabled_payload,
+        {"recordIO": False},
+    ) is None
+    assert invoked is False
+    assert sanitize_flight_payload(
+        ["x"] * 200_000,
+        {"recordIO": True, "maxPayloadBytes": 100},
+    ) == "[truncated:budget]"
+
+    class DynamicMapping(Mapping):
+        def __init__(self):
+            self.reads = 0
+
+        def __iter__(self):
+            return iter(("items",))
+
+        def __len__(self):
+            return 1
+
+        def __getitem__(self, key):
+            if key != "items":
+                raise KeyError(key)
+            self.reads += 1
+            return (
+                ["safe"]
+                if self.reads == 1
+                else ["expanded"] * 20_000
+            )
+
+        def items(self):
+            return [("items", self["items"])]
+
+    dynamic = DynamicMapping()
+    assert sanitize_flight_value(dynamic) == {"items": ["safe"]}
+    assert dynamic.reads == 1
+    shared_alias = ["x"] * 1_000
+    aliases = [shared_alias] * 1_000
+    assert sanitize_flight_value(aliases) == "[truncated:budget]"
+    assert sanitize_flight_value({"ä", "z"}) == ["z", "ä"]
+    assert sanitize_flight_value({1e-5, 1e-6}) == [1e-6, 1e-5]
+    secret_key = "password=ordinary-secret-value"
+    keyed = sanitize_flight_value(
+        {
+            "[redacted]": "control",
+            secret_key: "sensitive",
+        }
+    )
+    assert secret_key not in json.dumps(keyed)
+    assert keyed == {
+        "[redacted]": "control",
+        "[redacted]#2": "[redacted]",
+    }
+    assert sanitize_flight_value(
+        {"exact-property-secret": "value"},
+        {"redactedValues": ["exact-property-secret"]},
+    ) == {"[redacted]": "[redacted]"}
+    assert sanitize_flight_value(
+        {"prefixALPHABETAsuffix": "value"},
+        {"redactedValues": ["ALPHABETA"]},
+    ) == {"[redacted]": "value"}
+    deeply_encoded = "%74oken"
+    for _index in range(65):
+        deeply_encoded = deeply_encoded.replace("%", "%25")
+    assert sanitize_flight_value(
+        "https://example.test/?"
+        f"{deeply_encoded}=ordinary-secret-value"
+    ) == "[redacted]"
+    assert sanitize_flight_value(
+        {
+            "%5Bexcluded-path%5D": "encoded",
+            "[excluded-path]": "literal",
+        }
+    ) == {
+        "[excluded-path]": "encoded",
+        "[excluded-path]#2": "literal",
+    }
+    assert sanitize_flight_value(
+        {"%FF": 1, "ÿ": 2}
+    ) == {"�": 1, "ÿ": 2}
+    assert sanitize_flight_value('{"x":NaN}') == '{"x":NaN}'
+    assert sanitize_flight_value('{"x":Infinity}') == '{"x":Infinity}'
+    identity_key = "ab" * 32
+    encoded_identity = "".join(
+        f"%{ord(character):02x}"
+        for character in identity_key
+    )
+    assert sanitize_flight_value(
+        encoded_identity,
+        {"redactedValues": [identity_key]},
+    ) == "[redacted]"
+    error_secret = "ordinary-error-secret"
+    error = RuntimeError(
+        f'HTTP 400: {{"password":"{error_secret}"}}'
+    )
+    sanitized_error = sanitize_flight_value(error)
+    assert error_secret not in json.dumps(sanitized_error)
+    assert "[redacted]" in json.dumps(sanitized_error)
+    assert sanitize_flight_value(sanitized_error) == sanitized_error
+    nested_error = sanitize_flight_value(
+        RuntimeError(
+            'Error: {not-json: '
+            '{"password":"nested-error-secret"}}'
+        )
+    )
+    assert "nested-error-secret" not in json.dumps(nested_error)
+    assert "[redacted]" in json.dumps(nested_error)
+    capped = sanitize_flight_payload(
+        {"password": "x" * 2_000, "ordinary": "y" * 200},
+        {"recordIO": True, "maxPayloadBytes": 80},
+    )
+    assert capped.startswith("[truncated:")
+
+    token = f"ghp_{'z' * 32}"
+    bearer = " ".join(("Bearer", "header.payload.signature"))
+    assert sanitize_flight_value(f"é{token}") == "[redacted]"
+    assert sanitize_flight_value(f"{token}é") == "[redacted]"
+    assert sanitize_flight_value(f"é{bearer}") == "[redacted]"
+
+    excluded_file = sanitize_flight_value(
+        {
+            "path": "/repo/.env",
+            "content": "PRIVATE_VALUE=not-pattern-sensitive",
+            "bytes": [1, 2, 3],
+            "language": "dotenv",
+        }
+    )
+    assert excluded_file == {
+        "bytes": "[excluded-path]",
+        "content": "[excluded-path]",
+        "language": "dotenv",
+        "path": "[excluded-path]",
+    }
+    assert sanitize_flight_value(
+        {
+            "path": Path("/repo/.env"),
+            "content": "PRIVATE_VALUE=ordinary",
+        }
+    ) == {
+        "content": "[excluded-path]",
+        "path": "[excluded-path]",
+    }
+    assert sanitize_flight_value(
+        {
+            "sourcePath": "/repo/.env",
+            "content": "PRIVATE_VALUE=ordinary",
+        }
+    ) == {
+        "content": "[excluded-path]",
+        "sourcePath": "[excluded-path]",
+    }
+    assert sanitize_flight_value(
+        {
+            "sourcePath": "/repo/%252Eenv",
+            "content": "PRIVATE_VALUE=ordinary",
+        }
+    ) == {
+        "content": "[excluded-path]",
+        "sourcePath": "[excluded-path]",
+    }
+    assert sanitize_flight_value(
+        {
+            "sourcePath": (
+                "vscode-remote://ssh-remote+host/"
+                "home/alice/%2Eenv"
+            ),
+            "content": "PRIVATE_VALUE=ordinary",
+        }
+    ) == {
+        "content": "[excluded-path]",
+        "sourcePath": "[excluded-path]",
+    }
+    assert sanitize_flight_value(
+        {
+            "sourcePath": "vscode-remote://host/%ZZ/private/%2Eenv",
+            "content": "PRIVATE_VALUE=ordinary",
+        }
+    ) == {
+        "content": "[excluded-path]",
+        "sourcePath": "[excluded-path]",
+    }
+    for locator in ("sourceUri", "documentPath"):
+        assert sanitize_flight_value(
+            {
+                locator: "/repo/.env",
+                "content": "PRIVATE_VALUE=ordinary",
+            }
+        ) == {
+            "content": "[excluded-path]",
+            locator: "[excluded-path]",
+        }
+    assert sanitize_flight_value(
+        {
+            "textDocument": {"uri": "file:///repo/.env"},
+            "contentChanges": [
+                {"text": "PRIVATE_VALUE=ordinary"}
+            ],
+        }
+    ) == {
+        "textDocument": {"uri": "[excluded-path]"},
+        "contentChanges": "[excluded-path]",
+    }
+    assert sanitize_flight_value(
+        {"%2Eenv": "PRIVATE_VALUE=ordinary"}
+    ) == {"[excluded-path]": "[excluded-path]"}
+    assert sanitize_flight_value(
+        {"%252Eenv": "PRIVATE_VALUE=ordinary"}
+    ) == {"[excluded-path]": "[excluded-path]"}
+    descriptor = {"uri": "file:///repo/.env"}
+    for _depth in range(18):
+        descriptor = {"nested": descriptor}
+    assert sanitize_flight_value(
+        {
+            "descriptor": descriptor,
+            "content": "PRIVATE_VALUE=ordinary",
+        }
+    )["content"] == "[excluded-path]"
+    assert sanitize_flight_value(
+        {
+            "path": "/repo/.env",
+            "language": {"raw": "PRIVATE_VALUE=ordinary"},
+            "size": {"raw": 42},
+            "content": "PRIVATE_VALUE=ordinary",
+        }
+    ) == {
+        "content": "[excluded-path]",
+        "language": "[excluded-path]",
+        "path": "[excluded-path]",
+        "size": "[excluded-path]",
+    }
+    assert sanitize_flight_value(
+        {
+            "name": ".env",
+            "content": "PRIVATE_VALUE=ordinary",
+            "contents": "PRIVATE_VALUE=second",
+            "value": "PRIVATE_VALUE=third",
+        }
+    ) == {
+        "content": "[excluded-path]",
+        "contents": "[excluded-path]",
+        "name": "[excluded-path]",
+        "value": "[excluded-path]",
+    }
+    for uri in (
+        "file:///repo/.env?version=1",
+        "file:///repo/%2Eenv#fragment",
+    ):
+        assert sanitize_flight_value(
+            {"uri": uri, "content": "PRIVATE_VALUE=ordinary"}
+        ) == {
+            "content": "[excluded-path]",
+            "uri": "[excluded-path]",
+        }
+
+
+def test_sanitizer_redacts_secret_and_path_keys_without_collisions():
+    secret_key = f"ghp_{'k' * 32}"
+    path_key = "/Users/alice/.ssh/id_ed25519"
+    value = {
+        "[redacted]": "reserved",
+        "[redacted]#2": "reserved-two",
+        "[excluded-path]": "reserved-path",
+        secret_key: "secret-key-value",
+        path_key: "path-key-value",
+        "constructor": "prototype-value",
+        "apiKey": "field-value",
+        "safe": "ordinary",
+    }
+    reversed_value = dict(reversed(list(value.items())))
+
+    sanitized = sanitize_flight_value(value)
+    assert sanitize_flight_value(reversed_value) == sanitized
+    assert len(sanitized) == len(value)
+    serialized = json.dumps(sanitized)
+    assert secret_key not in serialized
+    assert path_key not in serialized
+    assert sanitized["[redacted]"] == "reserved"
+    assert sanitized["[redacted]#2"] == "reserved-two"
+    assert sanitized["[redacted]#3"] == "[redacted]"
+    assert sanitized["[redacted]#4"] == "secret-key-value"
+    assert sanitized["[excluded-path]"] == "reserved-path"
+    assert sanitized["[excluded-path]#2"] == "[excluded-path]"
+    assert sanitized["apiKey"] == "[redacted]"
+    assert sanitized["safe"] == "ordinary"
+    assert "constructor" not in sanitized
+
+    filenames = sanitize_flight_value(
+        {
+            "server.p12": {"bytes": [1, 2, 3]},
+            "service-account.json": {
+                "client_email": "service@example.test"
+            },
+            "/Users/alice/client-secret.pem": {"private": "secret"},
+        }
+    )
+    assert filenames == {
+        "[excluded-path]": "[excluded-path]",
+        "[excluded-path]#2": "[excluded-path]",
+        "[excluded-path]#3": "[excluded-path]",
+    }
+    assert "service@example.test" not in json.dumps(filenames)
+    assert "client-secret.pem" not in json.dumps(filenames)
+
+
+def test_error_summary_is_stable_and_contains_no_raw_error_text():
+    token = f"ghp_{'s' * 32}"
+    bearer = "Bearer header.payload.signature"
+    body = "raw upstream response body"
+    message = f"HTTP 401 {bearer} token={token} body={body}"
+    error = ProviderError(message)
+    error.code = "ERR_PROVIDER_AUTH"
+    error.status = 401
+
+    summary = summarize_flight_error(error)
+    assert summary == {
+        "errorName": "ProviderError",
+        "messageHash": hashlib.sha256(message.encode("utf-8")).hexdigest(),
+        "messageChars": len(message),
+        "errorCode": "ERR_PROVIDER_AUTH",
+        "httpStatus": 401,
+    }
+    serialized = json.dumps(summary)
+    assert token not in serialized
+    assert bearer not in serialized
+    assert body not in serialized
+    assert message not in serialized
+
+
+def test_trace_failure_hides_raw_error_by_default_and_keeps_exception_identity():
+    raw_message = "trace failed with raw response body"
+    original = RuntimeError(raw_message)
+    recorder = in_memory_recorder()
+
+    def fail():
+        raise original
+
+    with pytest.raises(RuntimeError) as caught:
+        recorder.run_trace({"traceId": "private-error"}, fail)
+    assert caught.value is original
+    failed = recorder.query({"kind": "trace.failed"})[0]
+    assert failed["metadata"]["messageChars"] == len(raw_message)
+    assert failed["metadata"]["messageHash"] == hashlib.sha256(
+        raw_message.encode("utf-8")
+    ).hexdigest()
+    assert "payload" not in failed
+    assert raw_message not in json.dumps(failed)
+
+    io_recorder = in_memory_recorder(privacy={"recordIO": True})
+    with pytest.raises(RuntimeError) as io_caught:
+        io_recorder.run_trace({"traceId": "opt-in-error"}, fail)
+    assert io_caught.value is original
+    io_failed = io_recorder.query({"kind": "trace.failed"})[0]
+    assert io_failed["payload"]["error"]["message"] == raw_message
+    assert raw_message not in json.dumps(io_failed["metadata"])
+
+
+def test_ecmascript_number_canonicalization_and_safe_integer_controls():
+    assert _canonical(
+        {
+            "a": 1e-7,
+            "b": 1e20,
+            "c": 1e21,
+            "d": -0.0,
+            "e": 1e-6,
+            "f": -1e-7,
+        }
+    ) == (
+        '{"a":1e-7,"b":100000000000000000000,"c":1e+21,'
+        '"d":0,"e":0.000001,"f":-1e-7}'
+    )
+    assert sanitize_flight_value(
+        {
+            "positive": JS_MAX_SAFE_INTEGER + 1,
+            "negative": -(JS_MAX_SAFE_INTEGER + 1),
+            "positiveFloat": 1e20,
+            "negativeFloat": -1e20,
+            "scientificFloat": 1e21,
+        }
+    ) == {
+        "negative": f"-{JS_MAX_SAFE_INTEGER + 1}n",
+        "negativeFloat": "-100000000000000000000n",
+        "positive": f"{JS_MAX_SAFE_INTEGER + 1}n",
+        "positiveFloat": "100000000000000000000n",
+        "scientificFloat": "1e+21n",
+    }
+
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    unsafe_metadata = ledger_event(
+        "unsafe-metadata",
+        "unsafe-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    unsafe_metadata["metadata"] = {"value": JS_MAX_SAFE_INTEGER + 1}
+    unsafe_metadata["contentHash"] = "0" * 64
+    with pytest.raises(FlightRecorderCorruptionError, match="safe integer"):
+        ledger.append(unsafe_metadata)
+
+    unsafe_sequence = ledger_event(
+        "unsafe-sequence",
+        "unsafe-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    unsafe_sequence["sequence"] = JS_MAX_SAFE_INTEGER + 1
+    unsafe_sequence["contentHash"] = "0" * 64
+    with pytest.raises(FlightRecorderCorruptionError, match="safe integer"):
+        ledger.append(unsafe_sequence)
+
+    unsafe_float = ledger_event(
+        "unsafe-float",
+        "unsafe-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    unsafe_float["metadata"] = {"value": 1e20}
+    unsafe_float["contentHash"] = "0" * 64
+    with pytest.raises(FlightRecorderCorruptionError, match="safe"):
+        ledger.append(unsafe_float)
+
+    recorder = in_memory_recorder()
+    sanitized_event = recorder.record(
+        {
+            "traceId": "unsafe-numeric-sanitized",
+            "kind": "context.assembled",
+            "source": "test",
+            "metadata": {"integralFloat": 1e20},
+        }
+    )
+    assert sanitized_event["metadata"]["integralFloat"] == "100000000000000000000n"
+
+
+def test_default_no_io_omits_payload():
+    assert sanitize_flight_payload({"raw": "discarded"}) is None
+    recorder = in_memory_recorder()
+    event = recorder.record(
+        {
+            "traceId": "no-io",
+            "kind": "agent.execute.completed",
+            "source": "test",
+            "metadata": {"token": "ordinary", "count": 3},
+            "payload": {"rawPrompt": "must not persist"},
+        }
+    )
+    assert "payload" not in event
+    assert event["metadata"] == {"count": 3, "token": "[redacted]"}
+    assert "must not persist" not in json.dumps(recorder.export_trace("no-io"))
+    auto_model = recorder.record(
+        {
+            "traceId": "model-policy",
+            "kind": "provider.attempt.started",
+            "source": "test",
+            "model": " AUTO ",
+        }
+    )
+    concrete_model = recorder.record(
+        {
+            "traceId": "model-policy",
+            "kind": "provider.attempt.completed",
+            "source": "test",
+            "model": " gpt-4.1 ",
+        }
+    )
+    assert "model" not in auto_model
+    assert concrete_model["model"] == "gpt-4.1"
+
+
+def test_absolute_workspace_ids_match_typescript_hash_and_never_persist_raw_path():
+    raw_workspace = "/Users/alice/project"
+    expected = "workspace:9ae7af749ba270e5853be6ee"
+    assert normalize_flight_workspace_id(raw_workspace) == expected
+    assert normalize_flight_workspace_id("channel:memory") == "channel:memory"
+    assert normalize_flight_workspace_id(
+        "workspace:0123456789abcdef01234567"
+    ) == "workspace:0123456789abcdef01234567"
+    for uri_workspace in (
+        "file:///Users/alice/private-project",
+        "workspace:/Users/alice/private-project",
+        r"workspace:C:\Users\alice\private-project",
+        "workspace:%2FUsers%2Falice%2Fprivate-project",
+        "workspace:%2FUsers%2Falice%2Fprivate-project%ZZ",
+        "workspace:%252FUsers%252Falice%252Fprivate-project",
+        "vscode-remote://ssh-remote+host/home/alice/private-project",
+    ):
+        normalized = normalize_flight_workspace_id(uri_workspace)
+        assert re.fullmatch(r"workspace:[0-9a-f]{24}", normalized)
+        assert normalized != uri_workspace
+
+    recorder = in_memory_recorder()
+    recorder.run_trace(
+        {"traceId": "private-workspace", "workspaceId": raw_workspace},
+        lambda: recorder.record({"kind": "context.assembled", "source": "test"}),
+    )
+    bundle = recorder.export_trace("private-workspace")
+    assert {event["workspaceId"] for event in bundle["events"]} == {expected}
+    assert raw_workspace not in json.dumps(bundle)
+    assert len(recorder.query({"workspaceId": raw_workspace})) == 3
+    assert len(recorder.export({"workspaceId": raw_workspace})["events"]) == 3
+
+
+def test_persistent_restart_permissions_and_sequence_continuity(work_dir):
+    database = work_dir / "private" / "flight.db"
+    database.parent.mkdir(mode=0o755)
+    first = FlightRecorder(enabled=True, database_path=database)
+    first.initialize()
+    assert first._ledger._db.execute(
+        "PRAGMA synchronous"
+    ).fetchone()[0] == 2
+    first.run_trace(
+        {"traceId": "continued", "sessionId": "person@example.com"},
+        lambda: first.record({"kind": "phase.one", "source": "test"}),
+    )
+
+    assert stat.S_IMODE(database.stat().st_mode) == 0o600
+    assert stat.S_IMODE(database.parent.stat().st_mode) == 0o755
+    assert stat.S_IMODE(Path(f"{database}-wal").stat().st_mode) == 0o600
+    assert stat.S_IMODE(Path(f"{database}-shm").stat().st_mode) == 0o600
+    assert stat.S_IMODE(
+        Path(f"{database}.identity-key").stat().st_mode
+    ) == 0o600
+    first.close()
+    Path(f"{database}-wal").unlink(missing_ok=True)
+    Path(f"{database}-shm").unlink(missing_ok=True)
+    connection = sqlite3.connect(database)
+    try:
+        assert connection.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        assert connection.execute("PRAGMA busy_timeout").fetchone()[0] == 5_000
+    finally:
+        connection.close()
+    sidecars = (
+        Path(f"{database}-wal"),
+        Path(f"{database}-shm"),
+    )
+    sidecar_inodes = {}
+    for sidecar in sidecars:
+        sidecar.write_bytes(b"")
+        sidecar.chmod(0o666)
+        sidecar_inodes[sidecar] = sidecar.stat().st_ino
+
+    second = FlightRecorder(enabled=True, database_path=database)
+    second.initialize()
+    for sidecar in sidecars:
+        assert sidecar.stat().st_ino == sidecar_inodes[sidecar]
+        assert stat.S_IMODE(sidecar.stat().st_mode) == 0o600
+    second.run_trace(
+        {"traceId": "continued", "sessionId": "person@example.com"},
+        lambda: second.record({"kind": "phase.two", "source": "test"}),
+    )
+    events = second.export_trace("continued")["events"]
+    assert [event["sequence"] for event in events] == [1, 2, 3, 4, 5, 6]
+    assert len(second.query({"sessionId": "person@example.com"})) == 6
+    second.close()
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink setup")
+def test_symlinked_database_and_identity_key_are_rejected(work_dir):
+    target = work_dir / "target.db"
+    target.write_text("do not modify", encoding="utf-8")
+    database = work_dir / "flight.db"
+    database.symlink_to(target)
+    linked = FlightRecorder(enabled=True, database_path=database)
+    linked.initialize()
+    assert linked.health()["initialized"] is False
+    assert "regular file" in linked.health()["lastError"]
+    assert target.read_text(encoding="utf-8") == "do not modify"
+
+    database.unlink()
+    first = FlightRecorder(
+        enabled=True,
+        database_path=database,
+        identity_key="ab" * 32,
+    )
+    first.initialize()
+    first.close()
+    key_path = Path(f"{database}.identity-key")
+    key_target = work_dir / "external-key"
+    key_target.write_text(f"{'ab' * 32}\n", encoding="utf-8")
+    key_path.unlink()
+    key_path.symlink_to(key_target)
+    key_linked = FlightRecorder(enabled=True, database_path=database)
+    key_linked.initialize()
+    assert key_linked.health()["initialized"] is False
+    assert "regular file" in key_linked.health()["lastError"]
+
+    real_parent = work_dir / "real-parent"
+    real_parent.mkdir()
+    parent_alias = work_dir / "parent-alias"
+    parent_alias.symlink_to(real_parent, target_is_directory=True)
+    parent_linked = FlightRecorder(
+        enabled=True,
+        database_path=parent_alias / "flight.db",
+    )
+    parent_linked.initialize()
+    assert parent_linked.health()["initialized"] is False
+    assert "symlink/reparse point" in parent_linked.health()["lastError"]
+
+    owner_database = work_dir / "owner-flight.db"
+    external_owners = work_dir / "external-owners"
+    external_owners.mkdir()
+    marker = external_owners / "marker.json"
+    marker.write_text("do not modify", encoding="utf-8")
+    Path(f"{owner_database}.owners").symlink_to(
+        external_owners,
+        target_is_directory=True,
+    )
+    owner_linked = FlightRecorder(
+        enabled=True,
+        database_path=owner_database,
+    )
+    owner_linked.initialize()
+    assert owner_linked.health()["initialized"] is False
+    assert "owner storage" in owner_linked.health()["lastError"]
+    assert marker.read_text(encoding="utf-8") == "do not modify"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX permissions")
+def test_insecure_custom_storage_parent_is_rejected(work_dir):
+    directory = work_dir / "insecure-parent"
+    directory.mkdir(mode=0o777)
+    directory.chmod(0o777)
+    recorder = FlightRecorder(
+        enabled=True,
+        database_path=directory / "flight.db",
+    )
+    recorder.initialize()
+
+    assert recorder.health()["initialized"] is False
+    assert "group/world writable" in recorder.health()["lastError"]
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink setup")
+def test_managed_home_symlink_is_rejected_before_hardening(
+    work_dir,
+    monkeypatch,
+):
+    real_home = work_dir / "real-home"
+    real_home.mkdir(mode=0o755)
+    home_alias = work_dir / "home-alias"
+    home_alias.symlink_to(real_home, target_is_directory=True)
+    monkeypatch.setenv("HOME", str(home_alias))
+    before_mode = stat.S_IMODE(real_home.stat().st_mode)
+
+    recorder = FlightRecorder(enabled=True)
+    recorder.initialize()
+
+    assert recorder.health()["initialized"] is False
+    assert "symlink/reparse point" in recorder.health()["lastError"]
+    assert stat.S_IMODE(real_home.stat().st_mode) == before_mode
+    assert not (real_home / ".openrappter").exists()
+
+
+def test_runtime_append_uses_short_busy_budget(work_dir):
+    database = work_dir / "runtime-busy" / "flight.db"
+    database.parent.mkdir()
+    ledger = SQLiteFlightLedger(database_path=database)
+    ledger.initialize()
+    start_event = ledger_event(
+        "runtime-maintenance",
+        "runtime-maintenance",
+        1,
+        "2026-01-01T00:00:00.000Z",
+        kind="trace.started",
+    )
+    ledger.append(start_event)
+    ledger.append(
+        ledger_event(
+            "runtime-prune-candidate",
+            "runtime-prune-candidate",
+            1,
+            "2026-01-01T00:00:01.000Z",
+        )
+    )
+    locker = sqlite3.connect(database, isolation_level=None)
+    try:
+        locker.execute("BEGIN IMMEDIATE")
+        started = time.monotonic()
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            ledger.append(
+                ledger_event(
+                    "runtime-busy",
+                    "runtime-busy",
+                    1,
+                    "2026-01-01T00:00:00.000Z",
+                )
+            )
+        assert time.monotonic() - started < 1
+        assert ledger._db.execute(
+            "PRAGMA busy_timeout"
+        ).fetchone()[0] == 5_000
+
+        started = time.monotonic()
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            ledger.release_event_ownership(start_event["id"])
+        assert time.monotonic() - started < 1
+
+        started = time.monotonic()
+        with pytest.raises(sqlite3.OperationalError, match="locked"):
+            ledger.prune_runtime(0)
+        assert time.monotonic() - started < 1
+        assert ledger._db.execute(
+            "PRAGMA busy_timeout"
+        ).fetchone()[0] == 5_000
+    finally:
+        locker.execute("ROLLBACK")
+        locker.close()
+        ledger.close()
+
+
+def test_clear_physically_purges_private_payload_bytes(work_dir):
+    database = work_dir / "secure-clear" / "flight.db"
+    database.parent.mkdir()
+    ledger = SQLiteFlightLedger(database_path=database)
+    ledger.initialize()
+    assert ledger._db.execute("PRAGMA secure_delete").fetchone()[0] == 1
+    sentinel = "PRIVATE_PAYLOAD_SENTINEL_7421"
+    sample = ledger_event(
+        "secure-clear-event",
+        "secure-clear-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    sample["payload"] = {"value": sentinel}
+    sample["contentHash"] = compute_flight_event_hash(sample)
+    ledger.append(sample)
+
+    ledger.clear()
+    ledger.close()
+    stored = b"".join(
+        path.read_bytes()
+        for path in (
+            database,
+            Path(f"{database}-wal"),
+            Path(f"{database}-shm"),
+        )
+        if path.exists()
+    )
+    assert sentinel.encode("utf-8") not in stored
+
+
+def test_replace_physically_purges_superseded_payload_bytes(work_dir):
+    database = work_dir / "secure-replace" / "flight.db"
+    database.parent.mkdir()
+    ledger = SQLiteFlightLedger(database_path=database)
+    ledger.initialize()
+    sentinel = "REPLACED_PRIVATE_SENTINEL_7421"
+    original = ledger_event(
+        "secure-replace-event",
+        "secure-replace-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    original["payload"] = {"value": sentinel}
+    original["contentHash"] = compute_flight_event_hash(original)
+    replacement = dict(original)
+    replacement["payload"] = {"value": "removed"}
+    replacement["contentHash"] = compute_flight_event_hash(replacement)
+    ledger.append(original)
+    ledger.import_(
+        {
+            "schema": FLIGHT_EXPORT_SCHEMA,
+            "exportedAt": "2026-01-01T00:00:01.000Z",
+            "events": [replacement],
+        },
+        replace=True,
+    )
+    ledger.close()
+
+    stored = b"".join(
+        path.read_bytes()
+        for path in (
+            database,
+            Path(f"{database}-wal"),
+            Path(f"{database}-shm"),
+        )
+        if path.exists()
+    )
+    assert sentinel.encode("utf-8") not in stored
+
+
+def test_empty_identity_key_is_recovered_atomically(work_dir):
+    database = work_dir / "empty-key" / "flight.db"
+    database.parent.mkdir()
+    key_path = Path(f"{database}.identity-key")
+    key_path.write_text("", encoding="utf-8")
+    recorder = FlightRecorder(enabled=True, database_path=database)
+    recorder.initialize()
+    recorder.run_trace(
+        {"traceId": "recovered-key", "sessionId": "person@example.com"},
+        lambda: None,
+    )
+
+    assert re.fullmatch(
+        r"[0-9a-f]{64}",
+        key_path.read_text(encoding="utf-8").strip(),
+    )
+    assert recorder.export_trace("recovered-key")["events"][0][
+        "sessionId"
+    ].startswith("session:")
+
+
+def test_identity_key_io_handles_short_reads_and_writes(work_dir, monkeypatch):
+    database = work_dir / "short-key-io" / "flight.db"
+    database.parent.mkdir()
+    real_write = os.write
+    real_read = os.read
+
+    def short_write(descriptor, data):
+        return real_write(descriptor, bytes(data[:3]))
+
+    def short_read(descriptor, count):
+        return real_read(descriptor, min(count, 2))
+
+    monkeypatch.setattr(os, "write", short_write)
+    monkeypatch.setattr(os, "read", short_read)
+    key = _load_or_create_identity_key(str(database))
+
+    persisted = Path(f"{database}.identity-key").read_text(
+        encoding="utf-8"
+    ).strip()
+    assert re.fullmatch(r"[0-9a-f]{64}", key)
+    assert persisted == key
+
+
+def test_explicit_identity_key_is_persisted_and_mismatch_rejected(work_dir):
+    database = work_dir / "explicit-key" / "flight.db"
+    database.parent.mkdir()
+    explicit = "ab" * 32
+    first = FlightRecorder(
+        enabled=True,
+        database_path=database,
+        identity_key=explicit,
+    )
+    second = FlightRecorder(enabled=True, database_path=database)
+    mismatch = FlightRecorder(
+        enabled=True,
+        database_path=database,
+        identity_key="cd" * 32,
+    )
+    try:
+        first.initialize()
+        first.run_trace(
+            {
+                "traceId": "explicit-key-first",
+                "sessionId": "same-person",
+            },
+            lambda: None,
+        )
+        assert Path(f"{database}.identity-key").read_text(
+            encoding="utf-8"
+        ).strip() == explicit
+
+        second.initialize()
+        second.run_trace(
+            {
+                "traceId": "explicit-key-second",
+                "sessionId": "same-person",
+            },
+            lambda: None,
+        )
+        first_session = first.export_trace(
+            "explicit-key-first"
+        )["events"][0]["sessionId"]
+        second_session = second.export_trace(
+            "explicit-key-second"
+        )["events"][0]["sessionId"]
+        assert second_session == first_session
+
+        mismatch.initialize()
+        assert mismatch.health()["initialized"] is False
+        assert "does not match the persisted key" in (
+            mismatch.health()["lastError"]
+        )
+        first.close()
+        second.close()
+        Path(f"{database}.identity-key").unlink()
+        missing = FlightRecorder(
+            enabled=True,
+            database_path=database,
+        )
+        try:
+            missing.initialize()
+            assert missing.health()["initialized"] is False
+            assert "missing for a non-empty ledger" in (
+                missing.health()["lastError"]
+            )
+        finally:
+            missing.close()
+    finally:
+        first.close()
+        second.close()
+        mismatch.close()
+
+
+def test_identity_key_is_bound_to_ledger_fingerprint(work_dir):
+    database = work_dir / "key-binding" / "flight.db"
+    database.parent.mkdir()
+    first = FlightRecorder(
+        enabled=True,
+        database_path=database,
+        identity_key="12" * 32,
+    )
+    first.initialize()
+    first.run_trace({"traceId": "bound-key"}, lambda: None)
+    first.close()
+
+    Path(f"{database}.identity-key").write_text(
+        f"{'34' * 32}\n",
+        encoding="utf-8",
+    )
+    second = FlightRecorder(enabled=True, database_path=database)
+    try:
+        second.initialize()
+        assert second.health()["initialized"] is False
+        assert "ledger fingerprint" in second.health()["lastError"]
+    finally:
+        second.close()
+
+
+def test_active_identity_key_and_sidecar_aliases_are_always_redacted():
+    identity_key = "ef" * 32
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=identity_key,
+        privacy={"recordIO": True},
+    )
+    recorder.initialize()
+    recorder.record(
+        {
+            "traceId": "identity-key-redaction",
+            "kind": "identity.probe",
+            "source": "test",
+            "metadata": {
+                "identityKey": identity_key,
+                "OPENRAPPTER_FLIGHT_ID_KEY": identity_key,
+                "assignment": (
+                    f"OPENRAPPTER_FLIGHT_ID_KEY={identity_key}"
+                ),
+                "path": "/tmp/flight.db.identity-key",
+            },
+            "payload": {"raw": identity_key},
+        }
+    )
+    recorder.record(
+        {
+            "traceId": "identity-kind-redaction",
+            "kind": identity_key.upper(),
+            "source": "test",
+        }
+    )
+
+    serialized = json.dumps(recorder.export())
+    assert identity_key not in serialized
+    assert identity_key.upper() not in serialized
+    assert "flight.db.identity-key" not in serialized
+    assert "[redacted]" in serialized
+    assert "[excluded-path]" in serialized
+
+
+def test_exact_privacy_precedes_opaque_identifier_passthrough():
+    provider_id = f"provider:{'a' * 24}"
+    session_id = f"session:{'b' * 24}"
+    workspace_id = f"workspace:{'c' * 24}"
+    recorder = in_memory_recorder(
+        privacy={
+            "redactedValues": [
+                provider_id,
+                session_id,
+                workspace_id,
+            ]
+        }
+    )
+
+    def record_probe():
+        recorder.record(
+            {
+                "kind": "opaque.probe",
+                "source": "test",
+                "providerId": provider_id,
+            }
+        )
+
+    recorder.run_trace(
+        {
+            "traceId": "opaque-redaction",
+            "sessionId": session_id,
+            "workspaceId": workspace_id,
+        },
+        record_probe,
+    )
+    events = recorder.query({"traceId": "opaque-redaction"})
+    probe = next(
+        event for event in events if event["kind"] == "opaque.probe"
+    )
+    assert re.fullmatch(r"provider:[0-9a-f]{24}", probe["providerId"])
+    assert probe["providerId"] != provider_id
+    assert re.fullmatch(r"session:[0-9a-f]{24}", probe["sessionId"])
+    assert probe["sessionId"] != session_id
+    assert re.fullmatch(
+        r"workspace:[0-9a-f]{24}",
+        probe["workspaceId"],
+    )
+    assert probe["workspaceId"] != workspace_id
+    assert provider_id not in json.dumps(events)
+    assert len(recorder.query({"sessionId": session_id})) == len(events)
+
+
+def test_sequence_allocation_uses_private_trace_lookup(monkeypatch):
+    ledger = SQLiteFlightLedger(in_memory=True)
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=TEST_IDENTITY_KEY,
+        retention_events=-1,
+        ledger=ledger,
+    )
+    recorder.initialize()
+    monkeypatch.setattr(
+        ledger,
+        "query",
+        lambda *_args, **_kwargs: (
+            _ for _ in ()
+        ).throw(RuntimeError("public query must not run")),
+    )
+
+    recorder.run_trace({"traceId": "private-sequence"}, lambda: None)
+    recorder.run_trace({"traceId": "private-sequence"}, lambda: None)
+
+    assert ledger.last_sequence("private-sequence") == 4
+
+
+def test_reentrant_close_and_clear_reject_before_pending_wait():
+    recorder = in_memory_recorder(retention_events=-1)
+    entered = threading.Event()
+    resume = threading.Event()
+
+    def active_operation():
+        entered.set()
+        assert resume.wait(timeout=2)
+        with pytest.raises(FlightRecorderError, match="active trace"):
+            recorder.close()
+        with pytest.raises(FlightRecorderError, match="active trace"):
+            recorder.clear()
+
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        trace = pool.submit(
+            recorder.run_trace,
+            {"traceId": "reentrant-shutdown"},
+            active_operation,
+        )
+        assert entered.wait(timeout=2)
+        closing = pool.submit(recorder.close)
+        deadline = time.time() + 2
+        while not recorder._closing and time.time() < deadline:
+            time.sleep(0.005)
+        assert recorder._closing is True
+        resume.set()
+        trace.result(timeout=2)
+        closing.result(timeout=2)
+
+
+def test_detached_async_work_is_re_rooted_after_trace_completion():
+    import asyncio
+
+    recorder = in_memory_recorder(retention_events=-1)
+
+    async def scenario():
+        gate = asyncio.Event()
+        detached = None
+
+        async def record_later():
+            await gate.wait()
+            return recorder.record(
+                {"kind": "detached.event", "source": "test"}
+            )
+
+        def operation():
+            nonlocal detached
+            detached = asyncio.create_task(record_later())
+
+        recorder.run_trace({"traceId": "detached-origin"}, operation)
+        gate.set()
+        return await detached
+
+    detached_event = asyncio.run(scenario())
+    assert detached_event is not None
+    assert detached_event["traceId"] != "detached-origin"
+    assert detached_event["parentId"] is None
+    assert [
+        event["kind"]
+        for event in recorder.query({"traceId": "detached-origin"})
+    ] == ["trace.started", "trace.completed"]
+
+
+def test_async_run_trace_awaits_body_and_records_terminal_outcome():
+    import asyncio
+
+    recorder = in_memory_recorder(retention_events=-1)
+
+    async def scenario():
+        async def succeed():
+            await asyncio.sleep(0)
+            recorder.record({"kind": "async.body", "source": "test"})
+            return "done"
+
+        assert await recorder.run_trace(
+            {"traceId": "async-success"},
+            succeed,
+        ) == "done"
+
+        async def fail():
+            await asyncio.sleep(0)
+            recorder.record(
+                {"kind": "async.before-failure", "source": "test"}
+            )
+            raise ValueError("async failure")
+
+        with pytest.raises(ValueError, match="async failure"):
+            await recorder.run_trace(
+                {"traceId": "async-failure"},
+                fail,
+            )
+
+    asyncio.run(scenario())
+    assert [
+        event["kind"]
+        for event in recorder.query({"traceId": "async-success"})
+    ] == ["trace.started", "async.body", "trace.completed"]
+    assert [
+        event["kind"]
+        for event in recorder.query({"traceId": "async-failure"})
+    ] == [
+        "trace.started",
+        "async.before-failure",
+        "trace.failed",
+    ]
+
+
+def test_async_with_parent_preserves_supplied_parent():
+    import asyncio
+
+    recorder = in_memory_recorder(retention_events=-1)
+
+    async def scenario():
+        async def operation():
+            parent = recorder.record(
+                {"kind": "async.parent", "source": "test"}
+            )
+
+            async def child():
+                await asyncio.sleep(0)
+                return recorder.record(
+                    {"kind": "async.child", "source": "test"}
+                )
+
+            return await recorder.with_parent(parent["id"], child)
+
+        return await recorder.run_trace(
+            {"traceId": "async-parent"},
+            operation,
+        )
+
+    child = asyncio.run(scenario())
+    events = recorder.query({"traceId": "async-parent"})
+    parent = next(
+        event for event in events if event["kind"] == "async.parent"
+    )
+    assert child["parentId"] == parent["id"]
+
+
+def test_async_close_and_clear_do_not_block_the_event_loop():
+    import asyncio
+
+    async def close_scenario():
+        recorder = in_memory_recorder(retention_events=-1)
+        entered = asyncio.Event()
+
+        async def operation():
+            entered.set()
+            await asyncio.sleep(0.05)
+
+        trace = asyncio.create_task(
+            recorder.run_trace(
+                {"traceId": "async-close"},
+                operation,
+            )
+        )
+        await entered.wait()
+        with pytest.raises(FlightRecorderError, match="aclose"):
+            recorder.close()
+        await recorder.aclose()
+        await trace
+        assert recorder.health()["initialized"] is False
+
+    async def clear_scenario():
+        recorder = in_memory_recorder(retention_events=-1)
+        entered = asyncio.Event()
+
+        async def operation():
+            entered.set()
+            await asyncio.sleep(0.05)
+
+        trace = asyncio.create_task(
+            recorder.run_trace(
+                {"traceId": "async-clear"},
+                operation,
+            )
+        )
+        await entered.wait()
+        with pytest.raises(FlightRecorderError, match="aclear"):
+            recorder.clear()
+        assert await recorder.aclear() is True
+        await trace
+        assert recorder.health()["eventCount"] == 0
+
+    asyncio.run(close_scenario())
+    asyncio.run(clear_scenario())
+
+
+def test_trace_setup_errors_do_not_leak_active_operation_count():
+    recorder = in_memory_recorder()
+    with pytest.raises(TypeError):
+        recorder.run_trace(
+            {"traceId": object()},
+            lambda: None,
+        )
+    assert recorder._active_trace_operations == 0
+    assert recorder.run_trace(
+        {"traceId": "numeric-session", "sessionId": 12345},
+        lambda: "ok",
+    ) == "ok"
+    recorder.close()
+
+
+def test_lone_unicode_surrogate_session_is_normalized_fail_open():
+    recorder = in_memory_recorder()
+    ran = False
+
+    def operation():
+        nonlocal ran
+        ran = True
+
+    recorder.run_trace(
+        {"traceId": "unicode-session", "sessionId": "\ud800"},
+        operation,
+    )
+    events = recorder.query({"traceId": "unicode-session"})
+    assert ran is True
+    assert len(events) == 2
+    assert re.fullmatch(
+        r"session:[0-9a-f]{24}",
+        events[0]["sessionId"],
+    )
+    assert recorder.health()["errorCount"] == 0
+    structural = recorder.record(
+        {
+            "traceId": "bad\ud800",
+            "kind": "unicode.identifier",
+            "source": "test",
+        }
+    )
+    assert structural["traceId"] == "bad\ufffd"
+    assert sanitize_flight_value(
+        {"value": "\ud800"}
+    ) == {"value": "\ufffd"}
+    first_order = sanitize_flight_value(
+        {"\ud800": "first", "\ufffd": "second"}
+    )
+    second_order = sanitize_flight_value(
+        {"\ufffd": "second", "\ud800": "first"}
+    )
+    assert first_order == second_order == {
+        "\ufffd": "first",
+        "\ufffd#2": "second",
+    }
+
+
+def test_custom_privacy_applies_to_structural_identifiers_except_kind():
+    recorder = in_memory_recorder(
+        privacy={
+            "excludedPathPatterns": [
+                re.compile(r"secret|custom\.kind", re.I)
+            ],
+            "redactedKeys": [
+                "id",
+                "traceId",
+                "source",
+                "parentId",
+            ],
+        }
+    )
+
+    def record_custom():
+        recorder.record(
+            {
+                "kind": "custom.kind",
+                "source": "secret-source",
+                "parentId": "secret-parent",
+            }
+        )
+
+    recorder.run_trace(
+        {"traceId": "secret-trace-customer-123"},
+        record_custom,
+    )
+    events = recorder.query(
+        {"traceId": "secret-trace-customer-123"}
+    )
+    custom = next(
+        event for event in events
+        if event["kind"] == "custom.kind"
+    )
+    assert re.fullmatch(r"trace:[0-9a-f]{24}", custom["traceId"])
+    assert re.fullmatch(r"source:[0-9a-f]{24}", custom["source"])
+    assert re.fullmatch(r"event:[0-9a-f]{24}", custom["parentId"])
+    assert all(
+        re.fullmatch(r"event:[0-9a-f]{24}", event["id"])
+        for event in events
+    )
+    assert len(recorder.query({"source": "secret-source"})) == 1
+    assert "secret-" not in json.dumps(events)
+
+
+def test_lifecycle_kinds_remain_non_redactable_for_active_retention():
+    recorder = in_memory_recorder(
+        retention_events=0,
+        privacy={"redactedValues": ["trace"]},
+    )
+
+    def operation():
+        recorder.record(
+            {"kind": "inside.lifecycle", "source": "test"}
+        )
+        active = recorder.query({"traceId": "private-lifecycle"})
+        assert [event["kind"] for event in active] == [
+            "trace.started",
+            "inside.lifecycle",
+        ]
+
+    recorder.run_trace({"traceId": "private-lifecycle"}, operation)
+
+
+def test_displayed_private_trace_ids_stay_stable_for_query_and_import():
+    recorder = in_memory_recorder(
+        privacy={"redactedValues": ["trace"]},
+    )
+
+    def operation():
+        recorder.record({"kind": "stable.event", "source": "test"})
+
+    recorder.run_trace({"traceId": "private-stable-trace"}, operation)
+    exported = recorder.export()
+    displayed_trace_id = exported["events"][0]["traceId"]
+
+    assert len(
+        recorder.query({"traceId": displayed_trace_id})
+    ) == len(exported["events"])
+    assert recorder.import_(
+        exported,
+        replace=True,
+    ) == len(exported["events"])
+
+
+def test_fail_open_error_formatting_survives_hostile_str():
+    class HostileError(Exception):
+        def __str__(self):
+            raise RuntimeError("stringification failed")
+
+    class HostileLedger:
+        def initialize(self):
+            pass
+
+        def append(self, _event):
+            raise HostileError()
+
+        def close(self):
+            pass
+
+        def count(self):
+            return 0
+
+        def query(self, *_args, **_kwargs):
+            return []
+
+        def prune(self, _keep):
+            return 0
+
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=TEST_IDENTITY_KEY,
+        ledger=HostileLedger(),
+    )
+    recorder.initialize()
+
+    assert recorder.record(
+        {"kind": "hostile.error", "source": "test"}
+    ) is None
+    assert recorder.health()["lastError"] == (
+        "HostileError: [unavailable]"
+    )
+
+
+def test_hostile_error_traversal_still_records_terminal_failure():
+    class HostileError(Exception):
+        @property
+        def code(self):
+            raise RuntimeError("blocked code")
+
+        def __str__(self):
+            raise RuntimeError("blocked stringification")
+
+    recorder = in_memory_recorder(privacy={"recordIO": True})
+    hostile = HostileError()
+    with pytest.raises(HostileError) as caught:
+        recorder.run_trace(
+            {"traceId": "hostile-terminal"},
+            lambda: (_ for _ in ()).throw(hostile),
+        )
+    assert caught.value is hostile
+    assert [
+        event["kind"]
+        for event in recorder.query({"traceId": "hostile-terminal"})
+    ] == ["trace.started", "trace.failed"]
+
+
+def test_health_survives_post_initialization_count_failure():
+    recorder = in_memory_recorder()
+
+    def fail_count():
+        raise RuntimeError("count failed")
+
+    recorder._ledger.count = fail_count
+    health = recorder.health()
+
+    assert health["initialized"] is True
+    assert health["eventCount"] == 0
+    assert health["errorCount"] >= 1
+    assert "count failed" in health["lastError"]
+
+
+def test_stale_reset_barrier_is_reclaimed(work_dir):
+    database = work_dir / "stale-reset" / "flight.db"
+    database.parent.mkdir()
+    Path(f"{database}.reset-lock").write_text(
+        "2147483647\n",
+        encoding="utf-8",
+    )
+    recorder = FlightRecorder(enabled=True, database_path=database)
+    recorder.initialize()
+
+    assert recorder.health()["initialized"] is True
+    assert not Path(f"{database}.reset-lock").exists()
+
+
+def test_initialization_retry_reregisters_owner(work_dir, monkeypatch):
+    database = work_dir / "retry-owner" / "flight.db"
+    database.parent.mkdir()
+    original_initialize = SQLiteFlightLedger.initialize
+    attempts = {"count": 0}
+
+    def fail_once(ledger):
+        attempts["count"] += 1
+        if attempts["count"] == 1:
+            raise RuntimeError("transient initialize failure")
+        return original_initialize(ledger)
+
+    monkeypatch.setattr(SQLiteFlightLedger, "initialize", fail_once)
+    recorder = FlightRecorder(enabled=True, database_path=database)
+    recorder.initialize()
+    assert recorder.health()["initialized"] is False
+    recorder._next_initialization_attempt_at = 0
+    recorder.initialize()
+
+    owners = list(Path(f"{database}.owners").glob("*.json"))
+    assert recorder.health()["initialized"] is True
+    assert len(owners) == 1
+
+
+def test_concurrent_close_callers_wait_for_same_cleanup():
+    class SlowCloseLedger(SQLiteFlightLedger):
+        def __init__(self):
+            super().__init__(in_memory=True)
+            self.entered = threading.Event()
+            self.release = threading.Event()
+
+        def close(self):
+            self.entered.set()
+            self.release.wait(timeout=5)
+            return super().close()
+
+    ledger = SlowCloseLedger()
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=TEST_IDENTITY_KEY,
+        ledger=ledger,
+    )
+    recorder.initialize()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        first = pool.submit(recorder.close)
+        assert ledger.entered.wait(timeout=5)
+        second = pool.submit(recorder.close)
+        time.sleep(0.02)
+        assert not second.done()
+        ledger.release.set()
+        first.result(timeout=5)
+        second.result(timeout=5)
+
+
+def test_exact_export_import_and_atomic_hash_tamper_refusal():
+    source = in_memory_recorder(privacy={"recordIO": True})
+    source.record(
+        {
+            "traceId": "portable",
+            "kind": "tool.call.completed",
+            "source": "test",
+            "payload": {"answer": 42},
+        }
+    )
+    exported = source.export()
+    assert "ownerPid" not in exported["events"][0]["metadata"]
+    assert source.import_(exported) == 0
+    destination = SQLiteFlightLedger(in_memory=True)
+    destination.initialize()
+    assert destination.import_(exported) == 1
+    assert destination.query() == exported["events"]
+
+    tampered = copy.deepcopy(exported)
+    tampered["events"].append(copy.deepcopy(exported["events"][0]))
+    tampered["events"][1]["id"] = "tampered-id"
+    tampered["events"][1]["traceId"] = "tampered-trace"
+    with pytest.raises(FlightRecorderCorruptionError, match="integrity"):
+        destination.import_(tampered)
+    assert destination.count() == 1
+
+
+def test_import_rejects_hash_valid_privacy_violations():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    unsafe_cases = [
+        ledger_event(
+            f"unsafe-{index}",
+            f"unsafe-trace-{index}",
+            1,
+            "2026-01-01T00:00:00.000Z",
+        )
+        for index in range(4)
+    ]
+    unsafe_cases[0]["sessionId"] = "alice@example.com"
+    unsafe_cases[1]["workspaceId"] = "/Users/alice/private"
+    unsafe_cases[2]["metadata"] = {"authorization": "raw-secret"}
+    unsafe_cases[3]["payload"] = {"token": "raw-token"}
+    for index, raw_workspace in enumerate(
+        (
+            "file:///Users/alice/private",
+            "workspace:/Users/alice/private",
+            r"workspace:C:\Users\alice\private",
+        ),
+        start=len(unsafe_cases),
+    ):
+        unsafe = ledger_event(
+            f"unsafe-{index}",
+            f"unsafe-trace-{index}",
+            1,
+            "2026-01-01T00:00:00.000Z",
+        )
+        unsafe["workspaceId"] = raw_workspace
+        unsafe_cases.append(unsafe)
+    forged_owner = ledger_event(
+        "unsafe-owner",
+        "unsafe-owner-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+        kind="trace.started",
+        metadata={"ownerPid": os.getpid()},
+    )
+    unsafe_cases.append(forged_owner)
+    for event in unsafe_cases:
+        event["contentHash"] = compute_flight_event_hash(event)
+        with pytest.raises(
+            FlightRecorderCorruptionError,
+            match="privacy|opaque session|raw path|live trace ownership",
+        ):
+            ledger.import_(
+                {
+                    "schema": FLIGHT_EXPORT_SCHEMA,
+                    "exportedAt": "2026-01-01T00:00:00.000Z",
+                    "events": [event],
+                }
+            )
+    assert ledger.count() == 0
+
+
+def test_import_rejects_secret_shaped_top_level_fields():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    token = f"ghp_{'x' * 32}"
+    invalid = ledger_event(
+        "top-level-secret",
+        "top-level-secret-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    invalid["providerId"] = token
+    invalid["contentHash"] = compute_flight_event_hash(invalid)
+
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="providerId.*privacy",
+    ):
+        ledger.import_(
+            {
+                "schema": FLIGHT_EXPORT_SCHEMA,
+                "exportedAt": "2026-01-01T00:00:00.000Z",
+                "events": [invalid],
+            }
+        )
+
+    secret_id = ledger_event(
+        token,
+        "secret-id-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="id.*privacy",
+    ):
+        ledger.import_(
+            {
+                "schema": FLIGHT_EXPORT_SCHEMA,
+                "exportedAt": "2026-01-01T00:00:00.000Z",
+                "events": [secret_id],
+            }
+        )
+
+
+def test_import_rejects_conflicting_duplicate_ids():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    original = ledger_event(
+        "duplicate-id",
+        "duplicate-original",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    conflicting = ledger_event(
+        "duplicate-id",
+        "duplicate-conflict",
+        1,
+        "2026-01-01T00:00:01.000Z",
+    )
+    ledger.append(original)
+
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="conflicts with existing content",
+    ):
+        ledger.import_(
+            {
+                "schema": FLIGHT_EXPORT_SCHEMA,
+                "exportedAt": "2026-01-01T00:00:02.000Z",
+                "events": [conflicting],
+            }
+        )
+
+
+def test_multi_row_replace_stages_swapped_sequences():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    first = ledger_event(
+        "swap-a",
+        "swap-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    second = ledger_event(
+        "swap-b",
+        "swap-trace",
+        2,
+        "2026-01-01T00:00:01.000Z",
+    )
+    ledger.append(first)
+    ledger.append(second)
+    swapped_a = dict(first)
+    swapped_a["sequence"] = 2
+    swapped_a["contentHash"] = compute_flight_event_hash(swapped_a)
+    swapped_b = dict(second)
+    swapped_b["sequence"] = 1
+    swapped_b["contentHash"] = compute_flight_event_hash(swapped_b)
+
+    assert ledger.import_(
+        {
+            "schema": FLIGHT_EXPORT_SCHEMA,
+            "exportedAt": "2026-01-01T00:00:02.000Z",
+            "events": [swapped_a, swapped_b],
+        },
+        replace=True,
+    ) == 2
+    assert [
+        (event["id"], event["sequence"])
+        for event in ledger.query({"traceId": "swap-trace"})
+    ] == [("swap-b", 1), ("swap-a", 2)]
+
+
+def test_import_validates_existing_ledger_before_mutation():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    ledger.append(
+        ledger_event(
+            "existing-corrupt",
+            "existing-corrupt-trace",
+            1,
+            "2026-01-01T00:00:00.000Z",
+        )
+    )
+    ledger._db.execute(
+        "UPDATE flight_events SET event_json = ? WHERE id = ?",
+        ("{bad", "existing-corrupt"),
+    )
+    incoming = ledger_event(
+        "unrelated-import",
+        "unrelated-import-trace",
+        1,
+        "2026-01-01T00:00:01.000Z",
+    )
+
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="not valid JSON",
+    ):
+        ledger.import_(
+            {
+                "schema": FLIGHT_EXPORT_SCHEMA,
+                "exportedAt": "2026-01-01T00:00:02.000Z",
+                "events": [incoming],
+            }
+        )
+    assert ledger.count() == 1
+
+
+def test_import_rejects_auto_as_concrete_model():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    invalid = ledger_event(
+        "auto-model",
+        "auto-model-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    invalid["model"] = "auto"
+    invalid["contentHash"] = compute_flight_event_hash(invalid)
+
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="concrete normalized model",
+    ):
+        ledger.import_(
+            {
+                "schema": FLIGHT_EXPORT_SCHEMA,
+                "exportedAt": "2026-01-01T00:00:00.000Z",
+                "events": [invalid],
+            }
+        )
+
+
+def test_import_rejects_payload_when_record_io_is_disabled():
+    source = in_memory_recorder(privacy={"recordIO": True})
+    source.record(
+        {
+            "traceId": "payload-import",
+            "kind": "payload",
+            "source": "test",
+            "payload": {"ordinary": "private"},
+        }
+    )
+    target = in_memory_recorder(privacy={"recordIO": False})
+
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="recordIO is disabled",
+    ):
+        target.import_(source.export_trace("payload-import"))
+
+
+def test_import_applies_custom_redaction_policy():
+    source = in_memory_recorder()
+    source.record(
+        {
+            "traceId": "custom-policy-import",
+            "kind": "metadata",
+            "source": "test",
+            "metadata": {"customerData": "raw-value"},
+        }
+    )
+    target = in_memory_recorder(
+        privacy={"redactedKeys": ["customerData"]}
+    )
+
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="active privacy policy",
+    ):
+        target.import_(source.export_trace("custom-policy-import"))
+
+
+def test_import_applies_custom_policy_to_top_level_identifiers():
+    source = in_memory_recorder()
+    source.record(
+        {
+            "traceId": "sensitive-trace",
+            "kind": "ordinary",
+            "source": "test",
+            "providerId": "internal-provider",
+        }
+    )
+    target = in_memory_recorder(
+        privacy={
+            "excludedPathPatterns": [
+                re.compile(r"sensitive|internal", re.I)
+            ]
+        }
+    )
+
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="active privacy policy",
+    ):
+        target.import_(source.export_trace("sensitive-trace"))
+
+    key_target = in_memory_recorder(
+        privacy={"redactedKeys": ["providerId"]}
+    )
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="active privacy policy",
+    ):
+        key_target.import_(source.export_trace("sensitive-trace"))
+
+
+def test_custom_key_policy_applies_to_recorded_envelope_fields():
+    recorder = in_memory_recorder(
+        privacy={"redactedKeys": ["providerId"]}
+    )
+    event = recorder.record(
+        {
+            "traceId": "custom-envelope-key",
+            "kind": "ordinary",
+            "source": "test",
+            "providerId": "internal-provider",
+        }
+    )
+
+    assert event["providerId"].startswith("provider:")
+    assert "internal-provider" not in json.dumps(event)
+
+
+def test_structural_lifecycle_fields_are_reserved_from_custom_key_policy():
+    recorder = in_memory_recorder(
+        privacy={
+            "redactedKeys": [
+                "traceId",
+                "parentId",
+                "kind",
+                "source",
+            ]
+        }
+    )
+    recorder.run_trace({"traceId": "structural-trace"}, lambda: None)
+    events = recorder.query({"traceId": "structural-trace"})
+    assert [event["kind"] for event in events] == [
+        "trace.started",
+        "trace.completed",
+    ]
+    assert recorder.clear() is True
+
+
+def test_identifier_pseudonyms_are_idempotent_across_import():
+    source = in_memory_recorder(
+        privacy={"redactedKeys": ["providerId"]}
+    )
+    source.record(
+        {
+            "traceId": "idempotent",
+            "kind": "ordinary",
+            "source": "test",
+            "providerId": "internal-provider",
+        }
+    )
+    bundle = source.export_trace("idempotent")
+    provider_id = bundle["events"][0]["providerId"]
+    target = in_memory_recorder(
+        privacy={"redactedKeys": ["providerId"]}
+    )
+
+    target.import_(bundle)
+    assert (
+        target.export_trace("idempotent")["events"][0]["providerId"]
+        == provider_id
+    )
+
+
+def test_normalized_trace_ids_do_not_leak_sequence_cache():
+    recorder = in_memory_recorder(
+        privacy={
+            "excludedPathPatterns": [
+                re.compile(r"secret-trace", re.I)
+            ]
+        }
+    )
+    for index in range(20):
+        recorder.run_trace(
+            {"traceId": f"secret-trace-{index}"},
+            lambda: None,
+        )
+    assert recorder._sequence_by_trace == {}
+
+
+def test_configured_payload_cap_above_default_is_honored():
+    recorder = in_memory_recorder(
+        privacy={"recordIO": True, "maxPayloadBytes": 30_000}
+    )
+    event = recorder.record(
+        {
+            "traceId": "large-configured-payload",
+            "kind": "payload",
+            "source": "test",
+            "payload": {"value": "x" * 20_000},
+        }
+    )
+
+    assert event is not None
+    assert recorder.count() == 1
+
+
+def test_terminal_failure_releases_start_ownership():
+    class TerminalFailLedger(SQLiteFlightLedger):
+        def __init__(self):
+            super().__init__(in_memory=True)
+
+        def append(self, event):
+            if event["kind"] == "trace.completed":
+                raise RuntimeError("terminal append failed")
+            return super().append(event)
+
+    ledger = TerminalFailLedger()
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=TEST_IDENTITY_KEY,
+        retention_events=-1,
+        ledger=ledger,
+    )
+    recorder.initialize()
+    assert recorder.run_trace(
+        {"traceId": "terminal-failure"},
+        lambda: "success",
+    ) == "success"
+    events = recorder.query({"traceId": "terminal-failure"})
+    assert "ownerPid" not in events[0]["metadata"]
+    assert recorder.clear() is True
+
+
+def test_failed_nested_start_does_not_terminate_ancestor():
+    class FailSecondAppendLedger(SQLiteFlightLedger):
+        def __init__(self):
+            super().__init__(in_memory=True)
+            self.attempts = 0
+
+        def append(self, event):
+            self.attempts += 1
+            if self.attempts == 2:
+                raise RuntimeError("nested start append failed")
+            return super().append(event)
+
+    ledger = FailSecondAppendLedger()
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=TEST_IDENTITY_KEY,
+        retention_events=-1,
+        ledger=ledger,
+    )
+    recorder.initialize()
+
+    def run_nested():
+        def nested_operation():
+            recorder.record({"kind": "nested.work", "source": "test"})
+            return "nested result"
+
+        assert recorder.run_trace({}, nested_operation) == "nested result"
+        active = recorder.query({"traceId": "nested-start-failure"})
+        assert [event["kind"] for event in active] == [
+            "trace.started",
+            "nested.work",
+        ]
+        assert active[1]["parentId"] is None
+
+    recorder.run_trace(
+        {"traceId": "nested-start-failure"},
+        run_nested,
+    )
+    events = recorder.query({"traceId": "nested-start-failure"})
+    assert [event["kind"] for event in events] == [
+        "trace.started",
+        "nested.work",
+        "trace.completed",
+    ]
+    assert events[2]["parentId"] == events[0]["id"]
+
+
+def test_cancelled_trace_releases_ownership():
+    import asyncio
+
+    recorder = in_memory_recorder()
+    with pytest.raises(asyncio.CancelledError):
+        recorder.run_trace(
+            {"traceId": "cancelled-trace"},
+            lambda: (_ for _ in ()).throw(asyncio.CancelledError()),
+        )
+
+    assert recorder.clear() is True
+
+
+def test_explicit_prune_failure_is_raised():
+    class PruneFailureLedger(SQLiteFlightLedger):
+        def prune(self, _keep):
+            raise RuntimeError("checkpoint failed")
+
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=TEST_IDENTITY_KEY,
+        ledger=PruneFailureLedger(in_memory=True),
+    )
+    recorder.initialize()
+    with pytest.raises(RuntimeError, match="checkpoint failed"):
+        recorder.prune(0)
+
+
+def test_replace_import_preserves_live_trace_ownership():
+    recorder = in_memory_recorder(retention_events=0)
+
+    def replace_inside_trace():
+        bundle = recorder.export_trace("replace-active")
+        assert "ownerPid" not in bundle["events"][0]["metadata"]
+        altered = copy.deepcopy(bundle)
+        altered["events"][0]["sessionId"] = (
+            "session:111111111111111111111111"
+        )
+        altered["events"][0]["workspaceId"] = (
+            "workspace:222222222222222222222222"
+        )
+        altered["events"][0]["metadata"]["scopeChanged"] = True
+        altered["events"][0]["contentHash"] = (
+            compute_flight_event_hash(altered["events"][0])
+        )
+        with pytest.raises(
+            FlightRecorderCorruptionError,
+            match="live trace|portable content",
+        ):
+            recorder.import_(altered, replace=True)
+        assert recorder.import_(bundle, replace=True) == len(
+            bundle["events"]
+        )
+        recorder.record({"kind": "inside-active", "source": "test"})
+        assert any(
+            event["kind"] == "trace.started"
+            for event in recorder.query({"traceId": "replace-active"})
+        )
+
+    recorder.run_trace({"traceId": "replace-active"}, replace_inside_trace)
+
+
+def test_replace_completed_trace_does_not_restore_start_ownership():
+    recorder = in_memory_recorder(retention_events=-1)
+    recorder.run_trace({"traceId": "replace-completed"}, lambda: None)
+    bundle = recorder.export_trace("replace-completed")
+
+    assert recorder.import_(bundle, replace=True) == len(bundle["events"])
+    start = next(
+        event
+        for event in recorder.query({"traceId": "replace-completed"})
+        if event["kind"] == "trace.started"
+    )
+    assert "ownerPid" not in start["metadata"]
+    assert "ownerIncarnation" not in start["metadata"]
+
+
+def test_import_cannot_terminate_a_live_trace():
+    recorder = in_memory_recorder(retention_events=0)
+
+    def import_terminal():
+        root = next(
+            event
+            for event in recorder.query({"traceId": "live-import"})
+            if event["kind"] == "trace.started"
+        )
+        terminal = ledger_event(
+            "forged-terminal",
+            root["traceId"],
+            root["sequence"] + 1,
+            "2026-01-01T00:00:01.000Z",
+            kind="trace.completed",
+            parent_id=root["id"],
+        )
+        with pytest.raises(
+            FlightRecorderCorruptionError,
+            match="live trace",
+        ):
+            recorder.import_(
+                {
+                    "schema": FLIGHT_EXPORT_SCHEMA,
+                    "exportedAt": "2026-01-01T00:00:02.000Z",
+                    "events": [terminal],
+                }
+            )
+        assert any(
+            event["kind"] == "trace.started"
+            for event in recorder.query({"traceId": "live-import"})
+        )
+
+    recorder.run_trace({"traceId": "live-import"}, import_terminal)
+
+
+def test_replace_cannot_move_event_out_of_another_live_trace():
+    recorder = in_memory_recorder(retention_events=-1)
+
+    def move_event():
+        context = recorder.record(
+            {"kind": "context.assembled", "source": "test"}
+        )
+        moved = ledger_event(
+            context["id"],
+            "other-trace",
+            1,
+            "2026-01-01T00:00:01.000Z",
+            kind="context.assembled",
+        )
+        with pytest.raises(
+            FlightRecorderCorruptionError,
+            match="move event.*live trace",
+        ):
+            recorder.import_(
+                {
+                    "schema": FLIGHT_EXPORT_SCHEMA,
+                    "exportedAt": "2026-01-01T00:00:02.000Z",
+                    "events": [moved],
+                },
+                replace=True,
+            )
+
+    recorder.run_trace({"traceId": "original-live"}, move_event)
+
+
+def test_explicit_inspection_fails_loud_and_recording_remains_fail_open():
+    recorder = in_memory_recorder()
+    recorder.record(
+        {
+            "traceId": "corrupt-trace",
+            "kind": "agent.execute.completed",
+            "source": "test",
+        }
+    )
+    recorder._ledger._db.execute(
+        "UPDATE flight_events SET event_json = ? WHERE trace_id = ?",
+        ("not-json", "corrupt-trace"),
+    )
+
+    with pytest.raises(FlightRecorderCorruptionError, match="not valid JSON"):
+        recorder.query({"traceId": "corrupt-trace"})
+    health = recorder.health()
+    assert health["errorCount"] == 1
+    assert "Corrupt flight event row" in health["lastError"]
+
+    with pytest.raises(FlightRecorderCorruptionError):
+        recorder.export()
+    with pytest.raises(FlightRecorderCorruptionError):
+        recorder.export_trace("corrupt-trace")
+    assert recorder.health()["errorCount"] == 3
+
+    def fail_append(_event):
+        raise RuntimeError("append path failed")
+
+    mutating = in_memory_recorder()
+    mutating._ledger.append = fail_append
+    assert mutating.run_trace(
+        {"traceId": "fail-open"},
+        lambda: "still works",
+    ) == "still works"
+    assert mutating.health()["errorCount"] >= 1
+    assert "append path failed" in mutating.health()["lastError"]
+
+    def fail_clear():
+        raise RuntimeError("clear failed")
+
+    mutating._ledger.clear = fail_clear
+    with pytest.raises(RuntimeError, match="clear failed"):
+        mutating.clear()
+    assert "clear failed" in mutating.health()["lastError"]
+
+    def fail_import(_data, *, replace=False):
+        raise RuntimeError(f"import failed: {replace}")
+
+    mutating._ledger.import_ = fail_import
+    with pytest.raises(RuntimeError, match="import failed"):
+        mutating.import_(
+            {
+                "schema": FLIGHT_EXPORT_SCHEMA,
+                "exportedAt": "2026-01-01T00:00:00.000Z",
+                "events": [],
+            }
+        )
+    assert "import failed" in mutating.health()["lastError"]
+
+
+def test_filtered_inspection_validates_every_snapshot_row():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    events = recorded_trace(
+        "filtered-corruption",
+        "filtered-corruption",
+        0,
+        middle_kinds=("context.assembled",),
+    )
+    for event in events:
+        ledger.append(event)
+    ledger._db.execute(
+        "UPDATE flight_events SET trace_id = ? WHERE id = ?",
+        ("hidden-corrupt-trace", events[1]["id"]),
+    )
+
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="traceId does not match event_json",
+    ):
+        ledger.query({"traceId": "filtered-corruption"})
+    with pytest.raises(
+        FlightRecorderCorruptionError,
+        match="traceId does not match event_json",
+    ):
+        ledger.export({"traceId": "filtered-corruption"})
+
+
+def test_global_query_orders_by_chronology_and_rejects_invalid_order():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    for trace in range(20):
+        ledger.append(
+            ledger_event(
+                f"chronology-{trace}",
+                f"trace-{trace}",
+                100 if trace == 0 else 1,
+                f"2026-01-01T00:00:{trace:02d}.000Z",
+            )
+        )
+
+    newest = ledger.query({"order": "desc", "limit": 5})
+    assert [event["id"] for event in newest] == [
+        "chronology-19",
+        "chronology-18",
+        "chronology-17",
+        "chronology-16",
+        "chronology-15",
+    ]
+    assert [event["id"] for event in ledger.query({"limit": 2})] == [
+        "chronology-0",
+        "chronology-1",
+    ]
+    with pytest.raises(ValueError, match="order"):
+        ledger.query({"order": "sideways"})
+
+
+def test_timestamp_order_filters_and_prune_use_utc_epoch():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    older_offset = ledger_event(
+        "older-offset",
+        "offset-trace",
+        100,
+        "2026-01-01T00:30:00+01:00",
+    )
+    newer_utc = ledger_event(
+        "newer-utc",
+        "utc-trace",
+        1,
+        "2025-12-31T23:45:00Z",
+    )
+    ledger.append(older_offset)
+    ledger.append(newer_utc)
+
+    assert [event["id"] for event in ledger.query()] == [
+        "older-offset",
+        "newer-utc",
+    ]
+    assert [event["id"] for event in ledger.query({"order": "desc"})] == [
+        "newer-utc",
+        "older-offset",
+    ]
+    assert ledger.query({"since": "2025-12-31T23:40:00Z"}) == [newer_utc]
+    assert ledger.query({"until": "2025-12-31T23:40:00Z"}) == [older_offset]
+    with pytest.raises(FlightRecorderCorruptionError, match="since"):
+        ledger.query({"since": "not-a-timestamp"})
+
+    assert ledger.prune(1) == 1
+    assert ledger.query() == [newer_utc]
+
+
+def test_strict_iso_dates_reject_impossible_calendars_and_invalid_offsets():
+    invalid_timestamps = (
+        "2026-02-29T00:00:00.000Z",
+        "2026-02-30T00:00:00.000Z",
+        "2026-04-31T00:00:00.000Z",
+        "2026-06-15T24:00:00.000Z",
+        "2026-06-15T12:00:00.1234Z",
+        "2026-06-15T12:00:00+00:60",
+        "2026-06-15T12:00:00+14:01",
+        "٢٠٢٦-٠٨-١٢T١٢:٣٤:٥٦.٧٨٩Z",
+    )
+    for index, timestamp in enumerate(invalid_timestamps):
+        ledger = SQLiteFlightLedger(in_memory=True)
+        ledger.initialize()
+        with pytest.raises(FlightRecorderCorruptionError, match="ISO timestamp"):
+            ledger.append(
+                ledger_event(
+                    f"invalid-date-{index}",
+                    "invalid-date-trace",
+                    1,
+                    timestamp,
+                )
+            )
+
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    with pytest.raises(FlightRecorderCorruptionError, match="ISO timestamp"):
+        ledger.import_(
+            {
+                "schema": FLIGHT_EXPORT_SCHEMA,
+                "exportedAt": "2026-02-30T00:00:00.000Z",
+                "events": [],
+            }
+        )
+    with pytest.raises(FlightRecorderCorruptionError, match="since"):
+        ledger.query({"since": "2026-04-31T00:00:00.000Z"})
+    valid = (
+        ledger_event(
+            "valid-leap-day",
+            "valid-date-trace",
+            1,
+            "2024-02-29T23:59:59.999Z",
+        ),
+        ledger_event(
+            "valid-offset",
+            "valid-date-trace",
+            2,
+            "2026-06-15T12:00:00.123-05:30",
+        ),
+        ledger_event(
+            "valid-maximum-offset",
+            "valid-date-trace",
+            3,
+            "2026-06-15T12:00:00+14:00",
+        ),
+    )
+    for event in valid:
+        ledger.append(event)
+    assert ledger.count() == 3
+
+
+def test_fractional_timestamp_precision_is_exact_and_version_independent():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    samples = (
+        ("fraction-1", "1970-01-01T00:00:00.1Z", 100),
+        ("fraction-2", "1970-01-01T00:00:00.12Z", 120),
+        ("fraction-3", "1970-01-01T00:00:00.123Z", 123),
+        ("pre-epoch", "1969-12-31T23:59:59.999Z", -1),
+    )
+    for index, (event_id, timestamp, _expected) in enumerate(samples, start=1):
+        ledger.append(
+            ledger_event(
+                event_id,
+                f"fraction-trace-{index}",
+                1,
+                timestamp,
+            )
+        )
+
+    stored = dict(
+        ledger._db.execute(
+            f"""
+            SELECT id, timestamp_ms FROM flight_events
+            WHERE id IN ({','.join('?' for _ in samples)})
+            """,
+            [event_id for event_id, _timestamp, _expected in samples],
+        ).fetchall()
+    )
+    assert stored == {
+        event_id: expected
+        for event_id, _timestamp, expected in samples
+    }
+
+
+def test_pre_timestamp_ms_database_migrates_and_backfills_transactionally(work_dir):
+    database = work_dir / "legacy-flight.db"
+    legacy_event = ledger_event(
+        "legacy-event",
+        "legacy-trace",
+        1,
+        "2026-01-01T00:30:00+01:00",
+    )
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE flight_events (
+                id TEXT PRIMARY KEY,
+                sequence INTEGER NOT NULL,
+                trace_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                source TEXT NOT NULL,
+                status TEXT NOT NULL,
+                session_id TEXT,
+                workspace_id TEXT,
+                provider_id TEXT,
+                agent_name TEXT,
+                tool_name TEXT,
+                event_json TEXT NOT NULL,
+                UNIQUE (trace_id, sequence)
+            );
+            CREATE INDEX idx_flight_events_timestamp
+                ON flight_events(timestamp);
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO flight_events (
+                id, sequence, trace_id, timestamp, kind, source, status,
+                session_id, workspace_id, provider_id, agent_name, tool_name,
+                event_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                legacy_event["id"],
+                legacy_event["sequence"],
+                legacy_event["traceId"],
+                legacy_event["timestamp"],
+                legacy_event["kind"],
+                legacy_event["source"],
+                legacy_event["status"],
+                None,
+                None,
+                None,
+                None,
+                None,
+                json.dumps(legacy_event, separators=(",", ":")),
+            ),
+        )
+
+    ledger = SQLiteFlightLedger(database_path=database)
+    ledger.initialize()
+    columns = {
+        row[1]: row
+        for row in ledger._db.execute("PRAGMA table_info(flight_events)").fetchall()
+    }
+    assert columns["timestamp_ms"][3] == 1
+    assert ledger.query() == [legacy_event]
+    stored_ms = ledger._db.execute(
+        "SELECT timestamp_ms FROM flight_events WHERE id = ?",
+        ("legacy-event",),
+    ).fetchone()[0]
+    assert stored_ms == 1_767_223_800_000
+
+
+def test_python_reads_typescript_alter_table_timestamp_layout(work_dir):
+    database = work_dir / "typescript-layout.db"
+    sample = ledger_event(
+        "typescript-layout-event",
+        "typescript-layout-trace",
+        1,
+        "2026-01-01T00:00:00.000Z",
+    )
+    with sqlite3.connect(database) as connection:
+        connection.executescript(
+            """
+            CREATE TABLE flight_events (
+                id TEXT PRIMARY KEY,
+                sequence INTEGER NOT NULL,
+                trace_id TEXT NOT NULL,
+                timestamp TEXT NOT NULL,
+                kind TEXT NOT NULL,
+                source TEXT NOT NULL,
+                status TEXT NOT NULL,
+                session_id TEXT,
+                workspace_id TEXT,
+                provider_id TEXT,
+                agent_name TEXT,
+                tool_name TEXT,
+                event_json TEXT NOT NULL,
+                timestamp_ms INTEGER NOT NULL DEFAULT 0,
+                UNIQUE (trace_id, sequence)
+            );
+            """
+        )
+        connection.execute(
+            """
+            INSERT INTO flight_events (
+                id, sequence, trace_id, timestamp, kind, source, status,
+                session_id, workspace_id, provider_id, agent_name, tool_name,
+                event_json, timestamp_ms
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                sample["id"],
+                sample["sequence"],
+                sample["traceId"],
+                sample["timestamp"],
+                sample["kind"],
+                sample["source"],
+                sample["status"],
+                None,
+                None,
+                None,
+                None,
+                None,
+                json.dumps(sample, separators=(",", ":")),
+                1_767_225_600_000,
+            ),
+        )
+
+    ledger = SQLiteFlightLedger(database_path=database)
+    ledger.initialize()
+    assert ledger.query() == [sample]
+
+
+def test_retention_keeps_an_oversized_completed_trace_whole():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    completed = recorded_trace(
+        "oversized-completed-trace",
+        "oversized",
+        0,
+        middle_kinds=(
+            "context.assembled",
+            "provider.attempt.completed",
+            "agent.execute.completed",
+        ),
+    )
+    for event in completed:
+        ledger.append(event)
+
+    assert ledger.prune(3) == 0
+    assert ledger.query({"traceId": "oversized-completed-trace"}) == completed
+
+
+def test_retention_prunes_an_older_completed_trace_as_a_whole():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    older = recorded_trace(
+        "older-completed-trace",
+        "older",
+        0,
+        middle_kinds=("context.assembled",),
+    )
+    newer = recorded_trace(
+        "newer-completed-trace",
+        "newer",
+        10,
+        middle_kinds=("context.assembled",),
+    )
+    for event in [*older, *newer]:
+        ledger.append(event)
+
+    assert ledger.prune(len(newer)) == len(older)
+    assert ledger.query() == newer
+    assert ledger.query({"traceId": "older-completed-trace"}) == []
+
+
+def test_retention_always_preserves_active_traces():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    completed = recorded_trace(
+        "old-completed-trace",
+        "old-completed",
+        0,
+        middle_kinds=("context.assembled",),
+    )
+    active = recorded_trace(
+        "active-trace",
+        "active",
+        10,
+        middle_kinds=("context.assembled", "provider.attempt.started"),
+        terminal=None,
+    )
+    for event in [*completed, *active]:
+        ledger.append(event)
+
+    assert ledger.prune(1) == 0
+    assert ledger.query({"traceId": "active-trace"}) == active
+    assert ledger.query({"traceId": "old-completed-trace"}) == completed
+    assert ledger.count() == len(active) + len(completed)
+
+
+def test_retention_preserves_newest_completed_trace_alongside_active():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    active = recorded_trace(
+        "active-pinned",
+        "active-pinned",
+        0,
+        middle_kinds=("context.assembled",),
+        terminal=None,
+    )
+    completed = recorded_trace(
+        "completed-pinned",
+        "completed-pinned",
+        10,
+    )
+    for event in [*active, *completed]:
+        ledger.append(event)
+
+    assert ledger.prune(3) == 0
+    assert ledger.query({"traceId": "active-pinned"}) == active
+    assert ledger.query({"traceId": "completed-pinned"}) == completed
+
+
+def test_retention_treats_a_restarted_completed_trace_as_active():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    old_completed = recorded_trace(
+        "old-completed-trace",
+        "old-completed",
+        0,
+    )
+    resumed = [
+        ledger_event(
+            "resumed-start-1",
+            "resumed-trace",
+            1,
+            "2026-01-01T00:00:10.000Z",
+            kind="trace.started",
+        ),
+        ledger_event(
+            "resumed-complete",
+            "resumed-trace",
+            2,
+            "2026-01-01T00:00:11.000Z",
+            kind="trace.completed",
+            parent_id="resumed-start-1",
+        ),
+        ledger_event(
+            "resumed-start-2",
+            "resumed-trace",
+            3,
+            "2026-01-01T00:00:12.000Z",
+            kind="trace.started",
+        ),
+        ledger_event(
+            "resumed-context",
+            "resumed-trace",
+            4,
+            "2026-01-01T00:00:13.000Z",
+            kind="context.assembled",
+            parent_id="resumed-start-2",
+        ),
+    ]
+    for event in [*old_completed, *resumed]:
+        ledger.append(event)
+
+    assert ledger.prune(1) == 0
+    assert ledger.query({"traceId": "resumed-trace"}) == resumed
+    assert ledger.query({"traceId": "old-completed-trace"}) == old_completed
+
+
+def test_retention_uses_sequence_depth_for_nested_and_clock_rollback_traces():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    completed = recorded_trace(
+        "completed-before-nested",
+        "completed-before-nested",
+        0,
+    )
+    nested_active = [
+        ledger_event(
+            "nested-outer-start",
+            "nested-active",
+            1,
+            "2026-06-01T00:00:00.000Z",
+            kind="trace.started",
+        ),
+        ledger_event(
+            "nested-inner-start",
+            "nested-active",
+            2,
+            "2026-06-01T00:00:01.000Z",
+            kind="trace.started",
+        ),
+        ledger_event(
+            "nested-inner-complete",
+            "nested-active",
+            3,
+            "2026-06-01T00:00:02.000Z",
+            kind="trace.completed",
+        ),
+    ]
+    rollback_active = [
+        ledger_event(
+            "rollback-start-1",
+            "rollback-active",
+            1,
+            "2026-05-01T00:00:00.000Z",
+            kind="trace.started",
+        ),
+        ledger_event(
+            "rollback-complete",
+            "rollback-active",
+            2,
+            "2026-05-01T00:00:01.000Z",
+            kind="trace.completed",
+        ),
+        ledger_event(
+            "rollback-start-2",
+            "rollback-active",
+            3,
+            "2025-01-01T00:00:00.000Z",
+            kind="trace.started",
+        ),
+    ]
+    for event in [*completed, *nested_active, *rollback_active]:
+        ledger.append(event)
+
+    assert ledger.prune(0) == len(completed)
+    assert ledger.query({"traceId": "nested-active"}) == nested_active
+    assert ledger.query({"traceId": "rollback-active"}) == rollback_active
+
+
+def test_ledger_refuses_clear_while_trace_is_active():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    ledger.append(
+        ledger_event(
+            "active-clear-start",
+            "active-clear",
+            1,
+            "2026-01-01T00:00:00.000Z",
+            kind="trace.started",
+        )
+    )
+    with pytest.raises(Exception, match="active traces"):
+        ledger.clear()
+    assert ledger.count() == 1
+    ledger.append(
+        ledger_event(
+            "active-clear-complete",
+            "active-clear",
+            2,
+            "2026-01-01T00:00:01.000Z",
+            kind="trace.completed",
+            parent_id="active-clear-start",
+        )
+    )
+    ledger.clear()
+    assert ledger.count() == 0
+
+
+def test_orphaned_trace_from_dead_process_is_prunable():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    ledger.append(
+        ledger_event(
+            "orphaned-start",
+            "orphaned-trace",
+            1,
+            "2026-01-01T00:00:00.000Z",
+            kind="trace.started",
+            metadata={"ownerPid": 2_147_483_647},
+        )
+    )
+
+    assert ledger.prune(0) == 1
+    assert ledger.count() == 0
+
+
+def test_reused_pid_with_different_incarnation_is_not_active():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    ledger.append(
+        ledger_event(
+            "reused-pid-start",
+            "reused-pid",
+            1,
+            "2026-01-01T00:00:00.000Z",
+            kind="trace.started",
+            metadata={
+                "ownerPid": os.getpid(),
+                "ownerIncarnation": "different-process-start",
+            },
+        )
+    )
+
+    assert ledger.prune(0) == 1
+
+
+def test_lifecycle_terminal_matches_exact_parent_start():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    live_start = ledger_event(
+        "live-start",
+        "parent-match",
+        1,
+        "2026-01-01T00:00:00.000Z",
+        kind="trace.started",
+        metadata={"ownerPid": os.getpid()},
+    )
+    dead_start = ledger_event(
+        "dead-start",
+        "parent-match",
+        2,
+        "2026-01-01T00:00:01.000Z",
+        kind="trace.started",
+        metadata={"ownerPid": 2_147_483_647},
+    )
+    live_complete = ledger_event(
+        "live-complete",
+        "parent-match",
+        3,
+        "2026-01-01T00:00:02.000Z",
+        kind="trace.completed",
+        parent_id=live_start["id"],
+    )
+    for event in (live_start, dead_start, live_complete):
+        ledger.append(event)
+
+    assert ledger.prune(0) == 3
+    assert ledger.count() == 0
+
+
+def test_retention_preserves_completed_trace_when_atomic_events_fill_target():
+    ledger = SQLiteFlightLedger(in_memory=True)
+    ledger.initialize()
+    completed = recorded_trace(
+        "completed-trace",
+        "completed",
+        0,
+        middle_kinds=("context.assembled", "agent.execute.completed"),
+    )
+    atomic = [
+        ledger_event(
+            f"atomic-{index}",
+            "atomic-trace",
+            index,
+            f"2026-01-01T00:00:{9 + index:02d}.000Z",
+        )
+        for index in range(1, 4)
+    ]
+    for event in [*completed, *atomic]:
+        ledger.append(event)
+
+    assert ledger.prune(5) == len(atomic)
+    assert ledger.query({"traceId": "completed-trace"}) == completed
+    assert ledger.query({"traceId": "atomic-trace"}) == []
+
+
+def test_concurrent_traces_are_isolated_and_ordered():
+    recorder = in_memory_recorder()
+
+    def run(index):
+        trace_id = f"concurrent-{index}"
+        recorder.run_trace(
+            {"traceId": trace_id, "sessionId": f"session-{index}"},
+            lambda: recorder.record(
+                {
+                    "kind": "agent.execute.completed",
+                    "source": "test",
+                    "agentName": f"Agent{index}",
+                }
+            ),
+        )
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(pool.map(run, range(20)))
+
+    for index in range(20):
+        events = recorder.export_trace(f"concurrent-{index}")["events"]
+        assert [event["sequence"] for event in events] == [1, 2, 3]
+        assert {event["traceId"] for event in events} == {f"concurrent-{index}"}
+        assert {event["sessionId"] for event in events} == {
+            normalize_flight_session_id(
+                f"session-{index}",
+                TEST_IDENTITY_KEY,
+            )
+        }
+
+
+def test_shared_recorders_enforce_retention_from_authoritative_count(work_dir):
+    database = work_dir / "shared-retention" / "flight.db"
+    database.parent.mkdir()
+    first = FlightRecorder(
+        enabled=True,
+        database_path=database,
+        retention_events=10,
+    )
+    second = FlightRecorder(
+        enabled=True,
+        database_path=database,
+        retention_events=10,
+    )
+    first.initialize()
+    second.initialize()
+    try:
+        for index in range(6):
+            first.record(
+                {
+                    "traceId": f"shared-first-{index}",
+                    "kind": "atomic",
+                    "source": "test",
+                }
+            )
+            second.record(
+                {
+                    "traceId": f"shared-second-{index}",
+                    "kind": "atomic",
+                    "source": "test",
+                }
+            )
+        assert first.count() == 10
+    finally:
+        first.close()
+        second.close()
+
+
+def test_many_shared_recorders_eventually_allocate_every_same_trace_sequence(
+    work_dir,
+):
+    database = work_dir / "shared-sequence" / "flight.db"
+    database.parent.mkdir()
+    recorders = [
+        FlightRecorder(
+            enabled=True,
+            database_path=database,
+            retention_events=-1,
+        )
+        for _ in range(12)
+    ]
+    for recorder in recorders:
+        recorder.initialize()
+    try:
+        with ThreadPoolExecutor(max_workers=12) as pool:
+            events = list(
+                pool.map(
+                    lambda recorder: recorder.record(
+                        {
+                            "traceId": "shared-concurrent-trace",
+                            "kind": "atomic",
+                            "source": "test",
+                        }
+                    ),
+                    recorders,
+                )
+            )
+        assert all(event is not None for event in events)
+        assert sorted(event["sequence"] for event in events) == list(
+            range(1, 13)
+        )
+    finally:
+        for recorder in recorders:
+            recorder.close()
+
+
+def test_completed_trace_sequence_and_lock_state_are_evicted():
+    recorder = in_memory_recorder()
+    for index in range(250):
+        recorder.run_trace({"traceId": f"bounded-{index}"}, lambda: None)
+
+    assert recorder._sequence_by_trace == {}
+    assert recorder._sequence_in_flight == set()
+    assert recorder._initialization_waiters == 0
+    assert recorder._initializing is False
+
+    recorder.run_trace({"traceId": "bounded-0"}, lambda: None)
+    assert [
+        event["sequence"]
+        for event in recorder.export_trace("bounded-0")["events"]
+    ] == [1, 2, 3, 4]
+    assert recorder._sequence_by_trace == {}
+    assert recorder._sequence_in_flight == set()
+
+
+def test_standalone_direct_records_evict_sequence_cache():
+    recorder = in_memory_recorder(retention_events=0)
+    for index in range(1_000):
+        recorder.record(
+            {
+                "traceId": f"standalone-{index}",
+                "kind": "atomic",
+                "source": "test",
+            }
+        )
+
+    assert recorder._sequence_by_trace == {}
+    assert recorder._sequence_in_flight == set()
+    assert recorder.count() == 0
+
+
+def test_close_waits_for_in_progress_clear():
+    class SlowClearLedger(SQLiteFlightLedger):
+        def __init__(self):
+            super().__init__(in_memory=True)
+            self.entered = threading.Event()
+            self.release = threading.Event()
+
+        def clear(self):
+            self.entered.set()
+            self.release.wait(timeout=5)
+            return super().clear()
+
+    ledger = SlowClearLedger()
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=TEST_IDENTITY_KEY,
+        ledger=ledger,
+    )
+    recorder.initialize()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        clearing = pool.submit(recorder.clear)
+        assert ledger.entered.wait(timeout=5)
+        closing = pool.submit(recorder.close)
+        time.sleep(0.02)
+        assert not closing.done()
+        ledger.release.set()
+        assert clearing.result(timeout=5) is True
+        closing.result(timeout=5)
+    assert recorder.health()["initialized"] is False
+
+
+def test_runtime_owner_metadata_bypasses_user_redaction_only_for_trace_start():
+    recorder = in_memory_recorder(
+        retention_events=0,
+        privacy={"redactedKeys": ["ownerPid"]},
+    )
+
+    def inspect_active():
+        assert any(
+            event["kind"] == "trace.started"
+            for event in recorder.query({"traceId": "reserved-owner"})
+        )
+
+    recorder.run_trace({"traceId": "reserved-owner"}, inspect_active)
+    ordinary = recorder.record(
+        {
+            "traceId": "user-owner-metadata",
+            "kind": "ordinary",
+            "source": "test",
+            "metadata": {
+                "ownerId": "forged",
+                "ownerPid": os.getpid(),
+            },
+        }
+    )
+    assert ordinary["metadata"] == {}
+
+
+def test_session_pseudonyms_are_keyed():
+    handle = "+15551234567"
+    first = normalize_flight_session_id(handle, TEST_IDENTITY_KEY)
+    second = normalize_flight_session_id(handle, "44" * 32)
+    assert re.fullmatch(r"session:[0-9a-f]{24}", first)
+    assert first == "session:e523e4096e6419b507b73af3"
+    assert first != second
+
+
+def test_top_level_identifiers_are_sanitized_during_recording():
+    recorder = in_memory_recorder()
+    token = f"ghp_{'x' * 32}"
+    event = recorder.record(
+        {
+            "traceId": token,
+            "kind": "ordinary",
+            "source": "/Users/alice/.ssh/id_ed25519",
+            "providerId": token,
+        }
+    )
+
+    serialized = json.dumps(event)
+    assert token not in serialized
+    assert "id_ed25519" not in serialized
+    assert event["traceId"].startswith("trace:")
+    workspace_event = recorder.record(
+        {
+            "traceId": "workspace-secret",
+            "kind": "ordinary",
+            "source": "test",
+            "workspaceId": token,
+        }
+    )
+    assert workspace_event["workspaceId"].startswith("workspace:")
+
+
+class SlowCountingLedger(SQLiteFlightLedger):
+    def __init__(self):
+        super().__init__(in_memory=True)
+        self.initialize_calls = 0
+        self._counter_lock = threading.Lock()
+
+    def initialize(self):
+        with self._counter_lock:
+            self.initialize_calls += 1
+        time.sleep(0.03)
+        super().initialize()
+
+
+class RetentionCountingLedger(SQLiteFlightLedger):
+    def __init__(self):
+        super().__init__(in_memory=True)
+        self.prune_calls = 0
+
+    def prune(self, keep):
+        self.prune_calls += 1
+        return super().prune(keep)
+
+
+class FailOnceAppendLedger(SQLiteFlightLedger):
+    def __init__(self):
+        super().__init__(in_memory=True)
+        self.failed = False
+
+    def append(self, event):
+        if not self.failed:
+            self.failed = True
+            raise RuntimeError("append failed once")
+        return super().append(event)
+
+
+class PruneFailingLedger(SQLiteFlightLedger):
+    def prune(self, _keep):
+        raise RuntimeError("prune failed")
+
+
+def test_append_and_retention_failures_preserve_sequence_and_durable_event_ids():
+    append_ledger = FailOnceAppendLedger()
+    append_recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        retention_events=-1,
+        ledger=append_ledger,
+    )
+    append_recorder.initialize()
+    assert append_recorder.record(
+        {"traceId": "append-retry", "kind": "first", "source": "test"}
+    ) is None
+    persisted = append_recorder.record(
+        {"traceId": "append-retry", "kind": "second", "source": "test"}
+    )
+    assert persisted["sequence"] == 1
+
+    prune_ledger = PruneFailingLedger(in_memory=True)
+    prune_recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        retention_events=0,
+        ledger=prune_ledger,
+    )
+    prune_recorder.initialize()
+    first = prune_recorder.record(
+        {"traceId": "prune-health", "kind": "first", "source": "test"}
+    )
+    second = prune_recorder.record(
+        {"traceId": "prune-health", "kind": "second", "source": "test"}
+    )
+    assert [first["sequence"], second["sequence"]] == [1, 2]
+    assert [event["id"] for event in prune_ledger.query()] == [
+        first["id"],
+        second["id"],
+    ]
+    assert prune_recorder.health()["errorCount"] == 2
+    assert "prune failed" in prune_recorder.health()["lastError"]
+
+
+def test_long_trace_sequence_recovery_uses_one_descending_query():
+    class LongTraceLedger:
+        def __init__(self):
+            self.queries = []
+            self.events = []
+
+        def initialize(self):
+            pass
+
+        def close(self):
+            pass
+
+        def count(self):
+            return len(self.events)
+
+        def query(self, query):
+            self.queries.append(query)
+            return [{"sequence": 1_010_000}]
+
+        def append(self, event):
+            self.events.append(event)
+
+        def prune(self, _keep):
+            return 0
+
+    ledger = LongTraceLedger()
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        retention_events=-1,
+        ledger=ledger,
+    )
+    recorder.initialize()
+    persisted = recorder.record(
+        {
+            "traceId": "million-event-trace",
+            "kind": "continued",
+            "source": "test",
+        }
+    )
+
+    assert persisted["sequence"] == 1_010_001
+    assert ledger.queries == [
+        {
+            "traceId": "million-event-trace",
+            "order": "desc",
+            "limit": 1,
+        }
+    ]
+
+
+def test_retention_maintenance_is_batched_above_the_target():
+    ledger = RetentionCountingLedger()
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        retention_events=101,
+        ledger=ledger,
+    )
+    recorder.initialize()
+
+    for index in range(112):
+        recorder.record(
+            {
+                "traceId": f"retention-batch-{index}",
+                "kind": "agent.execute.completed",
+                "source": "test",
+            }
+        )
+
+    assert ledger.prune_calls == 1
+    assert recorder.count() == 100
+
+
+def test_clear_blocks_direct_records_until_deletion_finishes():
+    class SlowClearLedger(SQLiteFlightLedger):
+        def __init__(self):
+            super().__init__(in_memory=True)
+            self.entered = threading.Event()
+            self.release = threading.Event()
+
+        def clear(self):
+            self.entered.set()
+            self.release.wait(timeout=5)
+            return super().clear()
+
+    ledger = SlowClearLedger()
+    recorder = FlightRecorder(
+        enabled=True,
+        in_memory=True,
+        identity_key=TEST_IDENTITY_KEY,
+        retention_events=-1,
+        ledger=ledger,
+    )
+    recorder.initialize()
+    recorder.record(
+        {"traceId": "before-clear", "kind": "before", "source": "test"}
+    )
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        clearing = pool.submit(recorder.clear)
+        assert ledger.entered.wait(timeout=5)
+        second_clear = pool.submit(recorder.clear)
+        assert recorder.record(
+            {
+                "traceId": "during-clear",
+                "kind": "during",
+                "source": "test",
+            }
+        ) is None
+        ledger.release.set()
+        assert clearing.result(timeout=5) is True
+        assert second_clear.result(timeout=5) is True
+    assert recorder.count() == 0
+
+
+def test_windows_invalid_pid_error_is_classified_as_dead(monkeypatch):
+    error = OSError("invalid process")
+    error.winerror = 87
+
+    def invalid_pid(_pid, _signal):
+        raise error
+
+    monkeypatch.setattr(os, "kill", invalid_pid)
+    assert _process_is_alive(999999) is False
+
+
+def test_process_incarnation_refreshes_after_fork(monkeypatch):
+    import openrappter.flight_recorder as module
+
+    child_pid = os.getpid() + 10_000
+    monkeypatch.setattr(module.os, "getpid", lambda: child_pid)
+    monkeypatch.setattr(
+        module,
+        "_read_process_incarnation",
+        lambda pid: f"child:{pid}",
+    )
+
+    assert _current_process_incarnation() == f"child:{child_pid}"
+
+
+def test_after_fork_reset_does_not_unlink_parent_owner(work_dir):
+    database = work_dir / "fork-owner" / "flight.db"
+    database.parent.mkdir()
+    recorder = FlightRecorder(enabled=True, database_path=database)
+    recorder.initialize()
+    owner_path = recorder._owner_path
+    assert owner_path is not None and owner_path.exists()
+
+    _reset_flight_recorder_after_fork()
+
+    assert owner_path.exists()
+    assert recorder._owner_path is None
+    assert recorder.health()["initialized"] is False
+    owner_path.unlink(missing_ok=True)
+
+
+def test_after_fork_reset_recreates_global_lock():
+    import openrappter.flight_recorder as module
+
+    previous_lock = module._global_lock
+    _reset_flight_recorder_after_fork()
+
+    assert module._global_lock is not previous_lock
+
+
+def test_barrier_disappearance_during_revalidation_is_reclaimed():
+    class DisappearingBarrier:
+        def __init__(self):
+            self.stat_calls = 0
+
+        def stat(self):
+            self.stat_calls += 1
+            if self.stat_calls == 1:
+                return type(
+                    "Stat",
+                    (),
+                    {
+                        "st_dev": 1,
+                        "st_ino": 1,
+                        "st_mtime_ns": 1,
+                        "st_size": 1,
+                    },
+                )()
+            raise FileNotFoundError
+
+        def read_text(self, **_kwargs):
+            return "2147483647"
+
+    assert _reset_barrier_is_active(DisappearingBarrier()) is False
+
+
+def test_concurrent_cold_start_initializes_once_and_reset_clears_state():
+    ledger = SlowCountingLedger()
+    recorder = FlightRecorder(enabled=True, in_memory=True, ledger=ledger)
+
+    with ThreadPoolExecutor(max_workers=12) as pool:
+        list(
+            pool.map(
+                lambda index: recorder.run_trace(
+                    {"traceId": f"cold-{index}"}, lambda: None
+                ),
+                range(12),
+            )
+        )
+
+    assert ledger.initialize_calls == 1
+    assert recorder.count() == 24
+    assert recorder.health()["initialized"] is True
+    assert recorder._initializing is False
+    assert recorder._initialization_waiters == 0
+    assert recorder._sequence_by_trace == {}
+    assert recorder._sequence_in_flight == set()
+
+    set_flight_recorder(recorder)
+    reset_flight_recorder_environment_for_tests()
+    assert recorder.health()["initialized"] is False
+    assert recorder._initializing is False
+    assert recorder._closing is False
+    assert recorder._initialization_waiters == 0
+    assert recorder._sequence_by_trace == {}
+    assert recorder._sequence_in_flight == set()
+    assert get_flight_recorder().health()["enabled"] is False
+
+
+class FailingLedger:
+    def __init__(self, failure):
+        self.failure = failure
+        self.initialized = False
+
+    def initialize(self):
+        if self.failure == "initialize":
+            raise RuntimeError("initialize failed")
+        self.initialized = True
+
+    def close(self):
+        pass
+
+    def append(self, _event):
+        if self.failure == "append":
+            raise RuntimeError("append failed")
+
+    def query(self, *_args, **_kwargs):
+        return []
+
+    def count(self):
+        return 0
+
+    def prune(self, _keep):
+        return 0
+
+
+def test_disabled_noop_and_fail_open_health():
+    disabled_ledger = FailingLedger("initialize")
+    disabled = FlightRecorder(enabled=False, ledger=disabled_ledger)
+    assert disabled.run_trace({}, lambda: 42) == 42
+    assert disabled.record({"kind": "ignored", "source": "test"}) is None
+    assert disabled.health() == {
+        "enabled": False,
+        "initialized": False,
+        "eventCount": 0,
+        "errorCount": 0,
+        "databasePath": str(Path.home() / ".openrappter" / "flight-recorder.db"),
+    }
+    with pytest.raises(FlightRecorderUnhealthyError, match="disabled"):
+        disabled.query()
+    with pytest.raises(FlightRecorderUnhealthyError, match="disabled"):
+        disabled.export()
+    with pytest.raises(FlightRecorderUnhealthyError, match="disabled"):
+        disabled.clear()
+
+    failing = FlightRecorder(enabled=True, ledger=FailingLedger("append"))
+    assert failing.run_trace({}, lambda: "still works") == "still works"
+    health = failing.health()
+    assert health["initialized"] is True
+    assert health["errorCount"] >= 1
+    assert "append failed" in health["lastError"]
+
+
+def test_initialization_failure_uses_retry_cooldown():
+    class CountingFailureLedger(FailingLedger):
+        def __init__(self):
+            super().__init__("initialize")
+            self.initialize_calls = 0
+
+        def initialize(self):
+            self.initialize_calls += 1
+            return super().initialize()
+
+    ledger = CountingFailureLedger()
+    recorder = FlightRecorder(enabled=True, ledger=ledger)
+    assert recorder.run_trace({}, lambda: "still works") == "still works"
+    assert ledger.initialize_calls == 1
+
+
+def test_concurrent_initialization_failures_share_one_cooldown_attempt():
+    class SlowFailureLedger(FailingLedger):
+        def __init__(self):
+            super().__init__("initialize")
+            self.initialize_calls = 0
+
+        def initialize(self):
+            self.initialize_calls += 1
+            time.sleep(0.05)
+            return super().initialize()
+
+    ledger = SlowFailureLedger()
+    recorder = FlightRecorder(enabled=True, ledger=ledger)
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        list(
+            pool.map(
+                lambda index: recorder.record(
+                    {
+                        "traceId": f"failed-init-{index}",
+                        "kind": "event",
+                        "source": "test",
+                    }
+                ),
+                range(8),
+            )
+        )
+
+    assert ledger.initialize_calls == 1
+
+
+def test_failed_initialization_is_fail_open_for_recording_but_unhealthy_for_inspection():
+    recorder = FlightRecorder(enabled=True, ledger=FailingLedger("initialize"))
+    assert recorder.record({"kind": "ignored", "source": "test"}) is None
+    health = recorder.health()
+    assert health["initialized"] is False
+    assert "initialize failed" in health["lastError"]
+
+    with pytest.raises(FlightRecorderUnhealthyError, match="initialize failed"):
+        recorder.query()
+    with pytest.raises(FlightRecorderUnhealthyError, match="initialize failed"):
+        recorder.export()
+    with pytest.raises(FlightRecorderUnhealthyError, match="initialize failed"):
+        recorder.clear()
+
+
+class RecordingAgent(BasicAgent):
+    def __init__(self, outcome=None, error=None):
+        super().__init__(
+            "RecordingAgent",
+            {
+                "name": "RecordingAgent",
+                "description": "test",
+                "parameters": {"type": "object", "properties": {}, "required": []},
+            },
+        )
+        self.outcome = outcome
+        self.error = error
+
+    def perform(self, **kwargs):
+        if self.error:
+            raise self.error
+        return self.outcome
+
+
+def test_basic_agent_records_context_and_preserves_return_and_error_semantics():
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    outcome = '{"status":"success"}'
+    assert RecordingAgent(outcome=outcome).execute(query="hello") is outcome
+    kinds = [event["kind"] for event in recorder.query({"agentName": "RecordingAgent"})]
+    assert kinds == [
+        "agent.execute.started",
+        "context.assembled",
+        "agent.execute.completed",
+    ]
+    agent_events = recorder.query({"agentName": "RecordingAgent"})
+    assert agent_events[1]["parentId"] == agent_events[0]["id"]
+    assert agent_events[2]["parentId"] == agent_events[0]["id"]
+
+    original = ValueError("original failure")
+    with pytest.raises(ValueError) as caught:
+        RecordingAgent(error=original).execute(query="fail")
+    assert caught.value is original
+    failed_agent = recorder.query({"kind": "agent.execute.failed"})[-1]
+    assert failed_agent["status"] == "error"
+    assert failed_agent["metadata"]["messageChars"] == len(str(original))
+    assert "original failure" not in json.dumps(failed_agent)
+
+    error_result = '{"status":"error","message":"command failed"}'
+    assert RecordingAgent(outcome=error_result).execute(query="error") == error_result
+    error_event = recorder.query({"kind": "agent.execute.failed"})[-1]
+    assert error_event["status"] == "error"
+    assert error_event["metadata"]["resultStatus"] == "error"
+
+    uppercase_error = '{"status":"ERROR","message":"command failed"}'
+    assert (
+        RecordingAgent(outcome=uppercase_error).execute(query="error")
+        == uppercase_error
+    )
+    uppercase_event = recorder.query(
+        {"kind": "agent.execute.failed"}
+    )[-1]
+    assert uppercase_event["metadata"]["resultStatus"] == "error"
+
+    io_recorder = in_memory_recorder(privacy={"recordIO": True})
+    set_flight_recorder(io_recorder)
+    RecordingAgent(
+        outcome='{"status":"success","password":"secret-value"}'
+    ).execute(query="success")
+    completed = io_recorder.query(
+        {"kind": "agent.execute.completed"}
+    )[0]
+    assert completed["payload"]["result"]["password"] == "[redacted]"
+
+
+def test_python_basic_agent_context_is_invocation_local():
+    barrier = threading.Barrier(2)
+
+    class ConcurrentAgent(BasicAgent):
+        def __init__(self):
+            super().__init__(
+                "ConcurrentAgent",
+                {
+                    "name": "ConcurrentAgent",
+                    "description": "context isolation",
+                    "parameters": {
+                        "type": "object",
+                        "properties": {},
+                        "required": [],
+                    },
+                },
+            )
+
+        def perform(self, **kwargs):
+            captured = self.context
+            expected_guid = kwargs.get("user_guid")
+            barrier.wait(timeout=2)
+            return json.dumps(
+                {
+                    "query": kwargs.get("query"),
+                    "sameContext": captured is self.context,
+                    "sameGuid": self._user_guid == expected_guid,
+                }
+            )
+
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    agent = ConcurrentAgent()
+    with ThreadPoolExecutor(max_workers=2) as pool:
+        results = list(
+            pool.map(
+                lambda item: json.loads(
+                    agent.execute(
+                        query=item,
+                        user_guid=f"guid-{item}",
+                    )
+                ),
+                ("alpha", "beta"),
+            )
+        )
+
+    assert {result["query"] for result in results} == {"alpha", "beta"}
+    assert all(result["sameContext"] for result in results)
+    assert all(result["sameGuid"] for result in results)
+
+
+class InMemoryChannel(BaseChannel):
+    def __init__(self):
+        super().__init__("memory", channel_type="mock")
+        self.sent = []
+
+    def connect(self):
+        self.connected = True
+
+    def disconnect(self):
+        self.connected = False
+
+    def send(self, _conversation_id, message: OutgoingMessage):
+        self.sent.append(message)
+
+
+class FakeProvider:
+    def __init__(self, response=None, error=None):
+        self.name = "fake-provider"
+        self.model = "configured-model"
+        self.response = response
+        self.error = error
+        self.received_options = None
+
+    def chat(self, _messages, _options=None):
+        self.received_options = _options
+        if self.error:
+            raise self.error
+        return self.response
+
+
+def test_provider_bridge_records_success_and_failure_without_io():
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    channel = InMemoryChannel()
+    success = ProviderChannelBridge(
+        channel,
+        FakeProvider(ProviderResponse(content="ok", model="actual-model")),
+    )
+    success._on_incoming(
+        IncomingMessage(channel_id="memory", conversation_id="c1", content="secret prompt")
+    )
+    completed = recorder.query({"kind": "provider.attempt.completed"})[0]
+    started = recorder.query({"kind": "provider.attempt.started"})[0]
+    assert completed["providerId"] == "fake-provider"
+    assert completed["model"] == "actual-model"
+    assert completed["parentId"] == started["id"]
+    assert completed["sessionId"] == normalize_flight_session_id(
+        "c1",
+        TEST_IDENTITY_KEY,
+    )
+    assert completed["workspaceId"] == "channel:memory"
+    assert "payload" not in completed
+
+    provider_token = f"ghp_{'p' * 32}"
+    provider_bearer = "Bearer header.payload.signature"
+    provider_body = "raw provider response body"
+    provider_message = (
+        f"HTTP 401 {provider_bearer} token={provider_token} body={provider_body}"
+    )
+    failure = ProviderChannelBridge(
+        channel,
+        FakeProvider(error=ProviderError(provider_message)),
+    )
+    with pytest.raises(ChannelDispatchError) as caught:
+        failure._on_incoming(
+            IncomingMessage(channel_id="memory", conversation_id="c2", content="other prompt")
+        )
+    assert str(caught.value) == provider_message
+    failed = recorder.query({"kind": "provider.attempt.failed"})[0]
+    failed_trace = recorder.query({"traceId": failed["traceId"]})
+    failed_started = next(
+        event for event in failed_trace if event["kind"] == "provider.attempt.started"
+    )
+    assert failed["parentId"] == failed_started["id"]
+    assert failed["metadata"]["errorName"] == "ProviderError"
+    assert failed["metadata"]["messageChars"] == len(provider_message)
+    assert failed["metadata"]["messageHash"] == hashlib.sha256(
+        provider_message.encode("utf-8")
+    ).hexdigest()
+    assert "payload" not in failed
+    assert failed["sessionId"] == normalize_flight_session_id(
+        "c2",
+        TEST_IDENTITY_KEY,
+    )
+    assert failed["workspaceId"] == "channel:memory"
+    exported = json.dumps(recorder.export())
+    assert "secret prompt" not in exported
+    assert provider_token not in exported
+    assert provider_bearer not in exported
+    assert provider_body not in exported
+    assert provider_message not in exported
+
+    unknown_failure = ProviderChannelBridge(
+        channel,
+        FakeProvider(error=RuntimeError("unexpected provider failure")),
+    )
+    with pytest.raises(RuntimeError, match="unexpected provider failure"):
+        unknown_failure._on_incoming(
+            IncomingMessage(
+                channel_id="memory",
+                conversation_id="c3",
+                content="third prompt",
+            )
+        )
+    runtime_failed = recorder.query({"kind": "provider.attempt.failed"})[-1]
+    assert runtime_failed["metadata"]["errorName"] == "RuntimeError"
+
+    unknown_model = ProviderChannelBridge(
+        channel,
+        FakeProvider(ProviderResponse(content="ok", model="")),
+        chat_options=ChatOptions(model="requested-only"),
+    )
+    unknown_model._on_incoming(
+        IncomingMessage(
+            channel_id="memory",
+            conversation_id="c4",
+            content="fourth prompt",
+        )
+    )
+    unattributed = recorder.query({"kind": "provider.attempt.completed"})[-1]
+    assert "model" not in unattributed
+    assert unattributed["metadata"]["modelPolicy"] == "requested-only"
+
+
+def test_auto_model_policy_reaches_provider_but_is_not_persisted_as_model():
+    assert normalize_flight_model_id(" AUTO ") is None
+    assert normalize_flight_model_id(" gpt-4.1 ") == "gpt-4.1"
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    channel = InMemoryChannel()
+    provider = FakeProvider(ProviderResponse(content="ok", model="resolved-model"))
+    bridge = ProviderChannelBridge(
+        channel,
+        provider,
+        chat_options=ChatOptions(model="auto"),
+    )
+
+    bridge._on_incoming(
+        IncomingMessage(channel_id="memory", conversation_id="auto-model", content="hi")
+    )
+
+    assert provider.received_options.model == "auto"
+    provider_events = recorder.query({"providerId": "fake-provider"})
+    assert [event["kind"] for event in provider_events] == [
+        "provider.attempt.started",
+        "provider.attempt.completed",
+    ]
+    assert "model" not in provider_events[0]
+    assert provider_events[1]["model"] == "resolved-model"
+    assert provider_events[1]["parentId"] == provider_events[0]["id"]
+    assert all(event["metadata"]["modelPolicy"] == "auto" for event in provider_events)
+
+
+def test_provider_bridge_records_structured_io_when_opted_in():
+    recorder = in_memory_recorder(privacy={"recordIO": True})
+    set_flight_recorder(recorder)
+    channel = InMemoryChannel()
+    bridge = ProviderChannelBridge(
+        channel,
+        FakeProvider(
+            ProviderResponse(
+                content='{"password":"ordinary-secret-value"}',
+                model="actual",
+            )
+        ),
+    )
+
+    bridge._on_incoming(
+        IncomingMessage(
+            channel_id="memory",
+            conversation_id="io",
+            content='{"password":"incoming-secret"}',
+        )
+    )
+
+    started = recorder.query({"kind": "provider.attempt.started"})[0]
+    completed = recorder.query({"kind": "provider.attempt.completed"})[0]
+    assert started["payload"]["messages"][-1]["content"] == {
+        "password": "[redacted]"
+    }
+    assert completed["payload"]["response"]["content"]["password"] == (
+        "[redacted]"
+    )
+
+
+class FakeRegistry:
+    def get_all_agents(self):
+        return {}
+
+    def get_agent_metadata_tools(self):
+        return []
+
+    def list_agents(self):
+        return []
+
+
+class ToolRegistry:
+    def __init__(self):
+        self.agent = RecordingAgent(outcome='{"status":"success","value":7}')
+
+    def get_all_agents(self):
+        return {"RecordingAgent": self.agent}
+
+    def get_agent_metadata_tools(self):
+        return [
+            {
+                "type": "function",
+                "function": self.agent.metadata,
+            }
+        ]
+
+    def list_agents(self):
+        return [
+            {
+                "name": "RecordingAgent",
+                "description": "deterministic test agent",
+            }
+        ]
+
+
+class FakeCopilot:
+    id = "fake-copilot"
+    model = "gpt-test"
+
+    def __init__(self, response):
+        self.response = response
+
+    def chat(self, **_kwargs):
+        return self.response
+
+
+@pytest.mark.parametrize(
+    ("response", "terminal_kind"),
+    [
+        ({"content": "hello", "tool_calls": None, "error": None}, "provider.attempt.completed"),
+        ({"content": None, "tool_calls": None, "error": "offline"}, "provider.attempt.failed"),
+    ],
+)
+def test_cli_assistant_provider_success_and_failure(response, terminal_kind):
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    assistant = Assistant(FakeRegistry())
+    assistant.copilot = FakeCopilot(response)
+    result = assistant.process_message("private input")
+    assert isinstance(result, str)
+    terminal = recorder.query({"kind": terminal_kind})[0]
+    provider_events = recorder.query({"traceId": terminal["traceId"]})
+    started = next(
+        event for event in provider_events if event["kind"] == "provider.attempt.started"
+    )
+    assert terminal["providerId"] == "fake-copilot"
+    assert "model" not in terminal
+    assert terminal["metadata"]["modelPolicy"] == "gpt-test"
+    assert started["parentId"] == provider_events[0]["id"]
+    assert terminal["parentId"] == started["id"]
+    assert terminal["sessionId"] == normalize_flight_session_id(
+        "python-cli",
+        TEST_IDENTITY_KEY,
+    )
+    assert terminal["workspaceId"] == normalize_flight_workspace_id(str(Path.cwd()))
+    assert str(Path.cwd()) not in json.dumps(recorder.export())
+    assert "payload" not in terminal
+    assert "private input" not in json.dumps(recorder.export())
+    if response.get("error"):
+        assert response["error"] not in json.dumps(recorder.export())
+
+
+def test_python_cli_provider_only_turn_records_replay_io():
+    recorder = in_memory_recorder(privacy={"recordIO": True})
+    set_flight_recorder(recorder)
+    assistant = Assistant(FakeRegistry())
+    assistant.copilot = FakeCopilot({
+        "content": '{"password":"response-secret","answer":"ok"}',
+        "tool_calls": None,
+        "error": None,
+        "model": "resolved-model",
+    })
+
+    assistant.process_message(
+        '{"password":"prompt-secret","request":"hello"}'
+    )
+
+    context = recorder.query({"kind": "context.assembled"})[0]
+    started = recorder.query({"kind": "provider.attempt.started"})[0]
+    completed = recorder.query({"kind": "provider.attempt.completed"})[0]
+    assert context["payload"]["messages"][-1]["content"]["password"] == (
+        "[redacted]"
+    )
+    assert started["payload"]["messages"] == context["payload"]["messages"]
+    assert completed["payload"]["response"]["content"]["password"] == (
+        "[redacted]"
+    )
+    exported = json.dumps(recorder.export())
+    assert "prompt-secret" not in exported
+    assert "response-secret" not in exported
+
+
+def test_python_cli_tool_and_agent_events_have_causal_parents():
+    recorder = in_memory_recorder(privacy={"recordIO": True})
+    set_flight_recorder(recorder)
+    assistant = Assistant(ToolRegistry())
+    assistant.copilot = FakeCopilot({
+        "content": None,
+        "error": None,
+        "model": "resolved-model",
+        "tool_calls": [
+            {
+                "name": "RecordingAgent",
+                "arguments": (
+                    '{"query":"safe","password":"correct horse battery staple",'
+                    '"api_key":"ordinary-secret-value"}'
+                ),
+            }
+        ],
+    })
+
+    assert json.loads(assistant.process_message("run tool"))["status"] == "success"
+    events = recorder.query({"sessionId": "python-cli"})
+    root = next(event for event in events if event["kind"] == "trace.started")
+    provider_started = next(
+        event for event in events if event["kind"] == "provider.attempt.started"
+    )
+    provider_completed = next(
+        event for event in events if event["kind"] == "provider.attempt.completed"
+    )
+    tool_started = next(event for event in events if event["kind"] == "tool.call.started")
+    agent_started = next(
+        event for event in events if event["kind"] == "agent.execute.started"
+    )
+    tool_completed = next(
+        event for event in events if event["kind"] == "tool.call.completed"
+    )
+
+    assert provider_started["parentId"] == root["id"]
+    assert provider_completed["parentId"] == provider_started["id"]
+    assert provider_completed["model"] == "resolved-model"
+    assert tool_started["parentId"] == provider_completed["id"]
+    assert agent_started["parentId"] == tool_started["id"]
+    assert tool_completed["parentId"] == tool_started["id"]
+    assert tool_started["payload"]["arguments"]["password"] == "[redacted]"
+    assert tool_started["payload"]["arguments"]["api_key"] == "[redacted]"
+
+
+def test_python_cli_classifies_uppercase_error_tool_results():
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    registry = ToolRegistry()
+    registry.agent.outcome = (
+        '{"status":"ERROR","message":"command failed"}'
+    )
+    assistant = Assistant(registry)
+    assistant.copilot = FakeCopilot({
+        "content": None,
+        "error": None,
+        "model": "resolved-model",
+        "tool_calls": [
+            {
+                "name": "RecordingAgent",
+                "arguments": '{"query":"safe"}',
+            }
+        ],
+    })
+
+    assistant.process_message("run failing tool")
+
+    assert recorder.query({"kind": "agent.execute.failed"})
+    tool_failed = recorder.query({"kind": "tool.call.failed"})
+    assert len(tool_failed) == 1
+    assert tool_failed[0]["status"] == "error"
+    assert tool_failed[0]["metadata"]["resultStatus"] == "error"
+    assert recorder.query({"kind": "tool.call.completed"}) == []
+
+
+def test_python_cli_provider_error_fallback_is_parented_as_a_tool_tree():
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    assistant = Assistant(ToolRegistry())
+    assistant.copilot = FakeCopilot({
+        "content": None,
+        "tool_calls": None,
+        "error": "provider offline",
+        "model": "resolved-model",
+    })
+
+    result = json.loads(assistant.process_message("recordingagent please"))
+    assert result["status"] == "success"
+    events = recorder.query({"sessionId": "python-cli"})
+    provider_failed = next(
+        event for event in events if event["kind"] == "provider.attempt.failed"
+    )
+    tool_started = next(
+        event for event in events if event["kind"] == "tool.call.started"
+    )
+    agent_started = next(
+        event for event in events if event["kind"] == "agent.execute.started"
+    )
+    tool_completed = next(
+        event for event in events if event["kind"] == "tool.call.completed"
+    )
+
+    assert tool_started["parentId"] == provider_failed["id"]
+    assert tool_started["metadata"]["route"] == "provider-error-fallback"
+    assert agent_started["parentId"] == tool_started["id"]
+    assert tool_completed["parentId"] == tool_started["id"]
+
+
+def test_python_cli_provider_error_without_match_does_not_fabricate_a_tool():
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    assistant = Assistant(FakeRegistry())
+    assistant.copilot = FakeCopilot({
+        "content": None,
+        "tool_calls": None,
+        "error": "provider offline",
+        "model": "resolved-model",
+    })
+
+    result = json.loads(assistant.process_message("hello"))
+    assert result["status"] == "info"
+    assert recorder.query({"kind": "provider.attempt.failed"})
+    assert recorder.query({"kind": "tool.call.started"}) == []
+
+
+def test_python_brainstem_records_provider_tool_and_agent_causality(monkeypatch):
+    import openrappter.brainstem as brainstem
+
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    agent = RecordingAgent(outcome='{"status":"success","value":7}')
+    replies = iter(
+        [
+            (
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "call-1",
+                            "function": {
+                                "name": "RecordingAgent",
+                                "arguments": '{"query":"safe"}',
+                            },
+                        }
+                    ],
+                },
+                "resolved-model",
+            ),
+            (
+                {
+                    "role": "assistant",
+                    "content": "done",
+                },
+                "resolved-model",
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        brainstem,
+        "load_agents",
+        lambda: {"RecordingAgent": agent},
+    )
+    monkeypatch.setattr(brainstem, "load_soul", lambda: "system")
+    monkeypatch.setattr(brainstem, "llm_chat", lambda _m, _t: next(replies))
+
+    envelope = brainstem.run_chat("run tool", [], "brainstem-session")
+
+    assert envelope["response"] == "done"
+    events = recorder.query({"sessionId": "brainstem-session"})
+    provider_started = next(
+        event for event in events
+        if event["kind"] == "provider.attempt.started"
+    )
+    provider_completed = next(
+        event for event in events
+        if event["kind"] == "provider.attempt.completed"
+    )
+    tool_started = next(
+        event for event in events if event["kind"] == "tool.call.started"
+    )
+    agent_started = next(
+        event for event in events if event["kind"] == "agent.execute.started"
+    )
+    assert provider_completed["parentId"] == provider_started["id"]
+    assert tool_started["parentId"] == provider_completed["id"]
+    assert agent_started["parentId"] == tool_started["id"]
+
+
+def test_python_brainstem_keeps_unreported_model_unattributed(monkeypatch):
+    import openrappter.brainstem as brainstem
+
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    monkeypatch.setattr(brainstem, "load_agents", lambda: {})
+    monkeypatch.setattr(brainstem, "load_soul", lambda: "system")
+    monkeypatch.setattr(
+        brainstem,
+        "llm_chat",
+        lambda _messages, _tools: (
+            {"role": "assistant", "content": "answer"},
+            None,
+        ),
+    )
+
+    envelope = brainstem.run_chat("hello", [], "brainstem-model")
+
+    assert envelope["model"].endswith(":unreported")
+    completed = recorder.query(
+        {"kind": "provider.attempt.completed"}
+    )[0]
+    assert "model" not in completed
+    assert completed["metadata"]["modelPolicy"] == brainstem.MODEL
+
+
+def test_python_brainstem_provider_only_turn_records_replay_io(monkeypatch):
+    import openrappter.brainstem as brainstem
+
+    recorder = in_memory_recorder(privacy={"recordIO": True})
+    set_flight_recorder(recorder)
+    monkeypatch.setattr(brainstem, "load_agents", lambda: {})
+    monkeypatch.setattr(brainstem, "load_soul", lambda: "system")
+    monkeypatch.setattr(
+        brainstem,
+        "llm_chat",
+        lambda _messages, _tools: (
+            {
+                "role": "assistant",
+                "content": (
+                    '{"password":"brain-response-secret",'
+                    '"answer":"ok"}'
+                ),
+            },
+            "resolved-model",
+        ),
+    )
+
+    brainstem.run_chat(
+        '{"password":"brain-prompt-secret","request":"hello"}',
+        [],
+        "brainstem-replay",
+    )
+
+    context = recorder.query({"kind": "context.assembled"})[0]
+    started = recorder.query({"kind": "provider.attempt.started"})[0]
+    completed = recorder.query({"kind": "provider.attempt.completed"})[0]
+    assert context["payload"]["messages"][-1]["content"]["password"] == (
+        "[redacted]"
+    )
+    assert started["payload"]["messages"] == context["payload"]["messages"]
+    assert completed["payload"]["response"]["content"]["password"] == (
+        "[redacted]"
+    )
+    exported = json.dumps(recorder.export())
+    assert "brain-prompt-secret" not in exported
+    assert "brain-response-secret" not in exported
+
+
+def test_python_brainstem_legacy_agent_prefers_perform_abi(monkeypatch):
+    import openrappter.brainstem as brainstem
+
+    class LegacyAgent:
+        name = "Legacy"
+        metadata = {
+            "name": "Legacy",
+            "description": "legacy",
+            "parameters": {
+                "type": "object",
+                "properties": {},
+                "required": [],
+            },
+        }
+
+        def execute(self, **_kwargs):
+            return "execute-result"
+
+        def perform(self, **_kwargs):
+            return (
+                '{"status":"success","path":"perform",'
+                '"password":"result-secret-value"}'
+            )
+
+    recorder = in_memory_recorder(privacy={"recordIO": True})
+    set_flight_recorder(recorder)
+    replies = iter(
+        [
+            (
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {
+                            "id": "legacy-call",
+                            "function": {
+                                "name": "Legacy",
+                                "arguments": "{}",
+                            },
+                        }
+                    ],
+                },
+                None,
+            ),
+            ({"role": "assistant", "content": "done"}, None),
+        ]
+    )
+    monkeypatch.setattr(
+        brainstem,
+        "load_agents",
+        lambda: {"Legacy": LegacyAgent()},
+    )
+    monkeypatch.setattr(brainstem, "load_soul", lambda: "system")
+    monkeypatch.setattr(
+        brainstem,
+        "llm_chat",
+        lambda _messages, _tools: next(replies),
+    )
+
+    envelope = brainstem.run_chat("legacy", [], "legacy-session")
+
+    assert '"path":"perform"' in envelope["agent_logs"]
+    assert "execute-result" not in envelope["agent_logs"]
+    assert "result-secret-value" not in json.dumps(recorder.export())
+
+
+def test_python_copilot_timeout_records_provider_failure(monkeypatch):
+    import asyncio
+
+    class FakeSession:
+        def on(self, _callback):
+            pass
+
+        async def send(self, _message):
+            pass
+
+        async def destroy(self):
+            pass
+
+    provider = CopilotProvider()
+    provider._sdk_available = True
+
+    async def create_session(_tools=None):
+        return FakeSession()
+
+    async def timeout_wait(_awaitable, timeout):
+        assert timeout == 60
+        if hasattr(_awaitable, "close"):
+            _awaitable.close()
+        raise asyncio.TimeoutError
+
+    provider._create_session = create_session
+    monkeypatch.setattr(asyncio, "wait_for", timeout_wait)
+
+    recorder = in_memory_recorder()
+    set_flight_recorder(recorder)
+    assistant = Assistant(FakeRegistry())
+    assistant.copilot = provider
+    result = assistant.process_message("hello")
+
+    assert json.loads(result)["status"] == "info"
+    failed = recorder.query({"kind": "provider.attempt.failed"})
+    assert len(failed) == 1
+    assert failed[0]["metadata"]["errorName"] == "Error"
+    assert failed[0]["metadata"]["messageChars"] == len(
+        "Copilot request timed out after 60 seconds"
+    )
+    assert recorder.query({"kind": "provider.attempt.completed"}) == []
+
+
+def test_importing_public_api_does_not_create_database(work_dir, monkeypatch):
+    home = work_dir / "home"
+    home.mkdir(mode=0o700)
+    monkeypatch.setenv("HOME", str(home))
+    assert get_flight_recorder().health()["enabled"] is False
+    assert not (home / ".openrappter").exists()
+
+
+def test_close_is_terminal_and_closed_inspection_fails():
+    recorder = FlightRecorder(enabled=True, in_memory=True)
+    recorder.close()
+    assert recorder.record({"kind": "after-close", "source": "test"}) is None
+    with pytest.raises(FlightRecorderUnhealthyError, match="closed"):
+        recorder.query()
+    with pytest.raises(FlightRecorderUnhealthyError, match="closed"):
+        recorder.export()
+
+    initialized = in_memory_recorder()
+    initialized.close()
+    with pytest.raises(FlightRecorderUnhealthyError, match="closed"):
+        initialized.count()
+
+
+def test_default_recorder_directory_is_hardened(
+    work_dir,
+    monkeypatch,
+):
+    home = work_dir / "managed-home"
+    home.mkdir(mode=0o755)
+    monkeypatch.setenv("HOME", str(home))
+    managed = ensure_flight_recorder_from_env(
+        {"OPENRAPPTER_FLIGHT_RECORDER": "1"}
+    )
+    managed.record({"kind": "managed", "source": "test"})
+    assert stat.S_IMODE(
+        (home / ".openrappter").stat().st_mode
+    ) == 0o700
+
+
+def test_environment_configuration_query_prune_count_and_clear(work_dir):
+    database = work_dir / "configured" / "flight.db"
+    recorder = ensure_flight_recorder_from_env(
+        {
+            "OPENRAPPTER_FLIGHT_RECORDER": "1",
+            "OPENRAPPTER_FLIGHT_DB": str(database),
+            "OPENRAPPTER_FLIGHT_RETENTION": "2",
+            "OPENRAPPTER_FLIGHT_RECORD_IO": "1",
+            "OPENRAPPTER_FLIGHT_MAX_PAYLOAD": "16",
+        }
+    )
+    for index in range(3):
+        recorder.record(
+            {
+                "traceId": "configured",
+                "kind": f"event.{index}",
+                "source": "test",
+                "payload": {"text": "x" * 100},
+            }
+        )
+    assert recorder.health()["databasePath"] == str(database)
+    assert recorder.count() == 3
+    assert len(recorder.query({"traceId": "configured"})) == 3
+    assert recorder.query({"kind": "event.2"})[0]["payload"].startswith("[truncated:")
+    assert recorder.prune(1) == 0
+    assert recorder.count() == 3
+    assert recorder.clear() is True
+    assert recorder.count() == 0

--- a/python/tests/test_flight_recorder_windows.py
+++ b/python/tests/test_flight_recorder_windows.py
@@ -20,7 +20,10 @@ def _read_acl(target: Path):
             "-NonInteractive",
             "-Command",
             (
-                "$acl = Get-Acl -LiteralPath $env:HF_TARGET; "
+                "$item = if ([System.IO.Directory]::Exists($env:HF_TARGET)) "
+                "{ New-Object System.IO.DirectoryInfo($env:HF_TARGET) } "
+                "else { New-Object System.IO.FileInfo($env:HF_TARGET) }; "
+                "$acl = $item.GetAccessControl(); "
                 "[pscustomobject]@{ Protected = $acl.AreAccessRulesProtected; "
                 "Owner = $acl.Owner; "
                 "Access = @($acl.Access | ForEach-Object { "

--- a/python/tests/test_flight_recorder_windows.py
+++ b/python/tests/test_flight_recorder_windows.py
@@ -48,7 +48,9 @@ def test_windows_private_storage_initializes(tmp_path: Path):
     recorder = FlightRecorder(enabled=True, database_path=database)
     try:
         recorder.initialize()
-        assert recorder.health()["initialized"] is True, recorder.health()
+        assert recorder.health()["initialized"] is True, (
+            recorder.health().get("lastError")
+        )
         recorder.run_trace({"traceId": "windows-storage"}, lambda: None)
         assert database.exists()
         assert Path(f"{database}.identity-key").exists()
@@ -89,7 +91,9 @@ def test_windows_reopen_materializes_private_sidecars(tmp_path: Path):
     database = directory / "flight.db"
     first = FlightRecorder(enabled=True, database_path=database)
     first.initialize()
-    assert first.health()["initialized"] is True, first.health()
+    assert first.health()["initialized"] is True, (
+        first.health().get("lastError")
+    )
     first.close()
     Path(f"{database}-wal").unlink(missing_ok=True)
     Path(f"{database}-shm").unlink(missing_ok=True)
@@ -97,7 +101,9 @@ def test_windows_reopen_materializes_private_sidecars(tmp_path: Path):
     second = FlightRecorder(enabled=True, database_path=database)
     try:
         second.initialize()
-        assert second.health()["initialized"] is True, second.health()
+        assert second.health()["initialized"] is True, (
+            second.health().get("lastError")
+        )
         for target in (
             Path(f"{database}-wal"),
             Path(f"{database}-shm"),

--- a/python/tests/test_flight_recorder_windows.py
+++ b/python/tests/test_flight_recorder_windows.py
@@ -1,0 +1,99 @@
+import os
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from openrappter.flight_recorder import (
+    FlightRecorder,
+    _process_is_alive,
+)
+
+
+def _read_acl(target: Path):
+    output = subprocess.check_output(
+        [
+            "powershell.exe",
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            (
+                "$acl = Get-Acl -LiteralPath $env:HF_TARGET; "
+                "[pscustomobject]@{ Protected = $acl.AreAccessRulesProtected; "
+                "Owner = $acl.Owner; "
+                "Access = @($acl.Access | ForEach-Object { "
+                "[pscustomobject]@{ Identity = $_.IdentityReference.Value; "
+                "Rights = $_.FileSystemRights.ToString(); "
+                "Inherited = $_.IsInherited } }) } | "
+                "ConvertTo-Json -Depth 4 -Compress"
+            ),
+        ],
+        text=True,
+        env={**os.environ, "HF_TARGET": str(target)},
+    )
+    return json.loads(output)
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only ACL coverage")
+def test_windows_private_storage_initializes(tmp_path: Path):
+    database = tmp_path / "flight.db"
+    recorder = FlightRecorder(enabled=True, database_path=database)
+    try:
+        recorder.initialize()
+        recorder.run_trace({"traceId": "windows-storage"}, lambda: None)
+        assert database.exists()
+        assert Path(f"{database}.identity-key").exists()
+        assert Path(f"{database}.owners").exists()
+        assert recorder.health()["initialized"] is True
+        assert _process_is_alive(os.getpid()) is True
+        assert _process_is_alive(4) is True
+        assert _process_is_alive(2_147_483_647) is False
+        recorder.run_trace(
+            {"traceId": "windows-active"},
+            lambda: recorder.record(
+                {"kind": "inside", "source": "test"}
+            ),
+        )
+        assert recorder.clear() is True
+        for target in (
+            database,
+            Path(f"{database}-wal"),
+            Path(f"{database}-shm"),
+            Path(f"{database}.identity-key"),
+        ):
+            acl = _read_acl(target)
+            assert acl["Protected"] is True
+            assert "\\" in acl["Owner"]
+            assert len(acl["Access"]) == 1
+            assert "\\" in acl["Access"][0]["Identity"]
+            assert "FullControl" in acl["Access"][0]["Rights"]
+            assert acl["Access"][0]["Inherited"] is False
+    finally:
+        recorder.close()
+
+
+@pytest.mark.skipif(os.name != "nt", reason="Windows-only ACL coverage")
+def test_windows_reopen_materializes_private_sidecars(tmp_path: Path):
+    database = tmp_path / "flight.db"
+    first = FlightRecorder(enabled=True, database_path=database)
+    first.initialize()
+    first.close()
+    Path(f"{database}-wal").unlink(missing_ok=True)
+    Path(f"{database}-shm").unlink(missing_ok=True)
+
+    second = FlightRecorder(enabled=True, database_path=database)
+    try:
+        second.initialize()
+        for target in (
+            Path(f"{database}-wal"),
+            Path(f"{database}-shm"),
+        ):
+            assert target.exists()
+            acl = _read_acl(target)
+            assert acl["Protected"] is True
+            assert len(acl["Access"]) == 1
+            assert "FullControl" in acl["Access"][0]["Rights"]
+            assert acl["Access"][0]["Inherited"] is False
+    finally:
+        second.close()

--- a/python/tests/test_flight_recorder_windows.py
+++ b/python/tests/test_flight_recorder_windows.py
@@ -48,6 +48,7 @@ def test_windows_private_storage_initializes(tmp_path: Path):
     recorder = FlightRecorder(enabled=True, database_path=database)
     try:
         recorder.initialize()
+        assert recorder.health()["initialized"] is True, recorder.health()
         recorder.run_trace({"traceId": "windows-storage"}, lambda: None)
         assert database.exists()
         assert Path(f"{database}.identity-key").exists()
@@ -88,6 +89,7 @@ def test_windows_reopen_materializes_private_sidecars(tmp_path: Path):
     database = directory / "flight.db"
     first = FlightRecorder(enabled=True, database_path=database)
     first.initialize()
+    assert first.health()["initialized"] is True, first.health()
     first.close()
     Path(f"{database}-wal").unlink(missing_ok=True)
     Path(f"{database}-shm").unlink(missing_ok=True)
@@ -95,6 +97,7 @@ def test_windows_reopen_materializes_private_sidecars(tmp_path: Path):
     second = FlightRecorder(enabled=True, database_path=database)
     try:
         second.initialize()
+        assert second.health()["initialized"] is True, second.health()
         for target in (
             Path(f"{database}-wal"),
             Path(f"{database}-shm"),

--- a/python/tests/test_flight_recorder_windows.py
+++ b/python/tests/test_flight_recorder_windows.py
@@ -7,6 +7,7 @@ import pytest
 
 from openrappter.flight_recorder import (
     FlightRecorder,
+    _harden_private_path,
     _process_is_alive,
 )
 
@@ -37,7 +38,10 @@ def _read_acl(target: Path):
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows-only ACL coverage")
 def test_windows_private_storage_initializes(tmp_path: Path):
-    database = tmp_path / "flight.db"
+    directory = tmp_path / "private"
+    directory.mkdir()
+    _harden_private_path(directory, directory=True)
+    database = directory / "flight.db"
     recorder = FlightRecorder(enabled=True, database_path=database)
     try:
         recorder.initialize()
@@ -75,7 +79,10 @@ def test_windows_private_storage_initializes(tmp_path: Path):
 
 @pytest.mark.skipif(os.name != "nt", reason="Windows-only ACL coverage")
 def test_windows_reopen_materializes_private_sidecars(tmp_path: Path):
-    database = tmp_path / "flight.db"
+    directory = tmp_path / "private-reopen"
+    directory.mkdir()
+    _harden_private_path(directory, directory=True)
+    database = directory / "flight.db"
     first = FlightRecorder(enabled=True, database_path=database)
     first.initialize()
     first.close()

--- a/python/tests/test_openrappter_brainstem.py
+++ b/python/tests/test_openrappter_brainstem.py
@@ -553,10 +553,14 @@ def test_direct_capi_chat_uses_supported_model_and_body(monkeypatch):
         }
 
     monkeypatch.setattr(brainstem, "_http_json", fake_http)
-    reply, served = brainstem.llm_chat([{"role": "user", "content": "hello"}], [])
+    reply, served, requested = brainstem.llm_chat(
+        [{"role": "user", "content": "hello"}],
+        [],
+    )
     assert reply["content"] == "ok"
-    # No `model` in the response body, so it falls back to what was requested.
-    assert served == "gpt-4o"
+    # The request policy is not evidence of which model served the response.
+    assert served is None
+    assert requested == "gpt-4o"
     assert captured["url"].endswith("/chat/completions")
     assert captured["payload"]["model"] == "gpt-4o"
     assert "max_tokens" not in captured["payload"]

--- a/python/tests/test_provider_openai_compatible.py
+++ b/python/tests/test_provider_openai_compatible.py
@@ -98,6 +98,43 @@ def test_chat_success_against_real_local_server():
         assert response.finish_reason == "stop"
 
 
+def test_missing_response_model_remains_unattributed():
+    @_quiet
+    class Handler(BaseHTTPRequestHandler):
+        def do_POST(self):
+            length = int(self.headers.get("Content-Length", 0))
+            self.rfile.read(length)
+            payload = json.dumps(
+                {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": "answer",
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ]
+                }
+            ).encode()
+            self.send_response(200)
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            self.wfile.write(payload)
+
+    with _FakeOpenAIServer(Handler) as server:
+        provider = OpenAICompatibleProvider(
+            base_url=server.base_url,
+            model="requested-model",
+            timeout=5.0,
+        )
+        response = provider.chat(
+            [ProviderMessage(role="user", content="hello")]
+        )
+
+    assert response.model == ""
+
+
 def test_authorization_header_sent_but_never_raised_in_errors():
     captured: list = []
 

--- a/scripts/release-preflight.test.mjs
+++ b/scripts/release-preflight.test.mjs
@@ -448,7 +448,19 @@ test('macOS workflow validates the tag before checkout and never injects output 
     '^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-bar$',
   ));
   assert.doesNotMatch(workflow, /run:\s*VERSION=\$\{\{/);
-  assert.match(workflow, /VERSION="\$RELEASE_VERSION" bash scripts\/build-mac-app\.sh/);
+  const versionedBuild =
+    /VERSION="\$RELEASE_VERSION"\s*\\\s*\n[\s\S]*?\bbash scripts\/build-mac-app\.sh/;
+  assert.match(workflow, versionedBuild);
+  // Prove the assertion is about the version wiring and the real build
+  // command, not merely two unrelated strings somewhere in the file.
+  assert.doesNotMatch(
+    workflow.replace('VERSION="$RELEASE_VERSION" \\', 'VERSION="1.2.3" \\'),
+    versionedBuild,
+  );
+  assert.doesNotMatch(
+    workflow.replace('bash scripts/build-mac-app.sh', 'bash scripts/other.sh'),
+    versionedBuild,
+  );
 });
 
 test('registry publication reconciles exact artifacts and selects an explicit npm tag', () => {

--- a/skills.md
+++ b/skills.md
@@ -210,6 +210,11 @@ python3 -m openrappter.cli [options]  # Direct
 | `-v, --version` | Show version |
 | `-h, --help` | Show help |
 | `onboard` | Run interactive setup wizard (TypeScript) |
+| `flight status` | Show Flight Recorder health and local event count |
+| `flight events [filters]` | List privacy-safe execution event summaries |
+| `flight export [filters]` | Export a versioned replay/eval bundle |
+| `flight import <path>` | Import an integrity-checked replay/eval bundle |
+| `flight clear --yes` | Delete the local event ledger |
 
 ### Interactive Mode Slash Commands
 

--- a/tools/flight-recorder-gate.mjs
+++ b/tools/flight-recorder-gate.mjs
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+/**
+ * Acceptance gate for OpenRappter Flight Recorder v1.
+ *
+ * This is the definition of "done" for openrappter#145. It never converts
+ * "cannot measure" into a skip: missing files, missing dependencies, a crashed
+ * test runner, or a skipped mutation probe all fail the gate.
+ */
+
+import { existsSync, mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { spawnSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import os from "node:os";
+import path from "node:path";
+
+const ROOT = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const TS = path.join(ROOT, "typescript");
+const PY = path.join(ROOT, "python");
+const results = [];
+
+function req(name, pass, detail = "") {
+  results.push({ name, pass: Boolean(pass), detail });
+  console.log(
+    `${pass ? " PASS" : "*FAIL"}  ${name}${detail ? ` — ${detail}` : ""}`,
+  );
+}
+
+function hasNonzeroSkips(output) {
+  return (
+    /\b[1-9]\d*\s+skipped\b/i.test(output) ||
+    /\bskipped\s+[1-9]\d*\b/i.test(output)
+  );
+}
+
+function run(name, command, args, cwd = TS) {
+  const r = spawnSync(command, args, {
+    cwd,
+    encoding: "utf8",
+    timeout: 600_000,
+    env: { ...process.env, CI: "1" },
+  });
+  const out = `${r.stdout ?? ""}\n${r.stderr ?? ""}`.trim();
+  const hasSkippedChecks = hasNonzeroSkips(out);
+  req(
+    name,
+    !r.error && r.status === 0 && !hasSkippedChecks,
+    r.error
+      ? r.error.message
+      : `exit=${r.status}${hasSkippedChecks ? ", skipped checks present" : ""}`,
+  );
+  if (r.status !== 0 || r.error || hasSkippedChecks) {
+    console.log(out.slice(-4000));
+  }
+}
+
+req(
+  "gate distinguishes zero skipped checks from real skips",
+  !hasNonzeroSkips("pass 24, skipped 0") && hasNonzeroSkips("Tests 3 skipped"),
+);
+
+const requiredTypeScript = [
+  "src/flight-recorder/types.ts",
+  "src/flight-recorder/integrity.ts",
+  "src/flight-recorder/redaction.ts",
+  "src/flight-recorder/ledger.ts",
+  "src/flight-recorder/recorder.ts",
+  "src/flight-recorder/index.ts",
+  "src/flight-recorder/flight-recorder.test.ts",
+  "src/flight-recorder/flight-recorder.mutation.test.ts",
+  "src/flight-recorder/runtime-integration.test.ts",
+  "src/flight-recorder/flight-recorder-cli.test.ts",
+  "src/cli/flight-recorder.ts",
+];
+const requiredPython = [
+  "openrappter/flight_recorder.py",
+  "tests/test_flight_recorder.py",
+];
+const artifactPaths = [
+  ...requiredTypeScript.map((rel) => path.join(TS, rel)),
+  ...requiredPython.map((rel) => path.join(PY, rel)),
+  path.join(ROOT, "contracts", "flight-recorder-vector.json"),
+  path.join(ROOT, "docs", "release-notes-1.12.0-evolution.html"),
+];
+const missing = artifactPaths.filter((file) => !existsSync(file));
+req(
+  "complete release artifact surface exists",
+  missing.length === 0,
+  missing.length
+    ? missing.map((file) => path.relative(ROOT, file)).join(", ")
+    : `${artifactPaths.length} files`,
+);
+
+const sourceFiles = [
+  ...requiredTypeScript
+    .filter((p) => p.endsWith(".ts") && !p.endsWith(".test.ts"))
+    .map((rel) => path.join(TS, rel)),
+  path.join(PY, "openrappter", "flight_recorder.py"),
+];
+const unfinished = sourceFiles.filter(
+  (file) =>
+    existsSync(file) &&
+    /\b(TODO|not implemented|throw new Error\(['"]TODO)/i.test(
+      readFileSync(file, "utf8"),
+    ),
+);
+req(
+  "no unfinished implementation markers",
+  unfinished.length === 0,
+  unfinished.length
+    ? unfinished.map((file) => path.relative(ROOT, file)).join(", ")
+    : `${sourceFiles.length} sources`,
+);
+
+run("privacy + mutation probes", "npx", [
+  "vitest",
+  "run",
+  "src/flight-recorder/redaction.test.ts",
+  "src/flight-recorder/flight-recorder.mutation.test.ts",
+]);
+run("ledger integrity + retention probes", "npx", [
+  "vitest",
+  "run",
+  "src/flight-recorder/ledger.test.ts",
+  "src/flight-recorder/flight-recorder.test.ts",
+]);
+run("runtime causality + packaged CLI behavior", "npx", [
+  "vitest",
+  "run",
+  "src/flight-recorder/runtime-integration.test.ts",
+  "src/flight-recorder/flight-recorder-cli.test.ts",
+]);
+// Three platform/environment-only surfaces cannot run in this Linux gate:
+//   - gateway conformance's fixed port 49184 is unavailable on origin/main too;
+//   - Google Voice's live-Chrome suite requires an explicitly configured,
+//     logged-in browser and deliberately skips all three tests without one.
+//   - Windows ACL behavior runs as a required native windows-latest release job.
+// Exclude exactly those proven baselines. Any other skip still fails `run()`.
+run(
+  "full regression suite (three proven platform baselines excluded)",
+  "npx",
+  [
+    "vitest",
+    "run",
+    "--exclude",
+    "src/gateway/__tests__/conformance.test.ts",
+    "--exclude",
+    "src/telephony/providers/google-voice-live.test.ts",
+    "--exclude",
+    "src/flight-recorder/windows-storage.test.ts",
+  ],
+);
+run("TypeScript production build", "npm", ["run", "build", "--silent"]);
+run("published-package smoke test", "npm", ["run", "test:package", "--silent"]);
+run("TypeScript lint (zero errors)", "npm", ["run", "lint", "--silent"]);
+
+const python = existsSync(path.join(PY, ".venv", "bin", "python"))
+  ? path.join(PY, ".venv", "bin", "python")
+  : (process.env.PYTHON ?? "python3");
+run(
+  "Python Flight Recorder behavior + mutation suite",
+  python,
+  ["-m", "pytest", "tests/test_flight_recorder.py", "-q"],
+  PY,
+);
+run(
+  "full Python regression suite",
+  python,
+  [
+    "-m",
+    "pytest",
+    "-q",
+    "--ignore=tests/test_flight_recorder_windows.py",
+  ],
+  PY,
+);
+run(
+  "Python compile/import check",
+  python,
+  ["-m", "compileall", "-q", "openrappter"],
+  PY,
+);
+run(
+  "release identity and workflow assertions",
+  process.execPath,
+  ["--test", "scripts/release-preflight.test.mjs"],
+  ROOT,
+);
+run(
+  "1.12.0 release preflight identity",
+  process.execPath,
+  [
+    "scripts/release-preflight.mjs",
+    "--tag",
+    "v1.12.0",
+    "--typescript-runtime-version",
+    "1.12.0",
+    "--python-runtime-version",
+    "1.12.0",
+  ],
+  ROOT,
+);
+
+const smokeRoot = mkdtempSync(
+  path.join(os.tmpdir(), "openrappter-flight-gate-"),
+);
+try {
+  const databasePath = path.join(smokeRoot, "flight.db");
+  const smoke = spawnSync(
+    process.execPath,
+    ["dist/index.js", "flight", "status", "--json"],
+    {
+      cwd: TS,
+      encoding: "utf8",
+      timeout: 60_000,
+      env: {
+        ...process.env,
+        OPENRAPPTER_FLIGHT_RECORDER: "1",
+        OPENRAPPTER_FLIGHT_DB: databasePath,
+        NODE_ENV: "production",
+      },
+    },
+  );
+  const output = `${smoke.stdout ?? ""}\n${smoke.stderr ?? ""}`;
+  req(
+    "cold-start CLI status uses a real private SQLite ledger",
+    smoke.status === 0 &&
+      /"initialized":\s*true/.test(output) &&
+      existsSync(databasePath),
+    `exit=${smoke.status}`,
+  );
+} finally {
+  rmSync(smokeRoot, { recursive: true, force: true });
+}
+
+const failed = results.filter((r) => !r.pass);
+console.log(`\n${"=".repeat(68)}`);
+console.log(
+  failed.length === 0
+    ? `FLIGHT RECORDER ACCEPTED — ${results.length}/${results.length} pass`
+    : `NOT ACCEPTED — ${failed.length} of ${results.length} failing`,
+);
+console.log("=".repeat(68));
+process.exit(failed.length === 0 ? 0 : 1);

--- a/typescript/package-lock.json
+++ b/typescript/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openrappter",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openrappter",
-      "version": "1.11.0",
+      "version": "1.12.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@clack/prompts": "^0.7.0",

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openrappter",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "🦖 Local-first AI agent powered by GitHub Copilot SDK — no API keys required",
   "type": "module",
   "main": "dist/index.js",

--- a/typescript/scripts/build-ui.mjs
+++ b/typescript/scripts/build-ui.mjs
@@ -5,17 +5,23 @@ import { fileURLToPath } from 'node:url';
 const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 const env = { ...process.env };
+const npmExecPath = env.npm_execpath;
 
 // Do not leak outer `npm pack --json/--dry-run` flags into nested installs.
 delete env.npm_config_json;
 delete env.npm_config_dry_run;
 
 function run(args) {
-  const result = spawnSync(npm, args, {
+  const result = spawnSync(
+    npmExecPath ? process.execPath : npm,
+    npmExecPath ? [npmExecPath, ...args] : args,
+    {
     cwd: packageRoot,
     env,
     stdio: 'inherit',
-  });
+    },
+  );
+  if (result.error) throw result.error;
   if (result.status !== 0) process.exit(result.status ?? 1);
 }
 

--- a/typescript/scripts/package-smoke.mjs
+++ b/typescript/scripts/package-smoke.mjs
@@ -1,38 +1,52 @@
-import { spawnSync } from 'node:child_process';
+import { spawnSync } from "node:child_process";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   rmSync,
+  statSync,
   writeFileSync,
-} from 'node:fs';
-import path from 'node:path';
-import { fileURLToPath } from 'node:url';
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
 
-const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
-const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-const scratch = mkdtempSync(path.join(packageRoot, '.package-smoke-'));
+const packageRoot = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  "..",
+);
+const npm = process.platform === "win32" ? "npm.cmd" : "npm";
+const scratch = mkdtempSync(path.join(packageRoot, ".package-smoke-"));
 
 function run(command, args, options = {}) {
   const result = spawnSync(command, args, {
     cwd: packageRoot,
-    encoding: 'utf8',
-    stdio: ['ignore', 'pipe', 'pipe'],
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
     ...options,
   });
   if (result.status !== 0) {
-    throw new Error([
-      `${command} ${args.join(' ')} failed with status ${result.status}`,
-      result.stdout,
-      result.stderr,
-    ].filter(Boolean).join('\n'));
+    throw new Error(
+      [
+        `${command} ${args.join(" ")} failed with status ${result.status}`,
+        result.stdout,
+        result.stderr,
+      ]
+        .filter(Boolean)
+        .join("\n"),
+    );
   }
   return result;
 }
 
 function parsePackResult(output) {
-  for (let start = output.indexOf('['); start >= 0; start = output.indexOf('[', start + 1)) {
+  for (
+    let start = output.indexOf("[");
+    start >= 0;
+    start = output.indexOf("[", start + 1)
+  ) {
     let depth = 0;
     let inString = false;
     let escaped = false;
@@ -40,13 +54,14 @@ function parsePackResult(output) {
       const char = output[index];
       if (inString) {
         if (escaped) escaped = false;
-        else if (char === '\\') escaped = true;
+        else if (char === "\\") escaped = true;
         else if (char === '"') inString = false;
         continue;
       }
+
       if (char === '"') inString = true;
-      else if (char === '[') depth++;
-      else if (char === ']' && --depth === 0) {
+      else if (char === "[") depth++;
+      else if (char === "]" && --depth === 0) {
         try {
           const parsed = JSON.parse(output.slice(start, index + 1));
           if (Array.isArray(parsed) && parsed[0]?.filename) return parsed;
@@ -60,65 +75,366 @@ function parsePackResult(output) {
   throw new Error(`npm pack did not emit its artifact JSON:\n${output}`);
 }
 
+function parseJsonValue(output, opening, closing) {
+  const start = output.indexOf(opening);
+  const end = output.lastIndexOf(closing);
+  if (start < 0 || end < start) {
+    throw new Error(`CLI output did not contain JSON:\n${output}`);
+  }
+  return JSON.parse(output.slice(start, end + 1));
+}
+
 try {
-  const packed = run(npm, [
-    'pack',
-    '--json',
-    '--pack-destination',
-    scratch,
-  ]);
+  const packed = run(npm, ["pack", "--json", "--pack-destination", scratch]);
   const packResult = parsePackResult(packed.stdout);
   const artifact = packResult[0];
-  if (!artifact?.filename) throw new Error('npm pack did not report a tarball');
+  if (!artifact?.filename) throw new Error("npm pack did not report a tarball");
 
-  const packedFiles = new Set((artifact.files ?? []).map((entry) => entry.path));
-  if (!packedFiles.has('ui/dist/index.html')) {
-    throw new Error('Tarball does not contain ui/dist/index.html');
+  const packedFiles = new Set(
+    (artifact.files ?? []).map((entry) => entry.path),
+  );
+  if (!packedFiles.has("ui/dist/index.html")) {
+    throw new Error("Tarball does not contain ui/dist/index.html");
   }
 
   const tarball = path.join(scratch, artifact.filename);
   if (!existsSync(tarball)) throw new Error(`Missing tarball: ${tarball}`);
 
-  const installRoot = path.join(scratch, 'install');
-  const home = path.join(scratch, 'home');
+  const installRoot = path.join(scratch, "install");
+  const home = path.join(scratch, "home");
   mkdirSync(installRoot, { recursive: true });
   mkdirSync(home, { recursive: true });
   writeFileSync(
-    path.join(installRoot, 'package.json'),
-    JSON.stringify({ name: 'openrappter-package-smoke', private: true }),
+    path.join(installRoot, "package.json"),
+    JSON.stringify({ name: "openrappter-package-smoke", private: true }),
   );
 
-  run(npm, [
-    'install',
-    '--ignore-scripts',
-    '--no-audit',
-    '--no-fund',
-    tarball,
-  ], { cwd: installRoot });
+  run(
+    npm,
+    ["install", "--ignore-scripts", "--no-audit", "--no-fund", tarball],
+    { cwd: installRoot },
+  );
 
-  const installedRoot = path.join(installRoot, 'node_modules', 'openrappter');
-  const installedIndex = path.join(installedRoot, 'ui', 'dist', 'index.html');
-  if (!existsSync(installedIndex) || readFileSync(installedIndex, 'utf8').length === 0) {
-    throw new Error('Installed package is missing ui/dist/index.html');
+  const installedRoot = path.join(installRoot, "node_modules", "openrappter");
+  const installedIndex = path.join(installedRoot, "ui", "dist", "index.html");
+  if (
+    !existsSync(installedIndex) ||
+    readFileSync(installedIndex, "utf8").length === 0
+  ) {
+    throw new Error("Installed package is missing ui/dist/index.html");
   }
 
-  const cli = run(process.execPath, [
-    path.join(installedRoot, 'bin', 'openrappter.mjs'),
-    '--web',
-  ], {
+  const cli = run(
+    process.execPath,
+    [path.join(installedRoot, "bin", "openrappter.mjs"), "--web"],
+    {
+      cwd: installRoot,
+      env: {
+        ...process.env,
+        HOME: home,
+        USERPROFILE: home,
+        OPENRAPPTER_WEB_CHECK: "1",
+      },
+    },
+  );
+  if (!cli.stdout.includes("Web UI assets available:")) {
+    throw new Error(
+      `Installed --web did not locate packaged UI assets:\n${cli.stdout}`,
+    );
+  }
+
+  // The historical Web UI smoke intentionally installs with --ignore-scripts.
+  // Flight Recorder uses better-sqlite3, whose native binding is prepared by
+  // its install script. Rebuild only that reviewed dependency before testing
+  // the runtime path an ordinary npm install provides.
+  run(npm, ["rebuild", "better-sqlite3"], { cwd: installRoot });
+
+  const flightDb = path.join(home, "flight.db");
+  const flightEnv = {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+    NODE_ENV: "production",
+    OPENRAPPTER_FLIGHT_RECORDER: "1",
+    OPENRAPPTER_FLIGHT_DB: flightDb,
+  };
+  const binary = path.join(installedRoot, "bin", "openrappter.mjs");
+  const managedHome = path.join(scratch, "managed-home");
+  mkdirSync(managedHome, { recursive: true, mode: 0o755 });
+  chmodSync(managedHome, 0o755);
+  const {
+    OPENRAPPTER_FLIGHT_DB: _ignoredFlightDb,
+    ...environmentWithoutFlightDb
+  } = process.env;
+  run(process.execPath, [binary, "flight", "status", "--json"], {
     cwd: installRoot,
     env: {
-      ...process.env,
-      HOME: home,
-      USERPROFILE: home,
-      OPENRAPPTER_WEB_CHECK: '1',
+      ...environmentWithoutFlightDb,
+      HOME: managedHome,
+      USERPROFILE: managedHome,
+      NODE_ENV: "production",
+      OPENRAPPTER_FLIGHT_RECORDER: "1",
     },
   });
-  if (!cli.stdout.includes('Web UI assets available:')) {
-    throw new Error(`Installed --web did not locate packaged UI assets:\n${cli.stdout}`);
+  const managedDirectory = path.join(managedHome, ".openrappter");
+  const managedDatabase = path.join(managedDirectory, "flight-recorder.db");
+  if ((statSync(managedDirectory).mode & 0o777) !== 0o700) {
+    throw new Error("Packaged default Flight Recorder directory is not 0700");
+  }
+  if ((statSync(managedDatabase).mode & 0o777) !== 0o600) {
+    throw new Error("Packaged default Flight Recorder database is not 0600");
+  }
+  if (
+    (statSync(`${managedDatabase}.identity-key`).mode & 0o777) !==
+    0o600
+  ) {
+    throw new Error("Packaged Flight Recorder identity key is not 0600");
   }
 
-  console.log(`Package smoke passed: ${artifact.filename} includes a runnable Web UI`);
+  // ShellAgent is deterministic and needs no provider credential.
+  run(process.execPath, [binary, "ls"], {
+    cwd: installRoot,
+    env: flightEnv,
+  });
+  const beforeExec = run(
+    process.execPath,
+    [binary, "flight", "status", "--json"],
+    {
+      cwd: installRoot,
+      env: flightEnv,
+    },
+  );
+  const beforeExecStatus = parseJsonValue(beforeExec.stdout, "{", "}");
+  run(process.execPath, [binary, "list directory", "--exec", "Shell"], {
+    cwd: installRoot,
+    env: flightEnv,
+  });
+
+  const status = run(process.execPath, [binary, "flight", "status", "--json"], {
+    cwd: installRoot,
+    env: flightEnv,
+  });
+  const statusJson = parseJsonValue(status.stdout, "{", "}");
+  if (
+    !statusJson.initialized ||
+    statusJson.eventCount <= beforeExecStatus.eventCount
+  ) {
+    throw new Error(
+      `Packaged --exec did not append a Flight Recorder trace:\n${status.stdout}`,
+    );
+  }
+  const mcpBinary = path.join(installedRoot, "dist", "mcp", "stdio.js");
+  const mcpRequest = `${JSON.stringify({
+    jsonrpc: "2.0",
+    id: 1,
+    method: "tools/call",
+    params: {
+      name: "Shell",
+      arguments: { query: "list directory" },
+    },
+  })}\n`;
+  const standaloneMcp = spawnSync(process.execPath, [mcpBinary], {
+    cwd: installRoot,
+    encoding: "utf8",
+    input: mcpRequest,
+    env: flightEnv,
+  });
+  if (
+    standaloneMcp.status !== 0 ||
+    !standaloneMcp.stdout.includes('"result"')
+  ) {
+    throw new Error(
+      `Packaged standalone MCP failed:\n${standaloneMcp.stdout}\n${standaloneMcp.stderr}`,
+    );
+  }
+  const standaloneExportResult = run(
+    process.execPath,
+    [binary, "flight", "export"],
+    { cwd: installRoot, env: flightEnv },
+  );
+  const standaloneExport = parseJsonValue(
+    standaloneExportResult.stdout,
+    "{",
+    "}",
+  );
+  const standaloneTool = [...standaloneExport.events]
+    .reverse()
+    .find((event) => event.kind === "tool.call.started");
+  const standaloneAgent = standaloneTool
+    ? standaloneExport.events.find(
+        (event) =>
+          event.traceId === standaloneTool.traceId &&
+          event.kind === "agent.execute.started",
+      )
+    : undefined;
+  if (
+    !standaloneTool ||
+    !standaloneAgent ||
+    standaloneAgent.parentId !== standaloneTool.id
+  ) {
+    throw new Error("Standalone MCP call omitted the tool-to-agent lifecycle");
+  }
+  const afterStandalone = run(
+    process.execPath,
+    [binary, "flight", "status", "--json"],
+    { cwd: installRoot, env: flightEnv },
+  );
+  const afterStandaloneStatus = parseJsonValue(
+    afterStandalone.stdout,
+    "{",
+    "}",
+  );
+  const mcpTraceId = "package-mcp-trace";
+  const mcpParentId = "package-provider-attempt";
+  const mcpResult = spawnSync(process.execPath, [mcpBinary], {
+    cwd: installRoot,
+    encoding: "utf8",
+    input: mcpRequest,
+    env: {
+      ...flightEnv,
+      OPENRAPPTER_FLIGHT_TRACE_ID: mcpTraceId,
+      OPENRAPPTER_FLIGHT_PARENT_ID: mcpParentId,
+      OPENRAPPTER_FLIGHT_SESSION_ID: "package-mcp-session",
+    },
+  });
+  if (mcpResult.status !== 0 || !mcpResult.stdout.includes('"result"')) {
+    throw new Error(
+      `Packaged MCP child failed to execute Shell:\n${mcpResult.stdout}\n${mcpResult.stderr}`,
+    );
+  }
+  const afterMcp = run(
+    process.execPath,
+    [binary, "flight", "status", "--json"],
+    {
+      cwd: installRoot,
+      env: flightEnv,
+    },
+  );
+  const afterMcpStatus = parseJsonValue(afterMcp.stdout, "{", "}");
+  if (afterMcpStatus.eventCount <= afterStandaloneStatus.eventCount) {
+    throw new Error("Packaged MCP child did not persist agent events");
+  }
+  const ownerDirectory = `${flightDb}.owners`;
+  if (
+    existsSync(ownerDirectory) &&
+    readdirSync(ownerDirectory).length > 0
+  ) {
+    throw new Error("Packaged MCP child leaked recorder owner markers");
+  }
+  const mcpExportResult = run(
+    process.execPath,
+    [binary, "flight", "export", "--trace", mcpTraceId],
+    {
+      cwd: installRoot,
+      env: flightEnv,
+    },
+  );
+  const mcpExport = parseJsonValue(mcpExportResult.stdout, "{", "}");
+  const mcpToolStarted = mcpExport.events.find(
+    (event) => event.kind === "tool.call.started",
+  );
+  const mcpAgentStarted = mcpExport.events.find(
+    (event) => event.kind === "agent.execute.started",
+  );
+  const mcpChildStarted = mcpExport.events.find(
+    (event) =>
+      event.kind === "trace.started" &&
+      event.parentId === mcpParentId,
+  );
+  if (
+    !mcpToolStarted ||
+    !mcpAgentStarted ||
+    !mcpChildStarted ||
+    mcpToolStarted.parentId !== mcpChildStarted.id ||
+    mcpAgentStarted.parentId !== mcpToolStarted.id ||
+    mcpExport.events.some((event) => event.traceId !== mcpTraceId)
+  ) {
+    throw new Error("Packaged MCP child did not preserve parent trace causality");
+  }
+
+  const eventsResult = run(
+    process.execPath,
+    [binary, "flight", "events", "--json"],
+    {
+      cwd: installRoot,
+      env: flightEnv,
+    },
+  );
+  const events = parseJsonValue(eventsResult.stdout, "[", "]");
+  if (!Array.isArray(events) || events.length < 5) {
+    throw new Error("Packaged flight events returned no trace");
+  }
+  if (events.some((event) => Object.hasOwn(event, "payload"))) {
+    throw new Error(
+      "Packaged default Flight Recorder persisted raw payload IO",
+    );
+  }
+
+  const exportPath = path.join(scratch, "flight-export.json");
+  writeFileSync(exportPath, "public placeholder", { mode: 0o644 });
+  chmodSync(exportPath, 0o644);
+  run(process.execPath, [binary, "flight", "export", "--output", exportPath], {
+    cwd: installRoot,
+    env: flightEnv,
+  });
+  const exported = JSON.parse(readFileSync(exportPath, "utf8"));
+  if (exported.schema !== "openrappter-flight-export/1.0") {
+    throw new Error("Packaged flight export has the wrong schema");
+  }
+  if ((statSync(exportPath).mode & 0o777) !== 0o600) {
+    throw new Error("Packaged flight export overwrite is not mode 0600");
+  }
+
+  run(process.execPath, [binary, "flight", "clear", "--yes"], {
+    cwd: installRoot,
+    env: flightEnv,
+  });
+  run(process.execPath, [binary, "flight", "import", exportPath], {
+    cwd: installRoot,
+    env: flightEnv,
+  });
+  const restored = run(
+    process.execPath,
+    [binary, "flight", "status", "--json"],
+    {
+      cwd: installRoot,
+      env: flightEnv,
+    },
+  );
+  const restoredStatus = parseJsonValue(restored.stdout, "{", "}");
+  if (restoredStatus.eventCount !== exported.events.length) {
+    throw new Error("Packaged flight export/import did not round-trip exactly");
+  }
+  const identityTemporaryArtifacts = [
+    `${flightDb}.identity-key.123.01234567-89ab-cdef-0123-456789abcdef.tmp`,
+    `${flightDb}.identity-key.456.0123456789abcdef0123456789abcdef.tmp`,
+  ];
+  const identityKeyContents = readFileSync(
+    `${flightDb}.identity-key`,
+    "utf8",
+  );
+  for (const artifact of identityTemporaryArtifacts) {
+    writeFileSync(artifact, identityKeyContents, { mode: 0o600 });
+  }
+  run(process.execPath, [binary, "reset", "--yes"], {
+    cwd: installRoot,
+    env: flightEnv,
+  });
+  for (const resetPath of [
+    flightDb,
+    `${flightDb}-wal`,
+    `${flightDb}-shm`,
+    `${flightDb}.identity-key`,
+    ...identityTemporaryArtifacts,
+  ]) {
+    if (existsSync(resetPath)) {
+      throw new Error(`Packaged reset left Flight Recorder state: ${resetPath}`);
+    }
+  }
+
+  console.log(
+    `Package smoke passed: ${artifact.filename} includes runnable Web UI and Flight Recorder`,
+  );
 } finally {
   rmSync(scratch, { recursive: true, force: true });
 }

--- a/typescript/src/__tests__/docs/site.test.ts
+++ b/typescript/src/__tests__/docs/site.test.ts
@@ -20,7 +20,14 @@ function parseHTML(filename: string): Document {
   return dom.window.document;
 }
 
-const HTML_FILES = ['index.html', 'docs.html', 'architecture.html', 'tutorial.html', 'changelog.html'];
+const HTML_FILES = [
+  'index.html',
+  'docs.html',
+  'architecture.html',
+  'tutorial.html',
+  'changelog.html',
+  CURRENT_RELEASE_FILE,
+];
 const DELETED_FILES = [
   'teach.html', 'single-file-agents.html', 'install.md', 'config.md',
   'skills.md', 'memory.md', 'api.md', 'agent-install.md',
@@ -94,8 +101,8 @@ describe('HTML well-formedness', () => {
       });
 
       it('links to styles.css', () => {
-        // index.html uses Tailwind CDN (self-contained), subpages use styles.css
-        if (file === 'index.html') {
+        // The homepage and release presentation are standalone Tailwind pages.
+        if (file === 'index.html' || file === CURRENT_RELEASE_FILE) {
           const tailwind = doc.querySelector('script[src*="tailwindcss"]');
           expect(tailwind).not.toBeNull();
         } else {
@@ -105,8 +112,8 @@ describe('HTML well-formedness', () => {
       });
 
       it('includes nav.js script', () => {
-        // index.html has inline nav JS, subpages use nav.js
-        if (file === 'index.html') return; // skip — nav is inline
+        // Standalone Tailwind pages keep their navigation behavior inline.
+        if (file === 'index.html' || file === CURRENT_RELEASE_FILE) return;
         const script = doc.querySelector('script[src="./nav.js"]');
         expect(script).not.toBeNull();
       });
@@ -195,8 +202,8 @@ describe('Navigation consistency', () => {
 
 /* ── 5. Current release identity ── */
 describe('Current release identity', () => {
-  it('publishes the 1.11.0 Pages release', () => {
-    expect(CURRENT_VERSION).toBe('1.11.0');
+  it('publishes the 1.12.0 Pages release', () => {
+    expect(CURRENT_VERSION).toBe('1.12.0');
   });
 
   it('homepage badge derives from package metadata', () => {
@@ -230,6 +237,17 @@ describe('Current release identity', () => {
     }
   });
 
+  it('presents Flight Recorder as private, provider-neutral evidence', () => {
+    const doc = parseHTML(CURRENT_RELEASE_FILE);
+    expect(doc.title).toContain('Flight Recorder');
+    const text = doc.body.textContent || '';
+    expect(text).toContain('OpenRappter can now explain itself.');
+    expect(text).toContain('provider-neutral');
+    expect(text).toContain('raw IO is off by default');
+    expect(text).toContain('openrappter-event/1.0');
+    expect(text).toContain('Copilot CLI child MCP');
+  });
+
   it('uses durable Bar release links instead of versioned DMG URLs', () => {
     const doc = parseHTML('index.html');
     const downloadLinks = Array.from(doc.querySelectorAll('a')).filter((link) =>
@@ -247,7 +265,15 @@ describe('Current release identity', () => {
 
   it('keeps release evidence tied to executable validation gates', () => {
     const text = parseHTML(CURRENT_RELEASE_FILE).body.textContent || '';
-    for (const evidence of ['npm test', 'pytest', 'RunTests', 'CI + smoke', 'SHA-256']) {
+    for (const evidence of [
+      'mutation tests',
+      'npm test',
+      'pytest',
+      'builds',
+      'lint',
+      'cold-start CLI smoke',
+      'SHA-256',
+    ]) {
       expect(text).toContain(evidence);
     }
     expect(text).not.toMatch(/3,210\+|849\+|Known dependency CVEs/);

--- a/typescript/src/__tests__/parity/mcp-server.test.ts
+++ b/typescript/src/__tests__/parity/mcp-server.test.ts
@@ -8,6 +8,8 @@ import { describe, it, expect, beforeEach } from 'vitest';
 import { McpServer, createMcpServer } from '../../mcp/server.js';
 import { BasicAgent } from '../../agents/BasicAgent.js';
 import type { AgentMetadata } from '../../agents/types.js';
+import { PassThrough } from 'node:stream';
+import { vi } from 'vitest';
 
 // ── Test helpers ──
 
@@ -96,6 +98,36 @@ describe('McpServer', () => {
     it('should create a server with defaults', () => {
       const s = new McpServer();
       expect(s.toolCount).toBe(0);
+    });
+
+    it('drains in-flight requests before EOF resolves serve()', async () => {
+      let completed = false;
+      const drainingServer = createMcpServer({
+        executeAgent: async (_name, _args, operation) => {
+          await new Promise(resolve => setTimeout(resolve, 20));
+          const result = await operation();
+          completed = true;
+          return result;
+        },
+      });
+      drainingServer.registerAgent(new EchoAgent());
+      const input = new PassThrough();
+      const write = vi
+        .spyOn(process.stdout, 'write')
+        .mockImplementation(() => true);
+      try {
+        const serving = drainingServer.serve(input);
+        input.end(`${JSON.stringify({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'tools/call',
+          params: { name: 'Echo', arguments: { query: 'slow' } },
+        })}\n`);
+        await serving;
+        expect(completed).toBe(true);
+      } finally {
+        write.mockRestore();
+      }
     });
 
     it('should create via factory function', () => {

--- a/typescript/src/__tests__/unit/cli-flags.test.ts
+++ b/typescript/src/__tests__/unit/cli-flags.test.ts
@@ -24,6 +24,78 @@ describe('CLI flags', () => {
   it('should have TTY guard on onboard command', () => {
     expect(indexSource).toContain('process.stdin.isTTY');
   });
+
+  it('bootstraps Flight Recorder after env hydration and before direct agent dispatch', () => {
+    const envLoad = indexSource.indexOf('const envVars = await loadEnv()');
+    const recorderBootstrap = indexSource.indexOf(
+      'await ensureFlightRecorderFromEnv();',
+      envLoad,
+    );
+    const discovery = indexSource.indexOf(
+      'await registry.discoverAgents();',
+      envLoad,
+    );
+
+    expect(envLoad).toBeGreaterThanOrEqual(0);
+    expect(recorderBootstrap).toBeGreaterThan(envLoad);
+    expect(discovery).toBeGreaterThan(recorderBootstrap);
+  });
+
+  it('hydrates managed gateway env before recorder bootstrap', () => {
+    const gatewayStart = indexSource.indexOf(
+      'async function startGatewayInProcess',
+    );
+    const hydration = indexSource.indexOf(
+      'await hydrateManagedEnv();',
+      gatewayStart,
+    );
+    const recorderBootstrap = indexSource.indexOf(
+      'await ensureFlightRecorderFromEnv();',
+      gatewayStart,
+    );
+
+    expect(hydration).toBeGreaterThan(gatewayStart);
+    expect(recorderBootstrap).toBeGreaterThan(hydration);
+  });
+
+  it('acquires the runtime lock before starting --web gateway mode', () => {
+    const webBranch = indexSource.indexOf('if (options.web)');
+    const lock = indexSource.indexOf('acquireLock({ filePath: lockFile })', webBranch);
+    const gateway = indexSource.indexOf('startGatewayInProcess({', webBranch);
+
+    expect(lock).toBeGreaterThan(webBranch);
+    expect(gateway).toBeGreaterThan(lock);
+  });
+
+  it('publishes named web gateway identity and endpoint', () => {
+    const webBranch = indexSource.indexOf('if (options.web)');
+    const declare = indexSource.indexOf(
+      'declareCurrentInstance(lockInstance)',
+      webBranch,
+    );
+    const endpoint = indexSource.indexOf(
+      'writeGatewayEndpoint({',
+      webBranch,
+    );
+
+    expect(declare).toBeGreaterThan(webBranch);
+    expect(endpoint).toBeGreaterThan(declare);
+  });
+
+  it('resolves reset database from hydrated process env before file fallback', () => {
+    const resetBranch = indexSource.indexOf(".command('reset')");
+    const processOverride = indexSource.indexOf(
+      'process.env.OPENRAPPTER_FLIGHT_DB',
+      resetBranch,
+    );
+    const fileFallback = indexSource.indexOf(
+      'resetEnv.OPENRAPPTER_FLIGHT_DB',
+      resetBranch,
+    );
+
+    expect(processOverride).toBeGreaterThan(resetBranch);
+    expect(fileFallback).toBeGreaterThan(processOverride);
+  });
 });
 
 describe('install.sh TTY guard', () => {
@@ -35,5 +107,17 @@ describe('install.sh TTY guard', () => {
     // install.sh uses gum_is_tty to guard interactive prompts
     expect(installSh).toContain('gum_is_tty');
     expect(installSh).toContain('/dev/tty');
+  });
+
+  describe('MCP stdio bootstrap', () => {
+    it('initializes Flight Recorder before serving child-process agents', async () => {
+      const source = await fs.readFile(
+        path.join(srcRoot, 'mcp', 'stdio.ts'),
+        'utf-8',
+      );
+      expect(source.indexOf('await ensureFlightRecorderFromEnv();')).toBeLessThan(
+        source.indexOf('await registry.getAllAgents();'),
+      );
+    });
   });
 });

--- a/typescript/src/agents/Assistant.ts
+++ b/typescript/src/agents/Assistant.ts
@@ -11,13 +11,42 @@
  * Uses direct GitHub token → Copilot API token exchange (no copilot binary needed).
  */
 
-import { CopilotProvider, COPILOT_DEFAULT_MODEL } from '../providers/copilot.js';
-import { CopilotCliDirectProvider } from '../providers/copilot-cli-direct.js';
-import { truncateHistory } from '../providers/messages.js';
-import type { LLMProvider, Message, Tool, ToolCall } from '../providers/types.js';
-import type { BasicAgent } from './BasicAgent.js';
-import { MemoryAgent } from './MemoryAgent.js';
-import { ensureWorkspace, loadWorkspaceFiles, buildWorkspaceContext, parseIdentityMarkdown, isOnboardingCompleted, WORKSPACE_DIR } from './workspace.js';
+import {
+  CopilotProvider,
+  COPILOT_DEFAULT_MODEL,
+} from "../providers/copilot.js";
+import { CopilotCliDirectProvider } from "../providers/copilot-cli-direct.js";
+import { getFlightRecorder } from "../flight-recorder/recorder.js";
+import { normalizeFlightModelId } from "../flight-recorder/integrity.js";
+import { agentResultIsError } from "./result-status.js";
+import {
+  sanitizeFlightValue,
+  summarizeFlightError,
+} from "../flight-recorder/redaction.js";
+import { truncateHistory } from "../providers/messages.js";
+import {
+  flightMessages,
+  flightProviderResponse,
+  formatFlightAgentLog,
+  sanitizeFlightAgentLog,
+} from "../providers/flight-io.js";
+import type {
+  LLMProvider,
+  Message,
+  ProviderResponse,
+  Tool,
+  ToolCall,
+} from "../providers/types.js";
+import type { BasicAgent } from "./BasicAgent.js";
+import { MemoryAgent } from "./MemoryAgent.js";
+import {
+  ensureWorkspace,
+  loadWorkspaceFiles,
+  buildWorkspaceContext,
+  parseIdentityMarkdown,
+  isOnboardingCompleted,
+  WORKSPACE_DIR,
+} from "./workspace.js";
 
 /**
  * The tool-call round cap, frozen by `rapp-runtime-parity/1.0` §2.2.
@@ -29,8 +58,8 @@ import { ensureWorkspace, loadWorkspaceFiles, buildWorkspaceContext, parseIdenti
  * where the vector allows 3.
  */
 const PARITY_MAX_ROUNDS = 3;
-import type { AgentIdentity } from './workspace.js';
-import { TwinVault, renderSoul } from '../twin/index.js';
+import type { AgentIdentity } from "./workspace.js";
+import { TwinVault, renderSoul } from "../twin/index.js";
 
 export interface AssistantConfig {
   /** Display name shown in system prompt */
@@ -84,6 +113,10 @@ export interface AssistantResponse {
   content: string;
   /** Log of agent invocations during this turn */
   agentLogs: string[];
+  /** Concrete provider-reported model, absent when unreported. */
+  model?: string;
+  /** Model selection policy requested for this turn. */
+  requestedModel?: string;
 }
 
 export interface AssistantConversationMessage {
@@ -92,7 +125,7 @@ export interface AssistantConversationMessage {
    * replayed from a brainstem client carries tool turns, and dropping them
    * leaves the model reasoning about results it can no longer see.
    */
-  role: 'user' | 'assistant' | 'tool';
+  role: "user" | "assistant" | "tool";
   content: string;
 }
 
@@ -105,15 +138,17 @@ export class Assistant {
   private workspaceDir: string;
   private cachedIdentity: AgentIdentity | null = null;
 
-  constructor(
-    agents: Map<string, BasicAgent>,
-    config?: AssistantConfig,
-  ) {
+  constructor(agents: Map<string, BasicAgent>, config?: AssistantConfig) {
     this.agents = agents;
+    const defaultModel =
+      config?.provider instanceof CopilotCliDirectProvider
+      || process.env.OPENRAPPTER_AI_BACKEND === "copilot-cli"
+        ? "auto"
+        : COPILOT_DEFAULT_MODEL;
     this.config = {
-      name: config?.name ?? 'openrappter',
-      description: config?.description ?? 'a helpful local-first AI assistant',
-      model: config?.model ?? COPILOT_DEFAULT_MODEL,
+      name: config?.name ?? "openrappter",
+      description: config?.description ?? "a helpful local-first AI assistant",
+      model: config?.model ?? defaultModel,
       githubToken: config?.githubToken,
       streaming: config?.streaming ?? true,
       maxToolRounds: config?.maxToolRounds ?? PARITY_MAX_ROUNDS,
@@ -135,7 +170,7 @@ export class Assistant {
       config?.provider ??
       // Prefer the GitHub Copilot CLI when explicitly selected: it owns its own
       // auth + refresh, so openrappter never runs the flaky device-code flow.
-      (process.env.OPENRAPPTER_AI_BACKEND === 'copilot-cli'
+      (process.env.OPENRAPPTER_AI_BACKEND === "copilot-cli"
         ? new CopilotCliDirectProvider({ model: this.config.model })
         : new CopilotProvider({
             githubToken: config?.githubToken,
@@ -154,8 +189,11 @@ export class Assistant {
    * from without a restart — the daemon re-selects a working backend and hands
    * it here, instead of printing a warning and failing the next request.
    */
-  setProvider(provider: LLMProvider): void {
+  setProvider(provider: LLMProvider, modelPolicy?: string): void {
     this.provider = provider;
+    if (modelPolicy !== undefined) {
+      this.config.model = modelPolicy;
+    }
   }
 
   /** Reload agents (e.g. after hot-load) */
@@ -198,17 +236,34 @@ export class Assistant {
     conversationKey?: string,
     signal?: AbortSignal,
   ): Promise<AssistantResponse> {
+    const key = conversationKey ?? "default";
+    return this.runTurnTrace(key, () =>
+      this.getResponseWithinTrace(message, onDelta, memoryContext, key, signal),
+    );
+  }
+
+  private async getResponseWithinTrace(
+    message: string,
+    onDelta: ((text: string) => void) | undefined,
+    memoryContext: string | undefined,
+    conversationKey: string,
+    signal?: AbortSignal,
+  ): Promise<AssistantResponse> {
     const agentLogs: string[] = [];
+    const turnProvider = this.provider;
+    const turnModel = this.getModel();
 
     // Build tools from agent metadata
     const tools = this.buildTools();
 
-    let workspaceContext = '';
+    let workspaceContext = "";
     if (this.config.loadWorkspaceContext) {
       await ensureWorkspace(this.workspaceDir);
       const workspaceFiles = await loadWorkspaceFiles(this.workspaceDir);
       const onboardingDone = await isOnboardingCompleted(this.workspaceDir);
-      const identityFile = workspaceFiles.find(f => f.name === 'IDENTITY.md' && !f.missing);
+      const identityFile = workspaceFiles.find(
+        (f) => f.name === "IDENTITY.md" && !f.missing,
+      );
       if (identityFile?.content) {
         this.cachedIdentity = parseIdentityMarkdown(identityFile.content);
       }
@@ -221,55 +276,91 @@ export class Assistant {
     }
 
     // Build system prompt
-    const systemContent = this.buildSystemPrompt(memoryContext, workspaceContext);
+    const systemContent = this.buildSystemPrompt(
+      memoryContext,
+      workspaceContext,
+    );
 
     // Get or create conversation history
-    const key = conversationKey ?? 'default';
-    let history = this.conversations.get(key);
+    let history = this.conversations.get(conversationKey);
     if (!history) {
-      history = [{ role: 'system', content: systemContent }];
-      this.conversations.set(key, history);
+      history = [{ role: "system", content: systemContent }];
+      this.conversations.set(conversationKey, history);
     } else {
       // Refresh system prompt so new memories are always available
-      history[0] = { role: 'system', content: systemContent };
+      history[0] = { role: "system", content: systemContent };
     }
 
     // Add user message
-    history.push({ role: 'user', content: message });
+    history.push({ role: "user", content: message });
+
+    await getFlightRecorder().record({
+      kind: "context.assembled",
+      source: "assistant",
+      status: "info",
+      metadata: {
+        sourceNames: ["workspace", "memory", "system", "history", "tools"],
+        categoryNames: [
+          "workspace",
+          "memory",
+          "system",
+          "conversation",
+          "tools",
+        ],
+        workspaceChars: workspaceContext.length,
+        memoryChars: memoryContext?.length ?? 0,
+        systemChars: systemContent.length,
+        toolCount: tools.length,
+        historyLength: history.length,
+        workspaceEnabled: this.config.loadWorkspaceContext ?? true,
+        memoryEnabled: this.config.loadMemoryContext ?? true,
+      },
+    });
 
     // Tool-call loop
     let rounds = 0;
+    let reportedModel: string | undefined;
     const maxRounds = this.config.maxToolRounds ?? PARITY_MAX_ROUNDS;
 
     while (rounds < maxRounds) {
       rounds++;
 
-      const response = await this.provider.chat(history, {
-        model: this.config.model,
-        tools: tools.length > 0 ? tools : undefined,
+      const providerCall = await this.callProvider(
+        history,
+        tools,
+        rounds,
         signal,
-      });
+        turnProvider,
+        turnModel,
+      );
+      const response = providerCall.response;
+      reportedModel = response.model;
 
       // Some providers run their own tool loop and report what ran instead of
       // handing back tool_calls. Without this the CLI backend produced an empty
       // agent_logs for a turn in which an agent demonstrably ran.
-      if (response.agent_logs?.length) agentLogs.push(...response.agent_logs);
+      if (response.agent_logs?.length) {
+        agentLogs.push(...response.agent_logs.map(sanitizeFlightAgentLog));
+      }
 
       // If the LLM responded with tool calls, execute them
       if (response.tool_calls && response.tool_calls.length > 0) {
         // Add assistant message with tool calls to history
         history.push({
-          role: 'assistant',
-          content: response.content ?? '',
+          role: "assistant",
+          content: response.content ?? "",
           tool_calls: response.tool_calls,
         });
 
         // Execute each tool call
         for (const tc of response.tool_calls) {
           try {
-            const result = await this.executeToolCall(tc, agentLogs);
+            const result = await getFlightRecorder().withParent(
+              providerCall.parentEventId ?? null,
+              () => this.executeToolCall(tc, agentLogs),
+            );
             history.push({
-              role: 'tool',
+              role: "tool",
               // §2.3 fixes this shape exactly, `name` included.
               name: tc.function.name,
               content: result,
@@ -279,9 +370,9 @@ export class Assistant {
             // Always push a tool response — even on error — to prevent
             // "tool_call_id did not have response" API errors
             history.push({
-              role: 'tool',
+              role: "tool",
               name: tc.function.name,
-              content: `Error: ${(err as Error).message ?? 'Tool call failed'}`,
+              content: `Error: ${(err as Error).message ?? "Tool call failed"}`,
               tool_call_id: tc.id,
             });
           }
@@ -292,13 +383,13 @@ export class Assistant {
       }
 
       // No tool calls — this is the final text response
-      const content = response.content ?? '';
-      history.push({ role: 'assistant', content });
+      const content = response.content ?? "";
+      history.push({ role: "assistant", content });
 
       // Trim history if it gets too long (keep system + last 40 messages)
       if (history.length > 42) {
         history = truncateHistory(history, 40);
-        this.conversations.set(key, history);
+        this.conversations.set(conversationKey, history);
       }
 
       if (onDelta) onDelta(content);
@@ -306,14 +397,20 @@ export class Assistant {
       return {
         content,
         agentLogs,
+        model: reportedModel,
+        requestedModel: turnModel,
       };
     }
 
     // Max rounds exceeded — return whatever we have
-    const lastAssistant = history.filter(m => m.role === 'assistant').pop();
+    const lastAssistant = history.filter((m) => m.role === "assistant").pop();
     return {
-      content: lastAssistant?.content || 'I ran out of tool-call rounds. Please try again.',
+      content:
+        lastAssistant?.content ||
+        "I ran out of tool-call rounds. Please try again.",
       agentLogs,
+      model: reportedModel,
+      requestedModel: turnModel,
     };
   }
 
@@ -327,8 +424,21 @@ export class Assistant {
     onDelta: (text: string) => void,
     conversationKey?: string,
   ): Promise<AssistantResponse> {
+    const key = conversationKey ?? "default";
+    return this.runTurnTrace(key, () =>
+      this.getResponseStreamingWithinTrace(message, onDelta, key),
+    );
+  }
+
+  private async getResponseStreamingWithinTrace(
+    message: string,
+    onDelta: (text: string) => void,
+    conversationKey: string,
+  ): Promise<AssistantResponse> {
     // Fall back to non-streaming if provider doesn't support chatStream
-    const chatStream = this.provider.chatStream;
+    const provider = this.provider;
+    const modelPolicy = this.config.model;
+    const chatStream = provider.chatStream;
     if (!chatStream) {
       return this.getResponse(message, onDelta, undefined, conversationKey);
     }
@@ -337,12 +447,14 @@ export class Assistant {
 
     const tools = this.buildTools();
 
-    let workspaceContext = '';
+    let workspaceContext = "";
     if (this.config.loadWorkspaceContext) {
       await ensureWorkspace(this.workspaceDir);
       const workspaceFiles = await loadWorkspaceFiles(this.workspaceDir);
       const onboardingDone = await isOnboardingCompleted(this.workspaceDir);
-      const identityFile = workspaceFiles.find(f => f.name === 'IDENTITY.md' && !f.missing);
+      const identityFile = workspaceFiles.find(
+        (f) => f.name === "IDENTITY.md" && !f.missing,
+      );
       if (identityFile?.content) {
         this.cachedIdentity = parseIdentityMarkdown(identityFile.content);
       }
@@ -352,75 +464,190 @@ export class Assistant {
     const memoryContext = this.config.loadMemoryContext
       ? await this.loadMemoryContext()
       : undefined;
-    const systemContent = this.buildSystemPrompt(memoryContext, workspaceContext);
+    const systemContent = this.buildSystemPrompt(
+      memoryContext,
+      workspaceContext,
+    );
 
-    const key = conversationKey ?? 'default';
-    let history = this.conversations.get(key);
+    let history = this.conversations.get(conversationKey);
     if (!history) {
-      history = [{ role: 'system', content: systemContent }];
-      this.conversations.set(key, history);
+      history = [{ role: "system", content: systemContent }];
+      this.conversations.set(conversationKey, history);
     } else {
-      history[0] = { role: 'system', content: systemContent };
+      history[0] = { role: "system", content: systemContent };
     }
 
-    history.push({ role: 'user', content: message });
+    history.push({ role: "user", content: message });
+
+    await getFlightRecorder().record({
+      kind: "context.assembled",
+      source: "assistant",
+      status: "info",
+      metadata: {
+        sourceNames: ["workspace", "memory", "system", "history", "tools"],
+        categoryNames: [
+          "workspace",
+          "memory",
+          "system",
+          "conversation",
+          "tools",
+        ],
+        workspaceChars: workspaceContext.length,
+        memoryChars: memoryContext?.length ?? 0,
+        systemChars: systemContent.length,
+        toolCount: tools.length,
+        historyLength: history.length,
+        workspaceEnabled: this.config.loadWorkspaceContext ?? true,
+        memoryEnabled: this.config.loadMemoryContext ?? true,
+      },
+    });
 
     let rounds = 0;
+    let finalReportedModel: string | undefined;
     const maxRounds = this.config.maxToolRounds ?? PARITY_MAX_ROUNDS;
+    // Preserve the post-initialization narrowing inside async retry closures.
+    const turnHistory = history;
 
     while (rounds < maxRounds) {
       rounds++;
 
-      let fullContent = '';
-      const toolCallAccumulator = new Map<number, { id: string; type: 'function'; function: { name: string; arguments: string } }>();
+      let fullContent = "";
+      const toolCallAccumulator = new Map<
+        number,
+        {
+          id: string;
+          type: "function";
+          function: { name: string; arguments: string };
+        }
+      >();
+      let providerParentEventId: string | undefined;
 
       // Retry streaming call on transient fetch failures
       const maxRetries = 2;
       let lastError: Error | undefined;
       for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        let reportedModel: string | undefined;
+        const attemptStarted = performance.now();
+        const recorder = getFlightRecorder();
+        const startedEvent = await recorder.record({
+          kind: "provider.attempt.started",
+          source: "assistant",
+          status: "started",
+          providerId: provider.id,
+          metadata: {
+            round: rounds,
+            attempt: attempt + 1,
+            messageCount: history.length,
+            toolCount: tools.length,
+            streaming: true,
+            modelPolicy,
+          },
+          payload: () => ({ messages: flightMessages(history!) }),
+        });
         try {
-          for await (const delta of chatStream.call(this.provider, history, {
-            model: this.config.model,
-            tools: tools.length > 0 ? tools : undefined,
-          })) {
-            if (delta.done) {
-              break;
-            }
+          await recorder.withParent(startedEvent?.id ?? null, async () => {
+            for await (const delta of chatStream.call(
+              provider,
+              turnHistory,
+              {
+                model: modelPolicy,
+                tools: tools.length > 0 ? tools : undefined,
+              },
+            )) {
+              if (delta.model) reportedModel = delta.model;
+              if (delta.done) {
+                break;
+              }
 
-            if (delta.content) {
-              fullContent += delta.content;
-              onDelta(delta.content);
-            }
+              if (delta.content) {
+                fullContent += delta.content;
+                onDelta(delta.content);
+              }
 
-            if (delta.tool_calls) {
-              for (const tc of delta.tool_calls) {
-                const existing = toolCallAccumulator.get(tc.index);
-                if (!existing && tc.id) {
-                  // Only create a new tool call entry when we have an ID
-                  toolCallAccumulator.set(tc.index, {
-                    id: tc.id,
-                    type: 'function',
-                    function: {
-                      name: tc.function?.name ?? '',
-                      arguments: tc.function?.arguments ?? '',
-                    },
-                  });
-                } else if (existing) {
-                  if (tc.id && !existing.id) existing.id = tc.id;
-                  if (tc.function?.name) existing.function.name += tc.function.name;
-                  if (tc.function?.arguments) existing.function.arguments += tc.function.arguments;
+              if (delta.tool_calls) {
+                for (const tc of delta.tool_calls) {
+                  const existing = toolCallAccumulator.get(tc.index);
+                  if (!existing && tc.id) {
+                    // Only create a new tool call entry when we have an ID
+                    toolCallAccumulator.set(tc.index, {
+                      id: tc.id,
+                      type: "function",
+                      function: {
+                        name: tc.function?.name ?? "",
+                        arguments: tc.function?.arguments ?? "",
+                      },
+                    });
+                  } else if (existing) {
+                    if (tc.id && !existing.id) existing.id = tc.id;
+                    if (tc.function?.name)
+                      existing.function.name += tc.function.name;
+                    if (tc.function?.arguments)
+                      existing.function.arguments += tc.function.arguments;
+                  }
                 }
               }
             }
-          }
+            const completedEvent = await recorder.record({
+              kind: "provider.attempt.completed",
+              source: "assistant",
+              status: "success",
+              providerId: provider.id,
+              model: normalizeFlightModelId(reportedModel),
+              durationMs: performance.now() - attemptStarted,
+              metadata: {
+                round: rounds,
+                attempt: attempt + 1,
+                messageCount: turnHistory.length,
+                toolCount: tools.length,
+                streaming: true,
+                modelPolicy,
+                toolCallsOccurred: toolCallAccumulator.size > 0,
+              },
+              payload: () => ({
+                messages: flightMessages(turnHistory),
+                response: flightProviderResponse({
+                  content: fullContent,
+                  tool_calls: Array.from(toolCallAccumulator.values()),
+                }),
+              }),
+            });
+            providerParentEventId = completedEvent?.id;
+          });
           lastError = undefined;
+          finalReportedModel = reportedModel;
           break; // Success — exit retry loop
         } catch (err) {
           lastError = err as Error;
-          if (attempt < maxRetries && (lastError.message.includes('fetch failed') || lastError.message.includes('HTTP 429'))) {
+          await recorder.withParent(startedEvent?.id ?? null, () =>
+            recorder.record({
+              kind: "provider.attempt.failed",
+              source: "assistant",
+              status: "error",
+              providerId: provider.id,
+              durationMs: performance.now() - attemptStarted,
+              metadata: {
+                round: rounds,
+                attempt: attempt + 1,
+                messageCount: turnHistory.length,
+                toolCount: tools.length,
+                streaming: true,
+                modelPolicy,
+                ...summarizeFlightError(lastError),
+              },
+              payload: () => ({
+                messages: flightMessages(turnHistory),
+                error: lastError,
+              }),
+            }),
+          );
+          if (
+            attempt < maxRetries &&
+            (lastError.message.includes("fetch failed") ||
+              lastError.message.includes("HTTP 429"))
+          ) {
             // Transient network error — wait briefly and retry
-            await new Promise(r => setTimeout(r, 1000 * (attempt + 1)));
-            fullContent = '';
+            await new Promise((r) => setTimeout(r, 1000 * (attempt + 1)));
+            fullContent = "";
             toolCallAccumulator.clear();
             continue;
           }
@@ -428,20 +655,25 @@ export class Assistant {
         }
       }
 
-      const assembledToolCalls = Array.from(toolCallAccumulator.values()).filter(tc => tc.id?.trim() !== '');
+      const assembledToolCalls = Array.from(
+        toolCallAccumulator.values(),
+      ).filter((tc) => tc.id?.trim() !== "");
 
       if (assembledToolCalls.length > 0) {
         history.push({
-          role: 'assistant',
-          content: fullContent || '',
+          role: "assistant",
+          content: fullContent || "",
           tool_calls: assembledToolCalls,
         });
 
         for (const tc of assembledToolCalls) {
           try {
-            const result = await this.executeToolCall(tc, agentLogs);
+            const result = await getFlightRecorder().withParent(
+              providerParentEventId ?? null,
+              () => this.executeToolCall(tc, agentLogs),
+            );
             history.push({
-              role: 'tool',
+              role: "tool",
               // §2.3 fixes this shape exactly, `name` included.
               name: tc.function.name,
               content: result,
@@ -449,9 +681,9 @@ export class Assistant {
             });
           } catch (err) {
             history.push({
-              role: 'tool',
+              role: "tool",
               name: tc.function.name,
-              content: `Error: ${(err as Error).message ?? 'Tool call failed'}`,
+              content: `Error: ${(err as Error).message ?? "Tool call failed"}`,
               tool_call_id: tc.id,
             });
           }
@@ -461,29 +693,35 @@ export class Assistant {
       }
 
       // No tool calls — final text response
-      history.push({ role: 'assistant', content: fullContent });
+      history.push({ role: "assistant", content: fullContent });
 
       if (history.length > 42) {
         history = truncateHistory(history, 40);
-        this.conversations.set(key, history);
+        this.conversations.set(conversationKey, history);
       }
 
       return {
         content: fullContent,
         agentLogs,
+        model: finalReportedModel,
+        requestedModel: modelPolicy,
       };
     }
 
-    const lastAssistant = history.filter(m => m.role === 'assistant').pop();
+    const lastAssistant = history.filter((m) => m.role === "assistant").pop();
     return {
-      content: lastAssistant?.content || 'I ran out of tool-call rounds. Please try again.',
+      content:
+        lastAssistant?.content ||
+        "I ran out of tool-call rounds. Please try again.",
       agentLogs,
+      model: finalReportedModel,
+      requestedModel: modelPolicy,
     };
   }
 
   /** Check if the provider supports streaming */
   private hasStreamSupport(): boolean {
-    return typeof this.provider.chatStream === 'function';
+    return typeof this.provider.chatStream === "function";
   }
 
   /** Clear a single conversation's history */
@@ -496,12 +734,12 @@ export class Assistant {
     const history = this.conversations.get(key) ?? [];
     return history
       .filter(
-        (message): message is Message & { role: 'user' | 'assistant' } =>
-          (message.role === 'user' || message.role === 'assistant')
-          && typeof message.content === 'string',
+        (message): message is Message & { role: "user" | "assistant" } =>
+          (message.role === "user" || message.role === "assistant") &&
+          typeof message.content === "string",
       )
       .slice(-40)
-      .map(message => ({ role: message.role, content: message.content }));
+      .map((message) => ({ role: message.role, content: message.content }));
   }
 
   /** Replace a conversation from a persisted user/assistant-only transcript. */
@@ -512,15 +750,14 @@ export class Assistant {
     const imported = messages
       .filter(
         (message): message is AssistantConversationMessage =>
-          (message.role === 'user' || message.role === 'assistant' || message.role === 'tool')
-          && typeof message.content === 'string',
+          (message.role === "user" ||
+            message.role === "assistant" ||
+            message.role === "tool") &&
+          typeof message.content === "string",
       )
       .slice(-40)
-      .map(message => ({ role: message.role, content: message.content }));
-    this.conversations.set(key, [
-      { role: 'system', content: '' },
-      ...imported,
-    ]);
+      .map((message) => ({ role: message.role, content: message.content }));
+    this.conversations.set(key, [{ role: "system", content: "" }, ...imported]);
   }
 
   /** Gracefully shut down */
@@ -530,6 +767,102 @@ export class Assistant {
 
   // ── Private helpers ───────────────────────────────────────────────────
 
+  private async runTurnTrace<T>(
+    conversationKey: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const recorder = getFlightRecorder();
+    if (recorder.currentTrace()) {
+      return operation();
+    }
+    return recorder.runTrace(
+      {
+        sessionId: conversationKey,
+        workspaceId: this.workspaceDir,
+      },
+      operation,
+    );
+  }
+
+  private async callProvider(
+    history: Message[],
+    tools: Tool[],
+    round: number,
+    signal?: AbortSignal,
+    provider: LLMProvider = this.provider,
+    modelPolicy: string = this.getModel(),
+  ): Promise<{ response: ProviderResponse; parentEventId?: string }> {
+    const recorder = getFlightRecorder();
+    const started = performance.now();
+    const startedEvent = await recorder.record({
+      kind: "provider.attempt.started",
+      source: "assistant",
+      status: "started",
+      providerId: provider.id,
+      metadata: {
+        round,
+        messageCount: history.length,
+        toolCount: tools.length,
+        streaming: false,
+        modelPolicy,
+      },
+      payload: () => ({ messages: flightMessages(history) }),
+    });
+
+    return recorder.withParent(startedEvent?.id ?? null, async () => {
+      try {
+        const response = await provider.chat(history, {
+          model: modelPolicy,
+          tools: tools.length > 0 ? tools : undefined,
+          signal,
+        });
+        const completedEvent = await recorder.record({
+          kind: "provider.attempt.completed",
+          source: "assistant",
+          status: "success",
+          providerId: provider.id,
+          model: normalizeFlightModelId(response.model),
+          durationMs: performance.now() - started,
+          metadata: {
+            round,
+            messageCount: history.length,
+            toolCount: tools.length,
+            streaming: false,
+            modelPolicy,
+            toolCallsOccurred: Boolean(response.tool_calls?.length),
+            ...(response.usage ? { usage: response.usage } : {}),
+          },
+          payload: () => ({
+            messages: flightMessages(history),
+            response: flightProviderResponse(response),
+          }),
+        });
+        return { response, parentEventId: completedEvent?.id };
+      } catch (error) {
+        await recorder.record({
+          kind: "provider.attempt.failed",
+          source: "assistant",
+          status: "error",
+          providerId: provider.id,
+          durationMs: performance.now() - started,
+          metadata: {
+            round,
+            messageCount: history.length,
+            toolCount: tools.length,
+            streaming: false,
+            modelPolicy,
+            ...summarizeFlightError(error),
+          },
+          payload: () => ({
+            messages: flightMessages(history),
+            error,
+          }),
+        });
+        throw error;
+      }
+    });
+  }
+
   /** Load persistent memories from disk and format as context string */
   private async loadMemoryContext(): Promise<string | undefined> {
     try {
@@ -538,58 +871,145 @@ export class Assistant {
       if (entries.length === 0) return undefined;
 
       // Sort by timestamp descending, take most recent 10
-      entries.sort((a, b) => (b.timestamp || '').localeCompare(a.timestamp || ''));
+      entries.sort((a, b) =>
+        (b.timestamp || "").localeCompare(a.timestamp || ""),
+      );
       const recent = entries.slice(0, 10);
 
       const lines = recent.map((e) => {
-        const date = e.date || e.timestamp?.split('T')[0] || '';
+        const date = e.date || e.timestamp?.split("T")[0] || "";
         return `• [${e.theme}] ${e.message} (${date})`;
       });
 
-      return lines.join('\n');
+      return lines.join("\n");
     } catch {
       return undefined;
     }
   }
 
   /** Execute a single tool call by dispatching to the matching agent */
-  private async executeToolCall(tc: ToolCall, agentLogs: string[]): Promise<string> {
+  private async executeToolCall(
+    tc: ToolCall,
+    agentLogs: string[],
+  ): Promise<string> {
     const agentName = tc.function.name;
-    const agent = this.agents.get(agentName);
-
-    // PARITY §2.3 fixes these strings exactly. `agent_logs` is contract, not
-    // cosmetics — Flight Recorder and rapp-god read it — and this runtime was
-    // emitting its own vocabulary ("Performed X → …", "Unknown agent: X")
-    // while the Python runtime emitted the spec's. Two substrates of the same
-    // product disagreeing on the wire is the failure PARITY §0 is about.
-    if (!agent) {
-      const msg = `Agent '${agentName}' not found.`;
-      agentLogs.push(`[${agentName}] ${msg}`);
-      return msg;
-    }
-
+    const recorder = getFlightRecorder();
+    const started = performance.now();
+    let params: Record<string, unknown> = {};
+    let parseSuccess = true;
     try {
-      let params: Record<string, unknown> = {};
-      try {
-        params = JSON.parse(tc.function.arguments);
-      } catch {
-        // §2.3: on parse failure the arguments default to `{}`. Passing the
-        // raw unparsed string through as `query` invents an argument the model
-        // never sent, and the agent then acts on it.
-        params = {};
+      params = JSON.parse(tc.function.arguments);
+    } catch {
+      parseSuccess = false;
+    }
+    const recordedParams = structuredClone(params);
+
+    const startedEvent = await recorder.record({
+      kind: "tool.call.started",
+      source: "assistant",
+      status: "started",
+      toolName: agentName,
+      metadata: {
+        parseSuccess,
+        argumentChars: tc.function.arguments.length,
+      },
+      payload: {
+        arguments: parseSuccess
+          ? recordedParams
+          : sanitizeFlightValue(tc.function.arguments),
+      },
+    });
+
+    return recorder.withParent(startedEvent?.id ?? null, async () => {
+      const agent = this.agents.get(agentName);
+
+      // PARITY §2.3 fixes these strings exactly. `agent_logs` is contract, not
+      // cosmetics — Flight Recorder and rapp-god read it — and this runtime was
+      // emitting its own vocabulary ("Performed X → …", "Unknown agent: X")
+      // while the Python runtime emitted the spec's. Two substrates of the same
+      // product disagreeing on the wire is the failure PARITY §0 is about.
+      if (!agent) {
+        const msg = `Agent '${agentName}' not found.`;
+        agentLogs.push(formatFlightAgentLog(agentName, msg));
+        await recorder.record({
+          kind: "tool.call.failed",
+          source: "assistant",
+          status: "error",
+          toolName: agentName,
+          durationMs: performance.now() - started,
+          metadata: {
+            parseSuccess,
+            resultLength: msg.length,
+            errorName: "UnknownAgentError",
+            errorCode: "unknown-agent",
+          },
+          payload: {
+            arguments: parseSuccess
+              ? recordedParams
+              : sanitizeFlightValue(tc.function.arguments),
+          },
+        });
+        return msg;
       }
 
-      const result = await agent.execute(params);
-      const resultStr = result == null ? 'Agent completed successfully' : String(result);
-      // Not truncated: the log line is the tool result, and a reader that
-      // cannot reproduce it cannot verify anything from it.
-      agentLogs.push(`[${agentName}] ${resultStr}`);
-      return resultStr;
-    } catch (err) {
-      const message = (err as Error).message;
-      agentLogs.push(`[${agentName}] ERROR: ${message}`);
-      return `Error: ${message}`;
-    }
+      try {
+        const result = await agent.execute(params);
+        const resultStr =
+          result == null ? "Agent completed successfully" : String(result);
+        const failed = agentResultIsError(resultStr);
+        let structuredResult: unknown = sanitizeFlightValue(resultStr);
+        try {
+          structuredResult = sanitizeFlightValue(JSON.parse(resultStr));
+        } catch {
+          // Non-JSON agent output remains a sanitized string.
+        }
+        // Not truncated: the log line is the tool result, and a reader that
+        // cannot reproduce it cannot verify anything from it.
+        agentLogs.push(formatFlightAgentLog(agentName, resultStr));
+        await recorder.record({
+          kind: failed ? "tool.call.failed" : "tool.call.completed",
+          source: "assistant",
+          status: failed ? "error" : "success",
+          toolName: agentName,
+          durationMs: performance.now() - started,
+          metadata: {
+            parseSuccess,
+            resultLength: resultStr.length,
+            ...(failed ? { resultStatus: "error" } : {}),
+          },
+          payload: {
+            arguments: parseSuccess
+              ? recordedParams
+              : sanitizeFlightValue(tc.function.arguments),
+            result: structuredResult,
+          },
+        });
+        return resultStr;
+      } catch (err) {
+        const message = (err as Error).message;
+        agentLogs.push(formatFlightAgentLog(agentName, message, true));
+        const result = `Error: ${message}`;
+        await recorder.record({
+          kind: "tool.call.failed",
+          source: "assistant",
+          status: "error",
+          toolName: agentName,
+          durationMs: performance.now() - started,
+          metadata: {
+            parseSuccess,
+            resultLength: result.length,
+            ...summarizeFlightError(err),
+          },
+          payload: {
+            arguments: parseSuccess
+              ? recordedParams
+              : sanitizeFlightValue(tc.function.arguments),
+            result: sanitizeFlightValue(result),
+          },
+        });
+        return result;
+      }
+    });
   }
 
   /** Convert agent metadata into OpenAI-compatible tool definitions */
@@ -600,11 +1020,14 @@ export class Assistant {
       if (!agent.metadata) continue;
 
       tools.push({
-        type: 'function',
+        type: "function",
         function: {
           name: agent.metadata.name,
           description: agent.metadata.description,
-          parameters: agent.metadata.parameters as unknown as Record<string, unknown>,
+          parameters: agent.metadata.parameters as unknown as Record<
+            string,
+            unknown
+          >,
         },
       });
     }
@@ -625,14 +1048,16 @@ export class Assistant {
     // An explicitly configured persona always wins. Without this a test bot,
     // a named sub-agent, or any purpose-built assistant would quietly turn
     // into the owner's twin the moment a vault existed on the machine.
-    const explicitPersona = Boolean(this.config.name || this.config.description);
+    const explicitPersona = Boolean(
+      this.config.name || this.config.description,
+    );
     const wanted = this.config.useTwin ?? !explicitPersona;
     if (!wanted) return null;
 
     try {
       const vault = new TwinVault();
       if (!vault.exists()) return null;
-      return renderSoul(vault.load(), { audience: 'owner' });
+      return renderSoul(vault.load(), { audience: "owner" });
     } catch {
       // A broken twin must never take the assistant down with it.
       return null;
@@ -651,11 +1076,15 @@ export class Assistant {
    * contribute standing context to its own turn. The hook is optional in the
    * ABI (§4), so it is read defensively rather than declared on `BasicAgent`.
    */
-  private buildSystemPrompt(memoryContext?: string, workspaceContext?: string): string {
+  private buildSystemPrompt(
+    memoryContext?: string,
+    workspaceContext?: string,
+  ): string {
     let prompt = this.buildBaseSystemPrompt(memoryContext, workspaceContext);
     for (const agent of this.agents.values()) {
-      const hook = (agent as unknown as { system_context?: () => unknown }).system_context;
-      if (typeof hook !== 'function') continue;
+      const hook = (agent as unknown as { system_context?: () => unknown })
+        .system_context;
+      if (typeof hook !== "function") continue;
       let extra: unknown;
       try {
         extra = hook.call(agent);
@@ -663,7 +1092,7 @@ export class Assistant {
         // One agent's hook must not take down the turn.
         continue;
       }
-      if (typeof extra === 'string' && extra.trim()) {
+      if (typeof extra === "string" && extra.trim()) {
         prompt += `\n\n${extra.trim()}`;
       }
     }
@@ -692,44 +1121,49 @@ export class Assistant {
    * different properties, and only the first one was missing.
    */
   private rappterSelf(): string {
-    const instance = (this.config.instance ?? '').trim();
+    const instance = (this.config.instance ?? "").trim();
     const who = instance
-      ? `You are a hatched twin on this device, named "${instance}". You run as your own `
-        + 'process on your own port, alongside an alpha rappter and possibly other twins. '
-        + 'You are not the alpha, and you are not the same rappter as any peer that '
-        + 'contacts you.\n\n'
-        + 'The alpha holds this device\'s single-owner outbound channels — the phone '
-        + 'line, the Google Voice number, iMessage, the Telegram bot. There is one of '
-        + 'each, and two rappters using one of them would talk over each other to a '
-        + 'real person, neither able to see what the other had already said. So do not '
-        + 'place calls, send SMS, or message anyone outside this device. If asked, say '
-        + 'plainly that this belongs to the alpha and offer to do the part that does '
-        + 'not leave the machine.'
-      : 'You are the alpha rappter on this device — the original, not a hatched twin. '
-        + 'Other twins may be hatched alongside you, each its own process on its own port.';
+      ? `You are a hatched twin on this device, named "${instance}". You run as your own ` +
+        "process on your own port, alongside an alpha rappter and possibly other twins. " +
+        "You are not the alpha, and you are not the same rappter as any peer that " +
+        "contacts you.\n\n" +
+        "The alpha holds this device's single-owner outbound channels — the phone " +
+        "line, the Google Voice number, iMessage, the Telegram bot. There is one of " +
+        "each, and two rappters using one of them would talk over each other to a " +
+        "real person, neither able to see what the other had already said. So do not " +
+        "place calls, send SMS, or message anyone outside this device. If asked, say " +
+        "plainly that this belongs to the alpha and offer to do the part that does " +
+        "not leave the machine."
+      : "You are the alpha rappter on this device — the original, not a hatched twin. " +
+        "Other twins may be hatched alongside you, each its own process on its own port.";
 
-    return `<rappter_self>\n${who}\n\n`
-      + 'This says what YOU are. It says nothing about whoever contacts you: a message '
-      + 'arriving over /chat or /twin may come from a rappter, a brainstem, or a person, '
-      + 'and you cannot tell which. Never assume, and never claim to know.\n'
-      + '</rappter_self>';
+    return (
+      `<rappter_self>\n${who}\n\n` +
+      "This says what YOU are. It says nothing about whoever contacts you: a message " +
+      "arriving over /chat or /twin may come from a rappter, a brainstem, or a person, " +
+      "and you cannot tell which. Never assume, and never claim to know.\n" +
+      "</rappter_self>"
+    );
   }
 
-  private buildBaseSystemPrompt(memoryContext?: string, workspaceContext?: string): string {
+  private buildBaseSystemPrompt(
+    memoryContext?: string,
+    workspaceContext?: string,
+  ): string {
     const displayName = this.cachedIdentity?.name || this.config.name;
     const twinSoul = this.twinIdentity();
 
     const agentList = Array.from(this.agents.values())
       .map((a) => `- **${a.metadata.name}**: ${a.metadata.description}`)
-      .join('\n');
+      .join("\n");
 
     const memoryBlock = memoryContext
       ? `\n<memory_context>\nThese are facts you have previously stored about the user:\n${memoryContext}\n</memory_context>\n`
-      : '';
+      : "";
 
     const workspaceBlock = workspaceContext
       ? `\n<workspace>\n${workspaceContext}\n</workspace>\n`
-      : '';
+      : "";
 
     const identityBlock = twinSoul
       ? `<identity>\n${twinSoul}\n</identity>`
@@ -807,5 +1241,5 @@ Revenue's up 12 percent and customers are happier - looking good this quarter.
 }
 
 function truncate(s: string, max: number): string {
-  return s.length <= max ? s : s.slice(0, max - 3) + '...';
+  return s.length <= max ? s : s.slice(0, max - 3) + "...";
 }

--- a/typescript/src/agents/BasicAgent.concurrent.test.ts
+++ b/typescript/src/agents/BasicAgent.concurrent.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import { BasicAgent } from "./BasicAgent.js";
+
+class ConcurrentContextAgent extends BasicAgent {
+  private arrivals = 0;
+  private release!: () => void;
+  private readonly ready = new Promise<void>((resolve) => {
+    this.release = resolve;
+  });
+
+  constructor() {
+    super("ConcurrentContext", {
+      name: "ConcurrentContext",
+      description: "Verifies invocation-local context",
+      parameters: {
+        type: "object",
+        properties: {},
+        required: [],
+      },
+    });
+  }
+
+  async perform(kwargs: Record<string, unknown>): Promise<string> {
+    const captured = this.context;
+    this.arrivals += 1;
+    if (this.arrivals === 2) this.release();
+    await this.ready;
+    return `${String(kwargs.query)}:${captured === this.context}`;
+  }
+}
+
+describe("BasicAgent concurrent context", () => {
+  it("keeps context invocation-local across awaits", async () => {
+    const agent = new ConcurrentContextAgent();
+
+    const results = await Promise.all([
+      agent.execute({ query: "alpha" }),
+      agent.execute({ query: "beta" }),
+    ]);
+
+    expect(results.sort()).toEqual(["alpha:true", "beta:true"]);
+  });
+});

--- a/typescript/src/agents/BasicAgent.ts
+++ b/typescript/src/agents/BasicAgent.ts
@@ -26,7 +26,16 @@
  * This mirrors the Python BasicAgent in agents/basic_agent.py
  */
 
-import { createHash } from 'crypto';
+import { createHash } from "crypto";
+import { AsyncLocalStorage } from "node:async_hooks";
+import {
+  ensureFlightRecorderFromEnv,
+  getFlightRecorder,
+  type FlightRecorder,
+} from "../flight-recorder/recorder.js";
+import { summarizeFlightError } from "../flight-recorder/redaction.js";
+import { sanitizeFlightValue } from "../flight-recorder/redaction.js";
+import { agentResultIsError } from "./result-status.js";
 import type {
   AgentMetadata,
   AgentContext,
@@ -44,12 +53,25 @@ import type {
   SloshDebugEvent,
   SloshDebugHandler,
   SignalCategory,
-} from './types.js';
+} from "./types.js";
 
 export abstract class BasicAgent {
   name: string;
   metadata: AgentMetadata;
-  context: AgentContext | null = null;
+  private readonly contextStorage = new AsyncLocalStorage<{
+    context: AgentContext | null;
+  }>();
+  private lastContext: AgentContext | null = null;
+
+  get context(): AgentContext | null {
+    return this.contextStorage.getStore()?.context ?? this.lastContext;
+  }
+
+  set context(value: AgentContext | null) {
+    const holder = this.contextStorage.getStore();
+    if (holder) holder.context = value;
+    this.lastContext = value;
+  }
 
   /**
    * The data_slush output from the most recent execute() call.
@@ -83,6 +105,69 @@ export abstract class BasicAgent {
    * interpreting between calls.
    */
   async execute(kwargs: Record<string, unknown> = {}): Promise<string> {
+    await ensureFlightRecorderFromEnv();
+    const recorder = getFlightRecorder();
+    const operation = async (): Promise<string> => {
+      const started = performance.now();
+      const startedEvent = await recorder.record({
+        kind: "agent.execute.started",
+        source: "basic-agent",
+        status: "started",
+        agentName: this.name,
+      });
+
+      return recorder.withParent(startedEvent?.id ?? null, async () => {
+        try {
+          const result = await this.executeWithinTrace(kwargs, recorder);
+          const failed = agentResultIsError(result);
+          let structuredResult: unknown = sanitizeFlightValue(result);
+          try {
+            structuredResult = sanitizeFlightValue(JSON.parse(result));
+          } catch {
+            // Non-JSON output remains a sanitized string.
+          }
+          await recorder.record({
+            kind: failed
+              ? "agent.execute.failed"
+              : "agent.execute.completed",
+            source: "basic-agent",
+            status: failed ? "error" : "success",
+            agentName: this.name,
+            durationMs: performance.now() - started,
+            metadata: {
+              resultLength: result.length,
+              ...(failed ? { resultStatus: "error" } : {}),
+            },
+            payload: { result: structuredResult },
+          });
+          return result;
+        } catch (error) {
+          await recorder.record({
+            kind: "agent.execute.failed",
+            source: "basic-agent",
+            status: "error",
+            agentName: this.name,
+            durationMs: performance.now() - started,
+            metadata: summarizeFlightError(error),
+            payload: { error },
+          });
+          throw error;
+        }
+      });
+    };
+
+    return this.contextStorage.run({ context: null }, async () => {
+      if (recorder.currentTrace()) {
+        return operation();
+      }
+      return recorder.runTrace({}, operation);
+    });
+  }
+
+  private async executeWithinTrace(
+    kwargs: Record<string, unknown>,
+    recorder: FlightRecorder,
+  ): Promise<string> {
     const query = BasicAgent.resolveSloshQuery(kwargs);
 
     // Extract per-call overrides
@@ -95,52 +180,80 @@ export abstract class BasicAgent {
     this.decaySignalUtility();
 
     const effectivePrivacy = this.sloshPrivacy;
+    const effectiveFilter = callFilter ?? this.sloshFilter;
+    const effectivePrefs = callPrefs ?? this.sloshPreferences;
+    let autoSuppressed: SignalCategory[] = [];
 
     if (effectivePrivacy?.disabled) {
       this.context = this.buildMinimalContext();
     } else {
       this.context = this.slosh(query);
-      this.emitDebug('post-slosh', this.context);
+      this.emitDebug("post-slosh", this.context);
 
-      const effectiveFilter = callFilter ?? this.sloshFilter;
       if (effectiveFilter) {
         this.applyFilter(this.context, effectiveFilter);
       }
 
-      const effectivePrefs = callPrefs ?? this.sloshPreferences;
       if (effectivePrefs) {
         this.applyPreferences(this.context, effectivePrefs);
       }
 
       // Auto-suppress categories with utility scores at/below threshold
-      const autoSuppressed = this.computeAutoSuppress();
+      autoSuppressed = this.computeAutoSuppress();
       if (autoSuppressed.length > 0) {
         const protectedCategories = effectiveFilter?.include;
         const toSuppress = protectedCategories
-          ? autoSuppressed.filter(c => !protectedCategories.includes(c))
+          ? autoSuppressed.filter((c) => !protectedCategories.includes(c))
           : autoSuppressed;
         if (toSuppress.length > 0) {
           this.applyFilter(this.context, { exclude: toSuppress });
         }
       }
 
-      this.emitDebug('post-filter', this.context);
+      this.emitDebug("post-filter", this.context);
 
       if (effectivePrivacy) {
         this.applyPrivacy(this.context, effectivePrivacy);
       }
-      this.emitDebug('post-privacy', this.context);
+      this.emitDebug("post-privacy", this.context);
     }
 
     // Attach breadcrumbs to context
     this.context.breadcrumbs = [...this.breadcrumbs];
 
     // Merge upstream data_slush into context if provided
-    const upstream = kwargs.upstream_slush as Record<string, unknown> | undefined;
-    if (upstream && typeof upstream === 'object') {
+    const upstream = kwargs.upstream_slush as
+      | Record<string, unknown>
+      | undefined;
+    if (upstream && typeof upstream === "object") {
       this.context.upstream_slush = upstream;
       delete kwargs.upstream_slush;
     }
+
+    await recorder.record({
+      kind: "context.assembled",
+      source: "basic-agent",
+      status: "info",
+      agentName: this.name,
+      metadata: {
+        categories: [
+          "temporal",
+          "query_signals",
+          "memory_echoes",
+          "behavioral",
+          "priors",
+        ],
+        filterInclude: effectiveFilter?.include ?? [],
+        filterExclude: effectiveFilter?.exclude ?? [],
+        preferencePrioritize: effectivePrefs?.prioritize ?? [],
+        preferenceSuppress: effectivePrefs?.suppress ?? [],
+        privacyDisabled: effectivePrivacy?.disabled ?? false,
+        privacyRedactCount: effectivePrivacy?.redact?.length ?? 0,
+        privacyObfuscateCount: effectivePrivacy?.obfuscate?.length ?? 0,
+        autoSuppressed,
+        hasUpstream: Boolean(upstream && typeof upstream === "object"),
+      },
+    });
 
     kwargs._context = this.context;
 
@@ -150,13 +263,14 @@ export abstract class BasicAgent {
     let parsed: Record<string, unknown> | null = null;
     try {
       parsed = JSON.parse(result);
-      this.lastDataSlush = parsed?.data_slush as Record<string, unknown> ?? null;
+      this.lastDataSlush =
+        (parsed?.data_slush as Record<string, unknown>) ?? null;
     } catch {
       this.lastDataSlush = null;
     }
 
     // Extract and process slosh_feedback
-    if (parsed && typeof parsed === 'object' && 'slosh_feedback' in parsed) {
+    if (parsed && typeof parsed === "object" && "slosh_feedback" in parsed) {
       this.processSloshFeedback(parsed.slosh_feedback as SloshFeedback);
     }
 
@@ -171,7 +285,9 @@ export abstract class BasicAgent {
       this.breadcrumbs = this.breadcrumbs.slice(0, this.maxBreadcrumbs);
     }
 
-    this.emitDebug('post-perform', this.context, { result_length: result.length });
+    this.emitDebug("post-perform", this.context, {
+      result_length: result.length,
+    });
 
     return result;
   }
@@ -180,12 +296,14 @@ export abstract class BasicAgent {
    * Build a data_slush dict for downstream chaining.
    * Convenience method so agents don't manually construct the dict.
    */
-  slushOut(options: {
-    agentName?: string;
-    confidence?: string;
-    signals?: Record<string, unknown>;
-    [key: string]: unknown;
-  } = {}): Record<string, unknown> {
+  slushOut(
+    options: {
+      agentName?: string;
+      confidence?: string;
+      signals?: Record<string, unknown>;
+      [key: string]: unknown;
+    } = {},
+  ): Record<string, unknown> {
     const { agentName, confidence, signals, ...extra } = options;
     const slush: Record<string, unknown> = {
       source_agent: agentName ?? this.name,
@@ -231,22 +349,22 @@ export abstract class BasicAgent {
    * chain); a present-but-non-string value sloshes as empty text.
    */
   protected static resolveSloshQuery(kwargs: Record<string, unknown>): string {
-    for (const key of ['query', 'request', 'user_input'] as const) {
+    for (const key of ["query", "request", "user_input"] as const) {
       const value = kwargs[key];
       if (value === undefined || value === null) continue;
-      return typeof value === 'string' ? value : '';
+      return typeof value === "string" ? value : "";
     }
-    return '';
+    return "";
   }
 
   /**
    * Data sloshing - gather contextual signals from multiple sources.
    * Returns enriched context frame.
    */
-  slosh(query: string = ''): AgentContext {
+  slosh(query: string = ""): AgentContext {
     // Defensive: slosh() is also callable directly, and every downstream
     // signal helper assumes text. A non-string here must not crash the agent.
-    if (typeof query !== 'string') query = '';
+    if (typeof query !== "string") query = "";
 
     const context: AgentContext = {
       timestamp: new Date().toISOString(),
@@ -268,11 +386,11 @@ export abstract class BasicAgent {
   getSignal<T>(key: string, defaultValue?: T): T | undefined {
     if (!this.context) return defaultValue;
 
-    if (key.includes('.')) {
-      const parts = key.split('.');
+    if (key.includes(".")) {
+      const parts = key.split(".");
       let value: unknown = this.context;
       for (const part of parts) {
-        if (value && typeof value === 'object' && part in value) {
+        if (value && typeof value === "object" && part in value) {
           value = (value as Record<string, unknown>)[part];
         } else {
           return defaultValue;
@@ -280,18 +398,25 @@ export abstract class BasicAgent {
       }
       return (value ?? defaultValue) as T;
     }
-    return ((this.context as unknown as Record<string, unknown>)[key] ?? defaultValue) as T;
+    return ((this.context as unknown as Record<string, unknown>)[key] ??
+      defaultValue) as T;
   }
 
   /**
    * Zero out excluded signal categories. include wins over exclude.
    */
   private applyFilter(context: AgentContext, filter: SloshFilter): void {
-    const categories: SignalCategory[] = ['temporal', 'query_signals', 'memory_echoes', 'behavioral', 'priors'];
+    const categories: SignalCategory[] = [
+      "temporal",
+      "query_signals",
+      "memory_echoes",
+      "behavioral",
+      "priors",
+    ];
     let excluded: SignalCategory[];
 
     if (filter.include && filter.include.length > 0) {
-      excluded = categories.filter(c => !filter.include!.includes(c));
+      excluded = categories.filter((c) => !filter.include!.includes(c));
     } else if (filter.exclude && filter.exclude.length > 0) {
       excluded = filter.exclude;
     } else {
@@ -300,19 +425,29 @@ export abstract class BasicAgent {
 
     for (const cat of excluded) {
       switch (cat) {
-        case 'temporal':
+        case "temporal":
           context.temporal = {} as TemporalContext;
           break;
-        case 'query_signals':
-          context.query_signals = { specificity: 'low', hints: [], word_count: 0, is_question: false, has_id_pattern: false };
+        case "query_signals":
+          context.query_signals = {
+            specificity: "low",
+            hints: [],
+            word_count: 0,
+            is_question: false,
+            has_id_pattern: false,
+          };
           break;
-        case 'memory_echoes':
+        case "memory_echoes":
           context.memory_echoes = [];
           break;
-        case 'behavioral':
-          context.behavioral = { prefers_brief: false, technical_level: 'standard', frequent_entities: [] };
+        case "behavioral":
+          context.behavioral = {
+            prefers_brief: false,
+            technical_level: "standard",
+            frequent_entities: [],
+          };
           break;
-        case 'priors':
+        case "priors":
           context.priors = {};
           break;
       }
@@ -323,12 +458,15 @@ export abstract class BasicAgent {
    * Apply preference-based signal tuning.
    * suppress delegates to applyFilter. prioritize adds hint.
    */
-  private applyPreferences(context: AgentContext, prefs: SloshPreferences): void {
+  private applyPreferences(
+    context: AgentContext,
+    prefs: SloshPreferences,
+  ): void {
     if (prefs.suppress && prefs.suppress.length > 0) {
       this.applyFilter(context, { exclude: prefs.suppress });
     }
     if (prefs.prioritize && prefs.prioritize.length > 0) {
-      const hint = `Signal priority: ${prefs.prioritize.join(', ')}`;
+      const hint = `Signal priority: ${prefs.prioritize.join(", ")}`;
       context.orientation.hints.unshift(hint);
     }
   }
@@ -357,11 +495,17 @@ export abstract class BasicAgent {
   private computeAutoSuppress(): SignalCategory[] {
     if (this.signalUtility.size === 0) return [];
 
-    const allCategories: SignalCategory[] = ['temporal', 'query_signals', 'memory_echoes', 'behavioral', 'priors'];
+    const allCategories: SignalCategory[] = [
+      "temporal",
+      "query_signals",
+      "memory_echoes",
+      "behavioral",
+      "priors",
+    ];
     const categoryScores = new Map<SignalCategory, number>();
 
     for (const [path, score] of this.signalUtility) {
-      const root = path.split('.')[0] as SignalCategory;
+      const root = path.split(".")[0] as SignalCategory;
       if (allCategories.includes(root)) {
         categoryScores.set(root, (categoryScores.get(root) ?? 0) + score);
       }
@@ -400,11 +544,26 @@ export abstract class BasicAgent {
     return {
       timestamp: new Date().toISOString(),
       temporal: {} as TemporalContext,
-      query_signals: { specificity: 'low', hints: [], word_count: 0, is_question: false, has_id_pattern: false },
+      query_signals: {
+        specificity: "low",
+        hints: [],
+        word_count: 0,
+        is_question: false,
+        has_id_pattern: false,
+      },
       memory_echoes: [],
-      behavioral: { prefers_brief: false, technical_level: 'standard', frequent_entities: [] },
+      behavioral: {
+        prefers_brief: false,
+        technical_level: "standard",
+        frequent_entities: [],
+      },
       priors: {},
-      orientation: { confidence: 'low', approach: 'clarify', hints: [], response_style: 'standard' },
+      orientation: {
+        confidence: "low",
+        approach: "clarify",
+        hints: [],
+        response_style: "standard",
+      },
     };
   }
 
@@ -421,7 +580,10 @@ export abstract class BasicAgent {
       for (const path of privacy.obfuscate) {
         const val = this.getNestedValue(context, path);
         if (val !== undefined) {
-          const hash = createHash('sha256').update(String(val)).digest('hex').slice(0, 8);
+          const hash = createHash("sha256")
+            .update(String(val))
+            .digest("hex")
+            .slice(0, 8);
           this.setNestedValue(context, path, `[obfuscated:${hash}]`);
         }
       }
@@ -432,10 +594,14 @@ export abstract class BasicAgent {
    * Walk a dot-separated path and return the value, or undefined.
    */
   private getNestedValue(obj: unknown, dotPath: string): unknown {
-    const parts = dotPath.split('.');
+    const parts = dotPath.split(".");
     let current = obj;
     for (const part of parts) {
-      if (current && typeof current === 'object' && part in (current as Record<string, unknown>)) {
+      if (
+        current &&
+        typeof current === "object" &&
+        part in (current as Record<string, unknown>)
+      ) {
         current = (current as Record<string, unknown>)[part];
       } else {
         return undefined;
@@ -448,16 +614,20 @@ export abstract class BasicAgent {
    * Walk a dot-separated path and set or delete the value at the leaf.
    */
   private setNestedValue(obj: unknown, dotPath: string, value: unknown): void {
-    const parts = dotPath.split('.');
+    const parts = dotPath.split(".");
     let current = obj;
     for (let i = 0; i < parts.length - 1; i++) {
-      if (current && typeof current === 'object' && parts[i] in (current as Record<string, unknown>)) {
+      if (
+        current &&
+        typeof current === "object" &&
+        parts[i] in (current as Record<string, unknown>)
+      ) {
         current = (current as Record<string, unknown>)[parts[i]];
       } else {
         return;
       }
     }
-    if (current && typeof current === 'object') {
+    if (current && typeof current === "object") {
       const leaf = parts[parts.length - 1];
       if (value === undefined) {
         delete (current as Record<string, unknown>)[leaf];
@@ -470,7 +640,11 @@ export abstract class BasicAgent {
   /**
    * Emit a debug event if debugging is enabled.
    */
-  private emitDebug(stage: SloshDebugEvent['stage'], context: AgentContext, meta?: Record<string, unknown>): void {
+  private emitDebug(
+    stage: SloshDebugEvent["stage"],
+    context: AgentContext,
+    meta?: Record<string, unknown>,
+  ): void {
     if (this.sloshDebug && this.onSloshDebug) {
       this.onSloshDebug({
         stage,
@@ -494,34 +668,42 @@ export abstract class BasicAgent {
     let likely_activity: string;
 
     if (hour >= 5 && hour < 9) {
-      time_of_day = 'early_morning';
-      likely_activity = 'preparing_for_day';
+      time_of_day = "early_morning";
+      likely_activity = "preparing_for_day";
     } else if (hour >= 9 && hour < 12) {
-      time_of_day = 'morning';
-      likely_activity = 'active_work';
+      time_of_day = "morning";
+      likely_activity = "active_work";
     } else if (hour >= 12 && hour < 17) {
-      time_of_day = 'afternoon';
-      likely_activity = 'follow_ups';
+      time_of_day = "afternoon";
+      likely_activity = "follow_ups";
     } else if (hour >= 17 && hour < 21) {
-      time_of_day = 'evening';
-      likely_activity = 'wrap_up';
+      time_of_day = "evening";
+      likely_activity = "wrap_up";
     } else {
-      time_of_day = 'night';
-      likely_activity = 'after_hours';
+      time_of_day = "night";
+      likely_activity = "after_hours";
     }
 
     let fiscal: string;
     if ([1, 4, 7, 10].includes(month) && day <= 15) {
-      fiscal = 'quarter_start';
+      fiscal = "quarter_start";
     } else if ([3, 6, 9, 12].includes(month) && day >= 15) {
-      fiscal = 'quarter_end_push';
+      fiscal = "quarter_end_push";
     } else if (month === 12) {
-      fiscal = 'year_end';
+      fiscal = "year_end";
     } else {
-      fiscal = 'mid_quarter';
+      fiscal = "mid_quarter";
     }
 
-    const days = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+    const days = [
+      "Sunday",
+      "Monday",
+      "Tuesday",
+      "Wednesday",
+      "Thursday",
+      "Friday",
+      "Saturday",
+    ];
 
     return {
       time_of_day,
@@ -530,7 +712,7 @@ export abstract class BasicAgent {
       quarter: `Q${Math.floor((month - 1) / 3) + 1}`,
       fiscal,
       likely_activity,
-      is_urgent_period: ['quarter_end_push', 'year_end'].includes(fiscal),
+      is_urgent_period: ["quarter_end_push", "year_end"].includes(fiscal),
     };
   }
 
@@ -539,51 +721,63 @@ export abstract class BasicAgent {
    */
   private sloshQuery(query: string): QuerySignals {
     if (!query) {
-      return { specificity: 'low', hints: [], word_count: 0, is_question: false, has_id_pattern: false };
+      return {
+        specificity: "low",
+        hints: [],
+        word_count: 0,
+        is_question: false,
+        has_id_pattern: false,
+      };
     }
 
     const queryLower = query.toLowerCase();
     const hints: string[] = [];
 
     // Temporal hints
-    if (['today', 'this morning', 'now'].some(w => queryLower.includes(w))) {
-      hints.push('temporal:today');
+    if (["today", "this morning", "now"].some((w) => queryLower.includes(w))) {
+      hints.push("temporal:today");
     }
-    if (['latest', 'recent', 'current', 'active'].some(w => queryLower.includes(w))) {
-      hints.push('temporal:recency');
+    if (
+      ["latest", "recent", "current", "active"].some((w) =>
+        queryLower.includes(w),
+      )
+    ) {
+      hints.push("temporal:recency");
     }
-    if (['yesterday', 'last week', 'previous'].some(w => queryLower.includes(w))) {
-      hints.push('temporal:past');
+    if (
+      ["yesterday", "last week", "previous"].some((w) => queryLower.includes(w))
+    ) {
+      hints.push("temporal:past");
     }
     if (/q[1-4]/i.test(queryLower)) {
-      hints.push('temporal:quarterly');
+      hints.push("temporal:quarterly");
     }
 
     // Ownership hints
     if (/\bmy\b|\bmine\b/.test(queryLower)) {
-      hints.push('ownership:user');
+      hints.push("ownership:user");
     }
     if (/\bour\b|\bteam\b/.test(queryLower)) {
-      hints.push('ownership:team');
+      hints.push("ownership:team");
     }
 
     const hasId = /[a-f0-9]{8}-/.test(queryLower);
     const hasNumber = /\b\d+\b/.test(queryLower);
 
-    let specificity: 'low' | 'medium' | 'high';
+    let specificity: "low" | "medium" | "high";
     if (hasId) {
-      specificity = 'high';
+      specificity = "high";
     } else if (hints.length >= 2 || hasNumber) {
-      specificity = 'medium';
+      specificity = "medium";
     } else {
-      specificity = 'low';
+      specificity = "low";
     }
 
     return {
       specificity,
       hints,
       word_count: query.split(/\s+/).length,
-      is_question: query.includes('?'),
+      is_question: query.includes("?"),
       has_id_pattern: hasId,
     };
   }
@@ -602,7 +796,7 @@ export abstract class BasicAgent {
   protected sloshBehavioral(): BehavioralHints {
     return {
       prefers_brief: false,
-      technical_level: 'standard',
+      technical_level: "standard",
       frequent_entities: [],
     };
   }
@@ -622,39 +816,39 @@ export abstract class BasicAgent {
     const priors = context.priors;
     const temporal = context.temporal;
 
-    let confidence: 'low' | 'medium' | 'high';
-    let approach: 'direct' | 'use_preference' | 'contextual' | 'clarify';
+    let confidence: "low" | "medium" | "high";
+    let approach: "direct" | "use_preference" | "contextual" | "clarify";
 
-    if (querySignals.specificity === 'high') {
-      confidence = 'high';
-      approach = 'direct';
+    if (querySignals.specificity === "high") {
+      confidence = "high";
+      approach = "direct";
     } else if (Object.keys(priors).length > 0) {
-      confidence = 'high';
-      approach = 'use_preference';
-    } else if (querySignals.specificity === 'medium') {
-      confidence = 'medium';
-      approach = 'contextual';
+      confidence = "high";
+      approach = "use_preference";
+    } else if (querySignals.specificity === "medium") {
+      confidence = "medium";
+      approach = "contextual";
     } else {
-      confidence = 'low';
-      approach = 'clarify';
+      confidence = "low";
+      approach = "clarify";
     }
 
     const hints: string[] = [];
     for (const hint of querySignals.hints) {
-      if (hint === 'temporal:recency') hints.push('Sort by most recent');
-      else if (hint === 'ownership:user') hints.push('Filter by current user');
-      else if (hint === 'temporal:today') hints.push("Focus on today's items");
+      if (hint === "temporal:recency") hints.push("Sort by most recent");
+      else if (hint === "ownership:user") hints.push("Filter by current user");
+      else if (hint === "temporal:today") hints.push("Focus on today's items");
     }
 
     if (temporal.is_urgent_period) {
-      hints.push('Quarter/year end - prioritize closing activities');
+      hints.push("Quarter/year end - prioritize closing activities");
     }
 
     return {
       confidence,
       approach,
       hints,
-      response_style: context.behavioral.prefers_brief ? 'concise' : 'standard',
+      response_style: context.behavioral.prefers_brief ? "concise" : "standard",
     };
   }
 }

--- a/typescript/src/agents/LearnNewAgent.ts
+++ b/typescript/src/agents/LearnNewAgent.ts
@@ -22,6 +22,7 @@ import { pathToFileURL } from 'url';
 import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
 import type { LLMProvider } from '../providers/types.js';
+import { chatWithFlightRecorder } from '../providers/recorded-chat.js';
 
 
 export const __manifest__ = {
@@ -364,10 +365,13 @@ Requirements:
 
 Generate ONLY the code. No markdown fences. No explanation.`;
 
-    const response = await this.provider.chat(
-      [{ role: 'user', content: prompt }],
-      { temperature: 0.7, max_tokens: 2000 },
-    );
+    const response = await chatWithFlightRecorder({
+      provider: this.provider,
+      messages: [{ role: 'user', content: prompt }],
+      options: { temperature: 0.7, max_tokens: 2000 },
+      source: "learn-new-agent",
+      attributes: { phase: "code-generation" },
+    });
 
     if (!response.content) return null;
 

--- a/typescript/src/agents/OuroborosAgent.ts
+++ b/typescript/src/agents/OuroborosAgent.ts
@@ -16,6 +16,7 @@
 import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
 import type { LLMProvider } from '../providers/types.js';
+import { chatWithFlightRecorder } from '../providers/recorded-chat.js';
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
 import { execSync } from 'child_process';
@@ -350,6 +351,13 @@ function spliceEvolution(
 const _envJs = fileURLToPath(new URL('../env.js', import.meta.url));
 const _envTs = fileURLToPath(new URL('../env.ts', import.meta.url));
 const ENV_MODULE_PATH = existsSync(_envJs) ? _envJs : _envTs;
+const _recordedChatJs = fileURLToPath(
+  new URL('../providers/recorded-chat.js', import.meta.url),
+);
+const _recordedChatTs = fileURLToPath(
+  new URL('../providers/recorded-chat.ts', import.meta.url),
+);
+const RECORDED_CHAT_MODULE_PATH = existsSync(_recordedChatJs) ? _recordedChatJs : _recordedChatTs;
 
 // Persistent cache directory for evolved files (must precede fixImports so regex matches definition first)
 export const EVOLVED_DIR = join(HOME_DIR, 'evolved');
@@ -359,6 +367,9 @@ function fixImports(source: string): string {
   // ESM imports of absolute paths must use file:// URLs (Windows-safe: handles backslashes).
   const basicAgentImportSpec = pathToFileURL(BASIC_AGENT_PATH).href;
   const envModuleImportSpec = pathToFileURL(ENV_MODULE_PATH).href;
+  const recordedChatImportSpec = pathToFileURL(
+    RECORDED_CHAT_MODULE_PATH,
+  ).href;
   // Fix the BasicAgent import to absolute file:// URL
   result = result.replace(
     /from ['"]\.\/BasicAgent\.js['"]/,
@@ -374,10 +385,18 @@ function fixImports(source: string): string {
     /from ['"]\.\.\/env\.js['"]/,
     `from ${JSON.stringify(envModuleImportSpec)}`,
   );
+  result = result.replace(
+    /from ['"]\.\.\/providers\/recorded-chat\.js['"]/,
+    `from ${JSON.stringify(recordedChatImportSpec)}`,
+  );
   // Freeze the ENV_MODULE_PATH constant (filesystem path) so generated files don't need import.meta.url
   result = result.replace(
     /const ENV_MODULE_PATH = .+;/,
     `const ENV_MODULE_PATH = ${JSON.stringify(ENV_MODULE_PATH)};`,
+  );
+  result = result.replace(
+    /const RECORDED_CHAT_MODULE_PATH = .+;/,
+    `const RECORDED_CHAT_MODULE_PATH = ${JSON.stringify(RECORDED_CHAT_MODULE_PATH)};`,
   );
   // Freeze EVOLVED_DIR so generated files don't re-resolve
   result = result.replace(
@@ -886,9 +905,15 @@ async function enhanceWithLLM(
 
     const prompt = promptParts.join('\n');
 
-    const response = await provider.chat([{ role: 'user', content: prompt }], {
-      temperature: 0.7,
-      max_tokens: 500,
+    const response = await chatWithFlightRecorder({
+      provider,
+      messages: [{ role: 'user', content: prompt }],
+      options: {
+        temperature: 0.7,
+        max_tokens: 500,
+      },
+      source: "ouroboros-agent",
+      attributes: { phase: "judge-enhancement" },
     });
 
     if (!response.content) return false;

--- a/typescript/src/agents/invocation-journal.test.ts
+++ b/typescript/src/agents/invocation-journal.test.ts
@@ -1,0 +1,157 @@
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  utimesSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  invocationsSince,
+  recordInvocation,
+  trimJournal,
+} from "./invocation-journal.js";
+
+const originalHome = process.env.OPENRAPPTER_HOME;
+let temporaryHome: string | undefined;
+
+afterEach(() => {
+  delete process.env.OPENRAPPTER_INVOCATION_REQUEST_ID;
+  if (originalHome === undefined) {
+    delete process.env.OPENRAPPTER_HOME;
+  } else {
+    process.env.OPENRAPPTER_HOME = originalHome;
+  }
+  if (temporaryHome) {
+    rmSync(temporaryHome, { recursive: true, force: true });
+    temporaryHome = undefined;
+  }
+});
+
+describe("agent invocation journal", () => {
+  it("sanitizes structured results before prefixing and truncating", () => {
+    temporaryHome = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-invocations-"),
+    );
+    process.env.OPENRAPPTER_HOME = temporaryHome;
+    process.env.OPENRAPPTER_INVOCATION_REQUEST_ID = "request-sanitize";
+    const secret = "ordinary-secret-value".repeat(20);
+
+    recordInvocation(
+      "Shell",
+      JSON.stringify({ password: secret, output: "ok" }),
+      true,
+    );
+
+    delete process.env.OPENRAPPTER_INVOCATION_REQUEST_ID;
+    const [line] = invocationsSince(0, "request-sanitize");
+    expect(line).toContain("[Shell] ERROR:");
+    expect(line).toContain("[redacted]");
+    expect(line).not.toContain("ordinary-secret-value");
+  });
+
+  it("does not persist uncorrelated standalone invocations", () => {
+    temporaryHome = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-invocations-"),
+    );
+    process.env.OPENRAPPTER_HOME = temporaryHome;
+    delete process.env.OPENRAPPTER_INVOCATION_REQUEST_ID;
+
+    recordInvocation("Shell", "standalone-result");
+
+    expect(
+      existsSync(
+        path.join(temporaryHome, "agent-invocations.jsonl"),
+      ),
+    ).toBe(false);
+  });
+
+  it("isolates overlapping request journals by correlation ID", () => {
+    temporaryHome = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-invocations-"),
+    );
+    process.env.OPENRAPPTER_HOME = temporaryHome;
+    process.env.OPENRAPPTER_INVOCATION_REQUEST_ID = "request-a";
+    recordInvocation("Shell", "result-a");
+    process.env.OPENRAPPTER_INVOCATION_REQUEST_ID = "request-b";
+    recordInvocation("Memory", "result-b");
+    delete process.env.OPENRAPPTER_INVOCATION_REQUEST_ID;
+
+    expect(invocationsSince(0, "request-a")).toEqual([
+      "[Shell] result-a",
+    ]);
+    expect(invocationsSince(0, "request-b")).toEqual([
+      "[Memory] result-b",
+    ]);
+  });
+
+  it("finds correlated entries beyond the legacy tail window", () => {
+    temporaryHome = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-invocations-"),
+    );
+    process.env.OPENRAPPTER_HOME = temporaryHome;
+    process.env.OPENRAPPTER_INVOCATION_REQUEST_ID = "request-target";
+    recordInvocation("Shell", "target-result");
+    process.env.OPENRAPPTER_INVOCATION_REQUEST_ID = "request-noise";
+    for (let index = 0; index < 300; index += 1) {
+      recordInvocation("Noise", `noise-${index}`);
+    }
+    delete process.env.OPENRAPPTER_INVOCATION_REQUEST_ID;
+
+    expect(
+      invocationsSince(Number.MAX_SAFE_INTEGER, "request-target"),
+    ).toEqual(["[Shell] target-result"]);
+  });
+
+  it("always cleans stale request files even when the legacy journal is short", () => {
+    temporaryHome = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-invocations-"),
+    );
+    process.env.OPENRAPPTER_HOME = temporaryHome;
+    writeFileSync(
+      path.join(temporaryHome, "agent-invocations.jsonl"),
+      '{"at":1,"line":"legacy"}\n',
+    );
+    const stale = path.join(
+      temporaryHome,
+      "agent-invocations.stale-request.jsonl",
+    );
+    writeFileSync(stale, '{"at":1,"line":"stale"}\n');
+    const old = new Date(Date.now() - 48 * 60 * 60 * 1_000);
+    utimesSync(stale, old, old);
+
+    trimJournal();
+    expect(existsSync(stale)).toBe(false);
+    expect(
+      existsSync(
+        path.join(temporaryHome, "agent-invocations.jsonl"),
+      ),
+    ).toBe(false);
+  });
+
+  it("refuses a symlinked journal home without touching its target", () => {
+    if (process.platform === "win32") return;
+    const root = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-invocations-"),
+    );
+    temporaryHome = root;
+    const target = path.join(root, "target");
+    const alias = path.join(root, "alias");
+    mkdirSync(target, { mode: 0o755 });
+    const before = statSync(target).mode & 0o777;
+    symlinkSync(target, alias, "dir");
+    process.env.OPENRAPPTER_HOME = alias;
+    process.env.OPENRAPPTER_INVOCATION_REQUEST_ID = "request-link";
+
+    recordInvocation("Shell", "must-not-write");
+
+    expect(readdirSync(target)).toEqual([]);
+    expect(statSync(target).mode & 0o777).toBe(before);
+  });
+});

--- a/typescript/src/agents/invocation-journal.ts
+++ b/typescript/src/agents/invocation-journal.ts
@@ -29,18 +29,159 @@
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { createHash } from 'crypto';
+import {
+  flightLogResult,
+  formatFlightAgentLog,
+} from '../providers/flight-io.js';
+import {
+  assertPrivateDirectory,
+  hardenPrivatePath,
+  syncParentDirectory,
+} from '../flight-recorder/permissions.js';
 
 /** One tool call, in the shape PARITY §2.3 freezes. */
 export interface JournalEntry {
   /** ms since epoch, when the call completed. */
   at: number;
+  /** Correlates one Copilot CLI request with its inherited MCP process. */
+  requestId?: string;
   /** `[<fn_name>] <result>` — success, or `[<fn_name>] ERROR: <e>` on failure. */
   line: string;
 }
 
-function journalPath(): string {
+function requestToken(requestId: string): string {
+  return /^[A-Za-z0-9_-]{1,128}$/.test(requestId)
+    ? requestId
+    : createHash('sha256').update(requestId).digest('hex');
+}
+
+function journalPath(requestId?: string): string {
   const dir = process.env.OPENRAPPTER_HOME ?? path.join(os.homedir(), '.openrappter');
-  return path.join(dir, 'agent-invocations.jsonl');
+  return path.join(
+    dir,
+    requestId
+      ? `agent-invocations.${requestToken(requestId)}.jsonl`
+      : 'agent-invocations.jsonl',
+  );
+}
+
+function prepareJournalDirectory(directory: string): void {
+  let existing = directory;
+  while (!fs.existsSync(existing)) {
+    const parent = path.dirname(existing);
+    if (parent === existing) break;
+    existing = parent;
+  }
+  assertPrivateDirectory(existing);
+  if (!fs.existsSync(directory)) {
+    fs.mkdirSync(directory, { recursive: true, mode: 0o700 });
+    const created = fs.lstatSync(directory);
+    if (created.isSymbolicLink() || !created.isDirectory()) {
+      throw new Error("Invocation journal directory is not private.");
+    }
+    hardenPrivatePath(directory, true);
+  }
+  const status = fs.lstatSync(directory);
+  if (status.isSymbolicLink() || !status.isDirectory()) {
+    throw new Error("Invocation journal directory is not private.");
+  }
+  assertPrivateDirectory(directory);
+}
+
+function appendPrivateJournal(file: string, content: string): void {
+  try {
+    const existing = fs.lstatSync(file);
+    if (existing.isSymbolicLink() || !existing.isFile()) {
+      throw new Error("Invocation journal must be a regular file.");
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  const descriptor = fs.openSync(
+    file,
+    fs.constants.O_CREAT |
+      fs.constants.O_APPEND |
+      fs.constants.O_WRONLY |
+      (fs.constants.O_NOFOLLOW ?? 0),
+    0o600,
+  );
+  try {
+    const opened = fs.fstatSync(descriptor);
+    const linked = fs.lstatSync(file);
+    if (
+      !opened.isFile() ||
+      linked.isSymbolicLink() ||
+      !linked.isFile() ||
+      opened.dev !== linked.dev ||
+      opened.ino !== linked.ino
+    ) {
+      throw new Error("Invocation journal identity changed.");
+    }
+    hardenPrivatePath(file);
+    fs.writeFileSync(descriptor, content, "utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function readPrivateJournal(file: string): string {
+  const descriptor = fs.openSync(
+    file,
+    fs.constants.O_RDONLY | (fs.constants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const opened = fs.fstatSync(descriptor);
+    const linked = fs.lstatSync(file);
+    if (
+      !opened.isFile() ||
+      linked.isSymbolicLink() ||
+      opened.dev !== linked.dev ||
+      opened.ino !== linked.ino
+    ) {
+      throw new Error("Invocation journal identity changed.");
+    }
+    return fs.readFileSync(descriptor, "utf8");
+  } finally {
+    fs.closeSync(descriptor);
+  }
+}
+
+function retireLegacyJournal(): void {
+  const file = journalPath();
+  let status: ReturnType<typeof fs.lstatSync>;
+  try {
+    status = fs.lstatSync(file);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  if (status.isSymbolicLink()) {
+    fs.unlinkSync(file);
+    return;
+  }
+  if (!status.isFile()) {
+    throw new Error("Legacy invocation journal is not a regular file.");
+  }
+  const descriptor = fs.openSync(
+    file,
+    fs.constants.O_WRONLY | (fs.constants.O_NOFOLLOW ?? 0),
+  );
+  try {
+    const zeroes = Buffer.alloc(64 * 1024);
+    let remaining = status.size;
+    while (remaining > 0) {
+      const size = Math.min(remaining, zeroes.length);
+      fs.writeSync(descriptor, zeroes, 0, size);
+      remaining -= size;
+    }
+    fs.ftruncateSync(descriptor, 0);
+    fs.fsyncSync(descriptor);
+  } finally {
+    fs.closeSync(descriptor);
+  }
+  fs.unlinkSync(file);
+  syncParentDirectory(path.dirname(file));
 }
 
 /** Truncate a result the way the Assistant loop does, so both paths agree. */
@@ -53,13 +194,22 @@ function truncate(s: string, max = 200): string {
  * down an agent call that otherwise succeeded.
  */
 export function recordInvocation(name: string, result: string, failed = false): void {
-  const line = failed
-    ? `[${name}] ERROR: ${truncate(result)}`
-    : `[${name}] ${truncate(result)}`;
+  const requestId = process.env.OPENRAPPTER_INVOCATION_REQUEST_ID;
+  if (!requestId) return;
+  const line = formatFlightAgentLog(
+    name,
+    truncate(flightLogResult(result)),
+    failed,
+  );
   try {
-    const p = journalPath();
-    fs.mkdirSync(path.dirname(p), { recursive: true });
-    fs.appendFileSync(p, JSON.stringify({ at: Date.now(), line } satisfies JournalEntry) + '\n');
+    const p = journalPath(requestId);
+    const directory = path.dirname(p);
+    prepareJournalDirectory(directory);
+    appendPrivateJournal(p, JSON.stringify({
+      at: Date.now(),
+      requestId,
+      line,
+    } satisfies JournalEntry) + '\n');
   } catch {
     // Best effort by design.
   }
@@ -71,24 +221,51 @@ export function recordInvocation(name: string, result: string, failed = false): 
  * Reads the tail only. The journal is append-only and a chat turn is seconds
  * long, so scanning the whole file would grow unboundedly slower for no gain.
  */
-export function invocationsSince(since: number, limit = 64): string[] {
+export function invocationsSince(
+  since: number,
+  requestId?: string,
+  limit = 64,
+): string[] {
   let raw: string;
+  const p = journalPath(requestId);
   try {
-    raw = fs.readFileSync(journalPath(), 'utf-8');
+    raw = readPrivateJournal(p);
   } catch {
     return [];
+  } finally {
+    if (requestId) {
+      try {
+        fs.unlinkSync(p);
+      } catch {
+        // Another reader or cleanup pass may have consumed it.
+      }
+    }
   }
-  const lines = raw.split('\n').filter(Boolean).slice(-limit * 4);
+  const allLines = raw.split('\n').filter(Boolean);
+  const lines = requestId
+    ? allLines
+    : allLines.slice(-limit * 4);
   const out: string[] = [];
-  for (const l of lines) {
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const l = lines[index];
     try {
       const e = JSON.parse(l) as JournalEntry;
-      if (e.at >= since && typeof e.line === 'string') out.push(e.line);
+      if (
+        typeof e.line === 'string' &&
+        (
+          requestId === undefined
+            ? e.at >= since
+            : e.requestId === requestId
+        )
+      ) {
+        out.push(e.line);
+        if (out.length >= limit) break;
+      }
     } catch {
       // A torn final line from a concurrent append. Skip it.
     }
   }
-  return out.slice(-limit);
+  return out.reverse();
 }
 
 /**
@@ -98,13 +275,37 @@ export function invocationsSince(since: number, limit = 64): string[] {
  * `recordInvocation` would put a read-modify-write on the hot path of every
  * agent call.
  */
-export function trimJournal(keep = 500): void {
+export function trimJournal(_keep = 500): void {
+  const dir = process.env.OPENRAPPTER_HOME ?? path.join(os.homedir(), '.openrappter');
   try {
-    const p = journalPath();
-    const lines = fs.readFileSync(p, 'utf-8').split('\n').filter(Boolean);
-    if (lines.length <= keep) return;
-    fs.writeFileSync(p, lines.slice(-keep).join('\n') + '\n');
+    prepareJournalDirectory(dir);
   } catch {
-    // No journal yet, or unreadable. Nothing to trim.
+    return;
+  }
+  try {
+    retireLegacyJournal();
+  } catch {
+    // Legacy retirement is best effort.
+  }
+  try {
+    const staleBefore = Date.now() - 24 * 60 * 60 * 1_000;
+    const requestFiles = fs.readdirSync(dir)
+      .filter((name) =>
+        /^agent-invocations\.[A-Za-z0-9_-]+\.jsonl$/.test(name),
+      )
+      .map((name) => path.join(dir, name));
+    for (const requestFile of requestFiles) {
+      const status = fs.lstatSync(requestFile);
+      if (status.isSymbolicLink()) {
+        fs.unlinkSync(requestFile);
+      } else if (
+        status.isFile() &&
+        status.mtimeMs < staleBefore
+      ) {
+        fs.unlinkSync(requestFile);
+      }
+    }
+  } catch {
+    // Stale request cleanup is best effort.
   }
 }

--- a/typescript/src/agents/result-status.ts
+++ b/typescript/src/agents/result-status.ts
@@ -1,0 +1,14 @@
+export function agentResultIsError(result: unknown): boolean {
+  if (typeof result !== "string") return false;
+  try {
+    const parsed = JSON.parse(result) as { status?: unknown };
+    return (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      typeof parsed.status === "string" &&
+      parsed.status.toLowerCase() === "error"
+    );
+  } catch {
+    return false;
+  }
+}

--- a/typescript/src/chat-flight.test.ts
+++ b/typescript/src/chat-flight.test.ts
@@ -1,0 +1,52 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { BasicAgent } from "./agents/BasicAgent.js";
+import { matchAndExecuteAgent } from "./chat.js";
+import {
+  FlightRecorder,
+  setFlightRecorder,
+} from "./flight-recorder/recorder.js";
+
+let previous: FlightRecorder | undefined;
+let recorder: FlightRecorder | undefined;
+
+afterEach(async () => {
+  if (previous) setFlightRecorder(previous);
+  await recorder?.close();
+  previous = undefined;
+  recorder = undefined;
+});
+
+describe("keyword-routed flight recording", () => {
+  it("does not turn agent success into failure when params become uncloneable", async () => {
+    recorder = new FlightRecorder({
+      enabled: true,
+      inMemory: true,
+      identityKey: "77".repeat(32),
+      privacy: { recordIO: true },
+    });
+    await recorder.initialize();
+    previous = setFlightRecorder(recorder);
+    const agent = {
+      metadata: {
+        name: "Shell",
+        description: "Run shell commands",
+      },
+      async execute(params: Record<string, unknown>) {
+        params.circular = params;
+        params.callback = () => "done";
+        return '{"status":"success"}';
+      },
+    } as unknown as BasicAgent;
+
+    const result = await matchAndExecuteAgent(
+      "run shell command",
+      new Map([["Shell", agent]]),
+    );
+
+    expect(result).toBe('{"status":"success"}');
+    expect(await recorder.query({ kind: "tool.call.failed" })).toEqual([]);
+    expect(
+      await recorder.query({ kind: "tool.call.completed" }),
+    ).toHaveLength(1);
+  });
+});

--- a/typescript/src/chat.ts
+++ b/typescript/src/chat.ts
@@ -1,25 +1,39 @@
-import chalk from 'chalk';
-import { AgentRegistry, BasicAgent } from './agents/index.js';
-import { hasCopilotAvailable, resolveGithubToken } from './copilot-check.js';
-import { deviceCodeLogin } from './providers/copilot-auth.js';
-import { saveEnv, loadEnv } from './env.js';
+import chalk from "chalk";
+import { AgentRegistry, BasicAgent } from "./agents/index.js";
+import { hasCopilotAvailable, resolveGithubToken } from "./copilot-check.js";
+import { deviceCodeLogin } from "./providers/copilot-auth.js";
+import { saveEnv, loadEnv } from "./env.js";
+import {
+  ensureFlightRecorderFromEnv,
+  getFlightRecorder,
+} from "./flight-recorder/index.js";
+import {
+  sanitizeFlightValue,
+  summarizeFlightError,
+} from "./flight-recorder/redaction.js";
+import { agentResultIsError } from "./agents/result-status.js";
 
-const NAME = 'openrappter';
-const EMOJI = '🦖';
+const NAME = "openrappter";
+const EMOJI = "🦖";
 
 /** Singleton CopilotProvider for quick chat (non-daemon mode) */
-let _chatProvider: import('./providers/copilot.js').CopilotProvider | null = null;
+let _chatProvider: import("./providers/copilot.js").CopilotProvider | null =
+  null;
 
 /** Reset the cached chat provider (e.g. after re-auth) */
 export function resetChatProvider(): void {
   _chatProvider = null;
 }
 
-export async function getChatProvider(): Promise<import('./providers/copilot.js').CopilotProvider> {
+export async function getChatProvider(): Promise<
+  import("./providers/copilot.js").CopilotProvider
+> {
   if (!_chatProvider) {
-    const { CopilotProvider } = await import('./providers/copilot.js');
+    const { CopilotProvider } = await import("./providers/copilot.js");
     const token = await resolveGithubToken();
-    _chatProvider = new CopilotProvider(token ? { githubToken: token } : undefined);
+    _chatProvider = new CopilotProvider(
+      token ? { githubToken: token } : undefined,
+    );
   }
   return _chatProvider;
 }
@@ -29,15 +43,24 @@ export async function getChatProvider(): Promise<import('./providers/copilot.js'
  */
 async function inlineAuth(): Promise<string | null> {
   try {
-    console.log(chalk.yellow('\nNo GitHub token found. Let\'s fix that now...\n'));
+    console.log(
+      chalk.yellow("\nNo GitHub token found. Let's fix that now...\n"),
+    );
     const token = await deviceCodeLogin((code, url) => {
       console.log(chalk.bold(`  Open: ${url}`));
       console.log(chalk.bold(`  Code: ${code}\n`));
       // Try to open browser
-      import('child_process').then(cp => {
-        const cmd = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
-        cp.exec(`${cmd} ${url}`);
-      }).catch(() => {});
+      import("child_process")
+        .then((cp) => {
+          const cmd =
+            process.platform === "darwin"
+              ? "open"
+              : process.platform === "win32"
+                ? "start"
+                : "xdg-open";
+          cp.exec(`${cmd} ${url}`);
+        })
+        .catch(() => {});
     });
     // Persist the token
     const env = await loadEnv();
@@ -45,15 +68,33 @@ async function inlineAuth(): Promise<string | null> {
     await saveEnv(env);
     process.env.GITHUB_TOKEN = token;
     resetChatProvider();
-    console.log(chalk.green('  Authenticated successfully!\n'));
+    console.log(chalk.green("  Authenticated successfully!\n"));
     return token;
   } catch (err) {
-    console.error(chalk.red(`  Authentication failed: ${(err as Error).message}\n`));
+    console.error(
+      chalk.red(`  Authentication failed: ${(err as Error).message}\n`),
+    );
     return null;
   }
 }
 
-export async function chat(message: string, registry: AgentRegistry): Promise<string> {
+export async function chat(
+  message: string,
+  registry: AgentRegistry,
+): Promise<string> {
+  await ensureFlightRecorderFromEnv();
+  const recorder = getFlightRecorder();
+  if (recorder.currentTrace()) return chatWithinTrace(message, registry);
+  return recorder.runTrace(
+    { sessionId: "cli", workspaceId: process.cwd() },
+    () => chatWithinTrace(message, registry),
+  );
+}
+
+async function chatWithinTrace(
+  message: string,
+  registry: AgentRegistry,
+): Promise<string> {
   // First try to match an agent using keyword patterns (fallback mode)
   const agents = await registry.getAllAgents();
   const result = await matchAndExecuteAgent(message, agents);
@@ -72,15 +113,15 @@ export async function chat(message: string, registry: AgentRegistry): Promise<st
       }
       // Auth failed — fall back to agents-only response
       return JSON.stringify({
-        status: 'info',
-        response: 'Authentication was cancelled or failed.',
+        status: "info",
+        response: "Authentication was cancelled or failed.",
         agents: Array.from(agents.keys()),
       });
     }
     // No TTY — can't do interactive auth
     return JSON.stringify({
-      status: 'info',
-      response: 'No GitHub token. Run: openrappter onboard',
+      status: "info",
+      response: "No GitHub token. Run: openrappter onboard",
     });
   }
 
@@ -88,19 +129,73 @@ export async function chat(message: string, registry: AgentRegistry): Promise<st
 }
 
 async function chatWithProvider(message: string): Promise<string> {
+  const recorder = getFlightRecorder();
+  const startedAt = performance.now();
+  let provider: import("./providers/copilot.js").CopilotProvider | undefined;
+  let providerStartedId: string | undefined;
   try {
-    const provider = await getChatProvider();
-    const response = await provider.chat([
-      { role: 'system', content: `You are ${NAME}, a helpful local-first AI assistant.` },
-      { role: 'user', content: message },
-    ]);
-    return response.content ?? `${EMOJI} ${NAME}: I processed your request but got no response.`;
+    // Keep acquisition inside the historical catch boundary. Moving it above
+    // the try made token-resolution errors escape instead of returning the
+    // existing inline-auth/error response.
+    provider = await getChatProvider();
+    const startedEvent = await recorder.record({
+      kind: "provider.attempt.started",
+      source: "cli-chat",
+      status: "started",
+      providerId: provider.id,
+      metadata: { messageCount: 2, toolCount: 0 },
+      payload: () => ({ message }),
+    });
+    providerStartedId = startedEvent?.id;
+    return await recorder.withParent(startedEvent?.id ?? null, async () => {
+      const response = await provider!.chat([
+        {
+          role: "system",
+          content: `You are ${NAME}, a helpful local-first AI assistant.`,
+        },
+        { role: "user", content: message },
+      ]);
+      await recorder.record({
+        kind: "provider.attempt.completed",
+        source: "cli-chat",
+        status: "success",
+        providerId: provider!.id,
+        model: response.model,
+        durationMs: performance.now() - startedAt,
+        metadata: {
+          hadContent: Boolean(response.content),
+          usage: response.usage,
+        },
+        payload: () => ({ response: response.content }),
+      });
+      return (
+        response.content ??
+        `${EMOJI} ${NAME}: I processed your request but got no response.`
+      );
+    });
   } catch (error) {
     const err = error as Error;
-    if (err.message.includes('timeout')) {
+    await recorder.record({
+      kind: "provider.attempt.failed",
+      source: "cli-chat",
+      status: "error",
+      providerId: provider?.id ?? "copilot",
+      durationMs: performance.now() - startedAt,
+      metadata: {
+        phase: provider ? "chat" : "resolve-provider",
+        ...summarizeFlightError(err),
+      },
+      payload: { error: err },
+      parentId: providerStartedId,
+    });
+    if (err.message.includes("timeout")) {
       return `${EMOJI} ${NAME}: Request timed out. Try a simpler question.`;
     }
-    if (err.message.includes('404') || err.message.includes('401') || err.message.includes('403')) {
+    if (
+      err.message.includes("404") ||
+      err.message.includes("401") ||
+      err.message.includes("403")
+    ) {
       // Auth error — try inline re-auth if TTY available
       if (process.stdin.isTTY) {
         const token = await inlineAuth();
@@ -109,8 +204,8 @@ async function chatWithProvider(message: string): Promise<string> {
         }
       }
       return JSON.stringify({
-        status: 'error',
-        response: 'GitHub token expired or invalid. Run: openrappter onboard',
+        status: "error",
+        response: "GitHub token expired or invalid. Run: openrappter onboard",
       });
     }
     return `${EMOJI} ${NAME}: I couldn't process that. Error: ${err.message}`;
@@ -123,14 +218,35 @@ async function chatWithProvider(message: string): Promise<string> {
  */
 export async function matchAndExecuteAgent(
   message: string,
-  agents: Map<string, BasicAgent>
+  agents: Map<string, BasicAgent>,
 ): Promise<string | null> {
   const msgLower = message.toLowerCase();
 
   // Keyword patterns for core agents
   const patterns: Record<string, string[]> = {
-    Memory: ['remember', 'store', 'save', 'memorize', 'recall', 'what do you know', 'memory', 'remind me', 'forget'],
-    Shell: ['run', 'execute', 'bash', 'ls', 'cat', 'read file', 'write file', 'list dir', 'command', '$'],
+    Memory: [
+      "remember",
+      "store",
+      "save",
+      "memorize",
+      "recall",
+      "what do you know",
+      "memory",
+      "remind me",
+      "forget",
+    ],
+    Shell: [
+      "run",
+      "execute",
+      "bash",
+      "ls",
+      "cat",
+      "read file",
+      "write file",
+      "list dir",
+      "command",
+      "$",
+    ],
   };
 
   // Find best matching agent
@@ -139,7 +255,7 @@ export async function matchAndExecuteAgent(
 
   // Check patterns first
   for (const [agentName, keywords] of Object.entries(patterns)) {
-    const score = keywords.filter(kw => msgLower.includes(kw)).length;
+    const score = keywords.filter((kw) => msgLower.includes(kw)).length;
     if (score > bestScore && agents.has(agentName)) {
       bestScore = score;
       bestMatch = agentName;
@@ -148,17 +264,103 @@ export async function matchAndExecuteAgent(
 
   // Stop words — common English words that should never trigger agent routing
   const stopWords = new Set([
-    'the', 'and', 'for', 'are', 'but', 'not', 'you', 'all', 'can', 'had',
-    'her', 'was', 'one', 'our', 'out', 'has', 'have', 'been', 'some', 'them',
-    'than', 'its', 'over', 'such', 'that', 'this', 'with', 'will', 'each',
-    'make', 'like', 'from', 'just', 'into', 'about', 'what', 'which', 'when',
-    'who', 'how', 'where', 'why', 'should', 'could', 'would', 'there', 'their',
-    'been', 'more', 'most', 'then', 'also', 'they', 'very', 'after', 'before',
-    'other', 'right', 'think', 'given', 'kind', 'focus', 'things', 'today',
-    'work', 'help', 'need', 'want', 'know', 'good', 'best', 'use', 'using',
-    'does', 'doing', 'done', 'give', 'gave', 'take', 'took', 'come', 'came',
-    'going', 'now', 'still', 'back', 'well', 'way', 'look', 'only', 'new',
-    'really', 'something', 'anything', 'everything', 'nothing', 'please',
+    "the",
+    "and",
+    "for",
+    "are",
+    "but",
+    "not",
+    "you",
+    "all",
+    "can",
+    "had",
+    "her",
+    "was",
+    "one",
+    "our",
+    "out",
+    "has",
+    "have",
+    "been",
+    "some",
+    "them",
+    "than",
+    "its",
+    "over",
+    "such",
+    "that",
+    "this",
+    "with",
+    "will",
+    "each",
+    "make",
+    "like",
+    "from",
+    "just",
+    "into",
+    "about",
+    "what",
+    "which",
+    "when",
+    "who",
+    "how",
+    "where",
+    "why",
+    "should",
+    "could",
+    "would",
+    "there",
+    "their",
+    "been",
+    "more",
+    "most",
+    "then",
+    "also",
+    "they",
+    "very",
+    "after",
+    "before",
+    "other",
+    "right",
+    "think",
+    "given",
+    "kind",
+    "focus",
+    "things",
+    "today",
+    "work",
+    "help",
+    "need",
+    "want",
+    "know",
+    "good",
+    "best",
+    "use",
+    "using",
+    "does",
+    "doing",
+    "done",
+    "give",
+    "gave",
+    "take",
+    "took",
+    "come",
+    "came",
+    "going",
+    "now",
+    "still",
+    "back",
+    "well",
+    "way",
+    "look",
+    "only",
+    "new",
+    "really",
+    "something",
+    "anything",
+    "everything",
+    "nothing",
+    "please",
   ]);
 
   // Also check dynamically loaded agents by their descriptions
@@ -181,9 +383,11 @@ export async function matchAndExecuteAgent(
 
     // Description matching: filter out stop words and short words,
     // require at least 2 meaningful keyword matches
-    const desc = agent.metadata?.description?.toLowerCase() ?? '';
-    const words = msgLower.split(/\s+/).filter(w => w.length > 3 && !stopWords.has(w));
-    const score = words.filter(w => desc.includes(w)).length;
+    const desc = agent.metadata?.description?.toLowerCase() ?? "";
+    const words = msgLower
+      .split(/\s+/)
+      .filter((w) => w.length > 3 && !stopWords.has(w));
+    const score = words.filter((w) => desc.includes(w)).length;
 
     if (score >= 2 && score > bestScore) {
       bestScore = score;
@@ -195,16 +399,66 @@ export async function matchAndExecuteAgent(
   if (bestMatch && bestScore > 0) {
     const agent = agents.get(bestMatch);
     if (agent) {
+      const recorder = getFlightRecorder();
+      const startedAt = performance.now();
+      const startedEvent = await recorder.record({
+        kind: "tool.call.started",
+        source: "cli-keyword-router",
+        status: "started",
+        toolName: bestMatch,
+        metadata: { route: "keyword", score: bestScore },
+        payload: () => ({ message }),
+      });
       try {
         // Smart param injection based on agent + intent
         const params: Record<string, unknown> = { query: message };
-        if (bestMatch === 'HackerNews') {
-          params.action = 'fetch'; // Default to fetch, not post
+        if (bestMatch === "HackerNews") {
+          params.action = "fetch"; // Default to fetch, not post
         }
-        return await agent.execute(params);
+        return await recorder.withParent(startedEvent?.id ?? null, async () => {
+          const result = await agent.execute(params);
+          const failed = agentResultIsError(result);
+          let structuredResult: unknown = sanitizeFlightValue(result);
+          try {
+            structuredResult = sanitizeFlightValue(JSON.parse(result));
+          } catch {
+            // Non-JSON output remains a sanitized string.
+          }
+          await recorder.record({
+            kind: failed ? "tool.call.failed" : "tool.call.completed",
+            source: "cli-keyword-router",
+            status: failed ? "error" : "success",
+            toolName: bestMatch!,
+            durationMs: performance.now() - startedAt,
+            metadata: {
+              route: "keyword",
+              resultLength: result.length,
+              ...(failed ? { resultStatus: "error" } : {}),
+            },
+            payload: () => ({
+              params,
+              result: structuredResult,
+            }),
+          });
+          return result;
+        });
       } catch (e) {
+        await recorder.withParent(startedEvent?.id ?? null, () =>
+          recorder.record({
+            kind: "tool.call.failed",
+            source: "cli-keyword-router",
+            status: "error",
+            toolName: bestMatch!,
+            durationMs: performance.now() - startedAt,
+            metadata: {
+              route: "keyword",
+              ...summarizeFlightError(e),
+            },
+            payload: { error: e },
+          }),
+        );
         return JSON.stringify({
-          status: 'error',
+          status: "error",
           message: `Error executing ${bestMatch}: ${(e as Error).message}`,
         });
       }
@@ -227,18 +481,20 @@ export function displayResult(result: string): void {
     } else if (data.output) {
       console.log(`\n${data.output}\n`);
     } else if (data.content) {
-      console.log(`\n${data.content.slice(0, 1000)}${data.truncated ? '...' : ''}\n`);
+      console.log(
+        `\n${data.content.slice(0, 1000)}${data.truncated ? "..." : ""}\n`,
+      );
     } else if (data.items) {
       // Directory listing
       console.log(`\n${data.path}:`);
       for (const item of data.items) {
-        const icon = item.type === 'directory' ? '📁' : '📄';
+        const icon = item.type === "directory" ? "📁" : "📄";
         console.log(`  ${icon} ${item.name}`);
       }
       console.log();
     } else if (data.matches) {
       // Memory recall
-      console.log(`\n${EMOJI} ${data.message || 'Memories'}:`);
+      console.log(`\n${EMOJI} ${data.message || "Memories"}:`);
       for (const match of data.matches) {
         console.log(`  • ${match.message}`);
       }

--- a/typescript/src/cli/flight-recorder.ts
+++ b/typescript/src/cli/flight-recorder.ts
@@ -1,0 +1,359 @@
+import type { Command } from "commander";
+import { randomUUID } from "node:crypto";
+import {
+  open,
+  readFile,
+  realpath,
+  rename,
+  stat,
+  unlink,
+} from "node:fs/promises";
+import path from "node:path";
+import { hardenPrivatePath } from "../flight-recorder/permissions.js";
+import {
+  ensureFlightRecorderFromEnv,
+  type FlightEventKind,
+} from "../flight-recorder/index.js";
+
+async function resolvePotentialPath(target: string): Promise<string> {
+  const suffix: string[] = [];
+  let current = target;
+  while (true) {
+    try {
+      return path.resolve(await realpath(current), ...suffix);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const parent = path.dirname(current);
+    if (parent === current) return path.resolve(target);
+    suffix.unshift(path.basename(current));
+    current = parent;
+  }
+}
+
+function integer(value: string): number {
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed < 0) {
+    throw new Error(`Expected a non-negative integer, got "${value}".`);
+  }
+  return parsed;
+}
+
+function eventSummary(
+  event: import("../flight-recorder/index.js").FlightEvent,
+): Record<string, unknown> {
+  return {
+    sequence: event.sequence,
+    timestamp: event.timestamp,
+    traceId: event.traceId,
+    kind: event.kind,
+    status: event.status,
+    source: event.source,
+    providerId: event.providerId,
+    model: event.model,
+    agentName: event.agentName,
+    toolName: event.toolName,
+    durationMs: event.durationMs,
+    metadata: event.metadata,
+    contentHash: event.contentHash,
+  };
+}
+
+async function assertSafeExportDestination(
+  destination: string,
+  databasePath: string | undefined,
+): Promise<void> {
+  if (!databasePath || databasePath === ":memory:") return;
+  const database = path.resolve(databasePath);
+  const artifacts = [
+    database,
+    `${database}-wal`,
+    `${database}-shm`,
+    `${database}.identity-key`,
+    `${database}.reset-lock`,
+    `${database}.owners`,
+  ];
+  const identityTemporaryPrefix = `${database}.identity-key.`;
+  const foldPath = (value: string): string =>
+    process.platform === "win32" || process.platform === "darwin"
+      ? value.toLowerCase()
+      : value;
+  const foldedDestination = foldPath(destination);
+  const foldedArtifacts = artifacts.map(foldPath);
+  const foldedOwnerDirectory = foldPath(`${database}.owners`);
+  const foldedIdentityTemporaryPrefix = foldPath(
+    identityTemporaryPrefix,
+  );
+  if (
+    foldedArtifacts.includes(foldedDestination) ||
+    foldedDestination.startsWith(
+      `${foldedOwnerDirectory}${path.sep}`,
+    ) ||
+    (
+      foldedDestination.startsWith(foldedIdentityTemporaryPrefix) &&
+      foldedDestination.endsWith(".tmp")
+    )
+  ) {
+    throw new Error(
+      "Flight export output must not target Flight Recorder storage.",
+    );
+  }
+
+  const canonicalDatabase = await resolvePotentialPath(database);
+  const canonicalDestination = await resolvePotentialPath(destination);
+  const canonicalArtifacts = [
+    canonicalDatabase,
+    `${canonicalDatabase}-wal`,
+    `${canonicalDatabase}-shm`,
+    `${canonicalDatabase}.identity-key`,
+    `${canonicalDatabase}.reset-lock`,
+    `${canonicalDatabase}.owners`,
+  ];
+  const foldedCanonicalDestination = foldPath(canonicalDestination);
+  const foldedCanonicalArtifacts = canonicalArtifacts.map(foldPath);
+  const foldedCanonicalOwnerDirectory = foldPath(
+    `${canonicalDatabase}.owners`,
+  );
+  const foldedCanonicalIdentityTemporaryPrefix = foldPath(
+    `${canonicalDatabase}.identity-key.`,
+  );
+  if (
+    foldedCanonicalArtifacts.includes(foldedCanonicalDestination) ||
+    foldedCanonicalDestination.startsWith(
+      `${foldedCanonicalOwnerDirectory}${path.sep}`,
+    ) ||
+    (
+      foldedCanonicalDestination.startsWith(
+        foldedCanonicalIdentityTemporaryPrefix,
+      ) &&
+      foldedCanonicalDestination.endsWith(".tmp")
+    )
+  ) {
+    throw new Error(
+      "Flight export output must not target Flight Recorder storage.",
+    );
+  }
+
+  const ownerDirectory = `${database}.owners`;
+  let ownerDirectoryStat: Awaited<ReturnType<typeof stat>> | undefined;
+  try {
+    ownerDirectoryStat = await stat(ownerDirectory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  if (ownerDirectoryStat) {
+    let current = destination;
+    while (true) {
+      try {
+        const currentStat = await stat(current);
+        if (
+          currentStat.dev === ownerDirectoryStat.dev &&
+          currentStat.ino === ownerDirectoryStat.ino
+        ) {
+          throw new Error(
+            "Flight export output must not target Flight Recorder owner storage.",
+          );
+        }
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+      }
+      const parent = path.dirname(current);
+      if (parent === current) break;
+      current = parent;
+    }
+  }
+
+  let destinationStat: Awaited<ReturnType<typeof stat>> | undefined;
+  try {
+    destinationStat = await stat(destination);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  if (!destinationStat) return;
+  for (const artifact of artifacts) {
+    try {
+      const artifactStat = await stat(artifact);
+      if (
+        artifactStat.dev === destinationStat.dev &&
+        artifactStat.ino === destinationStat.ino
+      ) {
+        throw new Error(
+          "Flight export output aliases Flight Recorder storage.",
+        );
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+  }
+}
+
+async function writePrivateExport(
+  file: string,
+  content: string,
+  databasePath?: string,
+): Promise<void> {
+  const destination = path.resolve(file);
+  await assertSafeExportDestination(destination, databasePath);
+  const temporary = `${destination}.${process.pid}.${randomUUID()}.tmp`;
+  let handle: Awaited<ReturnType<typeof open>> | undefined;
+  try {
+    handle = await open(temporary, "wx", 0o600);
+    hardenPrivatePath(temporary);
+    await handle.writeFile(content, "utf8");
+    await handle.sync();
+    await handle.chmod(0o600);
+    await handle.close();
+    handle = undefined;
+    await assertSafeExportDestination(destination, databasePath);
+    await rename(temporary, destination);
+    hardenPrivatePath(destination);
+  } finally {
+    await handle?.close().catch(() => {});
+    await unlink(temporary).catch(() => {});
+  }
+}
+
+export function registerFlightRecorderCommand(program: Command): void {
+  const flight = program
+    .command("flight")
+    .description("Inspect the local privacy-aware Flight Recorder");
+
+  flight
+    .command("status")
+    .description("Show recorder health, event count, and local database path")
+    .option("--json", "Print machine-readable JSON")
+    .action(async (options: { json?: boolean }) => {
+      const recorder = await ensureFlightRecorderFromEnv();
+      const health = await recorder.health();
+      if (options.json) {
+        console.log(JSON.stringify(health, null, 2));
+        return;
+      }
+      console.log(
+        `Flight Recorder: ${health.enabled ? "enabled" : "disabled"}`,
+      );
+      console.log(`  initialized : ${health.initialized}`);
+      console.log(`  events      : ${health.eventCount}`);
+      console.log(`  errors      : ${health.errorCount}`);
+      console.log(`  database    : ${health.databasePath ?? "(none)"}`);
+      if (health.lastError) console.log(`  last error  : ${health.lastError}`);
+    });
+
+  flight
+    .command("events")
+    .description("List privacy-safe event summaries")
+    .option("--trace <id>", "Filter by trace ID")
+    .option("--session <id>", "Filter by session ID")
+    .option("--kind <kind>", "Filter by event kind")
+    .option("--agent <name>", "Filter by agent name")
+    .option("--provider <id>", "Filter by provider ID")
+    .option("--limit <n>", "Maximum events", "50")
+    .option("--json", "Print one JSON array instead of JSON lines")
+    .action(
+      async (options: {
+        trace?: string;
+        session?: string;
+        kind?: string;
+        agent?: string;
+        provider?: string;
+        limit: string;
+        json?: boolean;
+      }) => {
+        const recorder = await ensureFlightRecorderFromEnv();
+        const events = await recorder.query({
+          traceId: options.trace,
+          sessionId: options.session,
+          kind: options.kind as FlightEventKind | undefined,
+          agentName: options.agent,
+          providerId: options.provider,
+          order: "desc",
+          limit: integer(options.limit),
+        });
+        if (options.json) {
+          console.log(JSON.stringify(events.map(eventSummary), null, 2));
+          return;
+        }
+        for (const event of events) {
+          console.log(JSON.stringify(eventSummary(event)));
+        }
+      },
+    );
+
+  flight
+    .command("export")
+    .description(
+      "Export a versioned trace/session/event bundle for replay or evals",
+    )
+    .option("--trace <id>", "Filter by trace ID")
+    .option("--session <id>", "Filter by session ID")
+    .option("--kind <kind>", "Filter by event kind")
+    .option("--output <path>", "Write to a file (mode 0600) instead of stdout")
+    .action(
+      async (options: {
+        trace?: string;
+        session?: string;
+        kind?: string;
+        output?: string;
+      }) => {
+        const recorder = await ensureFlightRecorderFromEnv();
+        const bundle = await recorder.export({
+          traceId: options.trace,
+          sessionId: options.session,
+          kind: options.kind as FlightEventKind | undefined,
+        });
+        if (!bundle) throw new Error("Flight Recorder is not initialized.");
+        const json = `${JSON.stringify(bundle, null, 2)}\n`;
+        if (!options.output) {
+          process.stdout.write(json);
+          return;
+        }
+        const health = await recorder.health();
+        await writePrivateExport(
+          options.output,
+          json,
+          health.databasePath,
+        );
+        console.log(
+          `Exported ${bundle.events.length} event(s) to ${options.output}`,
+        );
+      },
+    );
+
+  flight
+    .command("import <path>")
+    .description("Import an integrity-checked replay/eval bundle")
+    .option("--replace", "Replace existing events with matching event IDs")
+    .action(async (file: string, options: { replace?: boolean }) => {
+      const recorder = await ensureFlightRecorderFromEnv();
+      let data: unknown;
+      try {
+        data = JSON.parse(await readFile(file, "utf8"));
+      } catch (error) {
+        throw new Error(
+          `Cannot read Flight Recorder export: ${(error as Error).message}`,
+        );
+      }
+      const imported = await recorder.import(
+        data as import("../flight-recorder/index.js").FlightExport,
+        { replace: options.replace },
+      );
+      console.log(`Imported ${imported} event(s) from ${file}`);
+    });
+
+  flight
+    .command("clear")
+    .description("Delete every locally recorded event")
+    .option("--yes", "Confirm destructive deletion")
+    .action(async (options: { yes?: boolean }) => {
+      if (!options.yes) {
+        throw new Error("Refusing to clear without --yes.");
+      }
+      const recorder = await ensureFlightRecorderFromEnv();
+      if (!(await recorder.clear())) {
+        throw new Error(
+          "Flight Recorder could not clear its database. Check flight status.",
+        );
+      }
+      console.log("Flight Recorder cleared.");
+    });
+}

--- a/typescript/src/flight-recorder/flight-recorder-cli.test.ts
+++ b/typescript/src/flight-recorder/flight-recorder-cli.test.ts
@@ -1,0 +1,336 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { Command } from "commander";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { registerFlightRecorderCommand } from "../cli/flight-recorder.js";
+import {
+  ensureFlightRecorderFromEnv,
+  getFlightRecorder,
+  resetFlightRecorderEnvironmentForTests,
+} from "./recorder.js";
+
+let directory: string;
+let databasePath: string;
+const originalEnv = { ...process.env };
+
+beforeEach(() => {
+  directory = mkdtempSync(path.join(os.tmpdir(), "openrappter-flight-cli-"));
+  databasePath = path.join(directory, "flight.db");
+  process.env.OPENRAPPTER_FLIGHT_RECORDER = "1";
+  process.env.OPENRAPPTER_FLIGHT_DB = databasePath;
+  process.env.OPENRAPPTER_FLIGHT_RECORD_IO = "0";
+  process.env.NODE_ENV = "test";
+  resetFlightRecorderEnvironmentForTests();
+});
+
+afterEach(async () => {
+  await getFlightRecorder().close();
+  resetFlightRecorderEnvironmentForTests();
+  process.env = { ...originalEnv };
+  rmSync(directory, { recursive: true, force: true });
+  vi.restoreAllMocks();
+});
+
+function command(): Command {
+  const program = new Command();
+  program.exitOverride();
+  program.configureOutput({
+    writeOut: () => {},
+    writeErr: () => {},
+  });
+  registerFlightRecorderCommand(program);
+  return program;
+}
+
+describe("flight CLI", () => {
+  it("prints machine-readable status from the real local ledger", async () => {
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await command().parseAsync(["node", "test", "flight", "status", "--json"]);
+
+    const status = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(status).toMatchObject({
+      enabled: true,
+      initialized: true,
+      eventCount: 0,
+      errorCount: 0,
+      databasePath,
+    });
+    expect(statSync(databasePath).mode & 0o777).toBe(0o600);
+  });
+
+  it("lists privacy-safe event summaries and filters by trace", async () => {
+    const recorder = await ensureFlightRecorderFromEnv();
+    await recorder.runTrace(
+      { traceId: "wanted", sessionId: "session-a" },
+      async () => {
+        await recorder.record({
+          kind: "agent.execute.completed",
+          source: "cli-test",
+          agentName: "SafeAgent",
+          metadata: { token: "must disappear", ordinary: 7 },
+          payload: { prompt: "must not persist" },
+        });
+      },
+    );
+    await recorder.runTrace({ traceId: "other" }, async () => {});
+
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+    await command().parseAsync([
+      "node",
+      "test",
+      "flight",
+      "events",
+      "--trace",
+      "wanted",
+      "--kind",
+      "agent.execute.completed",
+      "--json",
+    ]);
+
+    const events = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      traceId: "wanted",
+      agentName: "SafeAgent",
+      metadata: { ordinary: 7, token: "[redacted]" },
+    });
+    expect(JSON.stringify(events)).not.toContain("must not persist");
+  });
+
+  it("never includes opt-in payloads in JSON summary output", async () => {
+    await getFlightRecorder().close();
+    resetFlightRecorderEnvironmentForTests();
+    process.env.OPENRAPPTER_FLIGHT_RECORD_IO = "1";
+    const recorder = await ensureFlightRecorderFromEnv();
+    await recorder.record({
+      traceId: "private-json-summary",
+      kind: "private",
+      source: "cli-test",
+      payload: { value: "private-payload-probe" },
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await command().parseAsync([
+      "node",
+      "test",
+      "flight",
+      "events",
+      "--trace",
+      "private-json-summary",
+      "--json",
+    ]);
+
+    const events = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(events).toHaveLength(1);
+    expect(events[0]).not.toHaveProperty("payload");
+    expect(JSON.stringify(events)).not.toContain("private-payload-probe");
+  });
+
+  it("lists newest cross-trace events first", async () => {
+    const recorder = await ensureFlightRecorderFromEnv();
+    await recorder.record({
+      traceId: "older-high-sequence",
+      kind: "old",
+      source: "cli-test",
+      timestamp: "2020-01-01T00:00:00.000Z",
+    });
+    await recorder.record({
+      traceId: "newer-low-sequence",
+      kind: "new",
+      source: "cli-test",
+      timestamp: "2030-01-01T00:00:00.000Z",
+    });
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await command().parseAsync([
+      "node",
+      "test",
+      "flight",
+      "events",
+      "--limit",
+      "1",
+      "--json",
+    ]);
+
+    const events = JSON.parse(String(log.mock.calls.at(-1)?.[0]));
+    expect(events).toHaveLength(1);
+    expect(events[0].kind).toBe("new");
+  });
+
+  it("exports a versioned mode-0600 bundle and clears only with confirmation", async () => {
+    const recorder = await ensureFlightRecorderFromEnv();
+    await recorder.runTrace({ traceId: "exported" }, async () => {});
+    const output = path.join(directory, "trace.json");
+    writeFileSync(output, "public placeholder", { mode: 0o644 });
+    chmodSync(output, 0o644);
+    const log = vi.spyOn(console, "log").mockImplementation(() => {});
+
+    await command().parseAsync([
+      "node",
+      "test",
+      "flight",
+      "export",
+      "--trace",
+      "exported",
+      "--output",
+      output,
+    ]);
+    const bundle = JSON.parse(readFileSync(output, "utf8"));
+    expect(bundle.schema).toBe("openrappter-flight-export/1.0");
+    expect(bundle.events.length).toBeGreaterThan(0);
+    expect(statSync(output).mode & 0o777).toBe(0o600);
+    expect(
+      readdirSync(directory).filter((name) => name.includes("trace.json.")),
+    ).toEqual([]);
+
+    await expect(
+      command().parseAsync(["node", "test", "flight", "clear"]),
+    ).rejects.toThrow(/--yes/);
+    expect((await recorder.health()).eventCount).toBeGreaterThan(0);
+
+    await command().parseAsync(["node", "test", "flight", "clear", "--yes"]);
+    expect((await recorder.health()).eventCount).toBe(0);
+    expect(
+      log.mock.calls.some(([line]) => String(line).includes("cleared")),
+    ).toBe(true);
+
+    await command().parseAsync(["node", "test", "flight", "import", output]);
+    expect((await recorder.health()).eventCount).toBe(bundle.events.length);
+  });
+
+  it("rejects export outputs that collide with live recorder storage", async () => {
+    const recorder = await ensureFlightRecorderFromEnv();
+    await recorder.runTrace({ traceId: "safe-export" }, async () => {});
+    const before = (await recorder.health()).eventCount;
+
+    for (const output of [
+      databasePath,
+      `${databasePath}-wal`,
+      `${databasePath}-shm`,
+      `${databasePath}.identity-key`,
+    ]) {
+      await expect(
+        command().parseAsync([
+          "node",
+          "test",
+          "flight",
+          "export",
+          "--output",
+          output,
+        ]),
+      ).rejects.toThrow(/recorder storage|aliases/i);
+    }
+    if (process.platform === "darwin" || process.platform === "win32") {
+      await expect(
+        command().parseAsync([
+          "node",
+          "test",
+          "flight",
+          "export",
+          "--output",
+          `${databasePath}.RESET-LOCK`,
+        ]),
+      ).rejects.toThrow(/recorder storage/i);
+    }
+    if (process.platform !== "win32") {
+      const ownerAlias = path.join(directory, "owners-alias");
+      symlinkSync(`${databasePath}.owners`, ownerAlias, "dir");
+      await expect(
+        command().parseAsync([
+          "node",
+          "test",
+          "flight",
+          "export",
+          "--output",
+          path.join(ownerAlias, "forged-owner.json"),
+        ]),
+      ).rejects.toThrow(/recorder storage|owner storage/i);
+
+      const databaseDirectoryAlias = path.join(
+        directory,
+        "database-directory-alias",
+      );
+      symlinkSync(directory, databaseDirectoryAlias, "dir");
+      await expect(
+        command().parseAsync([
+          "node",
+          "test",
+          "flight",
+          "export",
+          "--output",
+          path.join(
+            databaseDirectoryAlias,
+            `${path.basename(databasePath)}.reset-lock`,
+          ),
+        ]),
+      ).rejects.toThrow(/recorder storage/i);
+    }
+    expect((await recorder.health()).eventCount).toBe(before);
+    expect(
+      (await recorder.query({ traceId: "safe-export" })).length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("rejects invalid numeric limits instead of silently defaulting", async () => {
+    await expect(
+      command().parseAsync([
+        "node",
+        "test",
+        "flight",
+        "events",
+        "--limit",
+        "-1",
+      ]),
+    ).rejects.toThrow(/non-negative integer/);
+  });
+
+  it("fails loud when the persisted ledger is corrupt", async () => {
+    const recorder = await ensureFlightRecorderFromEnv();
+    await recorder.record({
+      traceId: "corrupt-me",
+      kind: "before-corruption",
+      source: "cli-test",
+    });
+    const module = await import("better-sqlite3");
+    const Database = module.default as unknown as new (filename: string) => {
+      prepare(sql: string): { run(...params: unknown[]): unknown };
+      close(): void;
+    };
+    const db = new Database(databasePath);
+    db.prepare(
+      "UPDATE flight_events SET event_json = '{\"broken\":true}' WHERE trace_id = ?",
+    ).run("corrupt-me");
+    db.close();
+
+    await expect(
+      command().parseAsync(["node", "test", "flight", "events", "--json"]),
+    ).rejects.toThrow(/corrupt/i);
+    expect((await recorder.health()).lastError).toMatch(/corrupt/i);
+  });
+
+  it("fails loud when the ledger cannot initialize instead of printing empty history", async () => {
+    process.env.OPENRAPPTER_FLIGHT_DB = "/dev/null/flight.db";
+    resetFlightRecorderEnvironmentForTests();
+
+    await expect(
+      command().parseAsync(["node", "test", "flight", "events", "--json"]),
+    ).rejects.toThrow(/unavailable|not a directory|ENOTDIR/i);
+
+    const health = await ensureFlightRecorderFromEnv().then((recorder) =>
+      recorder.health(),
+    );
+    expect(health.initialized).toBe(false);
+    expect(health.errorCount).toBeGreaterThan(0);
+    expect(health.lastError).toBeTruthy();
+  });
+});

--- a/typescript/src/flight-recorder/flight-recorder.mutation.test.ts
+++ b/typescript/src/flight-recorder/flight-recorder.mutation.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Mutation probes for the Flight Recorder acceptance gate.
+ *
+ * These are not duplicate happy-path tests. Each probe deliberately mutates
+ * one invariant and proves the corresponding assertion turns red.
+ */
+
+import { describe, expect, it } from "vitest";
+import { readFileSync } from "node:fs";
+import { computeFlightEventHash, verifyFlightEventHash } from "./integrity.js";
+import { SQLiteFlightLedger } from "./ledger.js";
+import { sanitizeFlightPayload } from "./redaction.js";
+import { FLIGHT_EVENT_SCHEMA, type FlightEvent } from "./types.js";
+
+function event(): FlightEvent {
+  const body: Omit<FlightEvent, "contentHash"> = {
+    schema: FLIGHT_EVENT_SCHEMA,
+    id: "mutation-event",
+    sequence: 1,
+    traceId: "trace-a",
+    parentId: null,
+    timestamp: "2026-01-01T00:00:00.000Z",
+    kind: "agent.execute.completed",
+    source: "mutation-test",
+    status: "success",
+    metadata: { ordinary: true },
+    payload: { value: 1 },
+  };
+  return { ...body, contentHash: computeFlightEventHash(body) };
+}
+
+describe("Flight Recorder mutation probes", () => {
+  it("detects a trace-correlation mutation", () => {
+    const original = event();
+    const mutated = { ...original, traceId: "trace-b" };
+
+    expect(verifyFlightEventHash(original)).toBe(true);
+    expect(verifyFlightEventHash(mutated)).toBe(false);
+  });
+
+  it("detects a payload mutation", () => {
+    const original = event();
+    const mutated = { ...original, payload: { value: 2 } };
+
+    expect(computeFlightEventHash(mutated)).not.toBe(original.contentHash);
+    expect(verifyFlightEventHash(mutated)).toBe(false);
+  });
+
+  it("proves secret redaction is not a vacuous string check", () => {
+    const secret = `ghp_${"z".repeat(32)}`;
+    const insecureControl = { recentEdit: { patch: `const x = "${secret}"` } };
+    const sanitized = sanitizeFlightPayload(insecureControl, {
+      recordIO: true,
+    });
+
+    expect(JSON.stringify(insecureControl)).toContain(secret);
+    expect(JSON.stringify(sanitized)).not.toContain(secret);
+    expect(JSON.stringify(sanitized)).toContain("[redacted]");
+  });
+
+  it("proves secret-shaped metadata keys cannot bypass redaction", () => {
+    const secret = `ghp_${"k".repeat(32)}`;
+    const input = { [secret]: "ordinary value" };
+    const sanitized = sanitizeFlightPayload(input, { recordIO: true });
+
+    expect(JSON.stringify(input)).toContain(secret);
+    expect(JSON.stringify(sanitized)).not.toContain(secret);
+    expect(JSON.stringify(sanitized)).toContain("[redacted]");
+  });
+
+  it("proves raw IO is absent unless explicitly opted in", () => {
+    const payload = { ordinary: "visible only with consent" };
+
+    expect(sanitizeFlightPayload(payload)).toBeUndefined();
+    expect(sanitizeFlightPayload(payload, { recordIO: true })).toEqual(payload);
+  });
+
+  it("imports the committed TypeScript/Python golden hash vector", async () => {
+    const vector = JSON.parse(
+      readFileSync(
+        new URL(
+          "../../../contracts/flight-recorder-vector.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as FlightEvent;
+
+    expect(computeFlightEventHash(vector)).toBe(vector.contentHash);
+    expect(verifyFlightEventHash(vector)).toBe(true);
+    const ledger = new SQLiteFlightLedger({ inMemory: true });
+    await ledger.initialize();
+    try {
+      expect(
+        await ledger.import({
+          schema: "openrappter-flight-export/1.0",
+          exportedAt: "2026-08-11T12:35:00.000Z",
+          events: [vector],
+        }),
+      ).toBe(1);
+      expect(await ledger.query({ traceId: vector.traceId })).toEqual([vector]);
+    } finally {
+      await ledger.close();
+    }
+  });
+});

--- a/typescript/src/flight-recorder/flight-recorder.test.ts
+++ b/typescript/src/flight-recorder/flight-recorder.test.ts
@@ -1,0 +1,2232 @@
+import {
+  chmodSync,
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  symlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import {
+  computeFlightEventHash,
+  normalizeFlightSessionId,
+  normalizeFlightWorkspaceId,
+  verifyFlightEventHash,
+} from "./integrity.js";
+import {
+  ensureFlightRecorderFromEnv,
+  FlightRecorder,
+  getFlightRecorder,
+  resetFlightRecorderEnvironmentForTests,
+  setFlightRecorder,
+} from "./recorder.js";
+import { SQLiteFlightLedger } from "./ledger.js";
+import type {
+  FlightEvent,
+  FlightEventQuery,
+  FlightExport,
+  FlightLedger,
+} from "./types.js";
+
+const closeables: FlightRecorder[] = [];
+const temporaryDirectories: string[] = [];
+const TEST_IDENTITY_KEY = "11".repeat(32);
+
+afterEach(async () => {
+  await Promise.all(closeables.splice(0).map((recorder) => recorder.close()));
+  vi.restoreAllMocks();
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+async function recorder(
+  options: ConstructorParameters<typeof FlightRecorder>[0] = {},
+) {
+  const instance = new FlightRecorder({
+    enabled: true,
+    inMemory: true,
+    identityKey: TEST_IDENTITY_KEY,
+    ...options,
+  });
+  closeables.push(instance);
+  await instance.initialize();
+  return instance;
+}
+
+describe("FlightRecorder", () => {
+  it("records one ordered, privacy-safe trace with valid integrity hashes", async () => {
+    const instance = await recorder({
+      privacy: { recordIO: true },
+    });
+    const githubToken = `ghp_${"a".repeat(32)}`;
+
+    const result = await instance.runTrace(
+      { traceId: "trace-one", sessionId: "session-one", workspaceId: "/repo" },
+      async () => {
+        await instance.record({
+          kind: "context.assembled",
+          source: "test",
+          status: "info",
+          metadata: {
+            categories: ["workspace", "memory"],
+            token: githubToken,
+          },
+          payload: {
+            prompt: "ordinary prompt",
+            authorization: `Bearer ${"b".repeat(32)}`,
+          },
+        });
+        return "unchanged result";
+      },
+    );
+
+    expect(result).toBe("unchanged result");
+    const exported = await instance.exportTrace("trace-one");
+    expect(exported?.events.map((event) => event.kind)).toEqual([
+      "trace.started",
+      "context.assembled",
+      "trace.completed",
+    ]);
+    expect(exported?.events.map((event) => event.sequence)).toEqual([1, 2, 3]);
+    for (const event of exported?.events ?? []) {
+      expect(event.traceId).toBe("trace-one");
+      expect(event.sessionId).toBe(
+        normalizeFlightSessionId("session-one", TEST_IDENTITY_KEY),
+      );
+      expect(event.workspaceId).toBe(normalizeFlightWorkspaceId("/repo"));
+      expect(verifyFlightEventHash(event)).toBe(true);
+    }
+    const context = exported?.events[1];
+    expect(context?.metadata.token).toBe("[redacted]");
+    expect(context?.payload).toEqual({
+      authorization: "[redacted]",
+      prompt: "ordinary prompt",
+    });
+    expect(JSON.stringify(exported)).not.toContain(githubToken);
+    expect(JSON.stringify(exported)).not.toContain("/repo");
+  });
+
+  it("hashes counterparty session identifiers while preserving queryability", async () => {
+    const instance = await recorder();
+    const handle = "imessage:iMessage;-;+15551234567";
+
+    await instance.runTrace({ traceId: "private-session", sessionId: handle }, async () => {});
+
+    const events = await instance.query({ sessionId: handle });
+    expect(events).toHaveLength(2);
+    expect(
+      events.every(
+        (event) =>
+          event.sessionId ===
+          normalizeFlightSessionId(handle, TEST_IDENTITY_KEY),
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(events)).not.toContain("+15551234567");
+  });
+
+  it("drops raw IO by default while preserving sanitized metadata", async () => {
+    const instance = await recorder();
+    await instance.runTrace({ traceId: "no-io" }, async () => {
+      await instance.record({
+        kind: "agent.execute.completed",
+        source: "agent",
+        metadata: { apiKey: "ordinary-but-key-is-sensitive", count: 3 },
+        payload: { rawPrompt: "must not persist" },
+      });
+    });
+
+    const events = (await instance.exportTrace("no-io"))!.events;
+    const agent = events.find(
+      (event) => event.kind === "agent.execute.completed",
+    )!;
+    expect(Object.hasOwn(agent, "payload")).toBe(false);
+    expect(agent.metadata).toEqual({ apiKey: "[redacted]", count: 3 });
+    expect(JSON.stringify(events)).not.toContain("must not persist");
+  });
+
+  it("normalizes auto model identity centrally for direct recorder callers", async () => {
+    const instance = await recorder();
+    const event = await instance.record({
+      traceId: "direct-auto",
+      kind: "provider.attempt.completed",
+      source: "direct-test",
+      model: "  AUTO  ",
+      metadata: { modelPolicy: "auto" },
+    });
+    expect(event?.model).toBeUndefined();
+    expect(event?.metadata.modelPolicy).toBe("auto");
+  });
+
+  it("continues per-trace sequence numbers after a durable restart", async () => {
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-"),
+    );
+    temporaryDirectories.push(directory);
+    chmodSync(directory, 0o755);
+    const databasePath = path.join(directory, "flight.db");
+
+    const first = new FlightRecorder({ enabled: true, databasePath });
+    await first.initialize();
+    await first.runTrace(
+      { traceId: "continued", sessionId: "person@example.com" },
+      async () => {
+      await first.record({ kind: "phase.one", source: "test" });
+      },
+    );
+
+    expect(statSync(databasePath).mode & 0o777).toBe(0o600);
+    expect(statSync(directory).mode & 0o777).toBe(0o755);
+    expect(statSync(`${databasePath}-wal`).mode & 0o777).toBe(0o600);
+    expect(statSync(`${databasePath}-shm`).mode & 0o777).toBe(0o600);
+    expect(
+      statSync(`${databasePath}.identity-key`).mode & 0o777,
+    ).toBe(0o600);
+    await first.close();
+    const sidecars = [`${databasePath}-wal`, `${databasePath}-shm`];
+    const sidecarInodes = new Map<string, number>();
+    for (const sidecar of sidecars) {
+      writeFileSync(sidecar, "", { mode: 0o666 });
+      chmodSync(sidecar, 0o666);
+      sidecarInodes.set(sidecar, statSync(sidecar).ino);
+    }
+
+    const second = new FlightRecorder({ enabled: true, databasePath });
+    closeables.push(second);
+    await second.initialize();
+    for (const sidecar of sidecars) {
+      expect(statSync(sidecar).ino).toBe(sidecarInodes.get(sidecar));
+      expect(statSync(sidecar).mode & 0o777).toBe(0o600);
+    }
+    await second.runTrace(
+      { traceId: "continued", sessionId: "person@example.com" },
+      async () => {
+      await second.record({ kind: "phase.two", source: "test" });
+      },
+    );
+
+    const events = (await second.exportTrace("continued"))!.events;
+    expect(events.map((event) => event.sequence)).toEqual([1, 2, 3, 4, 5, 6]);
+    expect(events.map((event) => event.kind)).toEqual([
+      "trace.started",
+      "phase.one",
+      "trace.completed",
+      "trace.started",
+      "phase.two",
+      "trace.completed",
+    ]);
+    expect(
+      await second.query({ sessionId: "person@example.com" }),
+    ).toHaveLength(6);
+  });
+
+  it("rejects symlinked database and identity-key artifacts", async () => {
+    if (process.platform === "win32") return;
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-symlink-"),
+    );
+    temporaryDirectories.push(directory);
+    const target = path.join(directory, "target.db");
+    writeFileSync(target, "do not modify", { mode: 0o600 });
+    const databasePath = path.join(directory, "flight.db");
+    symlinkSync(target, databasePath);
+    const linked = new FlightRecorder({ enabled: true, databasePath });
+    closeables.push(linked);
+    await linked.initialize();
+    expect(await linked.health()).toMatchObject({ initialized: false });
+    expect((await linked.health()).lastError).toMatch(/regular file/i);
+    expect(readFileSync(target, "utf8")).toBe("do not modify");
+
+    rmSync(databasePath);
+    const first = new FlightRecorder({
+      enabled: true,
+      databasePath,
+      identityKey: "ab".repeat(32),
+    });
+    closeables.push(first);
+    await first.initialize();
+    await first.close();
+    const keyPath = `${databasePath}.identity-key`;
+    const keyTarget = path.join(directory, "external-key");
+    writeFileSync(keyTarget, `${"ab".repeat(32)}\n`, { mode: 0o600 });
+    rmSync(keyPath);
+    symlinkSync(keyTarget, keyPath);
+    const keyLinked = new FlightRecorder({ enabled: true, databasePath });
+    closeables.push(keyLinked);
+    await keyLinked.initialize();
+    expect(await keyLinked.health()).toMatchObject({ initialized: false });
+    expect((await keyLinked.health()).lastError).toMatch(/regular file/i);
+
+    const realParent = path.join(directory, "real-parent");
+    mkdirSync(realParent);
+    const parentAlias = path.join(directory, "parent-alias");
+    symlinkSync(realParent, parentAlias, "dir");
+    const parentLinked = new FlightRecorder({
+      enabled: true,
+      databasePath: path.join(parentAlias, "flight.db"),
+    });
+    closeables.push(parentLinked);
+    await parentLinked.initialize();
+    expect(await parentLinked.health()).toMatchObject({
+      initialized: false,
+    });
+    expect((await parentLinked.health()).lastError).toMatch(
+      /user-controlled symlink/i,
+    );
+
+    const ownerDatabase = path.join(directory, "owner-flight.db");
+    const externalOwners = path.join(directory, "external-owners");
+    mkdirSync(externalOwners);
+    writeFileSync(
+      path.join(externalOwners, "marker.json"),
+      "do not modify",
+    );
+    symlinkSync(externalOwners, `${ownerDatabase}.owners`, "dir");
+    const ownerLinked = new FlightRecorder({
+      enabled: true,
+      databasePath: ownerDatabase,
+    });
+    closeables.push(ownerLinked);
+    await ownerLinked.initialize();
+    expect(await ownerLinked.health()).toMatchObject({
+      initialized: false,
+    });
+    expect((await ownerLinked.health()).lastError).toMatch(
+      /owner storage.*regular directory/i,
+    );
+    expect(
+      readFileSync(
+        path.join(externalOwners, "marker.json"),
+        "utf8",
+      ),
+    ).toBe("do not modify");
+  });
+
+  it("rejects group or world-writable custom storage parents", async () => {
+    if (process.platform === "win32") return;
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-insecure-parent-"),
+    );
+    temporaryDirectories.push(directory);
+    chmodSync(directory, 0o777);
+    const instance = new FlightRecorder({
+      enabled: true,
+      databasePath: path.join(directory, "flight.db"),
+    });
+    closeables.push(instance);
+
+    await instance.initialize();
+    expect(await instance.health()).toMatchObject({ initialized: false });
+    expect((await instance.health()).lastError).toMatch(
+      /group\/world writable/i,
+    );
+  });
+
+  it("recovers an empty crashed identity-key publication", async () => {
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-empty-key-"),
+    );
+    temporaryDirectories.push(directory);
+    const databasePath = path.join(directory, "flight.db");
+    writeFileSync(`${databasePath}.identity-key`, "", { mode: 0o600 });
+    const instance = new FlightRecorder({ enabled: true, databasePath });
+    closeables.push(instance);
+
+    await instance.initialize();
+    await instance.runTrace(
+      { traceId: "recovered-key", sessionId: "person@example.com" },
+      async () => {},
+    );
+
+    expect(
+      statSync(`${databasePath}.identity-key`).size,
+    ).toBeGreaterThan(0);
+    expect(
+      (await instance.exportTrace("recovered-key"))?.events[0].sessionId,
+    ).toMatch(/^session:[0-9a-f]{24}$/);
+  });
+
+  it("persists explicit identity keys and rejects later divergence", async () => {
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-explicit-key-"),
+    );
+    temporaryDirectories.push(directory);
+    const databasePath = path.join(directory, "flight.db");
+    const explicit = "ab".repeat(32);
+    const first = new FlightRecorder({
+      enabled: true,
+      databasePath,
+      identityKey: explicit,
+    });
+    const second = new FlightRecorder({ enabled: true, databasePath });
+    const mismatch = new FlightRecorder({
+      enabled: true,
+      databasePath,
+      identityKey: "cd".repeat(32),
+    });
+    closeables.push(first, second, mismatch);
+
+    await first.initialize();
+    await first.runTrace(
+      { traceId: "explicit-key-first", sessionId: "same-person" },
+      async () => {},
+    );
+    expect(
+      readFileSync(`${databasePath}.identity-key`, "utf8").trim(),
+    ).toBe(explicit);
+
+    await second.initialize();
+    await second.runTrace(
+      { traceId: "explicit-key-second", sessionId: "same-person" },
+      async () => {},
+    );
+    const firstSession = (
+      await first.exportTrace("explicit-key-first")
+    )!.events[0].sessionId;
+    const secondSession = (
+      await second.exportTrace("explicit-key-second")
+    )!.events[0].sessionId;
+    expect(secondSession).toBe(firstSession);
+
+    await mismatch.initialize();
+    expect(await mismatch.health()).toMatchObject({
+      initialized: false,
+    });
+    expect((await mismatch.health()).lastError).toMatch(
+      /does not match the persisted key/i,
+    );
+
+    await first.close();
+    await second.close();
+    rmSync(`${databasePath}.identity-key`, { force: true });
+    const missing = new FlightRecorder({ enabled: true, databasePath });
+    closeables.push(missing);
+    await missing.initialize();
+    expect(await missing.health()).toMatchObject({
+      initialized: false,
+    });
+    expect((await missing.health()).lastError).toMatch(
+      /missing for a non-empty ledger/i,
+    );
+  });
+
+  it("binds the persisted identity key to the ledger fingerprint", async () => {
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-key-binding-"),
+    );
+    temporaryDirectories.push(directory);
+    const databasePath = path.join(directory, "flight.db");
+    const first = new FlightRecorder({
+      enabled: true,
+      databasePath,
+      identityKey: "12".repeat(32),
+    });
+    closeables.push(first);
+    await first.initialize();
+    await first.runTrace({ traceId: "bound-key" }, async () => {});
+    await first.close();
+
+    writeFileSync(
+      `${databasePath}.identity-key`,
+      `${"34".repeat(32)}\n`,
+      { mode: 0o600 },
+    );
+    const second = new FlightRecorder({ enabled: true, databasePath });
+    closeables.push(second);
+    await second.initialize();
+
+    expect(await second.health()).toMatchObject({ initialized: false });
+    expect((await second.health()).lastError).toMatch(
+      /ledger fingerprint/i,
+    );
+  });
+
+  it("always redacts the active identity key and its sidecar aliases", async () => {
+    const identityKey = "ef".repeat(32);
+    const instance = new FlightRecorder({
+      enabled: true,
+      inMemory: true,
+      identityKey,
+      privacy: { recordIO: true },
+    });
+    closeables.push(instance);
+    await instance.initialize();
+    await instance.record({
+      traceId: "identity-key-redaction",
+      kind: "identity.probe",
+      source: "test",
+      metadata: {
+        identityKey,
+        OPENRAPPTER_FLIGHT_ID_KEY: identityKey,
+        assignment: `OPENRAPPTER_FLIGHT_ID_KEY=${identityKey}`,
+        path: "/tmp/flight.db.identity-key",
+      },
+      payload: {
+        raw: identityKey,
+      },
+    });
+    await instance.record({
+      traceId: "identity-kind-redaction",
+      kind: identityKey.toUpperCase(),
+      source: "test",
+    });
+
+    const serialized = JSON.stringify(await instance.export());
+    expect(serialized).not.toContain(identityKey);
+    expect(serialized).not.toContain(identityKey.toUpperCase());
+    expect(serialized).not.toContain("flight.db.identity-key");
+    expect(serialized).toContain("[redacted]");
+    expect(serialized).toContain("[excluded-path]");
+  });
+
+  it("applies exact-value privacy before opaque identifier passthrough", async () => {
+    const providerId = `provider:${"a".repeat(24)}`;
+    const sessionId = `session:${"b".repeat(24)}`;
+    const workspaceId = `workspace:${"c".repeat(24)}`;
+    const instance = await recorder({
+      privacy: {
+        redactedValues: [providerId, sessionId, workspaceId],
+      },
+    });
+    await instance.runTrace(
+      {
+        traceId: "opaque-redaction",
+        sessionId,
+        workspaceId,
+      },
+      async () => {
+        await instance.record({
+          kind: "opaque.probe",
+          source: "test",
+          providerId,
+        });
+      },
+    );
+
+    const events = await instance.query({ traceId: "opaque-redaction" });
+    const probe = events.find((event) => event.kind === "opaque.probe")!;
+    expect(probe.providerId).toMatch(/^provider:[0-9a-f]{24}$/);
+    expect(probe.providerId).not.toBe(providerId);
+    expect(probe.sessionId).toMatch(/^session:[0-9a-f]{24}$/);
+    expect(probe.sessionId).not.toBe(sessionId);
+    expect(probe.workspaceId).toMatch(/^workspace:[0-9a-f]{24}$/);
+    expect(probe.workspaceId).not.toBe(workspaceId);
+    expect(JSON.stringify(events)).not.toContain(providerId);
+    expect(await instance.query({ sessionId })).toHaveLength(events.length);
+  });
+
+  it("uses a private trace-scoped sequence lookup", async () => {
+    const ledger = new SQLiteFlightLedger({ inMemory: true });
+    const query = vi
+      .spyOn(ledger, "query")
+      .mockRejectedValue(new Error("public query must not run"));
+    const instance = new FlightRecorder(
+      {
+        enabled: true,
+        inMemory: true,
+        identityKey: TEST_IDENTITY_KEY,
+        retentionEvents: -1,
+      },
+      ledger,
+    );
+    closeables.push(instance);
+    await instance.initialize();
+
+    await instance.runTrace({ traceId: "private-sequence" }, async () => {});
+    await instance.runTrace({ traceId: "private-sequence" }, async () => {});
+
+    expect(query).not.toHaveBeenCalled();
+    expect(await ledger.lastSequence("private-sequence")).toBe(4);
+  });
+
+  it("recovers when another recorder advances the same durable trace", async () => {
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-shared-"),
+    );
+    temporaryDirectories.push(directory);
+    const databasePath = path.join(directory, "flight.db");
+    const first = new FlightRecorder({ enabled: true, databasePath });
+    const second = new FlightRecorder({ enabled: true, databasePath });
+    closeables.push(first, second);
+    await first.initialize();
+    await second.initialize();
+
+    expect(
+      (await first.record({
+        traceId: "shared-trace",
+        kind: "first",
+        source: "test",
+      }))?.sequence,
+    ).toBe(1);
+    expect(
+      (await second.record({
+        traceId: "shared-trace",
+        kind: "second",
+        source: "test",
+      }))?.sequence,
+    ).toBe(2);
+    expect(
+      (await first.record({
+        traceId: "shared-trace",
+        kind: "third",
+        source: "test",
+      }))?.sequence,
+    ).toBe(3);
+    expect(
+      (await first.record({
+        traceId: "shared-trace",
+        kind: "fourth",
+        source: "test",
+      }))?.sequence,
+    ).toBe(4);
+  });
+
+  it("enforces retention from the authoritative shared database count", async () => {
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-retention-shared-"),
+    );
+    temporaryDirectories.push(directory);
+    const databasePath = path.join(directory, "flight.db");
+    const first = new FlightRecorder({
+      enabled: true,
+      databasePath,
+      retentionEvents: 10,
+    });
+    const second = new FlightRecorder({
+      enabled: true,
+      databasePath,
+      retentionEvents: 10,
+    });
+    closeables.push(first, second);
+    await first.initialize();
+    await second.initialize();
+
+    for (let index = 0; index < 6; index += 1) {
+      await first.record({
+        traceId: `shared-first-${index}`,
+        kind: "atomic",
+        source: "test",
+      });
+      await second.record({
+        traceId: `shared-second-${index}`,
+        kind: "atomic",
+        source: "test",
+      });
+    }
+
+    expect((await first.health()).eventCount).toBe(10);
+  });
+
+  it("eventually allocates every same-trace sequence across many recorders", async () => {
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-many-recorders-"),
+    );
+    temporaryDirectories.push(directory);
+    const databasePath = path.join(directory, "flight.db");
+    const recorders = Array.from(
+      { length: 12 },
+      () =>
+        new FlightRecorder({
+          enabled: true,
+          databasePath,
+          retentionEvents: -1,
+        }),
+    );
+    closeables.push(...recorders);
+    await Promise.all(recorders.map((recorder) => recorder.initialize()));
+
+    const events = await Promise.all(
+      recorders.map((recorder) =>
+        recorder.record({
+          traceId: "shared-concurrent-trace",
+          kind: "atomic",
+          source: "test",
+        }),
+      ),
+    );
+
+    expect(events.every(Boolean)).toBe(true);
+    expect(
+      events.map((event) => event!.sequence).sort((a, b) => a - b),
+    ).toEqual(Array.from({ length: 12 }, (_, index) => index + 1));
+  });
+
+  it("records terminal events even when the wall clock moves backward", async () => {
+    const instance = await recorder();
+    vi.spyOn(Date, "now")
+      .mockReturnValueOnce(1_000)
+      .mockReturnValue(900);
+
+    await instance.runTrace({ traceId: "clock-rollback" }, async () => {});
+
+    expect(
+      (await instance.exportTrace("clock-rollback"))?.events.map(
+        (event) => event.kind,
+      ),
+    ).toEqual(["trace.started", "trace.completed"]);
+  });
+
+  it("uses a keyed session pseudonym instead of a guessable plain hash", () => {
+    const handle = "+15551234567";
+    const first = normalizeFlightSessionId(handle, TEST_IDENTITY_KEY);
+    const second = normalizeFlightSessionId(handle, "44".repeat(32));
+
+    expect(first).toMatch(/^session:[0-9a-f]{24}$/);
+    expect(first).toBe("session:b2141ccddd8e77eff1eb84f6");
+    expect(normalizeFlightSessionId(handle, "33".repeat(32))).toBe(
+      "session:e523e4096e6419b507b73af3",
+    );
+    expect(first).not.toBe(second);
+  });
+
+  it("shares only pseudonymized scope and effective storage settings with children", async () => {
+    const directory = mkdtempSync(
+      path.join(os.tmpdir(), "openrappter-flight-child-env-"),
+    );
+    temporaryDirectories.push(directory);
+    const databasePath = path.join(directory, "flight.db");
+    const instance = new FlightRecorder({
+      enabled: true,
+      databasePath,
+      retentionEvents: 321,
+      privacy: { recordIO: true, maxPayloadBytes: 1_234 },
+    });
+    closeables.push(instance);
+    await instance.initialize();
+
+    await instance.runTrace(
+      { traceId: "child-trace", sessionId: "person@example.com" },
+      async () => {
+        const environment = instance.childProcessEnvironment();
+        expect(environment).toMatchObject({
+          OPENRAPPTER_FLIGHT_RECORDER: "1",
+          OPENRAPPTER_FLIGHT_DB: databasePath,
+          OPENRAPPTER_FLIGHT_RETENTION: "321",
+          OPENRAPPTER_FLIGHT_RECORD_IO: "1",
+          OPENRAPPTER_FLIGHT_MAX_PAYLOAD: "1234",
+          OPENRAPPTER_FLIGHT_TRACE_ID: "child-trace",
+        });
+        expect(environment.OPENRAPPTER_FLIGHT_SESSION_ID).toMatch(
+          /^session:[0-9a-f]{24}$/,
+        );
+        expect(environment.OPENRAPPTER_FLIGHT_SESSION_ID).not.toContain(
+          "person@example.com",
+        );
+        expect(environment).not.toHaveProperty(
+          "OPENRAPPTER_FLIGHT_ID_KEY",
+        );
+      },
+    );
+  });
+
+  it("accepts payloads within a configured cap above the default", async () => {
+    const instance = await recorder({
+      privacy: { recordIO: true, maxPayloadBytes: 30_000 },
+    });
+    const event = await instance.record({
+      traceId: "large-configured-payload",
+      kind: "payload",
+      source: "test",
+      payload: { value: "x".repeat(20_000) },
+    });
+
+    expect(event).not.toBeNull();
+    expect((await instance.health()).eventCount).toBe(1);
+  });
+
+  it("releases start ownership when terminal persistence fails", async () => {
+    const ledger = new TerminalFailLedger();
+    const instance = new FlightRecorder(
+      {
+        enabled: true,
+        inMemory: true,
+        identityKey: TEST_IDENTITY_KEY,
+        retentionEvents: -1,
+      },
+      ledger,
+    );
+    closeables.push(instance);
+    await instance.initialize();
+
+    expect(
+      await instance.runTrace(
+        { traceId: "terminal-failure" },
+        async () => "success",
+      ),
+    ).toBe("success");
+    expect(
+      (await instance.query({ traceId: "terminal-failure" }))[0].metadata,
+    ).not.toHaveProperty("ownerPid");
+    await expect(instance.clear()).resolves.toBe(true);
+  });
+
+  it("does not terminate an ancestor when a nested start is not durable", async () => {
+    const ledger = new FailSecondAppendLedger();
+    const instance = new FlightRecorder(
+      {
+        enabled: true,
+        inMemory: true,
+        identityKey: TEST_IDENTITY_KEY,
+        retentionEvents: -1,
+      },
+      ledger,
+    );
+    closeables.push(instance);
+    await instance.initialize();
+
+    await instance.runTrace({ traceId: "nested-start-failure" }, async () => {
+      await expect(
+        instance.runTrace({}, async () => {
+          await instance.record({
+            kind: "nested.work",
+            source: "test",
+          });
+          return "nested result";
+        }),
+      ).resolves.toBe("nested result");
+      const active = await instance.query({
+        traceId: "nested-start-failure",
+      });
+      expect(active.map((event) => event.kind)).toEqual([
+        "trace.started",
+        "nested.work",
+      ]);
+      expect(active[1].parentId).toBeNull();
+    });
+
+    const events = await instance.query({
+      traceId: "nested-start-failure",
+    });
+    expect(events.map((event) => event.kind)).toEqual([
+      "trace.started",
+      "nested.work",
+      "trace.completed",
+    ]);
+    expect(events[2].parentId).toBe(events[0].id);
+  });
+
+  it("does not emit a failed terminal when a nested start was not durable", async () => {
+    const ledger = new FailSecondAppendLedger();
+    const instance = new FlightRecorder(
+      {
+        enabled: true,
+        inMemory: true,
+        identityKey: TEST_IDENTITY_KEY,
+        retentionEvents: -1,
+      },
+      ledger,
+    );
+    closeables.push(instance);
+    await instance.initialize();
+
+    await instance.runTrace({ traceId: "nested-start-throw" }, async () => {
+      await expect(
+        instance.runTrace({}, async () => {
+          throw new Error("nested failure");
+        }),
+      ).rejects.toThrow("nested failure");
+      expect(
+        (await instance.query({ traceId: "nested-start-throw" })).map(
+          (event) => event.kind,
+        ),
+      ).toEqual(["trace.started"]);
+    });
+
+    expect(
+      (await instance.query({ traceId: "nested-start-throw" })).map(
+        (event) => event.kind,
+      ),
+    ).toEqual(["trace.started", "trace.completed"]);
+  });
+
+  it("preserves explicit null parents inside an active trace", async () => {
+    const instance = await recorder();
+    await instance.runTrace({ traceId: "explicit-null-parent" }, async () => {
+      const detached = await instance.record({
+        kind: "detached.event",
+        source: "test",
+        parentId: null,
+      });
+      expect(detached?.parentId).toBeNull();
+      await instance.runTrace({ parentId: null }, async () => {});
+    });
+
+    const starts = (
+      await instance.query({ traceId: "explicit-null-parent" })
+    ).filter((event) => event.kind === "trace.started");
+    expect(starts).toHaveLength(2);
+    expect(starts[1].parentId).toBeNull();
+  });
+
+  it("keeps explicit global recorder configuration synchronized with bootstrap", async () => {
+    resetFlightRecorderEnvironmentForTests();
+    const first = await recorder();
+    const previous = setFlightRecorder(first);
+    const second = await recorder();
+    try {
+      expect(
+        await ensureFlightRecorderFromEnv({
+          NODE_ENV: "test",
+          OPENRAPPTER_FLIGHT_RECORDER: "0",
+        }),
+      ).toBe(first);
+
+      setFlightRecorder(second);
+      expect(await ensureFlightRecorderFromEnv()).toBe(second);
+    } finally {
+      setFlightRecorder(previous);
+      resetFlightRecorderEnvironmentForTests();
+    }
+  });
+
+  it("lets explicit configuration win a concurrent environment bootstrap", async () => {
+    resetFlightRecorderEnvironmentForTests();
+    const pending = ensureFlightRecorderFromEnv({
+      NODE_ENV: "test",
+      OPENRAPPTER_FLIGHT_RECORDER: "0",
+    });
+    const explicit = new FlightRecorder({
+      enabled: true,
+      inMemory: true,
+      identityKey: TEST_IDENTITY_KEY,
+    });
+    closeables.push(explicit);
+    const previous = setFlightRecorder(explicit);
+    await explicit.initialize();
+    try {
+      expect(await pending).toBe(explicit);
+      expect(getFlightRecorder()).toBe(explicit);
+      expect(await ensureFlightRecorderFromEnv()).toBe(explicit);
+    } finally {
+      setFlightRecorder(previous);
+      resetFlightRecorderEnvironmentForTests();
+    }
+  });
+
+  it("round-trips an export through the public recorder import API", async () => {
+    const source = await recorder({ privacy: { recordIO: true } });
+    await source.runTrace({ traceId: "portable" }, async () => {
+      await source.record({
+        kind: "portable.event",
+        source: "test",
+        payload: { answer: 42 },
+      });
+    });
+    const bundle = (await source.exportTrace("portable"))!;
+    expect(bundle.events[0].metadata).not.toHaveProperty("ownerPid");
+    expect(await source.import(bundle)).toBe(0);
+
+    const target = await recorder({ privacy: { recordIO: true } });
+    expect(await target.import(bundle)).toBe(bundle.events.length);
+    expect((await target.exportTrace("portable"))?.events).toEqual(
+      bundle.events,
+    );
+    expect(await target.import(bundle)).toBe(0);
+
+    const tampered = structuredClone(bundle);
+    tampered.events[0].traceId = "tampered";
+    await expect(target.import(tampered)).rejects.toThrow(/integrity/i);
+  });
+
+  it("rejects payload-bearing imports when recordIO is disabled", async () => {
+    const source = await recorder({ privacy: { recordIO: true } });
+    await source.record({
+      traceId: "payload-import",
+      kind: "payload",
+      source: "test",
+      payload: { ordinary: "private" },
+    });
+    const bundle = (await source.exportTrace("payload-import"))!;
+    const target = await recorder({ privacy: { recordIO: false } });
+
+    await expect(target.import(bundle)).rejects.toThrow(/recordIO is disabled/i);
+    expect((await target.health()).eventCount).toBe(0);
+  });
+
+  it("applies custom redaction policy to imported metadata", async () => {
+    const source = await recorder();
+    await source.record({
+      traceId: "custom-policy-import",
+      kind: "metadata",
+      source: "test",
+      metadata: { customerData: "raw-value" },
+    });
+    const bundle = (await source.exportTrace("custom-policy-import"))!;
+    const target = await recorder({
+      privacy: { redactedKeys: ["customerData"] },
+    });
+
+    await expect(target.import(bundle)).rejects.toThrow(
+      /active privacy policy/i,
+    );
+  });
+
+  it("applies custom privacy policy to imported top-level identifiers", async () => {
+    const source = await recorder();
+    await source.record({
+      traceId: "sensitive-trace",
+      kind: "ordinary",
+      source: "test",
+      providerId: "internal-provider",
+    });
+    const bundle = (await source.exportTrace("sensitive-trace"))!;
+    const target = await recorder({
+      privacy: {
+        excludedPathPatterns: [/sensitive|internal/i],
+      },
+    });
+
+    await expect(target.import(bundle)).rejects.toThrow(
+      /active privacy policy/i,
+    );
+
+    const keyTarget = await recorder({
+      privacy: { redactedKeys: ["providerId"] },
+    });
+    await expect(keyTarget.import(bundle)).rejects.toThrow(
+      /active privacy policy/i,
+    );
+
+    const modelSource = await recorder();
+    await modelSource.record({
+      traceId: "model-policy-import",
+      kind: "ordinary",
+      source: "test",
+      model: "sensitive-model",
+    });
+    const modelTarget = await recorder({
+      privacy: { redactedKeys: ["model"] },
+    });
+    await expect(
+      modelTarget.import(
+        (await modelSource.exportTrace("model-policy-import"))!,
+      ),
+    ).rejects.toThrow(/active privacy policy/i);
+  });
+
+  it("applies custom key policy to recorded envelope fields", async () => {
+    const instance = await recorder({
+      privacy: { redactedKeys: ["providerId"] },
+    });
+    const event = await instance.record({
+      traceId: "custom-envelope-key",
+      kind: "ordinary",
+      source: "test",
+      providerId: "internal-provider",
+    });
+
+    expect(event?.providerId).toMatch(/^provider:[0-9a-f]{24}$/);
+    expect(JSON.stringify(event)).not.toContain("internal-provider");
+  });
+
+  it("keeps structural lifecycle fields stable under custom key policy", async () => {
+    const instance = await recorder({
+      privacy: {
+        redactedKeys: ["traceId", "parentId", "kind", "source"],
+      },
+    });
+
+    await instance.runTrace(
+      { traceId: "structural-trace" },
+      async () => {},
+    );
+    const events = await instance.query({ traceId: "structural-trace" });
+    expect(events.map((event) => event.kind)).toEqual([
+      "trace.started",
+      "trace.completed",
+    ]);
+    await expect(instance.clear()).resolves.toBe(true);
+  });
+
+  it("keeps identifier pseudonyms idempotent across export and import", async () => {
+    const source = await recorder({
+      privacy: { redactedKeys: ["providerId"] },
+    });
+    await source.record({
+      traceId: "idempotent",
+      kind: "ordinary",
+      source: "test",
+      providerId: "internal-provider",
+    });
+    const bundle = (await source.exportTrace("idempotent"))!;
+    const providerId = bundle.events[0].providerId;
+    const target = await recorder({
+      privacy: { redactedKeys: ["providerId"] },
+    });
+
+    await target.import(bundle);
+    expect(
+      (await target.exportTrace("idempotent"))?.events[0].providerId,
+    ).toBe(providerId);
+  });
+
+  it("does not leak sequence cache entries for normalized trace IDs", async () => {
+    const instance = await recorder({
+      privacy: { excludedPathPatterns: [/secret-trace/i] },
+    });
+    for (let index = 0; index < 20; index += 1) {
+      await instance.runTrace(
+        { traceId: `secret-trace-${index}` },
+        async () => {},
+      );
+    }
+    const cache = instance as unknown as {
+      sequenceByTrace: Map<string, number>;
+    };
+    expect(cache.sequenceByTrace.size).toBe(0);
+  });
+
+  it("preserves internal ownership when replacing an active exported start", async () => {
+    const instance = await recorder({ retentionEvents: 0 });
+    await instance.runTrace({ traceId: "replace-active" }, async () => {
+      const bundle = (await instance.exportTrace("replace-active"))!;
+      expect(bundle.events[0].metadata).not.toHaveProperty("ownerPid");
+      const altered = structuredClone(bundle);
+      altered.events[0].sessionId = "session:111111111111111111111111";
+      altered.events[0].workspaceId =
+        "workspace:222222222222222222222222";
+      altered.events[0].metadata = {
+        ...altered.events[0].metadata,
+        scopeChanged: true,
+      };
+      altered.events[0].contentHash = computeFlightEventHash(
+        altered.events[0],
+      );
+      await expect(
+        instance.import(altered, { replace: true }),
+      ).rejects.toThrow(/live trace|portable content/i);
+
+      expect(
+        await instance.import(bundle, { replace: true }),
+      ).toBe(bundle.events.length);
+      await instance.record({
+        kind: "inside-active",
+        source: "test",
+      });
+      expect(
+        (await instance.query({ traceId: "replace-active" })).some(
+          (event) => event.kind === "trace.started",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("does not restore ownership when replacing a completed trace start", async () => {
+    const instance = await recorder({ retentionEvents: -1 });
+    await instance.runTrace(
+      { traceId: "replace-completed" },
+      async () => {},
+    );
+    const bundle = (await instance.exportTrace("replace-completed"))!;
+
+    expect(await instance.import(bundle, { replace: true })).toBe(
+      bundle.events.length,
+    );
+    const start = (
+      await instance.query({ traceId: "replace-completed" })
+    ).find((event) => event.kind === "trace.started")!;
+    expect(start.metadata).not.toHaveProperty("ownerPid");
+    expect(start.metadata).not.toHaveProperty("ownerIncarnation");
+  });
+
+  it("rejects new imported events that would terminate a live trace", async () => {
+    const instance = await recorder({ retentionEvents: 0 });
+    await instance.runTrace({ traceId: "live-import" }, async () => {
+      const root = (
+        await instance.query({ traceId: "live-import" })
+      ).find((event) => event.kind === "trace.started")!;
+      const body: Omit<FlightEvent, "contentHash"> = {
+        schema: "openrappter-event/1.0",
+        id: "forged-terminal",
+        sequence: root.sequence + 1,
+        traceId: root.traceId,
+        parentId: root.id,
+        kind: "trace.completed",
+        source: "import-test",
+        status: "success",
+        timestamp: new Date().toISOString(),
+        metadata: {},
+      };
+      const terminal: FlightEvent = {
+        ...body,
+        contentHash: computeFlightEventHash(body),
+      };
+
+      await expect(
+        instance.import({
+          schema: "openrappter-flight-export/1.0",
+          exportedAt: new Date().toISOString(),
+          events: [terminal],
+        }),
+      ).rejects.toThrow(/live trace/i);
+      expect(
+        (await instance.query({ traceId: "live-import" })).some(
+          (event) => event.kind === "trace.started",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("rejects replacing an event ID that belongs to another live trace", async () => {
+    const instance = await recorder({ retentionEvents: -1 });
+    await instance.runTrace({ traceId: "original-live" }, async () => {
+      const context = await instance.record({
+        kind: "context.assembled",
+        source: "test",
+      });
+      const body: Omit<FlightEvent, "contentHash"> = {
+        schema: "openrappter-event/1.0",
+        id: context!.id,
+        sequence: 1,
+        traceId: "other-trace",
+        parentId: null,
+        kind: "context.assembled",
+        source: "import-test",
+        status: "info",
+        timestamp: new Date().toISOString(),
+        metadata: {},
+      };
+      const moved = {
+        ...body,
+        contentHash: computeFlightEventHash(body),
+      };
+
+      await expect(
+        instance.import(
+          {
+            schema: "openrappter-flight-export/1.0",
+            exportedAt: new Date().toISOString(),
+            events: [moved],
+          },
+          { replace: true },
+        ),
+      ).rejects.toThrow(/move event.*live trace/i);
+    });
+  });
+
+  it("keeps concurrent traces isolated and ordered independently", async () => {
+    const instance = await recorder();
+    const ids = Array.from({ length: 20 }, (_, index) => `concurrent-${index}`);
+
+    await Promise.all(
+      ids.map((traceId, index) =>
+        instance.runTrace(
+          { traceId, sessionId: `session-${index}` },
+          async () => {
+            await Promise.resolve();
+            await instance.record({
+              kind: "agent.execute.completed",
+              source: "agent",
+              agentName: `Agent${index}`,
+            });
+          },
+        ),
+      ),
+    );
+
+    for (const [index, traceId] of ids.entries()) {
+      const events = (await instance.exportTrace(traceId))!.events;
+      expect(events).toHaveLength(3);
+      expect(new Set(events.map((event) => event.traceId))).toEqual(
+        new Set([traceId]),
+      );
+      expect(events.map((event) => event.sequence)).toEqual([1, 2, 3]);
+      expect(
+        events.every(
+          (event) =>
+            event.sessionId ===
+            normalizeFlightSessionId(
+              `session-${index}`,
+              TEST_IDENTITY_KEY,
+            ),
+        ),
+      ).toBe(true);
+    }
+  });
+
+  it("initializes the ledger exactly once under concurrent cold-start turns", async () => {
+    const ledger = new SlowCountingLedger();
+    const instance = new FlightRecorder({ enabled: true }, ledger);
+    closeables.push(instance);
+
+    await Promise.all(
+      Array.from({ length: 12 }, (_, index) =>
+        instance.runTrace({ traceId: `cold-${index}` }, async () => index),
+      ),
+    );
+
+    expect(ledger.initializeCalls).toBe(1);
+    expect(ledger.appendCalls).toBe(24);
+  });
+
+  it("does not reopen when close races an active initialization", async () => {
+    const ledger = new SlowCountingLedger();
+    const instance = new FlightRecorder({ enabled: true }, ledger);
+    const initialization = instance.initialize();
+
+    await instance.close();
+    await initialization;
+
+    expect(await instance.health()).toMatchObject({
+      initialized: false,
+      eventCount: 0,
+    });
+    expect(
+      await instance.record({
+        traceId: "closed-race",
+        kind: "after-close",
+        source: "test",
+      }),
+    ).toBeNull();
+  });
+
+  it("reserves an active trace slot before delayed initialization", async () => {
+    const ledger = new SlowCountingLedger();
+    const instance = new FlightRecorder(
+      { enabled: true, identityKey: TEST_IDENTITY_KEY },
+      ledger,
+    );
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const operation = instance.runTrace(
+      { traceId: "pre-init-active" },
+      async () => {
+        await gate;
+        return "done";
+      },
+    );
+    let closeDone = false;
+    const closing = instance.close().then(() => {
+      closeDone = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 25));
+    expect(closeDone).toBe(false);
+
+    release();
+    expect(await operation).toBe("done");
+    await closing;
+  });
+
+  it("sanitizes secret-shaped top-level identifiers during recording", async () => {
+    const instance = await recorder();
+    const token = `ghp_${"x".repeat(32)}`;
+    const event = await instance.record({
+      traceId: token,
+      kind: "ordinary",
+      source: "/Users/alice/.ssh/id_ed25519",
+      providerId: token,
+    });
+
+    expect(JSON.stringify(event)).not.toContain(token);
+    expect(JSON.stringify(event)).not.toContain("id_ed25519");
+    expect(event?.traceId).toMatch(/^trace:[0-9a-f]{24}$/);
+    const workspaceEvent = await instance.record({
+      traceId: "workspace-secret",
+      kind: "ordinary",
+      source: "test",
+      workspaceId: token,
+    });
+    expect(workspaceEvent?.workspaceId).toMatch(
+      /^workspace:[0-9a-f]{24}$/,
+    );
+  });
+
+  it("hashes filesystem identities hidden in workspace URI forms", () => {
+    const values = [
+      "file:///Users/alice/private-project",
+      "workspace:/Users/alice/private-project",
+      String.raw`workspace:C:\Users\alice\private-project`,
+      "workspace:%2FUsers%2Falice%2Fprivate-project",
+      "workspace:%2FUsers%2Falice%2Fprivate-project%ZZ",
+      "workspace:%252FUsers%252Falice%252Fprivate-project",
+      "vscode-remote://ssh-remote+host/home/alice/private-project",
+    ];
+    for (const value of values) {
+      expect(normalizeFlightWorkspaceId(value)).toMatch(
+        /^workspace:[0-9a-f]{24}$/,
+      );
+      expect(normalizeFlightWorkspaceId(value)).not.toBe(value);
+    }
+    expect(normalizeFlightWorkspaceId("channel:memory")).toBe(
+      "channel:memory",
+    );
+    expect(
+      normalizeFlightWorkspaceId("workspace:0123456789abcdef01234567"),
+    ).toBe("workspace:0123456789abcdef01234567");
+  });
+
+  it("normalizes raw workspace filters for query and export", async () => {
+    const instance = await recorder();
+    const workspace = "/Users/alice/private-project";
+    await instance.runTrace(
+      { traceId: "workspace-filter", workspaceId: workspace },
+      async () => {},
+    );
+
+    expect(await instance.query({ workspaceId: workspace })).toHaveLength(2);
+    expect(
+      (await instance.export({ workspaceId: workspace }))?.events,
+    ).toHaveLength(2);
+  });
+
+  it("normalizes lone Unicode surrogates before identity persistence", async () => {
+    const instance = await recorder();
+    let ran = false;
+    await instance.runTrace(
+      { traceId: "unicode-session", sessionId: "\ud800" },
+      async () => {
+        ran = true;
+      },
+    );
+
+    expect(ran).toBe(true);
+    const events = await instance.query({ traceId: "unicode-session" });
+    expect(events).toHaveLength(2);
+    expect(events[0].sessionId).toMatch(/^session:[0-9a-f]{24}$/);
+    expect((await instance.health()).errorCount).toBe(0);
+    const structural = await instance.record({
+      traceId: "bad\ud800",
+      kind: "unicode.identifier",
+      source: "test",
+    });
+    expect(structural?.traceId).toBe("bad\ufffd");
+  });
+
+  it("drains an admitted trace before closing its ledger", async () => {
+    const ledger = new RecordingLedger();
+    const instance = new FlightRecorder(
+      {
+        enabled: true,
+        identityKey: TEST_IDENTITY_KEY,
+        retentionEvents: -1,
+      },
+      ledger,
+    );
+    await instance.initialize();
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const operation = instance.runTrace(
+      { traceId: "close-active" },
+      async () => {
+        await gate;
+        return "done";
+      },
+    );
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    const closing = instance.close();
+
+    release();
+    expect(await operation).toBe("done");
+    await closing;
+    expect(ledger.events.map((event) => event.kind)).toEqual([
+      "trace.started",
+      "trace.completed",
+    ]);
+  });
+
+  it("rejects reentrant close and clear before joining pending operations", async () => {
+    const instance = await recorder({ retentionEvents: -1 });
+    let entered!: () => void;
+    const active = new Promise<void>((resolve) => {
+      entered = resolve;
+    });
+    let resume!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      resume = resolve;
+    });
+    const operation = instance.runTrace(
+      { traceId: "reentrant-shutdown" },
+      async () => {
+        entered();
+        await gate;
+        await expect(instance.close()).rejects.toThrow(/active trace/i);
+        await expect(instance.clear()).rejects.toThrow(/active trace/i);
+      },
+    );
+    await active;
+    const closing = instance.close();
+    resume();
+    await operation;
+    await closing;
+  });
+
+  it("re-roots detached async work after its trace generation ends", async () => {
+    const instance = await recorder({ retentionEvents: -1 });
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    let detached!: Promise<FlightEvent | null>;
+
+    await instance.runTrace({ traceId: "detached-origin" }, async () => {
+      detached = (async () => {
+        await gate;
+        return instance.record({
+          kind: "detached.event",
+          source: "test",
+        });
+      })();
+    });
+    release();
+    const detachedEvent = await detached;
+
+    expect(detachedEvent).not.toBeNull();
+    expect(detachedEvent?.traceId).not.toBe("detached-origin");
+    expect(detachedEvent?.parentId).toBeNull();
+    expect(
+      (await instance.query({ traceId: "detached-origin" })).map(
+        (event) => event.kind,
+      ),
+    ).toEqual(["trace.started", "trace.completed"]);
+  });
+
+  it("applies custom privacy to structural identifiers except kind", async () => {
+    const instance = await recorder({
+      privacy: {
+        excludedPathPatterns: [/secret|custom\.kind/i],
+        redactedKeys: ["id", "traceId", "source", "parentId"],
+      },
+    });
+    await instance.runTrace(
+      { traceId: "secret-trace-customer-123" },
+      async () => {
+        await instance.record({
+          kind: "custom.kind",
+          source: "secret-source",
+          parentId: "secret-parent",
+        });
+      },
+    );
+
+    const events = await instance.query({
+      traceId: "secret-trace-customer-123",
+    });
+    const custom = events.find((event) => event.kind === "custom.kind")!;
+    expect(custom.traceId).toMatch(/^trace:[0-9a-f]{24}$/);
+    expect(custom.source).toMatch(/^source:[0-9a-f]{24}$/);
+    expect(custom.parentId).toMatch(/^event:[0-9a-f]{24}$/);
+    expect(events.every((event) => /^event:[0-9a-f]{24}$/.test(event.id)))
+      .toBe(true);
+    expect(await instance.query({ source: "secret-source" })).toHaveLength(1);
+    expect(JSON.stringify(events)).not.toContain("secret-");
+  });
+
+  it("keeps lifecycle kinds non-redactable for active retention", async () => {
+    const instance = await recorder({
+      retentionEvents: 0,
+      privacy: { redactedValues: ["trace"] },
+    });
+    await instance.runTrace(
+      { traceId: "private-lifecycle" },
+      async () => {
+        await instance.record({
+          kind: "inside.lifecycle",
+          source: "test",
+        });
+        const active = await instance.query({
+          traceId: "private-lifecycle",
+        });
+        expect(active.map((event) => event.kind)).toEqual([
+          "trace.started",
+          "inside.lifecycle",
+        ]);
+      },
+    );
+  });
+
+  it("keeps displayed private trace IDs stable across record query and import", async () => {
+    const instance = await recorder({
+      privacy: { redactedValues: ["trace"] },
+    });
+    await instance.runTrace(
+      { traceId: "private-stable-trace" },
+      async () => {
+        await instance.record({
+          kind: "stable.event",
+          source: "test",
+        });
+      },
+    );
+    const exported = (await instance.export())!;
+    const displayedTraceId = exported.events[0].traceId;
+
+    expect(
+      (await instance.query({ traceId: displayedTraceId })).length,
+    ).toBe(exported.events.length);
+    await expect(
+      instance.import(exported, { replace: true }),
+    ).resolves.toBe(exported.events.length);
+  });
+
+  it("makes concurrent close callers await the same cleanup", async () => {
+    const ledger = new SlowCloseLedger();
+    const instance = new FlightRecorder(
+      { enabled: true, identityKey: TEST_IDENTITY_KEY },
+      ledger,
+    );
+    await instance.initialize();
+    const first = instance.close();
+    await ledger.closeEntered;
+    let secondDone = false;
+    const second = instance.close().then(() => {
+      secondDone = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(secondDone).toBe(false);
+
+    ledger.releaseClose();
+    await Promise.all([first, second]);
+    expect(secondDone).toBe(true);
+  });
+
+  it("blocks direct records while clear is deleting storage", async () => {
+    const ledger = new SlowClearLedger();
+    const instance = new FlightRecorder(
+      {
+        enabled: true,
+        identityKey: TEST_IDENTITY_KEY,
+        retentionEvents: -1,
+      },
+      ledger,
+    );
+    closeables.push(instance);
+    await instance.initialize();
+    await instance.record({
+      traceId: "before-clear",
+      kind: "before",
+      source: "test",
+    });
+
+    const clearing = instance.clear();
+    await ledger.clearEntered;
+    expect(
+      await instance.record({
+        traceId: "during-clear",
+        kind: "during",
+        source: "test",
+      }),
+    ).toBeNull();
+    ledger.releaseClear();
+    await clearing;
+    expect(ledger.events).toEqual([]);
+  });
+
+  it("makes close wait for an in-progress clear", async () => {
+    const ledger = new SlowClearLedger();
+    const instance = new FlightRecorder(
+      {
+        enabled: true,
+        identityKey: TEST_IDENTITY_KEY,
+        retentionEvents: -1,
+      },
+      ledger,
+    );
+    await instance.initialize();
+    const clearing = instance.clear();
+    await ledger.clearEntered;
+    let closed = false;
+    const closing = instance.close().then(() => {
+      closed = true;
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    expect(closed).toBe(false);
+
+    ledger.releaseClear();
+    await clearing;
+    await closing;
+    expect(closed).toBe(true);
+  });
+
+  it("rejects import admission once close begins", async () => {
+    const ledger = new SlowCloseLedger();
+    const instance = new FlightRecorder(
+      { enabled: true, identityKey: TEST_IDENTITY_KEY },
+      ledger,
+    );
+    await instance.initialize();
+    const closing = instance.close();
+    await ledger.closeEntered;
+    const bundle: FlightExport = {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: [],
+    };
+
+    await expect(instance.import(bundle)).rejects.toThrow(/close/i);
+    expect(ledger.importCalls).toBe(0);
+    ledger.releaseClose();
+    await closing;
+  });
+
+  it("evicts completed trace sequence caches in a long-running gateway", async () => {
+    const instance = await recorder();
+    for (let index = 0; index < 250; index += 1) {
+      await instance.runTrace(
+        { traceId: `gateway-turn-${index}` },
+        async () => {},
+      );
+    }
+
+    const cache = instance as unknown as {
+      sequenceByTrace: Map<string, number>;
+      sequenceLocks: Map<string, Promise<void>>;
+    };
+    expect(cache.sequenceByTrace.size).toBe(0);
+    expect(cache.sequenceLocks.size).toBe(0);
+    expect((await instance.health()).eventCount).toBe(500);
+  });
+
+  it("evicts sequence caches after standalone direct records", async () => {
+    const instance = await recorder({ retentionEvents: 0 });
+    for (let index = 0; index < 1_000; index += 1) {
+      await instance.record({
+        traceId: `standalone-${index}`,
+        kind: "atomic",
+        source: "test",
+      });
+    }
+
+    const cache = instance as unknown as {
+      sequenceByTrace: Map<string, number>;
+      sequenceLocks: Map<string, Promise<void>>;
+    };
+    expect(cache.sequenceByTrace.size).toBe(0);
+    expect(cache.sequenceLocks.size).toBe(0);
+    expect((await instance.health()).eventCount).toBe(0);
+  });
+
+  it("reserves runtime owner metadata from custom redaction policy", async () => {
+    const instance = await recorder({
+      retentionEvents: 0,
+      privacy: { redactedKeys: ["ownerPid"] },
+    });
+    await instance.runTrace({ traceId: "reserved-owner" }, async () => {
+      expect(
+        (await instance.query({ traceId: "reserved-owner" })).some(
+          (event) => event.kind === "trace.started",
+        ),
+      ).toBe(true);
+    });
+  });
+
+  it("removes user-supplied owner metadata outside runtime trace starts", async () => {
+    const instance = await recorder();
+    const event = await instance.record({
+      traceId: "user-owner-metadata",
+      kind: "ordinary",
+      source: "test",
+      metadata: { ownerId: "forged", ownerPid: process.pid },
+    });
+
+    expect(event?.metadata).toEqual({});
+    expect(
+      (await instance.exportTrace("user-owner-metadata"))?.events[0]
+        .metadata,
+    ).toEqual({});
+  });
+
+  it("rethrows the original operation error and records a failed terminal event", async () => {
+    const instance = await recorder();
+    const original = new TypeError("operation exploded");
+
+    await expect(
+      instance.runTrace({ traceId: "failed-trace" }, async () => {
+        throw original;
+      }),
+    ).rejects.toBe(original);
+
+    const events = (await instance.exportTrace("failed-trace"))!.events;
+    expect(events.map((event) => event.kind)).toEqual([
+      "trace.started",
+      "trace.failed",
+    ]);
+    expect(events[1].status).toBe("error");
+    expect(events[1].metadata.errorName).toBe("TypeError");
+    expect(events[1].metadata.messageChars).toBe("operation exploded".length);
+    expect(JSON.stringify(events[1])).not.toContain("operation exploded");
+  });
+
+  it("preserves hostile application errors and releases trace ownership", async () => {
+    const instance = await recorder();
+    const original = new Error("hidden");
+    Object.defineProperty(original, "message", {
+      get() {
+        throw new Error("hostile getter");
+      },
+    });
+    let caught: unknown;
+    try {
+      await instance.runTrace(
+        { traceId: "hostile-error" },
+        async () => {
+          throw original;
+        },
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(original);
+    await expect(instance.clear()).resolves.toBe(true);
+  });
+
+  it("is a true no-op when disabled", async () => {
+    const ledger = new CountingLedger();
+    const instance = new FlightRecorder({ enabled: false }, ledger);
+    closeables.push(instance);
+
+    await instance.initialize();
+    const result = await instance.runTrace(
+      { traceId: "disabled" },
+      async () => 42,
+    );
+    const recorded = await instance.record({ kind: "ignored", source: "test" });
+
+    expect(result).toBe(42);
+    expect(recorded).toBeNull();
+    expect(ledger.initializeCalls).toBe(0);
+    expect(ledger.appendCalls).toBe(0);
+    expect(await instance.health()).toMatchObject({
+      enabled: false,
+      initialized: false,
+      eventCount: 0,
+      errorCount: 0,
+    });
+  });
+
+  it("fails open on ledger initialization and append failures but exposes health", async () => {
+    const initFailure = new FlightRecorder(
+      { enabled: true },
+      new FailingLedger("initialize"),
+    );
+    closeables.push(initFailure);
+    const firstResult = await initFailure.runTrace(
+      {},
+      async () => "still works",
+    );
+    expect(firstResult).toBe("still works");
+    expect(await initFailure.health()).toMatchObject({
+      initialized: false,
+    });
+    expect((await initFailure.health()).errorCount).toBe(1);
+    expect((await initFailure.health()).lastError).toContain(
+      "initialize failed",
+    );
+
+    const appendFailure = new FlightRecorder(
+      { enabled: true },
+      new FailingLedger("append"),
+    );
+    closeables.push(appendFailure);
+    await appendFailure.initialize();
+    const secondResult = await appendFailure.runTrace(
+      {},
+      async () => "also works",
+    );
+    expect(secondResult).toBe("also works");
+    const health = await appendFailure.health();
+    expect(health.initialized).toBe(true);
+    expect(health.errorCount).toBeGreaterThanOrEqual(1);
+    expect(health.lastError).toContain("append failed");
+  });
+
+  it("uses an initialization cooldown within one failed trace", async () => {
+    const ledger = new CountingInitializationFailureLedger();
+    const instance = new FlightRecorder({ enabled: true }, ledger);
+
+    expect(
+      await instance.runTrace({}, async () => "still works"),
+    ).toBe("still works");
+    expect(ledger.initializeCalls).toBe(1);
+  });
+
+  it("uses monotonic time for initialization retry cooldowns", async () => {
+    let monotonic = 1_000;
+    vi.spyOn(performance, "now").mockImplementation(() => monotonic);
+    vi.spyOn(Date, "now").mockReturnValue(-1_000_000);
+    const ledger = new CountingInitializationFailureLedger();
+    const instance = new FlightRecorder({ enabled: true }, ledger);
+
+    await instance.initialize();
+    expect(ledger.initializeCalls).toBe(1);
+    monotonic = 2_001;
+    await instance.initialize();
+    expect(ledger.initializeCalls).toBe(2);
+  });
+
+  it("fails inspection loud on corruption while retaining recorder health", async () => {
+    const instance = new FlightRecorder(
+      { enabled: true },
+      new FailingLedger("query"),
+    );
+    closeables.push(instance);
+    await instance.initialize();
+
+    await expect(instance.query()).rejects.toThrow("query corrupt");
+    await expect(instance.export()).rejects.toThrow("query corrupt");
+    const health = await instance.health();
+    expect(health.initialized).toBe(true);
+    expect(health.errorCount).toBeGreaterThanOrEqual(2);
+    expect(health.lastError).toContain("query corrupt");
+  });
+
+  it("does not consume a trace sequence when append fails before durability", async () => {
+    const ledger = new FailOnceAppendLedger();
+    const instance = new FlightRecorder(
+      { enabled: true, retentionEvents: -1 },
+      ledger,
+    );
+    closeables.push(instance);
+    await instance.initialize();
+
+    expect(
+      await instance.record({
+        traceId: "append-retry",
+        kind: "first",
+        source: "test",
+      }),
+    ).toBeNull();
+    const persisted = await instance.record({
+      traceId: "append-retry",
+      kind: "second",
+      source: "test",
+    });
+
+    expect(persisted?.sequence).toBe(1);
+    expect(ledger.events.map((event) => event.sequence)).toEqual([1]);
+  });
+
+  it("loads the latest sequence with one descending query for very long traces", async () => {
+    const ledger = new LongTraceLedger();
+    const instance = new FlightRecorder(
+      { enabled: true, retentionEvents: -1 },
+      ledger,
+    );
+    closeables.push(instance);
+    await instance.initialize();
+
+    const persisted = await instance.record({
+      traceId: "million-event-trace",
+      kind: "continued",
+      source: "test",
+    });
+
+    expect(persisted?.sequence).toBe(1_010_001);
+    expect(ledger.queries).toEqual([
+      {
+        traceId: "million-event-trace",
+        order: "desc",
+        limit: 1,
+      },
+    ]);
+  });
+
+  it("returns a durable event when post-append retention maintenance fails", async () => {
+    const ledger = new PruneFailingLedger();
+    const instance = new FlightRecorder(
+      { enabled: true, retentionEvents: 0 },
+      ledger,
+    );
+    closeables.push(instance);
+    await instance.initialize();
+
+    const first = await instance.record({
+      traceId: "prune-health",
+      kind: "first",
+      source: "test",
+    });
+    const second = await instance.record({
+      traceId: "prune-health",
+      kind: "second",
+      source: "test",
+    });
+
+    expect(first?.sequence).toBe(1);
+    expect(second?.sequence).toBe(2);
+    expect(ledger.events.map((event) => event.id)).toEqual([
+      first?.id,
+      second?.id,
+    ]);
+    const health = await instance.health();
+    expect(health.errorCount).toBe(2);
+    expect(health.lastError).toContain("prune failed");
+  });
+
+  it("retention preserves the newest events across traces, not the largest sequence", async () => {
+    const instance = await recorder({ retentionEvents: 3 });
+    await instance.record({
+      traceId: "old-high-sequence",
+      kind: "old",
+      source: "test",
+      timestamp: "2020-01-01T00:00:00.000Z",
+    });
+    // Force a high old sequence without changing public state.
+    for (let index = 0; index < 10; index += 1) {
+      await instance.record({
+        traceId: "old-high-sequence",
+        kind: `old.${index}`,
+        source: "test",
+        timestamp: "2020-01-01T00:00:00.000Z",
+      });
+    }
+    await instance.record({
+      traceId: "new-low-sequence",
+      kind: "new",
+      source: "test",
+      timestamp: "2030-01-01T00:00:00.000Z",
+    });
+
+    const oldEvents = await instance.exportTrace("old-high-sequence");
+    const newEvents = await instance.exportTrace("new-low-sequence");
+    expect(newEvents?.events.map((event) => event.kind)).toEqual(["new"]);
+    expect(
+      (oldEvents?.events.length ?? 0) + (newEvents?.events.length ?? 0),
+    ).toBe(1);
+  });
+
+  it("batches retention maintenance instead of pruning every append above the target", async () => {
+    const ledger = new CountingLedger();
+    const instance = new FlightRecorder(
+      { enabled: true, retentionEvents: 101 },
+      ledger,
+    );
+    closeables.push(instance);
+    await instance.initialize();
+
+    for (let index = 0; index < 112; index += 1) {
+      await instance.record({
+        traceId: "retention-batch",
+        kind: "agent.execute.completed",
+        source: "test",
+      });
+    }
+
+    expect(ledger.appendCalls).toBe(112);
+    expect(ledger.pruneCalls).toBe(1);
+  });
+});
+
+class CountingLedger implements FlightLedger {
+  initializeCalls = 0;
+  appendCalls = 0;
+  pruneCalls = 0;
+  async initialize() {
+    this.initializeCalls += 1;
+  }
+  async close() {}
+  async append(_event: FlightEvent) {
+    this.appendCalls += 1;
+  }
+  async query(_query: FlightEventQuery = {}): Promise<FlightEvent[]> {
+    return [];
+  }
+  async count() {
+    return this.appendCalls;
+  }
+  async prune(_keep: number) {
+    this.pruneCalls += 1;
+    return 0;
+  }
+  async export(): Promise<FlightExport> {
+    return {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: [],
+    };
+  }
+  async import() {
+    return 0;
+  }
+  async clear() {}
+}
+
+class SlowCountingLedger extends CountingLedger {
+  override async initialize() {
+    this.initializeCalls += 1;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+}
+
+class RecordingLedger extends CountingLedger {
+  events: FlightEvent[] = [];
+
+  override async append(event: FlightEvent) {
+    this.appendCalls += 1;
+    this.events.push(event);
+  }
+
+  override async query(query: FlightEventQuery = {}) {
+    return this.events.filter(
+      (event) => !query.traceId || event.traceId === query.traceId,
+    );
+  }
+
+  override async count() {
+    return this.events.length;
+  }
+}
+
+class FailOnceAppendLedger extends RecordingLedger {
+  private failed = false;
+
+  override async append(event: FlightEvent) {
+    if (!this.failed) {
+      this.failed = true;
+      throw new Error("append failed once");
+    }
+    await super.append(event);
+  }
+}
+
+class FailSecondAppendLedger extends RecordingLedger {
+  private attempts = 0;
+
+  override async append(event: FlightEvent) {
+    this.attempts += 1;
+    if (this.attempts === 2) {
+      throw new Error("nested start append failed");
+    }
+    await super.append(event);
+  }
+}
+
+class PruneFailingLedger extends RecordingLedger {
+  override async prune(_keep: number): Promise<number> {
+    this.pruneCalls += 1;
+    throw new Error("prune failed");
+  }
+}
+
+class LongTraceLedger extends RecordingLedger {
+  queries: FlightEventQuery[] = [];
+
+  override async query(query: FlightEventQuery = {}) {
+    this.queries.push(query);
+    return [{ sequence: 1_010_000 } as FlightEvent];
+  }
+}
+
+class SlowClearLedger extends RecordingLedger {
+  private release!: () => void;
+  private entered!: () => void;
+  readonly clearEntered: Promise<void>;
+
+  constructor() {
+    super();
+    this.clearEntered = new Promise<void>((resolve) => {
+      this.entered = resolve;
+    });
+  }
+
+  releaseClear(): void {
+    this.release();
+  }
+
+  override async clear() {
+    this.entered();
+    await new Promise<void>((resolve) => {
+      this.release = resolve;
+    });
+    this.events = [];
+  }
+}
+
+class TerminalFailLedger extends SQLiteFlightLedger {
+  constructor() {
+    super({ inMemory: true });
+  }
+
+  override async append(event: FlightEvent): Promise<void> {
+    if (event.kind === "trace.completed") {
+      throw new Error("terminal append failed");
+    }
+    await super.append(event);
+  }
+}
+
+class FailingLedger implements FlightLedger {
+  private initialized = false;
+  constructor(private readonly failure: "initialize" | "append" | "query") {}
+  async initialize() {
+    if (this.failure === "initialize") throw new Error("initialize failed");
+    this.initialized = true;
+  }
+  async close() {}
+  async append(_event: FlightEvent) {
+    if (!this.initialized) throw new Error("not initialized");
+    if (this.failure === "append") throw new Error("append failed");
+  }
+  async query(_query?: FlightEventQuery) {
+    if (this.failure === "query") throw new Error("query corrupt");
+    return [];
+  }
+  async count() {
+    return 0;
+  }
+  async prune() {
+    return 0;
+  }
+  async export(): Promise<FlightExport> {
+    if (this.failure === "query") throw new Error("query corrupt");
+    return {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: [],
+    };
+  }
+  async import(_data: FlightExport) {
+    return 0;
+  }
+  async clear() {}
+}
+
+class CountingInitializationFailureLedger extends FailingLedger {
+  initializeCalls = 0;
+
+  constructor() {
+    super("initialize");
+  }
+
+  override async initialize() {
+    this.initializeCalls += 1;
+    await super.initialize();
+  }
+}
+
+class SlowCloseLedger extends RecordingLedger {
+  importCalls = 0;
+  private entered!: () => void;
+  private release!: () => void;
+  readonly closeEntered: Promise<void>;
+
+  constructor() {
+    super();
+    this.closeEntered = new Promise<void>((resolve) => {
+      this.entered = resolve;
+    });
+  }
+
+  releaseClose(): void {
+    this.release();
+  }
+
+  override async close() {
+    this.entered();
+    await new Promise<void>((resolve) => {
+      this.release = resolve;
+    });
+  }
+
+  override async import() {
+    this.importCalls += 1;
+    return 0;
+  }
+}

--- a/typescript/src/flight-recorder/index.ts
+++ b/typescript/src/flight-recorder/index.ts
@@ -1,0 +1,5 @@
+export * from "./types.js";
+export * from "./integrity.js";
+export * from "./redaction.js";
+export * from "./ledger.js";
+export * from "./recorder.js";

--- a/typescript/src/flight-recorder/integrity.ts
+++ b/typescript/src/flight-recorder/integrity.ts
@@ -1,0 +1,166 @@
+import { createHash, createHmac } from "node:crypto";
+import type { FlightEvent } from "./types.js";
+
+function normalizeUnicodeScalars(value: string): string {
+  let normalized = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        normalized += value[index] + value[index + 1];
+        index += 1;
+      } else {
+        normalized += "\ufffd";
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      normalized += "\ufffd";
+    } else {
+      normalized += value[index];
+    }
+  }
+  return normalized;
+}
+
+function canonical(value: unknown): string {
+  if (value === undefined) return "null";
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(",")}]`;
+  const object = value as Record<string, unknown>;
+  const keys = Object.keys(object)
+    .filter((key) => object[key] !== undefined)
+    // ECMAScript compares strings by UTF-16 code units. Python mirrors this
+    // exact order so non-BMP keys hash identically across runtimes.
+    .sort((left, right) => (left < right ? -1 : left > right ? 1 : 0));
+  return `{${keys.map((key) => `${JSON.stringify(key)}:${canonical(object[key])}`).join(",")}}`;
+}
+
+/** SHA-256 over the canonical event body, excluding the hash itself. */
+export function computeFlightEventHash(
+  event: Omit<FlightEvent, "contentHash"> | FlightEvent,
+): string {
+  const body = { ...event } as Partial<FlightEvent>;
+  delete body.contentHash;
+  return createHash("sha256").update(canonical(body)).digest("hex");
+}
+
+export function verifyFlightEventHash(event: FlightEvent): boolean {
+  return (
+    /^[0-9a-f]{64}$/.test(event.contentHash) &&
+    computeFlightEventHash(event) === event.contentHash
+  );
+}
+
+/**
+ * Convert an absolute filesystem path into a stable, non-reversible scope ID.
+ *
+ * Workspace identity is useful for filtering, but persisting `/Users/alice/...`
+ * bypasses payload redaction and leaks both the operator name and project
+ * location. Already-opaque IDs are preserved.
+ */
+export function normalizeFlightWorkspaceId(
+  value: string | undefined,
+): string | undefined {
+  if (!value) return value;
+  const normalizedValue = normalizeUnicodeScalars(value);
+  if (/^workspace:[0-9a-f]{24}$/.test(normalizedValue))
+    return normalizedValue;
+
+  const candidates = [normalizedValue];
+  let decoded = normalizedValue;
+  let stabilized = false;
+  for (let pass = 0; pass < 32; pass += 1) {
+    const next = decoded.replace(/(?:%[0-9a-f]{2})+/gi, (encoded) => {
+      try {
+        return decodeURIComponent(encoded);
+      } catch {
+        return new TextDecoder().decode(
+          Uint8Array.from(
+            [...encoded.matchAll(/%([0-9a-f]{2})/gi)],
+            (match) => Number.parseInt(match[1], 16),
+          ),
+        );
+      }
+    });
+    if (next === decoded) {
+      stabilized = true;
+      break;
+    }
+    decoded = next;
+  }
+  if (!stabilized) {
+    return `workspace:${createHash("sha256")
+      .update(normalizedValue)
+      .digest("hex")
+      .slice(0, 24)}`;
+  }
+  if (decoded !== normalizedValue) candidates.push(decoded);
+  const pathLike = candidates.some((candidate) => {
+    if (
+      /^[A-Za-z][A-Za-z0-9+.-]*:\/\//.test(candidate) ||
+      /^file:/i.test(candidate) ||
+      /^workspace:/i.test(candidate)
+    ) {
+      return true;
+    }
+    if (
+      candidate.startsWith("/") ||
+      /^[A-Za-z]:[\\/]/.test(candidate) ||
+      candidate.startsWith("\\\\")
+    ) {
+      return true;
+    }
+    const namespaced = /^[A-Za-z][A-Za-z0-9+.-]*:(.*)$/.exec(candidate);
+    if (!namespaced || candidate.includes("://")) return false;
+    const suffix = namespaced[1];
+    return (
+      suffix.startsWith("/") ||
+      /^[A-Za-z]:[\\/]/.test(suffix) ||
+      suffix.startsWith("\\\\")
+    );
+  });
+  if (!pathLike) return normalizedValue;
+  return `workspace:${createHash("sha256").update(normalizedValue).digest("hex").slice(0, 24)}`;
+}
+
+/**
+ * Convert conversation identifiers into stable opaque IDs.
+ *
+ * Channel session keys can contain phone numbers, email addresses, chat GUIDs,
+ * or other counterparty identifiers. Hash every raw value at the recorder
+ * boundary so correlation remains possible without persisting that identity.
+ */
+export function normalizeFlightSessionId(
+  value: string | undefined,
+  identityKey: string,
+  redactedValues: readonly string[] = [],
+): string | undefined {
+  if (!value) return value;
+  const normalizedValue = normalizeUnicodeScalars(value);
+  const exactSecret = redactedValues.some(
+    (candidate) =>
+      candidate.length > 0 &&
+      (/^[0-9a-f]{64}$/i.test(candidate)
+        ? normalizedValue.toLowerCase() === candidate.toLowerCase()
+        : normalizedValue === candidate),
+  );
+  if (
+    /^session:[0-9a-f]{24}$/.test(normalizedValue) &&
+    !exactSecret
+  ) return normalizedValue;
+  if (!/^[0-9a-f]{64}$/i.test(identityKey)) {
+    throw new Error("Flight Recorder identity key must be 32-byte hexadecimal.");
+  }
+  return `session:${createHmac("sha256", Buffer.from(identityKey, "hex"))
+    .update(normalizedValue)
+    .digest("hex")
+    .slice(0, 24)}`;
+}
+
+/** `"auto"` is a routing policy, not the identity of the model that answered. */
+export function normalizeFlightModelId(
+  value: string | undefined,
+): string | undefined {
+  const model = value?.trim();
+  return model && model.toLowerCase() !== "auto" ? model : undefined;
+}

--- a/typescript/src/flight-recorder/ledger.test.ts
+++ b/typescript/src/flight-recorder/ledger.test.ts
@@ -1,0 +1,1838 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+} from "node:fs";
+import { join } from "node:path";
+import { afterAll, afterEach, beforeAll, describe, expect, it } from "vitest";
+import { computeFlightEventHash } from "./integrity.js";
+import { SQLiteFlightLedger } from "./ledger.js";
+import {
+  FLIGHT_EVENT_SCHEMA,
+  type FlightEvent,
+  type FlightEventKind,
+  type FlightEventQuery,
+  type FlightExport,
+} from "./types.js";
+
+interface RawDatabase {
+  exec(sql: string): void;
+  close(): void;
+  pragma(sql: string, options?: { simple?: boolean }): unknown;
+  prepare(sql: string): {
+    get(...params: unknown[]): unknown;
+    all(...params: unknown[]): unknown[];
+    run(...params: unknown[]): { changes: number };
+  };
+}
+
+const ledgers: SQLiteFlightLedger[] = [];
+let testRoot: string;
+let eventCounter = 0;
+
+beforeAll(() => {
+  testRoot = mkdtempSync(join(process.cwd(), ".flight-ledger-test-"));
+});
+
+afterEach(async () => {
+  await Promise.all(ledgers.splice(0).map((ledger) => ledger.close()));
+});
+
+afterAll(() => {
+  rmSync(testRoot, { recursive: true, force: true });
+});
+
+function ledger(options: {
+  databasePath?: string;
+  inMemory?: boolean;
+}): SQLiteFlightLedger {
+  const instance = new SQLiteFlightLedger(options);
+  ledgers.push(instance);
+  return instance;
+}
+
+function databasePath(name: string): string {
+  return join(testRoot, `${name}.sqlite`);
+}
+
+function event(overrides: Partial<FlightEvent> = {}): FlightEvent {
+  eventCounter += 1;
+  const id = overrides.id ?? `event-${eventCounter}`;
+  const { contentHash, ...eventOverrides } = overrides;
+  const body = {
+    schema: FLIGHT_EVENT_SCHEMA,
+    id,
+    sequence: eventCounter,
+    kind: "agent.execute.completed",
+    source: "test-recorder",
+    status: "success",
+    traceId: `trace-${eventCounter}`,
+    parentId: `parent-${eventCounter}`,
+    sessionId: `session:${eventCounter.toString(16).padStart(24, "0")}`,
+    workspaceId: `workspace-${eventCounter}`,
+    providerId: "copilot",
+    model: "gpt-test",
+    agentName: "TestAgent",
+    toolName: "test-tool",
+    timestamp: new Date(Date.UTC(2026, 0, 1, 0, 0, eventCounter)).toISOString(),
+    durationMs: eventCounter,
+    metadata:
+      eventOverrides.kind === "trace.started"
+        ? { ownerPid: process.pid }
+        : {
+            index: eventCounter,
+            nested: { enabled: true, values: [1, "two", null] },
+          },
+    payload: { input: `payload-${eventCounter}`, output: ["ok"] },
+    ...eventOverrides,
+  } as Omit<FlightEvent, "contentHash">;
+  if (Object.hasOwn(overrides, "payload") && overrides.payload === undefined) {
+    delete body.payload;
+  }
+  return {
+    ...body,
+    contentHash: contentHash ?? computeFlightEventHash(body),
+  };
+}
+
+function recordedTrace(options: {
+  traceId: string;
+  prefix: string;
+  startedAt: string;
+  middleKinds?: FlightEventKind[];
+  terminal?: "trace.completed" | "trace.failed" | null;
+  sequenceStart?: number;
+}): FlightEvent[] {
+  const kinds: FlightEventKind[] = [
+    "trace.started",
+    ...(options.middleKinds ?? []),
+    ...(options.terminal === null
+      ? []
+      : [options.terminal ?? "trace.completed"]),
+  ];
+  const startedAt = Date.parse(options.startedAt);
+  return kinds.map((kind, index) =>
+    event({
+      id: `${options.prefix}-${index + 1}`,
+      traceId: options.traceId,
+      parentId: index === 0 ? null : `${options.prefix}-1`,
+      sequence: (options.sequenceStart ?? 1) + index,
+      kind,
+      ...(kind === "trace.started"
+        ? { metadata: { ownerPid: process.pid } }
+        : {}),
+      status:
+        kind === "trace.started"
+          ? "started"
+          : kind === "trace.failed"
+            ? "error"
+            : kind === "trace.completed"
+              ? "success"
+              : "info",
+      timestamp: new Date(startedAt + index * 1_000).toISOString(),
+    }),
+  );
+}
+
+async function rawDatabase(path: string): Promise<RawDatabase> {
+  const module = await import("better-sqlite3");
+  const Database = module.default as unknown as new (
+    filename: string,
+    options?: { timeout?: number },
+  ) => RawDatabase;
+  return new Database(path, { timeout: 5_000 });
+}
+
+function createLegacyFlightTable(database: RawDatabase): void {
+  database.exec(`
+    CREATE TABLE flight_events (
+      id TEXT PRIMARY KEY,
+      sequence INTEGER NOT NULL,
+      trace_id TEXT NOT NULL,
+      timestamp TEXT NOT NULL,
+      kind TEXT NOT NULL,
+      source TEXT NOT NULL,
+      status TEXT NOT NULL,
+      session_id TEXT,
+      workspace_id TEXT,
+      provider_id TEXT,
+      agent_name TEXT,
+      tool_name TEXT,
+      event_json TEXT NOT NULL,
+      UNIQUE (trace_id, sequence)
+    )
+  `);
+}
+
+function insertLegacyEvent(
+  database: RawDatabase,
+  sample: FlightEvent,
+  eventJson = JSON.stringify(sample),
+): void {
+  database
+    .prepare(
+      `INSERT INTO flight_events (
+        id, sequence, trace_id, timestamp, kind, source, status,
+        session_id, workspace_id, provider_id, agent_name, tool_name, event_json
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+    )
+    .run(
+      sample.id,
+      sample.sequence,
+      sample.traceId,
+      sample.timestamp,
+      sample.kind,
+      sample.source,
+      sample.status,
+      sample.sessionId ?? null,
+      sample.workspaceId ?? null,
+      sample.providerId ?? null,
+      sample.agentName ?? null,
+      sample.toolName ?? null,
+      eventJson,
+    );
+}
+
+describe("SQLiteFlightLedger", () => {
+  it("requires initialization, rejects use after close, and closes idempotently", async () => {
+    const instance = ledger({ inMemory: true });
+    const sample = event();
+
+    await expect(instance.append(sample)).rejects.toThrow(/not initialized/i);
+    await expect(instance.query()).rejects.toThrow(/not initialized/i);
+    await expect(instance.count()).rejects.toThrow(/not initialized/i);
+    await expect(instance.prune(1)).rejects.toThrow(/not initialized/i);
+    await expect(instance.export()).rejects.toThrow(/not initialized/i);
+    await expect(
+      instance.import({
+        schema: "openrappter-flight-export/1.0",
+        exportedAt: new Date().toISOString(),
+        events: [],
+      }),
+    ).rejects.toThrow(/not initialized/i);
+    await expect(instance.clear()).rejects.toThrow(/not initialized/i);
+
+    await instance.initialize();
+    await instance.close();
+    await instance.close();
+    await expect(instance.count()).rejects.toThrow(/closed/i);
+    await expect(instance.append(sample)).rejects.toThrow(/closed/i);
+    await expect(instance.initialize()).rejects.toThrow(/closed/i);
+  });
+
+  it("refuses clear while any trace remains active", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const started = event({
+      id: "active-clear-start",
+      traceId: "active-clear",
+      sequence: 1,
+      kind: "trace.started",
+      status: "started",
+    });
+    await instance.append(started);
+
+    await expect(instance.clear()).rejects.toThrow(/active traces/i);
+    expect(await instance.count()).toBe(1);
+
+    await instance.append(
+      event({
+        id: "active-clear-complete",
+        traceId: "active-clear",
+        sequence: 2,
+        kind: "trace.completed",
+        status: "success",
+        parentId: started.id,
+      }),
+    );
+    await instance.clear();
+    expect(await instance.count()).toBe(0);
+  });
+
+  it("reconciles unmatched starts owned by dead processes", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    await instance.append(
+      event({
+        id: "orphaned-start",
+        traceId: "orphaned-trace",
+        sequence: 1,
+        kind: "trace.started",
+        status: "started",
+        metadata: { ownerPid: 2_147_483_647 },
+      }),
+    );
+
+    expect(await instance.prune(0)).toBe(1);
+    expect(await instance.count()).toBe(0);
+  });
+
+  it("does not treat a reused PID with another incarnation as active", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    await instance.append(
+      event({
+        id: "reused-pid-start",
+        traceId: "reused-pid",
+        sequence: 1,
+        kind: "trace.started",
+        status: "started",
+        metadata: {
+          ownerPid: process.pid,
+          ownerIncarnation: "different-process-start",
+        },
+      }),
+    );
+
+    expect(await instance.prune(0)).toBe(1);
+  });
+
+  it("matches lifecycle terminals to their exact parent start", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const liveStart = event({
+      id: "live-start",
+      traceId: "parent-match",
+      sequence: 1,
+      kind: "trace.started",
+      status: "started",
+      metadata: { ownerPid: process.pid },
+    });
+    const deadStart = event({
+      id: "dead-start",
+      traceId: "parent-match",
+      sequence: 2,
+      kind: "trace.started",
+      status: "started",
+      metadata: { ownerPid: 2_147_483_647 },
+    });
+    const liveComplete = event({
+      id: "live-complete",
+      traceId: "parent-match",
+      sequence: 3,
+      kind: "trace.completed",
+      status: "success",
+      parentId: liveStart.id,
+    });
+    for (const sample of [liveStart, deadStart, liveComplete]) {
+      await instance.append(sample);
+    }
+
+    expect(await instance.prune(0)).toBe(3);
+    expect(await instance.count()).toBe(0);
+  });
+
+  it("does not reopen when close races asynchronous initialization", async () => {
+    const instance = ledger({ inMemory: true });
+    const initialization = instance.initialize();
+
+    await instance.close();
+    await initialization;
+
+    await expect(instance.count()).rejects.toThrow(/closed/i);
+    await expect(instance.initialize()).rejects.toThrow(/closed/i);
+  });
+
+  it("initializes one SQLite connection under concurrent callers", async () => {
+    const instance = ledger({
+      databasePath: databasePath("concurrent-initialize"),
+    });
+
+    await Promise.all([instance.initialize(), instance.initialize()]);
+    expect(await instance.count()).toBe(0);
+    await instance.close();
+    await expect(instance.count()).rejects.toThrow(/closed/i);
+  });
+
+  it("preserves complete events in memory and ignores duplicate IDs", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const complete = event({
+      id: "complete",
+      sequence: 7,
+      traceId: "trace-complete",
+    });
+    const withoutPayload = event({
+      id: "without-payload",
+      sequence: 8,
+      traceId: "trace-without",
+      payload: undefined,
+    });
+    const nullPayload = event({
+      id: "null-payload",
+      sequence: 9,
+      traceId: "trace-null",
+      payload: null,
+    });
+
+    await instance.append(complete);
+    await instance.append(withoutPayload);
+    await instance.append(nullPayload);
+    await instance.append(
+      event({ id: complete.id, traceId: "changed-trace", sequence: 99 }),
+    );
+
+    expect(await instance.query()).toEqual([
+      complete,
+      withoutPayload,
+      nullPayload,
+    ]);
+    expect(await instance.count()).toBe(3);
+    expect(
+      Object.hasOwn(
+        (await instance.query({ traceId: "trace-without" }))[0],
+        "payload",
+      ),
+    ).toBe(false);
+    expect(
+      (await instance.query({ traceId: "trace-null" }))[0].payload,
+    ).toBeNull();
+  });
+
+  it("allows identical sequences across traces and rejects collisions within one trace", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const traceA = event({
+      id: "same-sequence-a",
+      sequence: 1,
+      traceId: "trace-a",
+    });
+    const traceB = event({
+      id: "same-sequence-b",
+      sequence: 1,
+      traceId: "trace-b",
+    });
+
+    await instance.append(traceA);
+    await instance.append(traceB);
+    const collision = event({
+      id: "same-sequence-collision",
+      sequence: 1,
+      traceId: "trace-a",
+    });
+
+    expect(await instance.count()).toBe(2);
+    expect(await instance.query({ traceId: "trace-a" })).toEqual([traceA]);
+    expect(await instance.query({ traceId: "trace-b" })).toEqual([traceB]);
+    await expect(instance.append(collision)).rejects.toThrow(
+      /UNIQUE constraint failed/i,
+    );
+    expect(await instance.count()).toBe(2);
+  });
+
+  it("supports every query filter, kind arrays, stable ordering, limits, and offsets", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const first = event({
+      id: "query-first",
+      sequence: 2,
+      timestamp: "2026-01-01T00:00:02.000Z",
+      kind: "tool.call.started",
+      source: "source-a",
+      status: "started",
+      traceId: "trace-query",
+      sessionId: "session:aaaaaaaaaaaaaaaaaaaaaaaa",
+      workspaceId: "workspace-a",
+      providerId: "provider-a",
+      agentName: "AgentA",
+      toolName: "ToolA",
+    });
+    const second = event({
+      id: "query-second",
+      sequence: 1,
+      timestamp: "2026-01-01T00:00:03.000Z",
+      kind: "tool.call.completed",
+      source: "source-b",
+      status: "success",
+      traceId: "trace-other",
+      sessionId: "session:bbbbbbbbbbbbbbbbbbbbbbbb",
+      workspaceId: "workspace-b",
+      providerId: "provider-b",
+      agentName: "AgentB",
+      toolName: "ToolB",
+    });
+    const third = event({
+      id: "query-third",
+      sequence: 1,
+      timestamp: "2026-01-01T00:00:01.000Z",
+      kind: "tool.call.failed",
+      source: "source-c",
+      status: "error",
+      traceId: "trace-query",
+      sessionId: "session:cccccccccccccccccccccccc",
+      workspaceId: "workspace-c",
+      providerId: "provider-c",
+      agentName: "AgentC",
+      toolName: "ToolC",
+    });
+    await instance.append(first);
+    await instance.append(second);
+    await instance.append(third);
+
+    expect(await instance.query()).toEqual([third, first, second]);
+    expect(await instance.query({ order: "desc" })).toEqual([
+      second,
+      first,
+      third,
+    ]);
+    expect(await instance.query({ traceId: "trace-query" })).toEqual([
+      third,
+      first,
+    ]);
+    expect(
+      await instance.query({ traceId: "trace-query", order: "desc" }),
+    ).toEqual([first, third]);
+    const filters: Array<[FlightEventQuery, FlightEvent]> = [
+      [{ traceId: "trace-query", limit: 1, offset: 1 }, first],
+      [{ limit: 1, offset: 1 }, first],
+      [{ sessionId: "session:bbbbbbbbbbbbbbbbbbbbbbbb" }, second],
+      [{ workspaceId: "workspace-c" }, third],
+      [{ kind: "tool.call.started" }, first],
+      [{ kind: ["tool.call.completed", "tool.call.failed"], limit: 1 }, third],
+      [{ source: "source-a" }, first],
+      [{ providerId: "provider-b" }, second],
+      [{ agentName: "AgentC" }, third],
+      [{ toolName: "ToolA" }, first],
+      [{ status: "error" }, third],
+      [
+        {
+          since: "2026-01-01T00:00:02.000Z",
+          until: "2026-01-01T00:00:02.000Z",
+        },
+        first,
+      ],
+    ];
+    for (const [query, expected] of filters) {
+      expect(await instance.query(query)).toEqual([expected]);
+    }
+
+    expect(await instance.query({ kind: [] })).toEqual([]);
+    expect(await instance.query({ limit: 0 })).toEqual([]);
+    expect(await instance.query({ limit: 50_000 })).toHaveLength(3);
+    expect(await instance.query({ offset: 50_000_000 })).toEqual([]);
+    await expect(instance.query({ limit: -1 })).rejects.toThrow(/limit/i);
+    await expect(instance.query({ offset: 1.5 })).rejects.toThrow(/offset/i);
+    await expect(
+      instance.query({ order: "sideways" as "asc" }),
+    ).rejects.toThrow(/order/i);
+  });
+
+  it("orders and filters offset timestamps by their UTC instant", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const olderOffset = event({
+      id: "offset-older",
+      traceId: "offset-trace",
+      sequence: 1,
+      timestamp: "2026-01-01T00:30:00+01:00",
+    });
+    const newerUtc = event({
+      id: "utc-newer",
+      traceId: "utc-trace",
+      sequence: 1,
+      timestamp: "2025-12-31T23:45:00Z",
+    });
+    await instance.append(newerUtc);
+    await instance.append(olderOffset);
+
+    expect(await instance.query()).toEqual([olderOffset, newerUtc]);
+    expect(await instance.query({ order: "desc" })).toEqual([
+      newerUtc,
+      olderOffset,
+    ]);
+    expect(await instance.query({ since: "2025-12-31T23:40:00Z" })).toEqual([
+      newerUtc,
+    ]);
+    expect(await instance.query({ until: "2025-12-31T23:40:00Z" })).toEqual([
+      olderOffset,
+    ]);
+    await expect(instance.query({ since: "not-an-iso-date" })).rejects.toThrow(
+      /ISO timestamp/i,
+    );
+    await expect(
+      instance.query({ until: "2026-99-99T00:00:00Z" }),
+    ).rejects.toThrow(/ISO timestamp/i);
+    expect(await instance.prune(1)).toBe(1);
+    expect(await instance.query()).toEqual([newerUtc]);
+  });
+
+  it("returns the newest cross-trace events instead of old sequence-one starts", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    for (let trace = 0; trace < 20; trace += 1) {
+      await instance.append(
+        event({
+          id: `chronology-${trace}`,
+          traceId: `trace-${trace}`,
+          sequence: trace === 0 ? 100 : 1,
+          timestamp: `2026-01-01T00:00:${String(trace).padStart(2, "0")}.000Z`,
+        }),
+      );
+    }
+
+    const newest = await instance.query({ order: "desc", limit: 5 });
+    expect(newest.map((entry) => entry.id)).toEqual([
+      "chronology-19",
+      "chronology-18",
+      "chronology-17",
+      "chronology-16",
+      "chronology-15",
+    ]);
+  });
+
+  it("parameterizes caller values instead of interpolating SQL", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const sample = event({ source: "safe-source" });
+    await instance.append(sample);
+
+    expect(await instance.query({ source: "' OR 1=1 --" })).toEqual([]);
+    expect(await instance.query({ kind: ["x') OR 1=1 --"] })).toEqual([]);
+    expect(await instance.count()).toBe(1);
+  });
+
+  it("creates an isolated WAL-backed durable schema with configured pragmas and indexes", async () => {
+    const path = databasePath("schema");
+    const instance = ledger({ databasePath: path });
+    await instance.initialize();
+    await instance.append(event());
+
+    const configured = (instance as unknown as { db: RawDatabase }).db;
+    expect(configured.pragma("foreign_keys", { simple: true })).toBe(1);
+    expect(configured.pragma("busy_timeout", { simple: true })).toBe(5_000);
+    expect(configured.pragma("secure_delete", { simple: true })).toBe(1);
+    expect(configured.pragma("synchronous", { simple: true })).toBe(2);
+
+    const raw = await rawDatabase(path);
+    try {
+      expect(raw.pragma("journal_mode", { simple: true })).toBe("wal");
+      const tables = raw
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
+        )
+        .all() as Array<{ name: string }>;
+      expect(tables.map((row) => row.name)).toEqual([
+        "flight_events",
+        "flight_metadata",
+      ]);
+      const columns = raw
+        .prepare("PRAGMA table_info(flight_events)")
+        .all() as Array<{ name: string; notnull: number }>;
+      expect(columns).toContainEqual(
+        expect.objectContaining({ name: "timestamp_ms", notnull: 1 }),
+      );
+      const indexes = raw
+        .prepare(
+          "SELECT name FROM sqlite_master WHERE type = 'index' AND tbl_name = 'flight_events'",
+        )
+        .all() as Array<{ name: string }>;
+      expect(indexes.length).toBeGreaterThanOrEqual(10);
+      expect(indexes.map((row) => row.name)).toEqual(
+        expect.arrayContaining([
+          "idx_flight_events_sequence_timestamp_ms",
+          "idx_flight_events_timestamp_ms",
+        ]),
+      );
+    } finally {
+      raw.close();
+    }
+  });
+
+  it("bounds runtime append contention and restores the admin timeout", async () => {
+    const path = databasePath("runtime-busy");
+    const instance = ledger({ databasePath: path });
+    await instance.initialize();
+    const locker = await rawDatabase(path);
+    try {
+      locker.exec("BEGIN IMMEDIATE");
+      const started = performance.now();
+      await expect(
+        instance.append(event({ traceId: "runtime-busy" })),
+      ).rejects.toMatchObject({ code: expect.stringMatching(/^SQLITE_BUSY/) });
+      expect(performance.now() - started).toBeLessThan(1_000);
+      const configured = (instance as unknown as { db: RawDatabase }).db;
+      expect(configured.pragma("busy_timeout", { simple: true })).toBe(5_000);
+    } finally {
+      locker.exec("ROLLBACK");
+      locker.close();
+    }
+  });
+
+  it("bounds runtime ownership cleanup and automatic pruning contention", async () => {
+    const path = databasePath("runtime-maintenance-busy");
+    const instance = ledger({ databasePath: path });
+    await instance.initialize();
+    const start = event({
+      traceId: "runtime-maintenance",
+      sequence: 1,
+      kind: "trace.started",
+      status: "started",
+      parentId: null,
+      metadata: { ownerPid: process.pid },
+    });
+    await instance.append(start);
+    await instance.append(
+      event({
+        id: "runtime-prune-candidate",
+        traceId: "runtime-prune-candidate",
+        sequence: 1,
+        kind: "agent.execute.completed",
+        parentId: null,
+      }),
+    );
+    const locker = await rawDatabase(path);
+    try {
+      locker.exec("BEGIN IMMEDIATE");
+      let started = performance.now();
+      await expect(
+        instance.releaseEventOwnership(start.id),
+      ).rejects.toMatchObject({ code: expect.stringMatching(/^SQLITE_BUSY/) });
+      expect(performance.now() - started).toBeLessThan(1_000);
+
+      started = performance.now();
+      await expect(instance.pruneRuntime(0)).rejects.toMatchObject({
+        code: expect.stringMatching(/^SQLITE_BUSY/),
+      });
+      expect(performance.now() - started).toBeLessThan(1_000);
+      const configured = (instance as unknown as { db: RawDatabase }).db;
+      expect(configured.pragma("busy_timeout", { simple: true })).toBe(5_000);
+    } finally {
+      locker.exec("ROLLBACK");
+      locker.close();
+    }
+  });
+
+  it("never heals a corrupt row while releasing ownership", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const start = event({
+      id: "corrupt-ownership",
+      traceId: "corrupt-ownership",
+      sequence: 1,
+      kind: "trace.started",
+      status: "started",
+      parentId: null,
+      metadata: { ownerPid: process.pid },
+    });
+    await instance.append(start);
+    const configured = (instance as unknown as { db: RawDatabase }).db;
+    const row = configured
+      .prepare("SELECT event_json FROM flight_events WHERE id = ?")
+      .get(start.id) as { event_json: string };
+    const tampered = JSON.parse(row.event_json) as FlightEvent;
+    tampered.metadata.tampered = true;
+    configured
+      .prepare("UPDATE flight_events SET event_json = ? WHERE id = ?")
+      .run(JSON.stringify(tampered), start.id);
+
+    await expect(
+      instance.releaseEventOwnership(start.id),
+    ).rejects.toThrow(/integrity/i);
+    await expect(instance.query()).rejects.toThrow(/integrity/i);
+  });
+
+  it("physically purges private payload bytes on clear", async () => {
+    const path = databasePath("secure-clear");
+    const instance = ledger({ databasePath: path });
+    await instance.initialize();
+    const sentinel = "PRIVATE_PAYLOAD_SENTINEL_7421";
+    await instance.append(
+      event({
+        id: "secure-clear-event",
+        payload: { value: sentinel },
+      }),
+    );
+
+    await instance.clear();
+    await instance.close();
+    const bytes = [path, `${path}-wal`, `${path}-shm`]
+      .filter(existsSync)
+      .map((file) => readFileSync(file))
+      .reduce((combined, current) => Buffer.concat([combined, current]));
+    expect(bytes.includes(Buffer.from(sentinel))).toBe(false);
+  });
+
+  it("physically purges superseded payload bytes after replace import", async () => {
+    const path = databasePath("secure-replace");
+    const instance = ledger({ databasePath: path });
+    await instance.initialize();
+    const sentinel = "REPLACED_PRIVATE_SENTINEL_7421";
+    const original = event({
+      id: "secure-replace-event",
+      payload: { value: sentinel },
+    });
+    const replacement = event({
+      id: original.id,
+      sequence: original.sequence,
+      traceId: original.traceId,
+      payload: { value: "removed" },
+    });
+    await instance.append(original);
+    await instance.import(
+      {
+        schema: "openrappter-flight-export/1.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        events: [replacement],
+      },
+      { replace: true },
+    );
+    await instance.close();
+
+    const bytes = [path, `${path}-wal`, `${path}-shm`]
+      .filter(existsSync)
+      .map((file) => readFileSync(file))
+      .reduce((combined, current) => Buffer.concat([combined, current]));
+    expect(bytes.includes(Buffer.from(sentinel))).toBe(false);
+  });
+
+  it("migrates and backfills legacy rows without timestamp_ms", async () => {
+    const path = databasePath("timestamp-migration");
+    const olderOffset = event({
+      id: "legacy-offset-older",
+      traceId: "legacy-offset-trace",
+      sequence: 1,
+      timestamp: "2026-01-01T00:30:00+01:00",
+    });
+    const newerUtc = event({
+      id: "legacy-utc-newer",
+      traceId: "legacy-utc-trace",
+      sequence: 1,
+      timestamp: "2025-12-31T23:45:00Z",
+    });
+    const raw = await rawDatabase(path);
+    createLegacyFlightTable(raw);
+    insertLegacyEvent(raw, newerUtc);
+    insertLegacyEvent(raw, olderOffset);
+    raw.close();
+
+    const instance = ledger({ databasePath: path });
+    await instance.initialize();
+    expect(await instance.query()).toEqual([olderOffset, newerUtc]);
+
+    const inspected = await rawDatabase(path);
+    try {
+      const columns = inspected
+        .prepare("PRAGMA table_info(flight_events)")
+        .all() as Array<{ name: string; notnull: number }>;
+      expect(columns).toContainEqual(
+        expect.objectContaining({ name: "timestamp_ms", notnull: 1 }),
+      );
+      const rows = inspected
+        .prepare(
+          "SELECT id, timestamp_ms FROM flight_events ORDER BY timestamp_ms",
+        )
+        .all() as Array<{ id: string; timestamp_ms: number }>;
+      expect(rows).toEqual([
+        { id: olderOffset.id, timestamp_ms: Date.parse(olderOffset.timestamp) },
+        { id: newerUtc.id, timestamp_ms: Date.parse(newerUtc.timestamp) },
+      ]);
+    } finally {
+      inspected.close();
+    }
+  });
+
+  it("rolls back timestamp_ms migration when a legacy row is invalid", async () => {
+    const path = databasePath("timestamp-migration-invalid");
+    const valid = event({
+      id: "legacy-valid",
+      traceId: "legacy-valid-trace",
+      sequence: 1,
+    });
+    const invalid = event({
+      id: "legacy-invalid",
+      traceId: "legacy-invalid-trace",
+      sequence: 1,
+    });
+    const raw = await rawDatabase(path);
+    createLegacyFlightTable(raw);
+    insertLegacyEvent(raw, valid);
+    insertLegacyEvent(raw, invalid, "{");
+    raw.close();
+
+    const instance = ledger({ databasePath: path });
+    await expect(instance.initialize()).rejects.toThrow(
+      /timestamp_ms migration failed.*valid JSON/i,
+    );
+
+    const inspected = await rawDatabase(path);
+    try {
+      const columns = inspected
+        .prepare("PRAGMA table_info(flight_events)")
+        .all() as Array<{ name: string }>;
+      expect(columns.some((column) => column.name === "timestamp_ms")).toBe(
+        false,
+      );
+      expect(
+        (
+          inspected
+            .prepare("SELECT COUNT(*) AS count FROM flight_events")
+            .get() as { count: number }
+        ).count,
+      ).toBe(2);
+    } finally {
+      inspected.close();
+    }
+  });
+
+  it("counts and clears events", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    await instance.append(event());
+    await instance.append(event());
+    expect(await instance.count()).toBe(2);
+    await instance.clear();
+    expect(await instance.count()).toBe(0);
+    expect(await instance.query()).toEqual([]);
+  });
+
+  it("treats retention as a target and keeps an oversized completed trace whole", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const completed = recordedTrace({
+      traceId: "oversized-completed-trace",
+      prefix: "oversized",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      middleKinds: [
+        "context.assembled",
+        "provider.attempt.completed",
+        "agent.execute.completed",
+      ],
+    });
+    for (const sample of completed) {
+      await instance.append(sample);
+    }
+
+    expect(await instance.prune(3)).toBe(0);
+    expect(
+      await instance.query({ traceId: "oversized-completed-trace" }),
+    ).toEqual(completed);
+  });
+
+  it("prunes an older completed trace as a whole", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const older = recordedTrace({
+      traceId: "older-completed-trace",
+      prefix: "older-completed",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      middleKinds: ["context.assembled"],
+    });
+    const newer = recordedTrace({
+      traceId: "newer-completed-trace",
+      prefix: "newer-completed",
+      startedAt: "2026-02-01T00:00:00.000Z",
+      middleKinds: ["context.assembled"],
+    });
+    for (const sample of [...older, ...newer]) {
+      await instance.append(sample);
+    }
+
+    expect(await instance.prune(newer.length)).toBe(older.length);
+    expect(await instance.query()).toEqual(newer);
+    expect(await instance.query({ traceId: "older-completed-trace" })).toEqual(
+      [],
+    );
+  });
+
+  it("always preserves active traces while pruning older completed traces", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const completed = recordedTrace({
+      traceId: "old-completed-trace",
+      prefix: "old-completed",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      middleKinds: ["context.assembled"],
+    });
+    const active = recordedTrace({
+      traceId: "active-trace",
+      prefix: "active",
+      startedAt: "2026-08-11T18:00:00.000Z",
+      middleKinds: ["context.assembled", "provider.attempt.started"],
+      terminal: null,
+    });
+    for (const sample of [...completed, ...active]) {
+      await instance.append(sample);
+    }
+
+    expect(await instance.prune(1)).toBe(0);
+    expect(await instance.query({ traceId: "active-trace" })).toEqual(active);
+    expect(await instance.query({ traceId: "old-completed-trace" })).toEqual(
+      completed,
+    );
+    expect(await instance.count()).toBe(active.length + completed.length);
+  });
+
+  it("preserves the newest completed trace alongside active traces", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const active = recordedTrace({
+      traceId: "active-pinned",
+      prefix: "active-pinned",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      middleKinds: ["context.assembled"],
+      terminal: null,
+    });
+    const completed = recordedTrace({
+      traceId: "completed-pinned",
+      prefix: "completed-pinned",
+      startedAt: "2026-02-01T00:00:00.000Z",
+    });
+    for (const sample of [...active, ...completed]) {
+      await instance.append(sample);
+    }
+
+    expect(await instance.prune(3)).toBe(0);
+    expect(await instance.query({ traceId: "active-pinned" })).toEqual(active);
+    expect(await instance.query({ traceId: "completed-pinned" })).toEqual(
+      completed,
+    );
+  });
+
+  it("treats a resumed completed trace as active when its latest lifecycle is started", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const older = recordedTrace({
+      traceId: "older-finished",
+      prefix: "older-finished",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      middleKinds: [],
+    });
+    const firstRun = recordedTrace({
+      traceId: "resumed-trace",
+      prefix: "resumed-first",
+      startedAt: "2026-02-01T00:00:00.000Z",
+      middleKinds: [],
+    });
+    const resumed = recordedTrace({
+      traceId: "resumed-trace",
+      prefix: "resumed-second",
+      startedAt: "2026-03-01T00:00:00.000Z",
+      middleKinds: ["context.assembled"],
+      terminal: null,
+      sequenceStart: firstRun.length + 1,
+    });
+    for (const sample of [...older, ...firstRun, ...resumed]) {
+      await instance.append(sample);
+    }
+
+    expect(await instance.prune(1)).toBe(0);
+    expect(await instance.query({ traceId: "resumed-trace" })).toEqual([
+      ...firstRun,
+      ...resumed,
+    ]);
+    expect(await instance.query({ traceId: "older-finished" })).toEqual(older);
+  });
+
+  it("uses sequence-ordered lifecycle depth for nested and clock-rolled-back traces", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const completed = recordedTrace({
+      traceId: "completed-before-nested",
+      prefix: "completed-before-nested",
+      startedAt: "2026-01-01T00:00:00.000Z",
+    });
+    const nestedActive = [
+      event({
+        id: "nested-outer-start",
+        traceId: "nested-active",
+        sequence: 1,
+        kind: "trace.started",
+        timestamp: "2026-06-01T00:00:00.000Z",
+      }),
+      event({
+        id: "nested-inner-start",
+        traceId: "nested-active",
+        sequence: 2,
+        kind: "trace.started",
+        timestamp: "2026-06-01T00:00:01.000Z",
+      }),
+      event({
+        id: "nested-inner-complete",
+        traceId: "nested-active",
+        sequence: 3,
+        kind: "trace.completed",
+        timestamp: "2026-06-01T00:00:02.000Z",
+      }),
+    ];
+    const resumedAfterRollback = [
+      event({
+        id: "rollback-start-1",
+        traceId: "rollback-active",
+        sequence: 1,
+        kind: "trace.started",
+        timestamp: "2026-05-01T00:00:00.000Z",
+      }),
+      event({
+        id: "rollback-complete",
+        traceId: "rollback-active",
+        sequence: 2,
+        kind: "trace.completed",
+        timestamp: "2026-05-01T00:00:01.000Z",
+      }),
+      event({
+        id: "rollback-start-2",
+        traceId: "rollback-active",
+        sequence: 3,
+        kind: "trace.started",
+        timestamp: "2025-01-01T00:00:00.000Z",
+      }),
+    ];
+    for (const sample of [
+      ...completed,
+      ...nestedActive,
+      ...resumedAfterRollback,
+    ]) {
+      await instance.append(sample);
+    }
+
+    expect(await instance.prune(0)).toBe(completed.length);
+    expect(await instance.query({ traceId: "nested-active" })).toEqual(
+      nestedActive,
+    );
+    expect(await instance.query({ traceId: "rollback-active" })).toEqual(
+      resumedAfterRollback,
+    );
+  });
+
+  it("preserves the newest completed trace when newer atomic events consume the target", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const completed = recordedTrace({
+      traceId: "completed-trace",
+      prefix: "completed",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      middleKinds: ["context.assembled", "agent.execute.completed"],
+    });
+    const atomic = [
+      event({
+        id: "atomic-1",
+        traceId: "atomic-trace",
+        sequence: 1,
+        timestamp: "2026-01-01T00:00:10.000Z",
+      }),
+      event({
+        id: "atomic-2",
+        traceId: "atomic-trace",
+        sequence: 2,
+        timestamp: "2026-01-01T00:00:11.000Z",
+      }),
+      event({
+        id: "atomic-3",
+        traceId: "atomic-trace",
+        sequence: 3,
+        timestamp: "2026-01-01T00:00:12.000Z",
+      }),
+    ];
+    for (const sample of [...completed, ...atomic]) {
+      await instance.append(sample);
+    }
+
+    expect(await instance.prune(5)).toBe(atomic.length);
+    expect(await instance.query({ traceId: "completed-trace" })).toEqual(
+      completed,
+    );
+    expect(await instance.query({ traceId: "atomic-trace" })).toEqual([]);
+  });
+
+  it("prunes to the newest complete events and validates keep", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const oldest = event({
+      id: "prune-oldest",
+      sequence: 1,
+      timestamp: "2026-01-01T00:00:01.000Z",
+    });
+    const middle = event({
+      id: "prune-middle",
+      sequence: 2,
+      timestamp: "2026-01-01T00:00:02.000Z",
+    });
+    const newest = event({
+      id: "prune-newest",
+      sequence: 3,
+      timestamp: "2026-01-01T00:00:03.000Z",
+    });
+    await instance.append(oldest);
+    await instance.append(middle);
+    await instance.append(newest);
+
+    await expect(instance.prune(-1)).rejects.toThrow(/keep/i);
+    await expect(instance.prune(1.2)).rejects.toThrow(/keep/i);
+    expect(await instance.prune(2)).toBe(1);
+    expect(await instance.query()).toEqual([middle, newest]);
+    expect(await instance.prune(2)).toBe(0);
+    expect(await instance.prune(0)).toBe(2);
+    expect(await instance.count()).toBe(0);
+  });
+
+  it("prunes globally by timestamp rather than per-trace sequence", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const oldHighSequence = event({
+      id: "old-high-sequence",
+      traceId: "old-trace",
+      sequence: 100,
+      timestamp: "2026-01-01T00:00:00.000Z",
+    });
+    const newLowSequence = event({
+      id: "new-low-sequence",
+      traceId: "new-trace",
+      sequence: 1,
+      timestamp: "2026-08-11T18:00:00.000Z",
+    });
+    await instance.append(oldHighSequence);
+    await instance.append(newLowSequence);
+
+    expect(await instance.prune(1)).toBe(1);
+    expect(await instance.query()).toEqual([newLowSequence]);
+  });
+
+  it("uses insertion order as the deterministic prune tiebreak", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const timestamp = "2026-08-11T18:00:00.000Z";
+    const first = event({
+      id: "timestamp-tie-first",
+      traceId: "timestamp-tie-a",
+      sequence: 100,
+      timestamp,
+    });
+    const second = event({
+      id: "timestamp-tie-second",
+      traceId: "timestamp-tie-b",
+      sequence: 1,
+      timestamp,
+    });
+    await instance.append(first);
+    await instance.append(second);
+
+    expect(await instance.prune(1)).toBe(1);
+    expect(await instance.query()).toEqual([second]);
+  });
+
+  it("exports the exact versioned envelope and honors export filters", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const included = event({ traceId: "export-me" });
+    await instance.append(included);
+    await instance.append(event({ traceId: "skip-me" }));
+
+    const exported = await instance.export({ traceId: "export-me" });
+    expect(Object.keys(exported)).toEqual(["schema", "exportedAt", "events"]);
+    expect(exported.schema).toBe("openrappter-flight-export/1.0");
+    expect(Number.isNaN(Date.parse(exported.exportedAt))).toBe(false);
+    expect(exported.events).toEqual([included]);
+  });
+
+  it("exports complete snapshots beyond the public 10,000-row query cap", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const events = Array.from({ length: 10_001 }, (_, index) =>
+      event({
+        id: `uncapped-export-${index}`,
+        traceId: `uncapped-trace-${index}`,
+        sequence: 1,
+        timestamp: "2026-01-01T00:00:00.000Z",
+      }),
+    );
+    await instance.import({
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: "2026-01-01T00:00:00.000Z",
+      events,
+    });
+
+    expect(await instance.query()).toHaveLength(10_000);
+    expect((await instance.export()).events).toHaveLength(10_001);
+  });
+
+  it("round-trips exports exactly and includes a non-vacuous trace mutation check", async () => {
+    const source = ledger({ inMemory: true });
+    const target = ledger({ inMemory: true });
+    await source.initialize();
+    await target.initialize();
+    const events = [
+      event({ id: "roundtrip-a", sequence: 1, traceId: "trace-roundtrip-a" }),
+      event({ id: "roundtrip-b", sequence: 2, traceId: "trace-roundtrip-b" }),
+    ];
+    for (const sample of events) {
+      await source.append(sample);
+    }
+
+    const exported = await source.export();
+    expect(await target.import(exported)).toBe(2);
+    const reexported = await target.export();
+    expect(reexported.events).toEqual(exported.events);
+    expect(await target.query()).toEqual(events);
+
+    const mutated = structuredClone(exported.events);
+    mutated[0].traceId = "intentionally-mutated-trace";
+    expect(mutated).not.toEqual(reexported.events);
+  });
+
+  it("accepts exact duplicate IDs and requires replace for different content", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const original = event({
+      id: "replace-id",
+      sequence: 1,
+      traceId: "original-trace",
+    });
+    const replacement = event({
+      id: "replace-id",
+      sequence: 99,
+      traceId: "replacement-trace",
+    });
+    const originalExport: FlightExport = {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: [original],
+    };
+    const replacementExport: FlightExport = {
+      ...originalExport,
+      events: [replacement],
+    };
+
+    expect(await instance.import(originalExport)).toBe(1);
+    expect(await instance.import(originalExport)).toBe(0);
+    await expect(instance.import(replacementExport)).rejects.toThrow(
+      /conflicts with existing content/i,
+    );
+    expect(await instance.query()).toEqual([original]);
+    expect(await instance.import(replacementExport, { replace: true })).toBe(1);
+    expect(await instance.query()).toEqual([replacement]);
+  });
+
+  it("stages multi-row replacements before inserting swapped sequences", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const first = event({
+      id: "swap-a",
+      traceId: "swap-trace",
+      sequence: 1,
+    });
+    const second = event({
+      id: "swap-b",
+      traceId: "swap-trace",
+      sequence: 2,
+    });
+    await instance.append(first);
+    await instance.append(second);
+    const swappedA = event({
+      id: first.id,
+      traceId: first.traceId,
+      sequence: 2,
+    });
+    const swappedB = event({
+      id: second.id,
+      traceId: second.traceId,
+      sequence: 1,
+    });
+
+    expect(
+      await instance.import(
+        {
+          schema: "openrappter-flight-export/1.0",
+          exportedAt: "2026-01-01T00:00:00.000Z",
+          events: [swappedA, swappedB],
+        },
+        { replace: true },
+      ),
+    ).toBe(2);
+    expect(
+      (await instance.query({ traceId: "swap-trace" })).map(
+        (event) => [event.id, event.sequence],
+      ),
+    ).toEqual([
+      ["swap-b", 1],
+      ["swap-a", 2],
+    ]);
+  });
+
+  it("rejects a hash-stale trace mutation without partially importing", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const baseline = event({ id: "integrity-baseline" });
+    await instance.append(baseline);
+    const valid = event({ id: "integrity-valid" });
+    const tampered = {
+      ...event({ id: "integrity-tampered" }),
+      traceId: "mutated-after-hashing",
+    };
+    const imported: FlightExport = {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: [valid, tampered],
+    };
+
+    await expect(instance.import(imported)).rejects.toThrow(/integrity/i);
+    expect(await instance.query()).toEqual([baseline]);
+  });
+
+  it("rejects malformed event timestamps even when their hash matches", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const malformedTimestamp = event({
+      id: "malformed-timestamp",
+      timestamp: "not-an-iso-date",
+    });
+    const imported: FlightExport = {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: [malformedTimestamp],
+    };
+
+    await expect(instance.import(imported)).rejects.toThrow(/ISO timestamp/i);
+    expect(await instance.count()).toBe(0);
+  });
+
+  it("rejects lone surrogates in every top-level event string", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const invalid = event({ source: "\ud800" });
+
+    await expect(instance.append(invalid)).rejects.toThrow(/Unicode scalar/i);
+    expect(await instance.count()).toBe(0);
+  });
+
+  it("rejects impossible dates and invalid offsets while accepting strict ISO controls", async () => {
+    const invalidTimestamps = [
+      "2026-02-29T00:00:00.000Z",
+      "2026-02-30T00:00:00.000Z",
+      "2026-04-31T00:00:00.000Z",
+      "2026-06-15T24:00:00.000Z",
+      "2026-06-15T12:00:00.1234Z",
+      "2026-06-15T12:00:00+00:60",
+      "2026-06-15T12:00:00+14:01",
+    ];
+    for (const [index, timestamp] of invalidTimestamps.entries()) {
+      const instance = ledger({ inMemory: true });
+      await instance.initialize();
+      const invalid = event({ id: `invalid-date-${index}`, timestamp });
+      await expect(instance.append(invalid)).rejects.toThrow(/ISO timestamp/i);
+      await instance.close();
+    }
+
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    await expect(
+      instance.import({
+        schema: "openrappter-flight-export/1.0",
+        exportedAt: "2026-02-30T00:00:00.000Z",
+        events: [],
+      }),
+    ).rejects.toThrow(/ISO timestamp/i);
+    await expect(
+      instance.query({ since: "2026-04-31T00:00:00.000Z" }),
+    ).rejects.toThrow(/ISO timestamp/i);
+    const valid = [
+      event({
+        id: "valid-leap-day",
+        sequence: 1,
+        timestamp: "2024-02-29T23:59:59.999Z",
+      }),
+      event({
+        id: "valid-offset",
+        sequence: 2,
+        timestamp: "2026-06-15T12:00:00.123-05:30",
+      }),
+      event({
+        id: "valid-maximum-offset",
+        sequence: 3,
+        timestamp: "2026-06-15T12:00:00+14:00",
+      }),
+    ];
+    for (const sample of valid) {
+      await instance.append(sample);
+    }
+    expect(await instance.count()).toBe(3);
+  });
+
+  it("parses one-to-three fractional digits exactly without Date.parse normalization", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const samples = [
+      ["fraction-1", "1970-01-01T00:00:00.1Z", 100],
+      ["fraction-2", "1970-01-01T00:00:00.12Z", 120],
+      ["fraction-3", "1970-01-01T00:00:00.123Z", 123],
+      ["pre-epoch", "1969-12-31T23:59:59.999Z", -1],
+    ] as const;
+    for (const [id, timestamp] of samples) {
+      await instance.append(event({ id, timestamp }));
+    }
+
+    const configured = (instance as unknown as { db: RawDatabase }).db;
+    const stored = configured
+      .prepare(
+        `SELECT id, timestamp_ms FROM flight_events
+         WHERE id IN (${samples.map(() => "?").join(", ")})`,
+      )
+      .all(...samples.map(([id]) => id)) as Array<{
+      id: string;
+      timestamp_ms: number;
+    }>;
+    expect(Object.fromEntries(stored.map((row) => [row.id, row.timestamp_ms])))
+      .toEqual(Object.fromEntries(samples.map(([id, , ms]) => [id, ms])));
+  });
+
+  it("rejects unsafe integer payloads that cannot hash consistently across runtimes", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const unsafe = event({ payload: { value: Number.MAX_SAFE_INTEGER + 1 } });
+    unsafe.contentHash = computeFlightEventHash(unsafe);
+    const imported: FlightExport = {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: [unsafe],
+    };
+
+    await expect(instance.import(imported)).rejects.toThrow(/JSON-compatible/);
+    expect(await instance.count()).toBe(0);
+  });
+
+  it("rejects hash-valid imports that violate persisted privacy invariants", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const unsafeCases = [
+      event({ sessionId: "alice@example.com" }),
+      event({ workspaceId: "/Users/alice/private" }),
+      event({ workspaceId: "file:///Users/alice/private" }),
+      event({ workspaceId: "workspace:/Users/alice/private" }),
+      event({ workspaceId: String.raw`workspace:C:\Users\alice\private` }),
+      event({ metadata: { authorization: "raw-secret" } }),
+      event({ payload: { token: "raw-token" } }),
+      event({
+        kind: "trace.started",
+        status: "started",
+        metadata: { ownerPid: process.pid },
+      }),
+    ];
+    for (const unsafe of unsafeCases) {
+      unsafe.contentHash = computeFlightEventHash(unsafe);
+      await expect(
+        instance.import({
+          schema: "openrappter-flight-export/1.0",
+          exportedAt: "2026-01-01T00:00:00.000Z",
+          events: [unsafe],
+        }),
+      ).rejects.toThrow(/privacy|opaque session|raw path|live trace ownership/i);
+    }
+    expect(await instance.count()).toBe(0);
+  });
+
+  it("rejects secret-shaped top-level envelope fields", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const token = `ghp_${"x".repeat(32)}`;
+    const invalid = event({ providerId: token });
+    invalid.contentHash = computeFlightEventHash(invalid);
+
+    await expect(
+      instance.import({
+        schema: "openrappter-flight-export/1.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        events: [invalid],
+      }),
+    ).rejects.toThrow(/providerId.*privacy/i);
+
+    const secretId = event({ id: token });
+    secretId.contentHash = computeFlightEventHash(secretId);
+    await expect(
+      instance.import({
+        schema: "openrappter-flight-export/1.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        events: [secretId],
+      }),
+    ).rejects.toThrow(/id.*privacy/i);
+  });
+
+  it("rejects conflicting duplicate IDs unless replace is explicit", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const original = event({
+      id: "duplicate-id",
+      traceId: "duplicate-original",
+    });
+    const conflicting = event({
+      id: "duplicate-id",
+      traceId: "duplicate-conflict",
+    });
+    await instance.append(original);
+
+    await expect(
+      instance.import({
+        schema: "openrappter-flight-export/1.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        events: [conflicting],
+      }),
+    ).rejects.toThrow(/conflicts with existing content/i);
+  });
+
+  it("validates every existing row before importing anything", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    await instance.append(event({ id: "existing-corrupt" }));
+    const configured = (instance as unknown as { db: RawDatabase }).db;
+    configured
+      .prepare("UPDATE flight_events SET event_json = ? WHERE id = ?")
+      .run("{bad", "existing-corrupt");
+    const incoming = event({ id: "unrelated-import" });
+
+    await expect(
+      instance.import({
+        schema: "openrappter-flight-export/1.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        events: [incoming],
+      }),
+    ).rejects.toThrow(/not valid JSON/i);
+    expect(await instance.count()).toBe(1);
+  });
+
+  it("validates every snapshot row before applying inspection filters", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const trace = recordedTrace({
+      traceId: "filtered-corruption",
+      prefix: "filtered-corruption",
+      startedAt: "2026-01-01T00:00:00.000Z",
+      middleKinds: ["context.assembled"],
+    });
+    for (const entry of trace) await instance.append(entry);
+    const configured = (instance as unknown as { db: RawDatabase }).db;
+    configured
+      .prepare("UPDATE flight_events SET trace_id = ? WHERE id = ?")
+      .run("hidden-corrupt-trace", trace[1].id);
+
+    await expect(
+      instance.query({ traceId: "filtered-corruption" }),
+    ).rejects.toThrow(/traceId does not match event_json/i);
+    await expect(
+      instance.export({ traceId: "filtered-corruption" }),
+    ).rejects.toThrow(/traceId does not match event_json/i);
+  });
+
+  it("rejects auto as imported concrete model identity", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const invalid = event({ model: "auto" });
+    invalid.contentHash = computeFlightEventHash(invalid);
+
+    await expect(
+      instance.import({
+        schema: "openrappter-flight-export/1.0",
+        exportedAt: "2026-01-01T00:00:00.000Z",
+        events: [invalid],
+      }),
+    ).rejects.toThrow(/concrete normalized model/i);
+  });
+
+  it("imports the committed cross-runtime portability vector", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const vector = JSON.parse(
+      readFileSync(
+        new URL(
+          "../../../contracts/flight-recorder-vector.json",
+          import.meta.url,
+        ),
+        "utf8",
+      ),
+    ) as FlightEvent;
+    const imported: FlightExport = {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: [vector],
+    };
+
+    expect(await instance.import(imported)).toBe(1);
+    expect(await instance.query()).toEqual([vector]);
+  });
+
+  it("validates the envelope and every event field before changing the database", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const baseline = event({ id: "baseline" });
+    await instance.append(baseline);
+
+    const valid = event({ id: "valid-import" });
+    const invalidEvents: unknown[] = [
+      { ...valid, schema: "wrong-schema" },
+      { ...valid, id: 1 },
+      { ...valid, sequence: -1 },
+      { ...valid, sequence: 1.5 },
+      { ...valid, kind: 1 },
+      { ...valid, source: null },
+      { ...valid, status: "unknown" },
+      { ...valid, traceId: false },
+      { ...valid, parentId: 1 },
+      { ...valid, timestamp: 1 },
+      { ...valid, metadata: [] },
+      { ...valid, contentHash: null },
+      { ...valid, contentHash: "A".repeat(64) },
+      { ...valid, contentHash: "a".repeat(63) },
+      { ...valid, sessionId: 1 },
+      { ...valid, workspaceId: 1 },
+      { ...valid, providerId: 1 },
+      { ...valid, model: 1 },
+      { ...valid, agentName: 1 },
+      { ...valid, toolName: 1 },
+      { ...valid, durationMs: Number.POSITIVE_INFINITY },
+      { ...valid, payload: undefined },
+      { ...valid, unexpected: true },
+    ];
+
+    const wrongEnvelope = {
+      schema: "wrong-export",
+      exportedAt: new Date().toISOString(),
+      events: [],
+    } as unknown as FlightExport;
+    await expect(instance.import(wrongEnvelope)).rejects.toThrow(/schema/i);
+    await expect(
+      instance.query({
+        traceId: "baseline",
+        unexpected: true,
+      } as FlightEventQuery & { unexpected: boolean }),
+    ).rejects.toThrow(/unexpected field/i);
+
+    for (const invalidEvent of invalidEvents) {
+      const malformed = {
+        schema: "openrappter-flight-export/1.0",
+        exportedAt: new Date().toISOString(),
+        events: [valid, invalidEvent],
+      } as FlightExport;
+      await expect(instance.import(malformed)).rejects.toThrow();
+      expect(await instance.query()).toEqual([baseline]);
+    }
+  });
+
+  it("rolls back a whole import when a later serialized event is malformed", async () => {
+    const instance = ledger({ inMemory: true });
+    await instance.initialize();
+    const baseline = event({ id: "atomic-baseline" });
+    await instance.append(baseline);
+    const circular = event({ id: "circular" });
+    circular.metadata.self = circular.metadata;
+
+    const malformed: FlightExport = {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: [event({ id: "would-have-imported" }), circular],
+    };
+    await expect(instance.import(malformed)).rejects.toThrow(/circular/i);
+    expect(await instance.query()).toEqual([baseline]);
+  });
+
+  it("preserves exact event sequence and correlation after durable reopen", async () => {
+    const path = databasePath("reopen");
+    const first = ledger({ databasePath: path });
+    await first.initialize();
+    const events = [
+      event({
+        id: "reopen-a",
+        sequence: 42,
+        traceId: "durable-trace",
+        parentId: null,
+        sessionId: "session:dddddddddddddddddddddddd",
+      }),
+      event({
+        id: "reopen-b",
+        sequence: 43,
+        traceId: "durable-trace",
+        parentId: "reopen-a",
+        sessionId: "session:dddddddddddddddddddddddd",
+      }),
+    ];
+    await first.append(events[0]);
+    await first.append(events[1]);
+    await first.close();
+
+    const reopened = ledger({ databasePath: path });
+    await reopened.initialize();
+    expect(await reopened.query()).toEqual(events);
+    expect(await reopened.query({ traceId: "durable-trace" })).toEqual(events);
+  });
+
+  it("supports two durable instances writing distinct traces without loss or cross-correlation", async () => {
+    const path = databasePath("concurrent");
+    const first = ledger({ databasePath: path });
+    const second = ledger({ databasePath: path });
+    await Promise.all([first.initialize(), second.initialize()]);
+    const traceA = Array.from({ length: 40 }, (_, index) =>
+      event({
+        id: `concurrent-a-${index}`,
+        sequence: index,
+        traceId: "concurrent-trace-a",
+        timestamp: new Date(Date.UTC(2026, 1, 1, 0, 0, index)).toISOString(),
+      }),
+    );
+    const traceB = Array.from({ length: 40 }, (_, index) =>
+      event({
+        id: `concurrent-b-${index}`,
+        sequence: index,
+        traceId: "concurrent-trace-b",
+        timestamp: new Date(Date.UTC(2026, 1, 2, 0, 0, index)).toISOString(),
+      }),
+    );
+
+    await Promise.all(
+      traceA.flatMap((sample, index) => [
+        first.append(sample),
+        second.append(traceB[index]),
+      ]),
+    );
+
+    expect(await first.count()).toBe(80);
+    expect(await second.query({ traceId: "concurrent-trace-a" })).toEqual(
+      traceA,
+    );
+    expect(await first.query({ traceId: "concurrent-trace-b" })).toEqual(
+      traceB,
+    );
+    expect(
+      (await first.query({ traceId: "concurrent-trace-a" })).every(
+        (sample) => sample.traceId === "concurrent-trace-a",
+      ),
+    ).toBe(true);
+  });
+
+  it("surfaces invalid stored JSON instead of returning partial results", async () => {
+    const path = databasePath("bad-json");
+    const instance = ledger({ databasePath: path });
+    await instance.initialize();
+    await instance.append(event({ id: "good-row", sequence: 1 }));
+    await instance.append(event({ id: "bad-row", sequence: 2 }));
+
+    const raw = await rawDatabase(path);
+    try {
+      raw
+        .prepare("UPDATE flight_events SET event_json = ? WHERE id = ?")
+        .run("{", "bad-row");
+    } finally {
+      raw.close();
+    }
+
+    await expect(instance.query()).rejects.toThrow(/corrupt.*valid JSON/i);
+  });
+
+  it("rejects stored event JSON changed without updating its hash", async () => {
+    const path = databasePath("bad-row");
+    const instance = ledger({ databasePath: path });
+    await instance.initialize();
+    const sample = event({ id: "mismatched-row", traceId: "indexed-trace" });
+    await instance.append(sample);
+
+    const raw = await rawDatabase(path);
+    try {
+      raw
+        .prepare("UPDATE flight_events SET event_json = ? WHERE id = ?")
+        .run(
+          JSON.stringify({ ...sample, payload: { corrupted: true } }),
+          sample.id,
+        );
+    } finally {
+      raw.close();
+    }
+
+    await expect(instance.query()).rejects.toThrow(/integrity/i);
+  });
+});

--- a/typescript/src/flight-recorder/ledger.ts
+++ b/typescript/src/flight-recorder/ledger.ts
@@ -1,0 +1,1741 @@
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  lstatSync,
+  openSync,
+} from "node:fs";
+import { createHash, randomUUID } from "node:crypto";
+import type {
+  FlightEvent,
+  FlightEventQuery,
+  FlightEventStatus,
+  FlightExport,
+  FlightLedger,
+} from "./types.js";
+import { FLIGHT_EVENT_SCHEMA } from "./types.js";
+import {
+  computeFlightEventHash,
+  normalizeFlightModelId,
+  normalizeFlightWorkspaceId,
+  verifyFlightEventHash,
+} from "./integrity.js";
+import { isDeepStrictEqual } from "node:util";
+import {
+  sanitizeFlightMetadata,
+  sanitizeFlightPayload,
+  sanitizeFlightValue,
+} from "./redaction.js";
+import {
+  assertPrivateDirectory,
+  hardenPrivatePath,
+} from "./permissions.js";
+import { processMatchesIncarnation } from "./process-owner.js";
+import path from "node:path";
+
+const EXPORT_SCHEMA = "openrappter-flight-export/1.0" as const;
+const BUSY_TIMEOUT_MS = 5_000;
+const RUNTIME_BUSY_TIMEOUT_MS = 25;
+const MAX_BUSY_RETRIES = 4;
+const MAX_QUERY_LIMIT = 10_000;
+const MAX_QUERY_OFFSET = 1_000_000;
+const MAX_KIND_FILTERS = 100;
+
+interface Database {
+  exec(sql: string): void;
+  prepare(sql: string): Statement;
+  close(): void;
+  pragma(pragma: string): unknown;
+  transaction<T>(fn: () => T): () => T;
+}
+
+interface Statement {
+  run(...params: unknown[]): RunResult;
+  get(...params: unknown[]): unknown;
+  all(...params: unknown[]): unknown[];
+}
+
+interface RunResult {
+  changes: number;
+}
+
+type BetterSqlite3 = (
+  filename: string,
+  options?: { readonly?: boolean; timeout?: number },
+) => Database;
+
+interface FlightEventRow {
+  id: string;
+  sequence: number;
+  trace_id: string;
+  timestamp: string;
+  timestamp_ms: number;
+  kind: string;
+  source: string;
+  status: string;
+  session_id: string | null;
+  workspace_id: string | null;
+  provider_id: string | null;
+  agent_name: string | null;
+  tool_name: string | null;
+  event_json: string;
+}
+
+interface PruneEventRow extends FlightEventRow {
+  row_id: number;
+}
+
+interface MigrationEventRow extends FlightEventRow {
+  row_id: number;
+}
+
+interface RetentionTrace {
+  traceId: string;
+  rowCount: number;
+  lifecycle: "active" | "completed" | "atomic" | "malformed";
+  lifecycleDepth: number;
+  sawLifecycleStart: boolean;
+  malformedLifecycle: boolean;
+  lifecycleStarts: Map<
+    string,
+    { pid: number | null; incarnation?: string }
+  >;
+  latestTimestamp: number;
+  latestRowId: number;
+}
+
+interface SerializedEvent {
+  event: FlightEvent;
+  json: string;
+}
+
+const EVENT_KEYS = new Set([
+  "schema",
+  "id",
+  "sequence",
+  "kind",
+  "source",
+  "status",
+  "traceId",
+  "parentId",
+  "sessionId",
+  "workspaceId",
+  "providerId",
+  "model",
+  "agentName",
+  "toolName",
+  "timestamp",
+  "durationMs",
+  "metadata",
+  "payload",
+  "contentHash",
+]);
+
+const QUERY_KEYS = new Set([
+  "traceId",
+  "sessionId",
+  "workspaceId",
+  "kind",
+  "source",
+  "providerId",
+  "agentName",
+  "toolName",
+  "status",
+  "since",
+  "until",
+  "order",
+  "limit",
+  "offset",
+]);
+
+const EVENT_STATUSES = new Set<FlightEventStatus>([
+  "started",
+  "success",
+  "error",
+  "decision",
+  "info",
+]);
+
+export class SQLiteFlightLedger implements FlightLedger {
+  private db: Database | null = null;
+  private readonly databasePath: string;
+  private readonly inMemory: boolean;
+  private state: "created" | "initialized" | "closed" = "created";
+  private initializing: Promise<void> | null = null;
+
+  constructor(options: { databasePath?: string; inMemory?: boolean } = {}) {
+    this.databasePath = options.databasePath ?? "openrappter-flight.db";
+    this.inMemory = options.inMemory ?? false;
+  }
+
+  async initialize(): Promise<void> {
+    if (this.state === "closed") {
+      throw new Error("Flight ledger is closed and cannot be initialized.");
+    }
+    if (this.state === "initialized") return;
+    if (this.initializing) return this.initializing;
+    const operation = this.initializeOnce();
+    this.initializing = operation;
+    try {
+      await operation;
+    } finally {
+      if (this.initializing === operation) {
+        this.initializing = null;
+      }
+    }
+  }
+
+  private async initializeOnce(): Promise<void> {
+    if (this.state === "closed") {
+      throw new Error("Flight ledger is closed and cannot be initialized.");
+    }
+    if (this.state === "initialized") {
+      return;
+    }
+
+    let BetterSqlite: BetterSqlite3;
+    try {
+      const module = await import("better-sqlite3");
+      BetterSqlite = module.default as unknown as BetterSqlite3;
+    } catch {
+      throw new Error(
+        "better-sqlite3 is required for the flight ledger. Install it with: npm install better-sqlite3",
+      );
+    }
+
+    const preparedFiles = this.inMemory
+      ? undefined
+      : (
+          assertPrivateDirectory(path.dirname(this.databasePath)),
+          preparePrivateDatabaseFiles(this.databasePath)
+        );
+
+    const db = BetterSqlite(this.inMemory ? ":memory:" : this.databasePath, {
+      timeout: BUSY_TIMEOUT_MS,
+    });
+
+    try {
+      await retrySqliteBusy(() => {
+        if (preparedFiles) verifyPrivateDatabaseFiles(preparedFiles);
+        db.pragma("foreign_keys = ON");
+        db.pragma(`busy_timeout = ${BUSY_TIMEOUT_MS}`);
+        db.pragma("secure_delete = ON");
+        if (!this.inMemory) {
+          db.pragma("journal_mode = WAL");
+          db.pragma("synchronous = FULL");
+          verifyPrivateDatabaseFiles(preparedFiles!);
+        }
+        db.exec(`
+          CREATE TABLE IF NOT EXISTS flight_events (
+            id TEXT PRIMARY KEY,
+            sequence INTEGER NOT NULL,
+            trace_id TEXT NOT NULL,
+            timestamp TEXT NOT NULL,
+            timestamp_ms INTEGER NOT NULL,
+            kind TEXT NOT NULL,
+            source TEXT NOT NULL,
+            status TEXT NOT NULL,
+            session_id TEXT,
+            workspace_id TEXT,
+            provider_id TEXT,
+            agent_name TEXT,
+            tool_name TEXT,
+            event_json TEXT NOT NULL,
+            UNIQUE (trace_id, sequence)
+          );
+          CREATE TABLE IF NOT EXISTS flight_metadata (
+            key TEXT PRIMARY KEY,
+            value TEXT NOT NULL
+          );
+        `);
+
+        migrateTimestampColumn(db);
+
+        db.exec(`
+          CREATE INDEX IF NOT EXISTS idx_flight_events_sequence_timestamp_ms
+            ON flight_events(sequence, timestamp_ms);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_trace
+            ON flight_events(trace_id);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_session
+            ON flight_events(session_id);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_workspace
+            ON flight_events(workspace_id);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_kind
+            ON flight_events(kind);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_source
+            ON flight_events(source);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_provider
+            ON flight_events(provider_id);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_agent
+            ON flight_events(agent_name);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_tool
+            ON flight_events(tool_name);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_status
+            ON flight_events(status);
+          CREATE INDEX IF NOT EXISTS idx_flight_events_timestamp_ms
+            ON flight_events(timestamp_ms);
+        `);
+        if (!this.inMemory) {
+          verifyPrivateDatabaseFiles(preparedFiles!);
+          materializeAndHardenDatabaseFiles(db, this.databasePath);
+          verifyPrivateDatabaseFiles(preparedFiles!);
+        }
+      });
+    } catch (error) {
+      db.close();
+      throw error;
+    }
+
+    if (this.isClosed()) {
+      db.close();
+      return;
+    }
+    this.db = db;
+    this.state = "initialized";
+  }
+
+  async close(): Promise<void> {
+    if (this.state === "closed") {
+      return;
+    }
+    this.state = "closed";
+    if (this.initializing) {
+      await this.initializing;
+    }
+    this.db?.close();
+    this.db = null;
+  }
+
+  async append(event: FlightEvent): Promise<void> {
+    const db = this.ensureDb();
+    const serialized = serializeEvent(event, "event");
+    const statement = db.prepare(insertSql(false));
+    db.pragma(`busy_timeout = ${RUNTIME_BUSY_TIMEOUT_MS}`);
+    try {
+      statement.run(...eventParameters(serialized));
+    } finally {
+      db.pragma(`busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    }
+  }
+
+  async query(query: FlightEventQuery = {}): Promise<FlightEvent[]> {
+    return selectEvents(this.ensureDb(), query, true);
+  }
+
+  async count(): Promise<number> {
+    const db = this.ensureDb();
+    const row = db
+      .prepare("SELECT COUNT(*) AS count FROM flight_events")
+      .get() as {
+      count: number;
+    };
+    return row.count;
+  }
+
+  async lastSequence(traceId: string): Promise<number> {
+    assertString(traceId, "traceId");
+    const row = this.ensureDb()
+      .prepare(`
+        SELECT rowid AS row_id, *
+        FROM flight_events
+        WHERE trace_id = ?
+        ORDER BY sequence DESC, rowid DESC
+        LIMIT 1
+      `)
+      .get(traceId) as PruneEventRow | undefined;
+    return row ? rowToEvent(row).sequence : 0;
+  }
+
+  async bindIdentityKey(identityKey: string): Promise<void> {
+    if (!/^[0-9a-f]{64}$/i.test(identityKey)) {
+      throw new Error(
+        "Flight Recorder identity key must be 32-byte hexadecimal.",
+      );
+    }
+    const fingerprint = createHash("sha256")
+      .update(`openrappter-flight-identity/1:${identityKey.toLowerCase()}`)
+      .digest("hex");
+    const db = this.ensureDb();
+    await retrySqliteBusy(() =>
+      db.transaction(() => {
+        const row = db
+          .prepare(
+            "SELECT value FROM flight_metadata WHERE key = 'identity-key-fingerprint'",
+          )
+          .get() as { value?: string } | undefined;
+        if (row?.value !== undefined && row.value !== fingerprint) {
+          throw new Error(
+            "Flight Recorder identity key does not match the ledger fingerprint.",
+          );
+        }
+        if (row?.value === undefined) {
+          db.prepare(
+            "INSERT INTO flight_metadata (key, value) VALUES ('identity-key-fingerprint', ?)",
+          ).run(fingerprint);
+        }
+      })(),
+    );
+  }
+
+  /**
+   * `keep` is a target bound, not a hard bound: preserving active traces and
+   * replayable completed traces may retain more rows than requested.
+   */
+  async prune(keep: number): Promise<number> {
+    const db = this.ensureDb();
+    assertNonNegativeInteger(keep, "keep");
+
+    const deleted = await retrySqliteBusy(() => pruneOnce(db, keep));
+    if (deleted > 0) {
+      await purgeDeletedPages(db, false);
+    }
+    return deleted;
+  }
+
+  async pruneRuntime(keep: number): Promise<number> {
+    const db = this.ensureDb();
+    assertNonNegativeInteger(keep, "keep");
+    db.pragma(`busy_timeout = ${RUNTIME_BUSY_TIMEOUT_MS}`);
+    try {
+      const deleted = pruneOnce(db, keep);
+      if (deleted > 0) purgeDeletedPagesOnce(db, false);
+      return deleted;
+    } finally {
+      db.pragma(`busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    }
+  }
+
+  async export(query?: FlightEventQuery): Promise<FlightExport> {
+    const db = this.ensureDb();
+    return retrySqliteBusy(() =>
+      db.transaction(() => {
+        const events = selectEvents(db, query ?? {}, false).map(
+          exportableEvent,
+        );
+        return {
+          schema: EXPORT_SCHEMA,
+          exportedAt: new Date().toISOString(),
+          events,
+        };
+      })(),
+    );
+  }
+
+  async import(
+    data: FlightExport,
+    options: { replace?: boolean } = {},
+  ): Promise<number> {
+    const db = this.ensureDb();
+    const serializedEvents = validateExport(data);
+
+    const imported = await retrySqliteBusy(() =>
+      db.transaction(() => {
+        const existingRows = db
+          .prepare("SELECT * FROM flight_events")
+          .all() as FlightEventRow[];
+        const snapshot = buildImportSnapshot(existingRows);
+        const persistedEvents: SerializedEvent[] = [];
+        for (const event of serializedEvents) {
+          const existing = snapshot.existingById.get(event.event.id);
+          if (existing && options.replace !== true) {
+            if (
+              exportableEvent(existing).contentHash !==
+              event.event.contentHash
+            ) {
+              throw new Error(
+                `Flight event ID "${event.event.id}" conflicts with existing content.`,
+              );
+            }
+            continue;
+          }
+          assertLiveTraceImportSafe(snapshot, event);
+          const persisted =
+            options.replace === true
+              ? preserveLiveOwnership(snapshot, event)
+              : event;
+          persistedEvents.push(persisted);
+        }
+        if (options.replace === true) {
+          const deleteEvent = db.prepare(
+            "DELETE FROM flight_events WHERE id = ?",
+          );
+          for (const event of persistedEvents) {
+            deleteEvent.run(event.event.id);
+          }
+        }
+        const statement = db.prepare(insertSql(false));
+        let imported = 0;
+        for (const event of persistedEvents) {
+          imported += statement.run(...eventParameters(event)).changes;
+        }
+        return imported;
+      })(),
+    );
+    if (options.replace === true && imported > 0) {
+      await purgeDeletedPages(db, false);
+    }
+    return imported;
+  }
+
+  async clear(): Promise<void> {
+    const db = this.ensureDb();
+    await retrySqliteBusy(() =>
+      db.transaction(() => {
+        const rows = db
+          .prepare(`
+            SELECT rowid AS row_id, *
+            FROM flight_events
+            ORDER BY trace_id, sequence, rowid
+          `)
+          .all() as PruneEventRow[];
+        if (
+          buildRetentionTraces(rows).some(
+            (trace) => trace.lifecycle === "active",
+          )
+        ) {
+          throw new Error(
+            "Flight ledger cannot clear while active traces exist.",
+          );
+        }
+        db.prepare("DELETE FROM flight_events").run();
+      })(),
+    );
+    await purgeDeletedPages(db, true);
+  }
+
+  async releaseEventOwnership(eventId: string): Promise<void> {
+    const db = this.ensureDb();
+    db.pragma(`busy_timeout = ${RUNTIME_BUSY_TIMEOUT_MS}`);
+    try {
+      db.transaction(() => {
+        const row = db
+          .prepare(`
+            SELECT rowid AS row_id, *
+            FROM flight_events
+            WHERE id = ?
+          `)
+          .get(eventId) as PruneEventRow | undefined;
+        if (!row) return;
+        const event = rowToEvent(row);
+        if (
+          !Object.hasOwn(event.metadata, "ownerPid") &&
+          !Object.hasOwn(event.metadata, "ownerId") &&
+          !Object.hasOwn(event.metadata, "ownerIncarnation")
+        ) {
+          return;
+        }
+        const metadata = { ...event.metadata };
+        delete metadata.ownerPid;
+        delete metadata.ownerId;
+        delete metadata.ownerIncarnation;
+        const body = { ...event, metadata } as Omit<
+          FlightEvent,
+          "contentHash"
+        > &
+          Partial<FlightEvent>;
+        delete body.contentHash;
+        const released = {
+          ...body,
+          contentHash: computeFlightEventHash(body),
+        };
+        db.prepare("UPDATE flight_events SET event_json = ? WHERE id = ?")
+          .run(JSON.stringify(released), eventId);
+      })();
+    } finally {
+      db.pragma(`busy_timeout = ${BUSY_TIMEOUT_MS}`);
+    }
+  }
+
+  private ensureDb(): Database {
+    if (this.state === "closed") {
+      throw new Error("Flight ledger is closed.");
+    }
+    if (this.state !== "initialized" || !this.db) {
+      throw new Error(
+        "Flight ledger is not initialized. Call initialize() first.",
+      );
+    }
+    return this.db;
+  }
+
+  private isClosed(): boolean {
+    return this.state === "closed";
+  }
+}
+
+function pruneOnce(db: Database, keep: number): number {
+  return db.transaction(() => {
+    const { count: before } = db
+      .prepare("SELECT COUNT(*) AS count FROM flight_events")
+      .get() as { count: number };
+    if (before <= keep) return 0;
+
+    const rows = db
+      .prepare(`
+        SELECT rowid AS row_id, *
+        FROM flight_events
+        ORDER BY trace_id, sequence, rowid
+      `)
+      .all() as PruneEventRow[];
+    const traces = buildRetentionTraces(rows);
+    const active = traces.filter((trace) => trace.lifecycle === "active");
+    const candidates = traces
+      .filter((trace) => trace.lifecycle !== "active")
+      .sort(compareRetentionTraces);
+    const retainedTraceIds = new Set(active.map((trace) => trace.traceId));
+    let retainedRows = active.reduce(
+      (total, trace) => total + trace.rowCount,
+      0,
+    );
+    const newestCompleted =
+      keep > 0
+        ? candidates.find((trace) => trace.lifecycle === "completed")
+        : undefined;
+    if (newestCompleted) {
+      retainedTraceIds.add(newestCompleted.traceId);
+      retainedRows += newestCompleted.rowCount;
+    }
+    for (const trace of candidates) {
+      if (retainedTraceIds.has(trace.traceId)) continue;
+      if (retainedRows + trace.rowCount > keep) break;
+      retainedTraceIds.add(trace.traceId);
+      retainedRows += trace.rowCount;
+    }
+    if (
+      keep > 0 &&
+      active.length === 0 &&
+      retainedTraceIds.size === 0 &&
+      candidates[0]
+    ) {
+      retainedTraceIds.add(candidates[0].traceId);
+    }
+
+    const deleteTrace = db.prepare(
+      "DELETE FROM flight_events WHERE trace_id = ?",
+    );
+    let deleted = 0;
+    for (const trace of traces) {
+      if (!retainedTraceIds.has(trace.traceId)) {
+        deleted += deleteTrace.run(trace.traceId).changes;
+      }
+    }
+    return deleted;
+  })();
+}
+
+async function purgeDeletedPages(
+  db: Database,
+  vacuum: boolean,
+): Promise<void> {
+  await retrySqliteBusy(() => {
+    assertCheckpointComplete(db.pragma("wal_checkpoint(TRUNCATE)"));
+    if (vacuum) {
+      db.exec("VACUUM");
+      assertCheckpointComplete(db.pragma("wal_checkpoint(TRUNCATE)"));
+    }
+  });
+}
+
+function purgeDeletedPagesOnce(db: Database, vacuum: boolean): void {
+  assertCheckpointComplete(db.pragma("wal_checkpoint(TRUNCATE)"));
+  if (vacuum) {
+    db.exec("VACUUM");
+    assertCheckpointComplete(db.pragma("wal_checkpoint(TRUNCATE)"));
+  }
+}
+
+function assertCheckpointComplete(result: unknown): void {
+  const first = Array.isArray(result) ? result[0] : result;
+  const busy =
+    typeof first === "object" && first !== null
+      ? Number(
+          (first as Record<string, unknown>).busy ??
+            Object.values(first as Record<string, unknown>)[0],
+        )
+      : Number.NaN;
+  if (busy !== 0) {
+    const error = new Error("SQLITE_BUSY: WAL checkpoint did not complete");
+    (error as Error & { code: string }).code = "SQLITE_BUSY";
+    throw error;
+  }
+}
+
+function selectEvents(
+  db: Database,
+  query: FlightEventQuery,
+  publicQuery: boolean,
+): FlightEvent[] {
+  assertOnlyKeys(
+    query as Record<string, unknown>,
+    QUERY_KEYS,
+    "flight event query",
+  );
+  for (const [label, value] of [
+    ["traceId", query.traceId],
+    ["sessionId", query.sessionId],
+    ["workspaceId", query.workspaceId],
+    ["source", query.source],
+    ["providerId", query.providerId],
+    ["agentName", query.agentName],
+    ["toolName", query.toolName],
+    ["status", query.status],
+  ] as const) {
+    if (value !== undefined) assertString(value, label);
+  }
+
+  let kindFilter: Set<string> | undefined;
+  if (query.kind !== undefined) {
+    const kinds = Array.isArray(query.kind) ? query.kind : [query.kind];
+    if (kinds.length > MAX_KIND_FILTERS) {
+      throw new Error(
+        `kind filter may contain at most ${MAX_KIND_FILTERS} values.`,
+      );
+    }
+    for (const kind of kinds) assertString(kind, "kind");
+    kindFilter = new Set(kinds);
+  }
+
+  const sinceMs =
+    query.since === undefined
+      ? undefined
+      : isoTimestampToMs(query.since, "since");
+  const untilMs =
+    query.until === undefined
+      ? undefined
+      : isoTimestampToMs(query.until, "until");
+
+  let limit: number | undefined;
+  let offset: number;
+  if (publicQuery) {
+    limit = boundedInteger(
+      query.limit,
+      "limit",
+      MAX_QUERY_LIMIT,
+      MAX_QUERY_LIMIT,
+    );
+    offset = boundedInteger(query.offset, "offset", MAX_QUERY_OFFSET, 0);
+  } else {
+    if (query.limit !== undefined) {
+      assertNonNegativeInteger(query.limit, "limit");
+      limit = query.limit;
+    }
+    if (query.offset !== undefined) {
+      assertNonNegativeInteger(query.offset, "offset");
+    }
+    offset = query.offset ?? 0;
+  }
+
+  const order = query.order ?? "asc";
+  if (order !== "asc" && order !== "desc") {
+    throw new Error('order must be "asc" or "desc".');
+  }
+
+  const validated = (
+    db
+      .prepare("SELECT rowid AS row_id, * FROM flight_events")
+      .all() as PruneEventRow[]
+  ).map((row) => ({ row, event: rowToEvent(row) }));
+
+  const filtered = validated.filter(({ row, event }) => {
+    if (query.traceId !== undefined && event.traceId !== query.traceId)
+      return false;
+    if (query.sessionId !== undefined && event.sessionId !== query.sessionId)
+      return false;
+    if (
+      query.workspaceId !== undefined &&
+      event.workspaceId !== query.workspaceId
+    )
+      return false;
+    if (query.source !== undefined && event.source !== query.source)
+      return false;
+    if (
+      query.providerId !== undefined &&
+      event.providerId !== query.providerId
+    )
+      return false;
+    if (query.agentName !== undefined && event.agentName !== query.agentName)
+      return false;
+    if (query.toolName !== undefined && event.toolName !== query.toolName)
+      return false;
+    if (query.status !== undefined && event.status !== query.status)
+      return false;
+    if (kindFilter !== undefined && !kindFilter.has(event.kind)) return false;
+    if (sinceMs !== undefined && row.timestamp_ms < sinceMs) return false;
+    if (untilMs !== undefined && row.timestamp_ms > untilMs) return false;
+    return true;
+  });
+
+  const multiplier = order === "asc" ? 1 : -1;
+  filtered.sort((left, right) => {
+    const fields =
+      query.traceId === undefined
+        ? [
+            left.row.timestamp_ms - right.row.timestamp_ms,
+            left.row.row_id - right.row.row_id,
+          ]
+        : [
+            left.event.sequence - right.event.sequence,
+            left.row.timestamp_ms - right.row.timestamp_ms,
+            left.row.row_id - right.row.row_id,
+          ];
+    return (fields.find((value) => value !== 0) ?? 0) * multiplier;
+  });
+
+  if (limit === 0) return [];
+  return filtered
+    .slice(offset, limit === undefined ? undefined : offset + limit)
+    .map(({ event }) => event);
+}
+
+function hardenDatabaseFiles(databasePath: string): void {
+  for (const candidate of [
+    databasePath,
+    `${databasePath}-wal`,
+    `${databasePath}-shm`,
+  ]) {
+    if (existsSync(candidate)) {
+      hardenPrivatePath(candidate);
+    }
+  }
+}
+
+interface PrivateFileIdentity {
+  path: string;
+  dev: number;
+  ino: number;
+}
+
+function preparePrivateDatabaseFiles(
+  databasePath: string,
+): PrivateFileIdentity[] {
+  const identities: PrivateFileIdentity[] = [];
+  for (const candidate of [
+    databasePath,
+    `${databasePath}-wal`,
+    `${databasePath}-shm`,
+  ]) {
+    try {
+      const existing = lstatSync(candidate);
+      if (existing.isSymbolicLink() || !existing.isFile()) {
+        throw new Error(
+          `Flight Recorder storage must be a regular file: ${candidate}`,
+        );
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+    const descriptor = openSync(
+      candidate,
+      constants.O_CREAT |
+        constants.O_RDWR |
+        (constants.O_NOFOLLOW ?? 0),
+      0o600,
+    );
+    try {
+      const opened = fstatSync(descriptor);
+      const linked = lstatSync(candidate);
+      if (
+        !opened.isFile() ||
+        linked.isSymbolicLink() ||
+        !linked.isFile() ||
+        opened.dev !== linked.dev ||
+        opened.ino !== linked.ino
+      ) {
+        throw new Error(
+          `Flight Recorder storage changed during private open: ${candidate}`,
+        );
+      }
+      hardenPrivatePath(candidate);
+      identities.push({
+        path: candidate,
+        dev: opened.dev,
+        ino: opened.ino,
+      });
+    } finally {
+      closeSync(descriptor);
+    }
+  }
+  return identities;
+}
+
+function verifyPrivateDatabaseFiles(
+  identities: PrivateFileIdentity[],
+): void {
+  for (const identity of identities) {
+    const current = lstatSync(identity.path);
+    if (
+      current.isSymbolicLink() ||
+      !current.isFile() ||
+      current.dev !== identity.dev ||
+      current.ino !== identity.ino
+    ) {
+      throw new Error(
+        `Flight Recorder storage identity changed: ${identity.path}`,
+      );
+    }
+  }
+}
+
+function materializeAndHardenDatabaseFiles(
+  db: Database,
+  databasePath: string,
+): void {
+  const probeId = `__openrappter_sidecar_probe__:${randomUUID()}`;
+  db.transaction(() => {
+    db.prepare(`
+      INSERT INTO flight_events (
+        id, sequence, trace_id, timestamp, timestamp_ms, kind, source,
+        status, session_id, workspace_id, provider_id, agent_name,
+        tool_name, event_json
+      ) VALUES (?, 0, ?, '1970-01-01T00:00:00.000Z', 0, 'sidecar.probe',
+                'flight-recorder', 'info', NULL, NULL, NULL, NULL, NULL, '{}')
+    `).run(probeId, probeId);
+    db.prepare("DELETE FROM flight_events WHERE id = ?").run(probeId);
+  })();
+
+  const candidates = [
+    databasePath,
+    `${databasePath}-wal`,
+    `${databasePath}-shm`,
+  ];
+  const missing = candidates.filter((candidate) => !existsSync(candidate));
+  if (missing.length > 0) {
+    throw new Error(
+      `Flight Recorder private SQLite files were not materialized: ${missing.join(", ")}`,
+    );
+  }
+  hardenDatabaseFiles(databasePath);
+}
+
+function migrateTimestampColumn(db: Database): void {
+  const columns = db
+    .prepare("PRAGMA table_info(flight_events)")
+    .all() as Array<{
+    name: string;
+  }>;
+  if (columns.some((column) => column.name === "timestamp_ms")) {
+    return;
+  }
+
+  try {
+    db.transaction(() => {
+      db.exec(
+        "ALTER TABLE flight_events ADD COLUMN timestamp_ms INTEGER NOT NULL DEFAULT 0",
+      );
+      const rows = db
+        .prepare("SELECT rowid AS row_id, * FROM flight_events")
+        .all() as MigrationEventRow[];
+      const update = db.prepare(
+        "UPDATE flight_events SET timestamp_ms = ? WHERE rowid = ?",
+      );
+      for (const row of rows) {
+        const event = rowToEvent(row, false);
+        update.run(
+          isoTimestampToMs(event.timestamp, `event "${event.id}"`),
+          row.row_id,
+        );
+      }
+    })();
+  } catch (error) {
+    if (isSqliteBusy(error)) {
+      throw error;
+    }
+    throw new Error(
+      `Flight ledger timestamp_ms migration failed: ${errorMessage(error)}`,
+    );
+  }
+}
+
+function buildRetentionTraces(rows: PruneEventRow[]): RetentionTrace[] {
+  const traces = new Map<string, RetentionTrace>();
+
+  for (const row of rows) {
+    const event = rowToEvent(row);
+    const timestamp = row.timestamp_ms;
+    let trace = traces.get(event.traceId);
+    if (!trace) {
+      trace = {
+        traceId: event.traceId,
+        rowCount: 0,
+        lifecycle: "atomic",
+        lifecycleDepth: 0,
+        sawLifecycleStart: false,
+        malformedLifecycle: false,
+        lifecycleStarts: new Map(),
+        latestTimestamp: timestamp,
+        latestRowId: row.row_id,
+      };
+      traces.set(event.traceId, trace);
+    }
+
+    trace.rowCount += 1;
+    if (event.kind === "trace.started") {
+      trace.sawLifecycleStart = true;
+      if (event.id) {
+        const ownerPid = Number(event.metadata.ownerPid);
+        trace.lifecycleStarts.set(event.id, {
+          pid:
+            Number.isSafeInteger(ownerPid) && ownerPid > 0
+              ? ownerPid
+              : null,
+          incarnation:
+            typeof event.metadata.ownerIncarnation === "string"
+              ? event.metadata.ownerIncarnation
+              : undefined,
+        });
+        trace.lifecycleDepth = trace.lifecycleStarts.size;
+      } else {
+        trace.malformedLifecycle = true;
+      }
+    } else if (
+      event.kind === "trace.completed" ||
+      event.kind === "trace.failed"
+    ) {
+      if (
+        event.parentId &&
+        trace.lifecycleStarts.delete(event.parentId)
+      ) {
+        trace.lifecycleDepth = trace.lifecycleStarts.size;
+      } else {
+        trace.malformedLifecycle = true;
+      }
+    }
+    if (
+      timestamp > trace.latestTimestamp ||
+      (timestamp === trace.latestTimestamp && row.row_id > trace.latestRowId)
+    ) {
+      trace.latestTimestamp = timestamp;
+      trace.latestRowId = row.row_id;
+    }
+  }
+
+  for (const trace of traces.values()) {
+    trace.lifecycle =
+      trace.lifecycleDepth > 0 &&
+      [...trace.lifecycleStarts.values()].some(
+        (owner) =>
+          owner.pid !== null &&
+          processMatchesIncarnation(owner.pid, owner.incarnation),
+      )
+        ? "active"
+        : !trace.sawLifecycleStart && !trace.malformedLifecycle
+          ? "atomic"
+          : trace.sawLifecycleStart && !trace.malformedLifecycle
+            ? "completed"
+            : "malformed";
+  }
+
+  return [...traces.values()];
+}
+
+function compareRetentionTraces(
+  left: RetentionTrace,
+  right: RetentionTrace,
+): number {
+  return (
+    right.latestTimestamp - left.latestTimestamp ||
+    right.latestRowId - left.latestRowId
+  );
+}
+
+function insertSql(replace: boolean): string {
+  const values = `
+    id, sequence, trace_id, timestamp, timestamp_ms, kind, source, status,
+    session_id, workspace_id, provider_id, agent_name, tool_name, event_json
+  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`;
+
+  if (!replace) {
+    return `INSERT INTO flight_events (${values}
+      ON CONFLICT(id) DO NOTHING`;
+  }
+
+  return `INSERT INTO flight_events (${values}
+    ON CONFLICT(id) DO UPDATE SET
+      sequence = excluded.sequence,
+      trace_id = excluded.trace_id,
+      timestamp = excluded.timestamp,
+      timestamp_ms = excluded.timestamp_ms,
+      kind = excluded.kind,
+      source = excluded.source,
+      status = excluded.status,
+      session_id = excluded.session_id,
+      workspace_id = excluded.workspace_id,
+      provider_id = excluded.provider_id,
+      agent_name = excluded.agent_name,
+      tool_name = excluded.tool_name,
+      event_json = excluded.event_json`;
+}
+
+function eventParameters(serialized: SerializedEvent): unknown[] {
+  const { event, json } = serialized;
+  return [
+    event.id,
+    event.sequence,
+    event.traceId,
+    event.timestamp,
+    isoTimestampToMs(event.timestamp, `event "${event.id}"`),
+    event.kind,
+    event.source,
+    event.status,
+    event.sessionId ?? null,
+    event.workspaceId ?? null,
+    event.providerId ?? null,
+    event.agentName ?? null,
+    event.toolName ?? null,
+    json,
+  ];
+}
+
+interface ImportSnapshot {
+  existingById: Map<string, FlightEvent>;
+  liveTraceIds: Set<string>;
+  liveStartIds: Set<string>;
+}
+
+function buildImportSnapshot(rows: FlightEventRow[]): ImportSnapshot {
+  const existingById = new Map<string, FlightEvent>();
+  const byTrace = new Map<string, FlightEvent[]>();
+  for (const row of rows) {
+    const event = rowToEvent(row);
+    existingById.set(event.id, event);
+    const trace = byTrace.get(event.traceId) ?? [];
+    trace.push(event);
+    byTrace.set(event.traceId, trace);
+  }
+
+  const liveTraceIds = new Set<string>();
+  const liveStartIds = new Set<string>();
+  for (const [traceId, events] of byTrace) {
+    events.sort((left, right) => left.sequence - right.sequence);
+    const unmatched = new Map<
+      string,
+      { ownerPid?: number; ownerIncarnation?: string }
+    >();
+    for (const event of events) {
+      if (event.kind === "trace.started") {
+        unmatched.set(event.id, {
+          ownerPid:
+            typeof event.metadata.ownerPid === "number"
+              ? event.metadata.ownerPid
+              : undefined,
+          ownerIncarnation:
+            typeof event.metadata.ownerIncarnation === "string"
+              ? event.metadata.ownerIncarnation
+              : undefined,
+        });
+      } else if (
+        (event.kind === "trace.completed" ||
+          event.kind === "trace.failed") &&
+        event.parentId
+      ) {
+        unmatched.delete(event.parentId);
+      }
+    }
+    for (const [startId, owner] of unmatched) {
+      if (
+        owner.ownerPid !== undefined &&
+        processMatchesIncarnation(
+          owner.ownerPid,
+          owner.ownerIncarnation,
+        )
+      ) {
+        liveTraceIds.add(traceId);
+        liveStartIds.add(startId);
+      }
+    }
+  }
+  return { existingById, liveTraceIds, liveStartIds };
+}
+
+function preserveLiveOwnership(
+  snapshot: ImportSnapshot,
+  incoming: SerializedEvent,
+): SerializedEvent {
+  const existing = snapshot.existingById.get(incoming.event.id);
+  if (!existing) return incoming;
+
+  const ownerPid = Number(existing.metadata?.ownerPid);
+  const ownerIncarnation =
+    typeof existing.metadata?.ownerIncarnation === "string"
+      ? existing.metadata.ownerIncarnation
+      : undefined;
+  if (
+    existing.kind !== "trace.started" ||
+    !Number.isSafeInteger(ownerPid) ||
+    ownerPid <= 0 ||
+    !processMatchesIncarnation(ownerPid, ownerIncarnation) ||
+    !snapshot.liveStartIds.has(existing.id)
+  ) {
+    return incoming;
+  }
+  if (
+    incoming.event.kind !== "trace.started" ||
+    incoming.event.traceId !== existing.traceId ||
+    incoming.event.sequence !== existing.sequence ||
+    exportableEvent(existing).contentHash !== incoming.event.contentHash
+  ) {
+    throw new Error(
+      `Cannot replace live trace start "${existing.id}" with different portable content.`,
+    );
+  }
+
+  const metadata = {
+    ...incoming.event.metadata,
+    ownerPid,
+    ...(ownerIncarnation === undefined
+      ? {}
+      : { ownerIncarnation }),
+    ...(existing.metadata.ownerId === undefined
+      ? {}
+      : { ownerId: existing.metadata.ownerId }),
+  };
+  const body = {
+    ...incoming.event,
+    metadata,
+  } as Omit<FlightEvent, "contentHash"> & Partial<FlightEvent>;
+  delete body.contentHash;
+  return serializeEvent(
+    {
+      ...body,
+      contentHash: computeFlightEventHash(body),
+    },
+    `replacement event "${incoming.event.id}"`,
+  );
+}
+
+function assertLiveTraceImportSafe(
+  snapshot: ImportSnapshot,
+  incoming: SerializedEvent,
+): void {
+  const existing = snapshot.existingById.get(incoming.event.id);
+  if (existing) {
+    if (
+      existing.traceId !== incoming.event.traceId &&
+      snapshot.liveTraceIds.has(existing.traceId)
+    ) {
+      throw new Error(
+        `Cannot move event "${incoming.event.id}" out of live trace "${existing.traceId}".`,
+      );
+    }
+  }
+  if (!snapshot.liveTraceIds.has(incoming.event.traceId)) {
+    return;
+  }
+  if (existing) {
+    const portableExisting = exportableEvent(existing);
+    if (portableExisting.contentHash === incoming.event.contentHash) return;
+  }
+  throw new Error(
+    `Cannot import event "${incoming.event.id}" into live trace "${incoming.event.traceId}".`,
+  );
+}
+
+function rowToEvent(
+  row: FlightEventRow,
+  verifyTimestampMs = true,
+): FlightEvent {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(row.event_json);
+  } catch (error) {
+    throw new Error(
+      `Corrupt flight event row "${row.id}": event_json is not valid JSON: ${errorMessage(error)}`,
+    );
+  }
+
+  let event: FlightEvent;
+  try {
+    event = validateEvent(parsed, `flight event row "${row.id}"`);
+  } catch (error) {
+    throw new Error(
+      `Corrupt flight event row "${row.id}": ${errorMessage(error)}`,
+    );
+  }
+  const mismatches: string[] = [];
+  compareIndexed(mismatches, "id", row.id, event.id);
+  compareIndexed(mismatches, "sequence", row.sequence, event.sequence);
+  compareIndexed(mismatches, "traceId", row.trace_id, event.traceId);
+  compareIndexed(mismatches, "timestamp", row.timestamp, event.timestamp);
+  if (verifyTimestampMs) {
+    compareIndexed(
+      mismatches,
+      "timestampMs",
+      row.timestamp_ms,
+      isoTimestampToMs(event.timestamp, `event "${event.id}"`),
+    );
+  }
+  compareIndexed(mismatches, "kind", row.kind, event.kind);
+  compareIndexed(mismatches, "source", row.source, event.source);
+  compareIndexed(mismatches, "status", row.status, event.status);
+  compareIndexed(
+    mismatches,
+    "sessionId",
+    row.session_id,
+    event.sessionId ?? null,
+  );
+  compareIndexed(
+    mismatches,
+    "workspaceId",
+    row.workspace_id,
+    event.workspaceId ?? null,
+  );
+  compareIndexed(
+    mismatches,
+    "providerId",
+    row.provider_id,
+    event.providerId ?? null,
+  );
+  compareIndexed(
+    mismatches,
+    "agentName",
+    row.agent_name,
+    event.agentName ?? null,
+  );
+  compareIndexed(mismatches, "toolName", row.tool_name, event.toolName ?? null);
+
+  if (mismatches.length > 0) {
+    throw new Error(
+      `Corrupt flight event row "${row.id}": ${mismatches.join(", ")}.`,
+    );
+  }
+  return event;
+}
+
+function compareIndexed(
+  mismatches: string[],
+  field: string,
+  indexedValue: unknown,
+  eventValue: unknown,
+): void {
+  if (indexedValue !== eventValue) {
+    mismatches.push(`${field} does not match event_json`);
+  }
+}
+
+function validateExport(data: unknown): SerializedEvent[] {
+  if (!isPlainObject(data)) {
+    throw new Error("Flight export must be an object.");
+  }
+  assertOnlyKeys(
+    data,
+    new Set(["schema", "exportedAt", "events"]),
+    "flight export",
+  );
+  if (data.schema !== EXPORT_SCHEMA) {
+    throw new Error(`Flight export schema must be "${EXPORT_SCHEMA}".`);
+  }
+  assertString(data.exportedAt, "flight export exportedAt");
+  assertIsoTimestamp(data.exportedAt, "flight export exportedAt");
+  if (!Array.isArray(data.events)) {
+    throw new Error("Flight export events must be an array.");
+  }
+  const ids = new Set<string>();
+  return data.events.map((event, index) => {
+    if (
+      isPlainObject(event) &&
+      isPlainObject(event.metadata) &&
+      (Object.hasOwn(event.metadata, "ownerPid") ||
+        Object.hasOwn(event.metadata, "ownerId") ||
+        Object.hasOwn(event.metadata, "ownerIncarnation"))
+    ) {
+      throw new Error(
+        `flight export events[${index}] must not claim live trace ownership.`,
+      );
+    }
+    const serialized = serializeEvent(
+      event,
+      `flight export events[${index}]`,
+    );
+    if (ids.has(serialized.event.id)) {
+      throw new Error(
+        `flight export contains duplicate event ID "${serialized.event.id}".`,
+      );
+    }
+    ids.add(serialized.event.id);
+    return serialized;
+  });
+}
+
+function exportableEvent(event: FlightEvent): FlightEvent {
+  if (
+    !Object.hasOwn(event.metadata, "ownerPid") &&
+    !Object.hasOwn(event.metadata, "ownerId") &&
+    !Object.hasOwn(event.metadata, "ownerIncarnation")
+  ) {
+    return event;
+  }
+  const metadata = { ...event.metadata };
+  delete metadata.ownerPid;
+  delete metadata.ownerId;
+  delete metadata.ownerIncarnation;
+  const body = { ...event, metadata } as Omit<FlightEvent, "contentHash"> &
+    Partial<Pick<FlightEvent, "contentHash">>;
+  delete body.contentHash;
+  return {
+    ...body,
+    contentHash: computeFlightEventHash(body),
+  } as FlightEvent;
+}
+
+function serializeEvent(value: unknown, label: string): SerializedEvent {
+  const event = validateEvent(value, label);
+  let json: string;
+  try {
+    json = JSON.stringify(event);
+  } catch (error) {
+    throw new Error(
+      `${label} is not JSON-serializable: ${errorMessage(error)}`,
+    );
+  }
+  if (json === undefined) {
+    throw new Error(`${label} is not JSON-serializable.`);
+  }
+  return { event, json };
+}
+
+function validateEvent(value: unknown, label: string): FlightEvent {
+  if (!isPlainObject(value)) {
+    throw new Error(`${label} must be an object.`);
+  }
+  assertOnlyKeys(value, EVENT_KEYS, label);
+
+  if (value.schema !== FLIGHT_EVENT_SCHEMA) {
+    throw new Error(`${label}.schema must be "${FLIGHT_EVENT_SCHEMA}".`);
+  }
+  assertString(value.id, `${label}.id`);
+  assertNonNegativeInteger(value.sequence, `${label}.sequence`);
+  assertString(value.kind, `${label}.kind`);
+  assertString(value.source, `${label}.source`);
+  if (!EVENT_STATUSES.has(value.status as FlightEventStatus)) {
+    throw new Error(`${label}.status is invalid.`);
+  }
+  assertString(value.traceId, `${label}.traceId`);
+  if (value.parentId !== null) {
+    assertString(value.parentId, `${label}.parentId`);
+  }
+  assertString(value.timestamp, `${label}.timestamp`);
+  assertIsoTimestamp(value.timestamp, `${label}.timestamp`);
+  assertString(value.contentHash, `${label}.contentHash`);
+  if (!/^[0-9a-f]{64}$/.test(value.contentHash)) {
+    throw new Error(
+      `${label}.contentHash must be 64 lowercase hexadecimal characters.`,
+    );
+  }
+  if (!isPlainObject(value.metadata)) {
+    throw new Error(`${label}.metadata must be an object.`);
+  }
+
+  for (const key of [
+    "sessionId",
+    "workspaceId",
+    "providerId",
+    "model",
+    "agentName",
+    "toolName",
+  ] as const) {
+    if (value[key] !== undefined) {
+      assertString(value[key], `${label}.${key}`);
+    }
+    if (
+      value.model !== undefined &&
+      normalizeFlightModelId(value.model as string) !== value.model
+    ) {
+      throw new Error(`${label}.model must be a concrete normalized model ID.`);
+    }
+    for (const key of [
+      "id",
+      "kind",
+      "source",
+      "traceId",
+      "parentId",
+      "providerId",
+      "workspaceId",
+      "model",
+      "agentName",
+      "toolName",
+    ] as const) {
+      const field = value[key];
+      if (
+        typeof field === "string" &&
+        sanitizeFlightValue(field) !== field
+      ) {
+        throw new Error(`${label}.${key} violates Flight Recorder privacy.`);
+      }
+    }
+  }
+  if (value.durationMs !== undefined) {
+    if (
+      typeof value.durationMs !== "number" ||
+      !Number.isFinite(value.durationMs) ||
+      value.durationMs < 0 ||
+      (Number.isInteger(value.durationMs) &&
+        !Number.isSafeInteger(value.durationMs))
+    ) {
+      throw new Error(
+        `${label}.durationMs must be a finite non-negative JSON-safe number.`,
+      );
+    }
+  }
+
+  assertJsonValue(value.metadata, `${label}.metadata`);
+  if (
+    value.sessionId !== undefined &&
+    !/^session:[0-9a-f]{24}$/.test(value.sessionId as string)
+  ) {
+    throw new Error(`${label}.sessionId must be an opaque session identifier.`);
+  }
+  if (
+    value.workspaceId !== undefined &&
+    normalizeFlightWorkspaceId(value.workspaceId as string) !==
+      value.workspaceId
+  ) {
+    throw new Error(`${label}.workspaceId must not contain a raw path.`);
+  }
+  if (
+    !isDeepStrictEqual(
+      sanitizeFlightMetadata(value.metadata),
+      value.metadata,
+    )
+  ) {
+    throw new Error(`${label}.metadata violates Flight Recorder privacy.`);
+  }
+  if (Object.hasOwn(value, "payload")) {
+    assertJsonValue(value.payload, `${label}.payload`);
+    if (
+      !isDeepStrictEqual(
+        sanitizeFlightPayload(value.payload, {
+          recordIO: true,
+          maxPayloadBytes: Number.MAX_SAFE_INTEGER,
+        }),
+        value.payload,
+      )
+    ) {
+      throw new Error(`${label}.payload violates Flight Recorder privacy.`);
+    }
+  }
+  const event = value as unknown as FlightEvent;
+  if (!verifyFlightEventHash(event)) {
+    throw new Error(`Flight event integrity check failed for ${label}.`);
+  }
+  return event;
+}
+
+function assertJsonValue(
+  value: unknown,
+  label: string,
+  seen: Set<object> = new Set(),
+): void {
+  if (typeof value === "string") {
+    assertUnicodeScalarString(value, label);
+    return;
+  }
+  if (
+    value === null ||
+    typeof value === "boolean" ||
+    (typeof value === "number" &&
+      Number.isFinite(value) &&
+      (!Number.isInteger(value) || Number.isSafeInteger(value)))
+  ) {
+    return;
+  }
+  if (typeof value !== "object") {
+    throw new Error(`${label} must contain only JSON-compatible values.`);
+  }
+  if (seen.has(value)) {
+    throw new Error(`${label} must not contain circular references.`);
+  }
+  seen.add(value);
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      assertJsonValue(item, `${label}[${index}]`, seen),
+    );
+  } else {
+    if (!isPlainObject(value)) {
+      throw new Error(`${label} must contain only plain JSON objects.`);
+    }
+    for (const [key, item] of Object.entries(value)) {
+      assertUnicodeScalarString(key, `${label} key`);
+      assertJsonValue(item, `${label}.${key}`, seen);
+    }
+  }
+  seen.delete(value);
+}
+
+function assertUnicodeScalarString(value: string, label: string): void {
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (
+        !Number.isInteger(next) ||
+        next < 0xdc00 ||
+        next > 0xdfff
+      ) {
+        throw new Error(`${label} must contain valid Unicode scalar values.`);
+      }
+      index += 1;
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      throw new Error(`${label} must contain valid Unicode scalar values.`);
+    }
+  }
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object" || Array.isArray(value)) {
+    return false;
+  }
+  const prototype = Object.getPrototypeOf(value);
+  return prototype === Object.prototype || prototype === null;
+}
+
+function assertOnlyKeys(
+  value: Record<string, unknown>,
+  allowed: Set<string>,
+  label: string,
+): void {
+  const unexpected = Object.keys(value).filter((key) => !allowed.has(key));
+  if (unexpected.length > 0) {
+    throw new Error(`${label} contains unexpected field "${unexpected[0]}".`);
+  }
+}
+
+function assertString(value: unknown, label: string): asserts value is string {
+  if (typeof value !== "string") {
+    throw new Error(`${label} must be a string.`);
+  }
+  assertUnicodeScalarString(value, label);
+}
+
+function assertIsoTimestamp(value: string, label: string): void {
+  isoTimestampToMs(value, label);
+}
+
+function isoTimestampToMs(value: string, label: string): number {
+  const isoTimestamp =
+    /^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2}):(\d{2})(?:\.(\d{1,3}))?(Z|([+-])(\d{2}):(\d{2}))$/;
+  const match = isoTimestamp.exec(value);
+  if (!match) {
+    throw new Error(`${label} must be a parseable ISO timestamp.`);
+  }
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+  const hour = Number(match[4]);
+  const minute = Number(match[5]);
+  const second = Number(match[6]);
+  const fraction = match[7] ?? "";
+  const offsetSign = match[9];
+  const offsetHour = match[10] === undefined ? 0 : Number(match[10]);
+  const offsetMinute = match[11] === undefined ? 0 : Number(match[11]);
+  const leapYear =
+    year % 4 === 0 && (year % 100 !== 0 || year % 400 === 0);
+  const daysInMonth = [
+    31,
+    leapYear ? 29 : 28,
+    31,
+    30,
+    31,
+    30,
+    31,
+    31,
+    30,
+    31,
+    30,
+    31,
+  ];
+  const validCalendar =
+    year >= 1 &&
+    month >= 1 &&
+    month <= 12 &&
+    day >= 1 &&
+    day <= daysInMonth[month - 1] &&
+    hour <= 23 &&
+    minute <= 59 &&
+    second <= 59 &&
+    offsetHour <= 14 &&
+    offsetMinute <= 59 &&
+    (offsetHour < 14 || offsetMinute === 0);
+  if (!validCalendar) {
+    throw new Error(`${label} must be a parseable ISO timestamp.`);
+  }
+
+  const fractionMs = Number(fraction.slice(0, 3).padEnd(3, "0") || "0");
+  const offset =
+    (offsetHour * 60 + offsetMinute) *
+    (offsetSign === "-" ? -1 : 1);
+  const timestampMs =
+    daysFromCivil(year, month, day) * 86_400_000 +
+    hour * 3_600_000 +
+    minute * 60_000 +
+    second * 1_000 +
+    fractionMs -
+    offset * 60_000;
+  if (!Number.isSafeInteger(timestampMs)) {
+    throw new Error(`${label} must be a parseable ISO timestamp.`);
+  }
+  return timestampMs;
+}
+
+function daysFromCivil(year: number, month: number, day: number): number {
+  const adjustedYear = year - (month <= 2 ? 1 : 0);
+  const era = Math.floor(adjustedYear / 400);
+  const yearOfEra = adjustedYear - era * 400;
+  const shiftedMonth = month + (month > 2 ? -3 : 9);
+  const dayOfYear =
+    Math.floor((153 * shiftedMonth + 2) / 5) + day - 1;
+  const dayOfEra =
+    yearOfEra * 365 +
+    Math.floor(yearOfEra / 4) -
+    Math.floor(yearOfEra / 100) +
+    dayOfYear;
+  return era * 146_097 + dayOfEra - 719_468;
+}
+
+function assertNonNegativeInteger(
+  value: unknown,
+  label: string,
+): asserts value is number {
+  if (typeof value !== "number" || !Number.isSafeInteger(value) || value < 0) {
+    throw new Error(`${label} must be a non-negative safe integer.`);
+  }
+}
+
+function boundedInteger(
+  value: number | undefined,
+  label: string,
+  maximum: number,
+  fallback: number,
+): number {
+  if (value === undefined) {
+    return fallback;
+  }
+  assertNonNegativeInteger(value, label);
+  return Math.min(value, maximum);
+}
+
+async function retrySqliteBusy<T>(operation: () => T): Promise<T> {
+  for (let attempt = 0; ; attempt += 1) {
+    try {
+      return operation();
+    } catch (error) {
+      if (!isSqliteBusy(error) || attempt >= MAX_BUSY_RETRIES) {
+        throw error;
+      }
+      await new Promise((resolve) => setTimeout(resolve, 10 * 2 ** attempt));
+    }
+  }
+}
+
+function isSqliteBusy(error: unknown): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const code = "code" in error ? String(error.code) : "";
+  return code === "SQLITE_BUSY" || code.startsWith("SQLITE_BUSY_");
+}
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}

--- a/typescript/src/flight-recorder/permissions.ts
+++ b/typescript/src/flight-recorder/permissions.ts
@@ -61,7 +61,8 @@ try {
     "powershell.exe",
     ["-NoProfile", "-NonInteractive", "-Command", command],
     {
-      stdio: "ignore",
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
       windowsHide: true,
       env: { ...process.env, HF_TARGET: target, HF_USER: user },
     },

--- a/typescript/src/flight-recorder/permissions.ts
+++ b/typescript/src/flight-recorder/permissions.ts
@@ -43,7 +43,8 @@ try {
   $actual = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
   $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
   $rules = @($actual.Access)
-  if (-not $actual.AreAccessRulesProtected -or $ownerSid.Value -ne $sid.Value -or $rules.Count -ne 1) {
+  $allowedOwners = @($sid.Value, 'S-1-5-18', 'S-1-5-32-544')
+  if (-not $actual.AreAccessRulesProtected -or $allowedOwners -notcontains $ownerSid.Value -or $rules.Count -ne 1) {
     throw 'Flight Recorder ACL verification failed.'
   }
   $ruleSid = $rules[0].IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])

--- a/typescript/src/flight-recorder/permissions.ts
+++ b/typescript/src/flight-recorder/permissions.ts
@@ -99,7 +99,7 @@ $ErrorActionPreference = 'Stop'
 try {
   $identity = New-Object System.Security.Principal.NTAccount($env:HF_USER)
   $sid = $identity.Translate([System.Security.Principal.SecurityIdentifier])
-  $allowed = @($sid.Value, 'S-1-5-18', 'S-1-5-32-544')
+  $allowed = @($sid.Value, 'S-1-3-4', 'S-1-5-18', 'S-1-5-32-544')
   $writeRights = (
     [System.Security.AccessControl.FileSystemRights]::Write -bor
     [System.Security.AccessControl.FileSystemRights]::Modify -bor

--- a/typescript/src/flight-recorder/permissions.ts
+++ b/typescript/src/flight-recorder/permissions.ts
@@ -25,6 +25,9 @@ export function hardenPrivatePath(
   const securityType = directory
     ? "System.Security.AccessControl.DirectorySecurity"
     : "System.Security.AccessControl.FileSecurity";
+  const ioType = directory
+    ? "System.IO.DirectoryInfo"
+    : "System.IO.FileInfo";
   const inheritance = directory
     ? "[System.Security.AccessControl.InheritanceFlags]'ContainerInherit,ObjectInherit'"
     : "[System.Security.AccessControl.InheritanceFlags]::None";
@@ -38,9 +41,10 @@ try {
   $acl.SetAccessRuleProtection($true, $false)
   $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($sid, 'FullControl', ${inheritance}, [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow)
   $acl.AddAccessRule($rule)
-  Set-Acl -LiteralPath $env:HF_TARGET -AclObject $acl -ErrorAction Stop
+  $item = New-Object ${ioType}($env:HF_TARGET)
+  $item.SetAccessControl($acl)
 
-  $actual = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
+  $actual = $item.GetAccessControl()
   $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
   $rules = @($actual.Access)
   $allowedOwners = @($sid.Value, 'S-1-5-18', 'S-1-5-32-544')
@@ -107,7 +111,8 @@ try {
     [System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
     [System.Security.AccessControl.FileSystemRights]::TakeOwnership
   )
-  $acl = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
+  $item = New-Object System.IO.DirectoryInfo($env:HF_TARGET)
+  $acl = $item.GetAccessControl()
   $ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
   if ($allowed -notcontains $ownerSid.Value) {
     throw "Flight Recorder storage parent has untrusted owner $($ownerSid.Value)."

--- a/typescript/src/flight-recorder/permissions.ts
+++ b/typescript/src/flight-recorder/permissions.ts
@@ -1,0 +1,172 @@
+import { execFileSync } from "node:child_process";
+import {
+  chmodSync,
+  closeSync,
+  fsyncSync,
+  lstatSync,
+  openSync,
+  statSync,
+} from "node:fs";
+import path from "node:path";
+
+export function hardenPrivatePath(
+  target: string,
+  directory = false,
+): void {
+  if (process.platform !== "win32") {
+    chmodSync(target, directory ? 0o700 : 0o600);
+    return;
+  }
+
+  const user = process.env.USERNAME;
+  if (!user) {
+    throw new Error("USERNAME is required to harden Flight Recorder ACLs.");
+  }
+  const securityType = directory
+    ? "System.Security.AccessControl.DirectorySecurity"
+    : "System.Security.AccessControl.FileSecurity";
+  const inheritance = directory
+    ? "[System.Security.AccessControl.InheritanceFlags]'ContainerInherit,ObjectInherit'"
+    : "[System.Security.AccessControl.InheritanceFlags]::None";
+  const command = `
+$ErrorActionPreference = 'Stop'
+try {
+  $identity = New-Object System.Security.Principal.NTAccount($env:HF_USER)
+  $sid = $identity.Translate([System.Security.Principal.SecurityIdentifier])
+  $acl = New-Object ${securityType}
+  $acl.SetOwner($sid)
+  $acl.SetAccessRuleProtection($true, $false)
+  $rule = New-Object System.Security.AccessControl.FileSystemAccessRule($sid, 'FullControl', ${inheritance}, [System.Security.AccessControl.PropagationFlags]::None, [System.Security.AccessControl.AccessControlType]::Allow)
+  $acl.AddAccessRule($rule)
+  Set-Acl -LiteralPath $env:HF_TARGET -AclObject $acl -ErrorAction Stop
+
+  $actual = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
+  $ownerSid = $actual.GetOwner([System.Security.Principal.SecurityIdentifier])
+  $rules = @($actual.Access)
+  if (-not $actual.AreAccessRulesProtected -or $ownerSid.Value -ne $sid.Value -or $rules.Count -ne 1) {
+    throw 'Flight Recorder ACL verification failed.'
+  }
+  $ruleSid = $rules[0].IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
+  $fullControl = [System.Security.AccessControl.FileSystemRights]::FullControl
+  if ($ruleSid.Value -ne $sid.Value -or $rules[0].IsInherited -or $rules[0].AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow -or (($rules[0].FileSystemRights -band $fullControl) -ne $fullControl)) {
+    throw 'Flight Recorder ACL rule verification failed.'
+  }
+} catch {
+  [Console]::Error.WriteLine($_.Exception.ToString())
+  exit 1
+}
+`;
+  execFileSync(
+    "powershell.exe",
+    ["-NoProfile", "-NonInteractive", "-Command", command],
+    {
+      stdio: "ignore",
+      windowsHide: true,
+      env: { ...process.env, HF_TARGET: target, HF_USER: user },
+    },
+  );
+}
+
+export function assertPrivateDirectory(target: string): void {
+  let current = path.resolve(target);
+  while (true) {
+    const linked = lstatSync(current);
+    if (
+      linked.isSymbolicLink() &&
+      (
+        process.platform === "win32" ||
+        typeof process.getuid !== "function" ||
+        linked.uid !== 0
+      )
+    ) {
+      throw new Error(
+        `Flight Recorder storage parent must not use a user-controlled symlink: ${current}`,
+      );
+    }
+    const parent = path.dirname(current);
+    if (parent === current) break;
+    current = parent;
+  }
+  if (process.platform === "win32") {
+    const command = `
+$ErrorActionPreference = 'Stop'
+try {
+  $identity = New-Object System.Security.Principal.NTAccount($env:HF_USER)
+  $sid = $identity.Translate([System.Security.Principal.SecurityIdentifier])
+  $allowed = @($sid.Value, 'S-1-5-18', 'S-1-5-32-544')
+  $writeRights = (
+    [System.Security.AccessControl.FileSystemRights]::Write -bor
+    [System.Security.AccessControl.FileSystemRights]::Modify -bor
+    [System.Security.AccessControl.FileSystemRights]::FullControl -bor
+    [System.Security.AccessControl.FileSystemRights]::CreateFiles -bor
+    [System.Security.AccessControl.FileSystemRights]::CreateDirectories -bor
+    [System.Security.AccessControl.FileSystemRights]::Delete -bor
+    [System.Security.AccessControl.FileSystemRights]::DeleteSubdirectoriesAndFiles -bor
+    [System.Security.AccessControl.FileSystemRights]::ChangePermissions -bor
+    [System.Security.AccessControl.FileSystemRights]::TakeOwnership
+  )
+  $acl = Get-Acl -LiteralPath $env:HF_TARGET -ErrorAction Stop
+  $ownerSid = $acl.GetOwner([System.Security.Principal.SecurityIdentifier])
+  if ($allowed -notcontains $ownerSid.Value) {
+    throw "Flight Recorder storage parent has untrusted owner $($ownerSid.Value)."
+  }
+  foreach ($rule in @($acl.Access)) {
+    if ($rule.AccessControlType -ne [System.Security.AccessControl.AccessControlType]::Allow) { continue }
+    $ruleSid = $rule.IdentityReference.Translate([System.Security.Principal.SecurityIdentifier])
+    if ($allowed -contains $ruleSid.Value) { continue }
+    if (($rule.FileSystemRights -band $writeRights) -ne 0) {
+      throw "Flight Recorder storage parent grants write access to $($ruleSid.Value)."
+    }
+  }
+} catch {
+  [Console]::Error.WriteLine($_.Exception.ToString())
+  exit 1
+}
+`;
+    const user = process.env.USERNAME;
+    if (!user) {
+      throw new Error(
+        "USERNAME is required to validate Flight Recorder ACLs.",
+      );
+    }
+    execFileSync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", command],
+      {
+        stdio: "ignore",
+        windowsHide: true,
+        env: { ...process.env, HF_TARGET: target, HF_USER: user },
+      },
+    );
+    return;
+  }
+  const status = statSync(target);
+  if (!status.isDirectory()) {
+    throw new Error(
+      `Flight Recorder storage parent must be a directory: ${target}`,
+    );
+  }
+  if (
+    typeof process.getuid === "function" &&
+    status.uid !== process.getuid()
+  ) {
+    throw new Error(
+      `Flight Recorder storage parent must be owned by the current user: ${target}`,
+    );
+  }
+  if ((status.mode & 0o022) !== 0) {
+    throw new Error(
+      `Flight Recorder storage parent must not be group/world writable: ${target}`,
+    );
+  }
+}
+
+export function syncParentDirectory(target: string): void {
+  if (process.platform === "win32") return;
+  const descriptor = openSync(target, "r");
+  try {
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+}

--- a/typescript/src/flight-recorder/process-owner.test.ts
+++ b/typescript/src/flight-recorder/process-owner.test.ts
@@ -1,0 +1,120 @@
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  acquireRecorderResetBarrier,
+  CURRENT_PROCESS_INCARNATION,
+  listLiveRecorderOwners,
+  recorderOwnerDirectory,
+  recorderResetLockPath,
+  processMatchesIncarnation,
+  registerRecorderOwner,
+  unregisterRecorderOwner,
+} from "./process-owner.js";
+
+const roots: string[] = [];
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+function databasePath(): string {
+  const root = mkdtempSync(path.join(os.tmpdir(), "flight-owner-"));
+  roots.push(root);
+  return path.join(root, "flight.db");
+}
+
+describe("Flight Recorder process ownership", () => {
+  it("reclaims a reset barrier owned by a dead process", () => {
+    const database = databasePath();
+    writeFileSync(recorderResetLockPath(database), "2147483647\n");
+
+    const owner = registerRecorderOwner(database, "owner-a");
+    expect(owner).toContain("owner-a.json");
+    unregisterRecorderOwner(owner);
+  });
+
+  it("fails closed when the owner directory cannot be inspected", () => {
+    const database = databasePath();
+    writeFileSync(recorderOwnerDirectory(database), "not-a-directory");
+
+    expect(() => listLiveRecorderOwners(database)).toThrow();
+  });
+
+  it("fails closed on a malformed owner entry", () => {
+    const database = databasePath();
+    const directory = recorderOwnerDirectory(database);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(path.join(directory, "partial.json"), "");
+
+    expect(() => listLiveRecorderOwners(database)).toThrow(
+      /cannot be inspected/i,
+    );
+  });
+
+  it("reclaims an owner file after PID reuse with a different incarnation", () => {
+    const database = databasePath();
+    const directory = recorderOwnerDirectory(database);
+    mkdirSync(directory, { recursive: true });
+    writeFileSync(
+      path.join(directory, "reused.json"),
+      `${JSON.stringify({
+        pid: process.pid,
+        incarnation: "different-process-start",
+      })}\n`,
+    );
+
+    expect(listLiveRecorderOwners(database)).toEqual([]);
+  });
+
+  it("uses a timezone-invariant current process incarnation", () => {
+    const originalTimezone = process.env.TZ;
+    process.env.TZ = "America/New_York";
+    try {
+      expect(
+        processMatchesIncarnation(
+          process.pid,
+          CURRENT_PROCESS_INCARNATION,
+        ),
+      ).toBe(true);
+    } finally {
+      if (originalTimezone === undefined) delete process.env.TZ;
+      else process.env.TZ = originalTimezone;
+    }
+  });
+
+  it("treats a live PID with unavailable incarnation as active", () => {
+    expect(processMatchesIncarnation(process.pid, undefined)).toBe(true);
+  });
+
+  it("does not reclaim a reset barrier owned by this live process", () => {
+    const database = databasePath();
+    mkdirSync(path.dirname(database), { recursive: true });
+    writeFileSync(recorderResetLockPath(database), `${process.pid}\n`);
+
+    expect(() => acquireRecorderResetBarrier(database)).toThrow(
+      /reset is in progress/i,
+    );
+  });
+
+  it("releases only the barrier nonce it acquired", () => {
+    const database = databasePath();
+    const release = acquireRecorderResetBarrier(database);
+    writeFileSync(
+      recorderResetLockPath(database),
+      `${JSON.stringify({ pid: process.pid, nonce: "replacement" })}\n`,
+    );
+
+    release();
+    expect(existsSync(recorderResetLockPath(database))).toBe(true);
+  });
+});

--- a/typescript/src/flight-recorder/process-owner.ts
+++ b/typescript/src/flight-recorder/process-owner.ts
@@ -1,0 +1,456 @@
+import {
+  closeSync,
+  existsSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import type { Dirent } from "node:fs";
+import { randomUUID } from "node:crypto";
+import { execFileSync } from "node:child_process";
+import path from "node:path";
+import {
+  assertPrivateDirectory,
+  hardenPrivatePath,
+  syncParentDirectory,
+} from "./permissions.js";
+
+const processOwnedPaths = new Set<string>();
+let exitHandlerInstalled = false;
+
+function installExitHandler(): void {
+  if (exitHandlerInstalled) return;
+  exitHandlerInstalled = true;
+  process.once("exit", () => {
+    for (const ownerPath of processOwnedPaths) {
+      try {
+        unlinkSync(ownerPath);
+      } catch {
+        // Process exit cleanup is best effort.
+      }
+    }
+  });
+}
+
+function processAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === "EPERM";
+  }
+}
+
+function readProcessIncarnation(pid: number): string | null {
+    try {
+      if (process.platform === "linux") {
+        const stat = readFileSync(`/proc/${pid}/stat`, "utf8");
+        const fields = stat
+          .slice(stat.lastIndexOf(")") + 2)
+          .trim()
+          .split(/\s+/);
+        const startTicks = fields[19];
+        return startTicks ? `linux:${startTicks}` : null;
+      }
+      if (process.platform === "win32") {
+        return `win:${execFileSync(
+          "powershell.exe",
+          [
+            "-NoProfile",
+            "-NonInteractive",
+            "-Command",
+            `(Get-Process -Id ${pid}).StartTime.ToUniversalTime().ToFileTimeUtc()`,
+          ],
+          { encoding: "utf8", windowsHide: true },
+        ).trim()}`;
+      }
+      const started = execFileSync(
+        "ps",
+        ["-o", "lstart=", "-p", String(pid)],
+        {
+          encoding: "utf8",
+          env: { ...process.env, LC_ALL: "C", TZ: "UTC" },
+        },
+      ).trim();
+      return started ? `ps-c-utc:${started}` : null;
+    } catch {
+      return null;
+    }
+}
+
+export const CURRENT_PROCESS_INCARNATION =
+  readProcessIncarnation(process.pid) ?? undefined;
+
+export function processMatchesIncarnation(
+  pid: number,
+  incarnation: string | undefined,
+): boolean {
+  if (!processAlive(pid)) return false;
+  if (!incarnation) return true;
+  const current =
+    pid === process.pid
+      ? CURRENT_PROCESS_INCARNATION
+      : readProcessIncarnation(pid);
+  return current === null || current === incarnation;
+}
+
+export function recorderOwnerDirectory(databasePath: string): string {
+  return `${databasePath}.owners`;
+}
+
+export function recorderResetLockPath(databasePath: string): string {
+  return `${databasePath}.reset-lock`;
+}
+
+function resetBarrierIsActive(lockPath: string): boolean {
+  try {
+    const observed = lstatSync(lockPath);
+    const raw = readFileSync(lockPath, "utf8").trim();
+    let pid: number;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      pid =
+        typeof parsed === "object" && parsed !== null
+          ? Number((parsed as { pid?: unknown }).pid)
+          : Number(parsed);
+    } catch {
+      pid = Number.parseInt(raw, 10);
+    }
+    if (!Number.isSafeInteger(pid) || pid <= 0) {
+      throw new Error("Flight Recorder reset barrier is invalid.");
+    }
+    const parsed = (() => {
+      try {
+        return JSON.parse(raw) as { incarnation?: unknown };
+      } catch {
+        return {};
+      }
+    })();
+    const incarnation =
+      typeof parsed.incarnation === "string"
+        ? parsed.incarnation
+        : undefined;
+    if (
+      Number.isSafeInteger(pid) &&
+      pid > 0 &&
+      processMatchesIncarnation(pid, incarnation)
+    ) {
+      return true;
+    }
+    const current = lstatSync(lockPath);
+    if (
+      current.dev !== observed.dev ||
+      current.ino !== observed.ino ||
+      current.mtimeMs !== observed.mtimeMs ||
+      current.size !== observed.size
+    ) {
+      return true;
+    }
+    unlinkSync(lockPath);
+    syncParentDirectory(path.dirname(lockPath));
+    return false;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return false;
+    throw error;
+  }
+}
+
+export function registerRecorderOwner(
+  databasePath: string,
+  ownerId: string,
+): string {
+  const resetLock = recorderResetLockPath(databasePath);
+  if (resetBarrierIsActive(resetLock)) {
+    throw new Error("Flight Recorder reset is in progress.");
+  }
+  const directory = recorderOwnerDirectory(databasePath);
+  prepareRecorderOwnerDirectory(directory);
+  hardenPrivatePath(directory, true);
+  const ownerPath = path.join(directory, `${ownerId}.json`);
+  const temporary = `${ownerPath}.${process.pid}.${randomUUID()}.tmp`;
+  const descriptor = openSync(temporary, "wx", 0o600);
+  try {
+    hardenPrivatePath(temporary);
+    writeFileSync(
+      descriptor,
+      `${JSON.stringify({
+        ownerId,
+        pid: process.pid,
+        ...(CURRENT_PROCESS_INCARNATION
+          ? { incarnation: CURRENT_PROCESS_INCARNATION }
+          : {}),
+      })}\n`,
+      "utf8",
+    );
+    fsyncSync(descriptor);
+  } finally {
+    closeSync(descriptor);
+  }
+  try {
+    linkSync(temporary, ownerPath);
+    syncParentDirectory(directory);
+  } finally {
+    unlinkSync(temporary);
+    syncParentDirectory(directory);
+  }
+  if (resetBarrierIsActive(resetLock)) {
+    unlinkSync(ownerPath);
+    syncParentDirectory(directory);
+    throw new Error("Flight Recorder reset is in progress.");
+  }
+  processOwnedPaths.add(ownerPath);
+  installExitHandler();
+  return ownerPath;
+}
+
+export function unregisterRecorderOwner(ownerPath: string | undefined): void {
+  if (!ownerPath) return;
+  processOwnedPaths.delete(ownerPath);
+  try {
+    unlinkSync(ownerPath);
+    syncParentDirectory(path.dirname(ownerPath));
+  } catch {
+    // A reset may already have removed the owner directory.
+  }
+}
+
+export function listLiveRecorderOwners(
+  databasePath: string,
+  excludedPid = process.pid,
+): number[] {
+  const directory = recorderOwnerDirectory(databasePath);
+  const live: number[] = [];
+  try {
+    validateRecorderOwnerDirectory(directory);
+    for (const entry of readdirSync(directory)) {
+      const ownerPath = path.join(directory, entry);
+      try {
+        const owner = JSON.parse(readFileSync(ownerPath, "utf8")) as {
+          pid?: unknown;
+          incarnation?: unknown;
+        };
+        const pid = Number(owner.pid);
+        if (
+          Number.isSafeInteger(pid) &&
+          pid > 0 &&
+          processMatchesIncarnation(
+            pid,
+            typeof owner.incarnation === "string"
+              ? owner.incarnation
+              : undefined,
+          )
+        ) {
+          if (pid !== excludedPid) live.push(pid);
+        } else {
+          unlinkSync(ownerPath);
+        }
+      } catch (error) {
+        throw new Error(
+          `Flight Recorder owner record cannot be inspected: ${
+            (error as Error).message
+          }`,
+        );
+      }
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return [];
+    throw error;
+  }
+  return [...new Set(live)];
+}
+
+export function acquireRecorderResetBarrier(
+  databasePath: string,
+): () => void {
+  const lockPath = recorderResetLockPath(databasePath);
+  mkdirSync(path.dirname(lockPath), { recursive: true, mode: 0o700 });
+  assertPrivateDirectory(path.dirname(lockPath));
+  const nonce = randomUUID();
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    if (resetBarrierIsActive(lockPath)) {
+      throw new Error("Another Flight Recorder reset is in progress.");
+    }
+    const temporary = `${lockPath}.${process.pid}.${nonce}.tmp`;
+    let descriptor: number | undefined;
+    try {
+      descriptor = openSync(temporary, "wx", 0o600);
+      hardenPrivatePath(temporary);
+      writeFileSync(
+        descriptor,
+        `${JSON.stringify({
+          pid: process.pid,
+          nonce,
+          ...(CURRENT_PROCESS_INCARNATION
+            ? { incarnation: CURRENT_PROCESS_INCARNATION }
+            : {}),
+        })}\n`,
+        "utf8",
+      );
+      fsyncSync(descriptor);
+      closeSync(descriptor);
+      descriptor = undefined;
+      try {
+        linkSync(temporary, lockPath);
+        syncParentDirectory(path.dirname(lockPath));
+        return () => {
+          try {
+            const owner = JSON.parse(
+              readFileSync(lockPath, "utf8"),
+            ) as { nonce?: unknown };
+            if (owner.nonce === nonce) {
+              unlinkSync(lockPath);
+              syncParentDirectory(path.dirname(lockPath));
+            }
+          } catch {
+            // Never unlink a barrier whose ownership cannot be verified.
+          }
+        };
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
+      try {
+        unlinkSync(temporary);
+      } catch {
+        // The temporary publication may already be gone.
+      }
+    }
+  }
+  throw new Error("Flight Recorder reset barrier could not be acquired.");
+}
+
+export function removeRecorderOwnerDirectory(databasePath: string): void {
+  const directory = recorderOwnerDirectory(databasePath);
+  try {
+    validateRecorderOwnerDirectory(directory);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return;
+    throw error;
+  }
+  rmSync(directory, {
+    recursive: true,
+    force: true,
+  });
+}
+
+function prepareRecorderOwnerDirectory(directory: string): void {
+  try {
+    validateRecorderOwnerDirectory(directory);
+    return;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  assertPrivateDirectory(path.dirname(directory));
+  mkdirSync(directory, { mode: 0o700 });
+  validateRecorderOwnerDirectory(directory);
+}
+
+function validateRecorderOwnerDirectory(directory: string): void {
+  const before = lstatSync(directory);
+  if (before.isSymbolicLink() || !before.isDirectory()) {
+    throw new Error(
+      `Flight Recorder owner storage must be a regular directory: ${directory}`,
+    );
+  }
+  assertPrivateDirectory(directory);
+  const after = lstatSync(directory);
+  if (
+    after.isSymbolicLink() ||
+    !after.isDirectory() ||
+    before.dev !== after.dev ||
+    before.ino !== after.ino
+  ) {
+    throw new Error(
+      `Flight Recorder owner storage identity changed: ${directory}`,
+    );
+  }
+}
+
+export function removeRecorderIdentityArtifacts(
+  databasePath: string,
+): number {
+  const keyPath = `${databasePath}.identity-key`;
+  const directory = path.dirname(keyPath);
+  const keyName = path.basename(keyPath);
+  const escapedKeyName = keyName.replace(
+    /[.*+?^${}()|[\]\\]/g,
+    "\\$&",
+  );
+  const temporaryPattern = new RegExp(
+    `^${escapedKeyName}\\.\\d+\\.[0-9a-f-]+\\.tmp$`,
+  );
+  let entries: Dirent[];
+  try {
+    entries = readdirSync(directory, { withFileTypes: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") return 0;
+    throw error;
+  }
+
+  let caseAliasVerified = false;
+  let canonicalStat: ReturnType<typeof lstatSync> | undefined;
+  try {
+    canonicalStat = lstatSync(keyPath);
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+  }
+  if (canonicalStat) {
+    for (const entry of entries) {
+      if (
+        entry.name === keyName ||
+        entry.name.toLowerCase() !== keyName.toLowerCase()
+      ) {
+        continue;
+      }
+      try {
+        const entryStat = lstatSync(path.join(directory, entry.name));
+        if (
+          entryStat.dev === canonicalStat.dev &&
+          entryStat.ino === canonicalStat.ino
+        ) {
+          caseAliasVerified = true;
+          break;
+        }
+      } catch {
+        // A concurrent deletion is handled by the final remnant scan.
+      }
+    }
+  }
+  const foldedTemporaryPattern = new RegExp(
+    `^${escapedKeyName.toLowerCase()}\\.\\d+\\.[0-9a-f-]+\\.tmp$`,
+  );
+  const matchesIdentityArtifact = (name: string): boolean =>
+    name === keyName ||
+    temporaryPattern.test(name) ||
+    (
+      caseAliasVerified &&
+      (
+        name.toLowerCase() === keyName.toLowerCase() ||
+        foldedTemporaryPattern.test(name.toLowerCase())
+      )
+    );
+
+  const candidates = entries
+    .filter((entry) => matchesIdentityArtifact(entry.name))
+    .map((entry) => path.join(directory, entry.name));
+  for (const candidate of candidates) unlinkSync(candidate);
+  if (candidates.length > 0) syncParentDirectory(directory);
+
+  const remnants = readdirSync(directory, { withFileTypes: true })
+    .filter((entry) => matchesIdentityArtifact(entry.name))
+    .map((entry) => path.join(directory, entry.name));
+  if (remnants.length > 0) {
+    throw new Error(
+      `Reset could not remove Flight Recorder identity artifacts: ${remnants.join(", ")}`,
+    );
+  }
+  return candidates.length;
+}

--- a/typescript/src/flight-recorder/recorder.ts
+++ b/typescript/src/flight-recorder/recorder.ts
@@ -1,0 +1,1463 @@
+/**
+ * Flight Recorder runtime facade.
+ *
+ * The recorder is deliberately fail-open for the product and fail-loud in its
+ * own health state: an unavailable audit database must never stop an agent
+ * response, but it must also never masquerade as a healthy recorder.
+ */
+
+import { AsyncLocalStorage } from "node:async_hooks";
+import { createHash, randomBytes, randomUUID } from "node:crypto";
+import {
+  closeSync,
+  constants,
+  existsSync,
+  fstatSync,
+  fsyncSync,
+  linkSync,
+  lstatSync,
+  mkdirSync,
+  openSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { isDeepStrictEqual } from "node:util";
+import {
+  computeFlightEventHash,
+  normalizeFlightModelId,
+  normalizeFlightSessionId,
+  normalizeFlightWorkspaceId,
+} from "./integrity.js";
+import { SQLiteFlightLedger } from "./ledger.js";
+import {
+  assertPrivateDirectory,
+  hardenPrivatePath,
+  syncParentDirectory,
+} from "./permissions.js";
+import {
+  CURRENT_PROCESS_INCARNATION,
+  registerRecorderOwner,
+  unregisterRecorderOwner,
+} from "./process-owner.js";
+import {
+  sanitizeFlightMetadata,
+  sanitizeFlightPayload,
+  sanitizeFlightValue,
+  summarizeFlightError,
+} from "./redaction.js";
+import {
+  FLIGHT_EVENT_SCHEMA,
+  type FlightEvent,
+  type FlightEventInput,
+  type FlightExport,
+  type FlightEventQuery,
+  type FlightLedger,
+  type FlightRecorderHealth,
+  type FlightRecorderOptions,
+  type FlightRecorderPrivacy,
+  type FlightTraceContext,
+} from "./types.js";
+
+const DEFAULT_DB = path.join(
+  os.homedir(),
+  ".openrappter",
+  "flight-recorder.db",
+);
+const DEFAULT_RETENTION = 10_000;
+const RETENTION_BATCH_RATIO = 0.1;
+let environmentRecorder: Promise<FlightRecorder> | null = null;
+let recorderGeneration = 0;
+
+function errorText(error: unknown): string {
+  try {
+    if (error instanceof Error) {
+      return `${String(error.name)}: ${String(error.message)}`;
+    }
+    return String(error);
+  } catch {
+    return "UnknownError: [unavailable]";
+  }
+}
+
+function safeErrorSummary(error: unknown): Record<string, unknown> {
+  try {
+    return summarizeFlightError(error);
+  } catch {
+    return { errorName: "UnknownError" };
+  }
+}
+
+function privateIdentifier(
+  value: string | undefined,
+  privacy: FlightRecorderPrivacy,
+  prefix: string,
+  fieldKey: string = prefix,
+): string | undefined {
+  if (value === undefined) return undefined;
+  if (typeof value !== "string") {
+    throw new TypeError(`${fieldKey} must be a string.`);
+  }
+  value = normalizeIdentifierUnicode(value);
+  if (
+    fieldKey === "kind" &&
+    (
+      value === "trace.started" ||
+      value === "trace.completed" ||
+      value === "trace.failed"
+    )
+  ) {
+    return value;
+  }
+
+  function normalizeIdentifierUnicode(value: string): string {
+    let normalized = "";
+    for (let index = 0; index < value.length; index += 1) {
+      const code = value.charCodeAt(index);
+      if (code >= 0xd800 && code <= 0xdbff) {
+        const next = value.charCodeAt(index + 1);
+        if (next >= 0xdc00 && next <= 0xdfff) {
+          normalized += value[index] + value[index + 1];
+          index += 1;
+        } else {
+          normalized += "\ufffd";
+        }
+      } else if (code >= 0xdc00 && code <= 0xdfff) {
+        normalized += "\ufffd";
+      } else {
+        normalized += value[index];
+      }
+    }
+    return normalized;
+  }
+  if (
+    matchesExactRedactedValue(value, privacy.redactedValues)
+  ) {
+    return `${prefix}:${createHash("sha256")
+      .update(value)
+      .digest("hex")
+      .slice(0, 24)}`;
+  }
+  if (isCanonicalPrivateIdentifier(value, prefix)) {
+    return value;
+  }
+  if (
+    sanitizeFlightValue(value, {
+      redactedValues: privacy.redactedValues,
+    }) !== value
+  ) {
+    return `${prefix}:${createHash("sha256")
+      .update(value)
+      .digest("hex")
+      .slice(0, 24)}`;
+  }
+
+  if (fieldKey === "kind") {
+    return sanitizeFlightValue(value, {
+      redactedValues: privacy.redactedValues,
+    }) === value
+      ? value
+      : `${prefix}:${createHash("sha256")
+          .update(value)
+          .digest("hex")
+          .slice(0, 24)}`;
+  }
+  const policyKeys =
+    fieldKey === "id" || fieldKey === "parentId"
+      ? ["id", "parentId"]
+      : [fieldKey];
+  if (
+    policyKeys.some(
+      (key) =>
+        sanitizeFlightMetadata({ [key]: value }, privacy)[key] !== value,
+    )
+  ) {
+    return `${prefix}:${createHash("sha256")
+      .update(value)
+      .digest("hex")
+      .slice(0, 24)}`;
+  }
+
+  const sanitized = sanitizeFlightValue(value, privacy);
+  if (sanitized === value) return value;
+  return `${prefix}:${createHash("sha256")
+    .update(value)
+    .digest("hex")
+    .slice(0, 24)}`;
+}
+
+function isCanonicalPrivateIdentifier(
+  value: string,
+  prefix: string,
+): boolean {
+  return new RegExp(`^${prefix}:[0-9a-f]{24}$`).test(value);
+}
+
+function matchesExactRedactedValue(
+  value: string,
+  redactedValues: readonly string[] | undefined,
+): boolean {
+  return (redactedValues ?? []).some(
+    (candidate) =>
+      candidate.length > 0 &&
+      (/^[0-9a-f]{64}$/i.test(candidate)
+        ? value.toLowerCase() === candidate.toLowerCase()
+        : value === candidate),
+  );
+}
+
+function isTraceSequenceConflict(error: unknown): boolean {
+  const candidate = error as { code?: unknown; message?: unknown };
+  return (
+    candidate?.code === "SQLITE_CONSTRAINT_UNIQUE" ||
+    candidate?.code === "SQLITE_CONSTRAINT" ||
+    (typeof candidate?.message === "string" &&
+      /UNIQUE constraint failed:\s*flight_events\.trace_id,\s*flight_events\.sequence/i.test(
+        candidate.message,
+      ))
+  );
+}
+
+function loadOrCreateIdentityKey(
+  databasePath: string,
+  explicitKey?: string,
+  allowUnconfiguredCreate = true,
+): string {
+  const explicit = explicitKey?.trim();
+  const environment =
+    process.env.OPENRAPPTER_FLIGHT_ID_KEY?.trim();
+  if (
+    explicit &&
+    environment &&
+    explicit.toLowerCase() !== environment.toLowerCase()
+  ) {
+    throw new Error(
+      "Configured Flight Recorder identity keys do not match.",
+    );
+  }
+
+  const configured = explicit || environment;
+  if (configured) {
+    if (!/^[0-9a-f]{64}$/i.test(configured)) {
+      throw new Error(
+        "OPENRAPPTER_FLIGHT_ID_KEY must be 32-byte hexadecimal.",
+      );
+    }
+  }
+
+  const keyPath = `${databasePath}.identity-key`;
+  for (let attempt = 0; attempt < 3; attempt += 1) {
+    try {
+      const observed = lstatSync(keyPath);
+      if (observed.isSymbolicLink() || !observed.isFile()) {
+        throw new Error(
+          "Flight Recorder identity key must be a regular file.",
+        );
+      }
+      const descriptor = openSync(
+        keyPath,
+        constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+      );
+      let existing: string;
+      try {
+        const opened = fstatSync(descriptor);
+        const current = lstatSync(keyPath);
+        if (
+          current.isSymbolicLink() ||
+          !current.isFile() ||
+          opened.dev !== current.dev ||
+          opened.ino !== current.ino
+        ) {
+          throw new Error(
+            "Flight Recorder identity key changed during private open.",
+          );
+        }
+        existing = readFileSync(descriptor, "utf8").trim();
+      } finally {
+        closeSync(descriptor);
+      }
+      if (/^[0-9a-f]{64}$/i.test(existing)) {
+        if (
+          configured &&
+          existing.toLowerCase() !== configured.toLowerCase()
+        ) {
+          throw new Error(
+            "Configured Flight Recorder identity key does not match the persisted key.",
+          );
+        }
+        hardenPrivatePath(keyPath);
+        return existing.toLowerCase();
+      }
+      if (existing.length > 0) {
+        throw new Error("Flight Recorder identity key is invalid.");
+      }
+      const current = lstatSync(keyPath);
+      if (
+        current.dev !== observed.dev ||
+        current.ino !== observed.ino ||
+        current.mtimeMs !== observed.mtimeMs ||
+        current.size !== observed.size
+      ) {
+        continue;
+      }
+      unlinkSync(keyPath);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") throw error;
+    }
+
+    if (!configured && !allowUnconfiguredCreate) {
+      throw new Error(
+        "Flight Recorder identity key is missing for a non-empty ledger.",
+      );
+    }
+    const key =
+      configured?.toLowerCase() ?? randomBytes(32).toString("hex");
+    const temporary = `${keyPath}.${process.pid}.${randomUUID()}.tmp`;
+    let descriptor: number | undefined;
+    let published = false;
+    try {
+      descriptor = openSync(temporary, "wx", 0o600);
+      hardenPrivatePath(temporary);
+      writeFileSync(descriptor, `${key}\n`, "utf8");
+      fsyncSync(descriptor);
+      closeSync(descriptor);
+      descriptor = undefined;
+      try {
+        linkSync(temporary, keyPath);
+        hardenPrivatePath(keyPath);
+        syncParentDirectory(path.dirname(keyPath));
+        published = true;
+        return key;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== "EEXIST") throw error;
+      }
+    } finally {
+      if (descriptor !== undefined) closeSync(descriptor);
+      try {
+        unlinkSync(temporary);
+      } catch {
+        // Another process may already have cleaned its temporary key.
+      }
+      if (published) syncParentDirectory(path.dirname(keyPath));
+    }
+  }
+  throw new Error("Flight Recorder identity key could not be created.");
+}
+
+function prepareManagedDatabaseDirectory(directory: string): void {
+  let existing = directory;
+  while (!existsSync(existing)) {
+    const parent = path.dirname(existing);
+    if (parent === existing) break;
+    existing = parent;
+  }
+  assertPrivateDirectory(existing);
+  mkdirSync(directory, { recursive: true, mode: 0o700 });
+  assertPrivateDirectory(directory);
+  hardenPrivatePath(directory, true);
+}
+
+interface TraceGeneration {
+  active: boolean;
+}
+
+interface StoredFlightTraceContext extends FlightTraceContext {
+  generation?: TraceGeneration;
+}
+
+export class FlightRecorder {
+  private readonly options: Required<
+    Pick<FlightRecorderOptions, "enabled" | "retentionEvents">
+  > &
+    Omit<FlightRecorderOptions, "enabled" | "retentionEvents">;
+  private readonly privacy: FlightRecorderPrivacy;
+  private readonly managesDatabaseParent: boolean;
+  private readonly ownsLedger: boolean;
+  private readonly traceStorage =
+    new AsyncLocalStorage<StoredFlightTraceContext>();
+  private readonly sequenceByTrace = new Map<string, number>();
+  private readonly sequenceLocks = new Map<string, Promise<void>>();
+  private ledger: FlightLedger | null;
+  private initialized = false;
+  private initializing: Promise<void> | null = null;
+  private nextInitializationAttemptAt = 0;
+  private closed = false;
+  private closing = false;
+  private clearing = false;
+  private clearOperation: Promise<boolean> | null = null;
+  private closeOperation: Promise<void> | null = null;
+  private activeTraceOperations = 0;
+  private readonly traceIdleWaiters = new Set<() => void>();
+  private activeMutations = 0;
+  private readonly mutationIdleWaiters = new Set<() => void>();
+  private errorCount = 0;
+  private lastError: string | undefined;
+  private retainedEventCount = 0;
+  private nextRetentionCheckCount = 0;
+  private retentionMaintenance: Promise<void> | null = null;
+  private identityKey: string | undefined;
+  private readonly ownerId = randomUUID();
+  private ownerPath: string | undefined;
+
+  constructor(options: FlightRecorderOptions = {}, ledger?: FlightLedger) {
+    this.options = {
+      ...options,
+      enabled: options.enabled ?? true,
+      retentionEvents: options.retentionEvents ?? DEFAULT_RETENTION,
+    };
+    this.privacy = {
+      ...options.privacy,
+      redactedKeys: [...(options.privacy?.redactedKeys ?? [])],
+      redactedValues: [...(options.privacy?.redactedValues ?? [])],
+      excludedPathPatterns: [
+        ...(options.privacy?.excludedPathPatterns ?? []),
+      ],
+    };
+    this.identityKey = options.identityKey?.trim().toLowerCase();
+    this.managesDatabaseParent = options.databasePath === undefined;
+    this.ownsLedger = ledger === undefined;
+    this.ledger = ledger ?? null;
+  }
+
+  async initialize(): Promise<void> {
+    if (
+      !this.options.enabled ||
+      this.initialized ||
+      this.closed ||
+      this.closing ||
+      performance.now() < this.nextInitializationAttemptAt
+    ) return;
+    if (this.initializing) return this.initializing;
+    this.initializing = this.initializeOnce();
+    try {
+      await this.initializing;
+    } finally {
+      this.initializing = null;
+    }
+  }
+
+  private async initializeOnce(): Promise<void> {
+    try {
+      const databasePath = this.options.databasePath ?? DEFAULT_DB;
+      const createsLedger = this.ledger === null;
+      if (!this.options.inMemory && createsLedger) {
+        const directory = path.dirname(databasePath);
+        if (this.managesDatabaseParent) {
+          prepareManagedDatabaseDirectory(directory);
+        } else {
+          mkdirSync(directory, { recursive: true, mode: 0o700 });
+          assertPrivateDirectory(directory);
+        }
+        this.ownerPath = registerRecorderOwner(
+          databasePath,
+          this.ownerId,
+        );
+      }
+      if (this.options.inMemory || !createsLedger) {
+        this.identityKey ??= randomBytes(32).toString("hex");
+      }
+      this.ledger ??= new SQLiteFlightLedger({
+        databasePath,
+        inMemory: this.options.inMemory,
+      });
+      await this.ledger.initialize();
+      if (this.closed || this.closing) {
+        await this.ledger.close();
+        return;
+      }
+      this.retainedEventCount = await this.ledger.count();
+      if (!this.options.inMemory && createsLedger) {
+        this.identityKey = loadOrCreateIdentityKey(
+          databasePath,
+          this.identityKey,
+          this.retainedEventCount === 0,
+        );
+      }
+      if (!this.identityKey || !/^[0-9a-f]{64}$/i.test(this.identityKey)) {
+        throw new Error(
+          "Flight Recorder identity key must be 32-byte hexadecimal.",
+        );
+      }
+      await this.ledger.bindIdentityKey?.(this.identityKey);
+      if (!this.privacy.redactedValues?.includes(this.identityKey)) {
+        this.privacy.redactedValues = [
+          ...(this.privacy.redactedValues ?? []),
+          this.identityKey,
+        ];
+      }
+      this.nextRetentionCheckCount = this.options.retentionEvents + 1;
+      if (!this.options.inMemory && createsLedger) {
+        hardenPrivatePath(databasePath);
+      }
+      this.initialized = true;
+      this.nextInitializationAttemptAt = 0;
+      this.lastError = undefined;
+    } catch (error) {
+      if (this.ownsLedger && this.ledger) {
+        try {
+          await this.ledger.close();
+        } catch {
+          // Preserve the original initialization error.
+        }
+        this.ledger = null;
+      }
+      unregisterRecorderOwner(this.ownerPath);
+      this.ownerPath = undefined;
+      this.noteError(error);
+      this.nextInitializationAttemptAt = performance.now() + 1_000;
+      // Fail open: callers can continue using OpenRappter and inspect health().
+      this.initialized = false;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.currentTrace()) {
+      throw new Error(
+        "Flight Recorder cannot close from inside an active trace.",
+      );
+    }
+    if (this.closeOperation) return this.closeOperation;
+    const operation = this.closeOnce();
+    this.closeOperation = operation;
+    try {
+      await operation;
+    } finally {
+      if (this.closeOperation === operation) {
+        this.closeOperation = null;
+      }
+    }
+  }
+
+  private async closeOnce(): Promise<void> {
+    if (this.closed) return;
+    if (this.currentTrace()) {
+      throw new Error(
+        "Flight Recorder cannot close from inside an active trace.",
+      );
+    }
+    this.closing = true;
+    if (this.clearOperation) {
+      try {
+        await this.clearOperation;
+      } catch {
+        // Close must still release resources after a failed clear.
+      }
+    }
+    if (this.initializing) {
+      await this.initializing;
+    }
+    await this.waitForActiveTraces();
+    await this.waitForMutations();
+    this.closed = true;
+    await Promise.all([...this.sequenceLocks.values()]);
+    try {
+      await this.ledger?.close();
+    } catch (error) {
+      this.noteError(error);
+    } finally {
+      this.initialized = false;
+      this.sequenceByTrace.clear();
+      this.sequenceLocks.clear();
+      this.retainedEventCount = 0;
+      this.nextRetentionCheckCount = 0;
+      this.retentionMaintenance = null;
+      this.closing = false;
+      unregisterRecorderOwner(this.ownerPath);
+      this.ownerPath = undefined;
+    }
+  }
+
+  currentTrace(): FlightTraceContext | undefined {
+    const context = this.currentTraceState();
+    if (!context) return undefined;
+    const { generation: _generation, ...publicContext } = context;
+    return publicContext;
+  }
+
+  private currentTraceState(): StoredFlightTraceContext | undefined {
+    const context = this.traceStorage.getStore();
+    return context?.generation?.active === false ? undefined : context;
+  }
+
+  childProcessEnvironment(): NodeJS.ProcessEnv {
+    const hasCustomPrivacy =
+      (this.privacy.redactedKeys?.length ?? 0) > 0 ||
+      (this.privacy.excludedPathPatterns?.length ?? 0) > 0 ||
+      (this.privacy.redactedValues ?? []).some(
+        (value) => value !== this.identityKey,
+      );
+    const shareable =
+      this.options.enabled &&
+      this.initialized &&
+      !this.options.inMemory &&
+      this.ownsLedger &&
+      !hasCustomPrivacy;
+    if (!shareable) {
+      return { OPENRAPPTER_FLIGHT_RECORDER: "0" };
+    }
+    const trace = this.currentTrace();
+    return {
+      OPENRAPPTER_FLIGHT_RECORDER: "1",
+      OPENRAPPTER_FLIGHT_DB: this.options.databasePath ?? DEFAULT_DB,
+      OPENRAPPTER_FLIGHT_RETENTION: String(this.options.retentionEvents),
+      OPENRAPPTER_FLIGHT_RECORD_IO:
+        this.privacy.recordIO === true ? "1" : "0",
+      ...(this.privacy.maxPayloadBytes === undefined
+        ? {}
+        : {
+            OPENRAPPTER_FLIGHT_MAX_PAYLOAD: String(
+              this.privacy.maxPayloadBytes,
+            ),
+          }),
+      ...(trace
+        ? {
+            OPENRAPPTER_FLIGHT_TRACE_ID: trace.traceId,
+            ...(trace.parentId
+              ? { OPENRAPPTER_FLIGHT_PARENT_ID: trace.parentId }
+              : {}),
+            ...(trace.sessionId
+              ? { OPENRAPPTER_FLIGHT_SESSION_ID: trace.sessionId }
+              : {}),
+            ...(trace.workspaceId
+              ? { OPENRAPPTER_FLIGHT_WORKSPACE_ID: trace.workspaceId }
+              : {}),
+          }
+        : {}),
+    };
+  }
+
+  async withTraceContext<T>(
+    context: FlightTraceContext,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const generation = { active: true };
+    try {
+      return await this.traceStorage.run(
+        { ...context, generation },
+        operation,
+      );
+    } finally {
+      generation.active = false;
+    }
+  }
+
+  async withParent<T>(
+    parentId: string | null | undefined,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const current = this.currentTraceState();
+    if (!current) return operation();
+    return this.traceStorage.run(
+      {
+        ...current,
+        parentId:
+          parentId === undefined ? current.parentId ?? null : parentId,
+      },
+      operation,
+    );
+  }
+
+  /**
+   * Run work inside one correlated trace and record its terminal outcome.
+   *
+   * A nested call preserves the existing trace by default and uses the current
+   * event as its parent only when the caller supplies one explicitly.
+   */
+  async runTrace<T>(
+    context: Partial<FlightTraceContext>,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const inherited = this.currentTrace();
+    if (!inherited && (this.closed || this.closing || this.clearing)) {
+      return operation();
+    }
+    this.activeTraceOperations += 1;
+    try {
+      if (
+        this.options.enabled &&
+        !this.initialized &&
+        !this.closed &&
+        !this.closing
+      ) {
+        await this.initialize();
+      }
+      const normalizedTraceId = privateIdentifier(
+        inherited?.traceId ??
+          context.traceId ??
+          randomUUID(),
+        inherited?.traceId
+          ? { ...this.privacy, redactedValues: [] }
+          : this.privacy,
+        "trace",
+        "traceId",
+      )!;
+      const trace: FlightTraceContext = {
+        traceId: normalizedTraceId,
+        sessionId: this.identityKey
+          ? normalizeFlightSessionId(
+              context.sessionId ?? inherited?.sessionId,
+              this.identityKey,
+              this.privacy.redactedValues,
+            )
+          : context.sessionId ?? inherited?.sessionId,
+        workspaceId: normalizeFlightWorkspaceId(
+          privateIdentifier(
+            context.workspaceId ?? inherited?.workspaceId,
+            this.privacy,
+            "workspace",
+            "workspaceId",
+          ),
+        ),
+        parentId:
+          context.parentId === undefined
+            ? inherited?.parentId ?? null
+            : context.parentId,
+      };
+      const generation = { active: true };
+      try {
+        return await this.traceStorage.run(
+          { ...trace, generation },
+          async () => {
+            const started = performance.now();
+            const root = await this.record({
+              kind: "trace.started",
+              source: "runtime",
+              status: "started",
+              metadata: { nested: Boolean(inherited) },
+            });
+            return this.withParent(root?.id ?? null, async () => {
+              try {
+                if (!root) return await operation();
+                const result = await operation();
+                const terminal = await this.record({
+                  kind: "trace.completed",
+                  source: "runtime",
+                  status: "success",
+                  durationMs: performance.now() - started,
+                });
+                if (!terminal && root) {
+                  await this.releaseStartOwnership(root.id);
+                }
+                return result;
+              } catch (error) {
+                if (!root) throw error;
+                let terminal: FlightEvent | null = null;
+                try {
+                  terminal = await this.record({
+                    kind: "trace.failed",
+                    source: "runtime",
+                    status: "error",
+                    durationMs: performance.now() - started,
+                    metadata: safeErrorSummary(error),
+                    payload: { error: errorText(error) },
+                  });
+                } finally {
+                  if (!terminal && root) {
+                    await this.releaseStartOwnership(root.id);
+                  }
+                }
+                throw error;
+              } finally {
+                this.sequenceByTrace.delete(normalizedTraceId);
+              }
+            });
+          },
+        );
+      } finally {
+        generation.active = false;
+      }
+    } finally {
+      this.activeTraceOperations -= 1;
+      if (this.activeTraceOperations === 0) {
+        for (const resolve of this.traceIdleWaiters) resolve();
+        this.traceIdleWaiters.clear();
+      }
+    }
+  }
+
+  /**
+   * Append one sanitized event.
+   *
+   * Returns null when disabled or unhealthy. It never throws into the product
+   * execution path; health() carries the failure instead.
+   */
+  async record(input: FlightEventInput): Promise<FlightEvent | null> {
+    if (
+      !this.options.enabled ||
+      this.closed ||
+      (this.closing && !this.currentTrace())
+    ) return null;
+    if (!this.initialized || !this.ledger) {
+      await this.initialize();
+      if (this.closed || !this.initialized || !this.ledger) return null;
+    }
+
+    const context = this.currentTrace();
+    if (this.clearing && !context) return null;
+    const traceId = privateIdentifier(
+      input.traceId ?? context?.traceId ?? randomUUID(),
+      this.privacy,
+      "trace",
+      "traceId",
+    )!;
+
+    this.activeMutations += 1;
+    try {
+      let event: FlightEvent | undefined;
+      let conflictAttempt = 0;
+      while (!this.closed) {
+        try {
+          event = await this.withTraceSequence(traceId, async (sequence) => {
+            const timestamp = input.timestamp ?? new Date().toISOString();
+            const sanitizedPayload = sanitizeFlightPayload(
+              input.payload,
+              this.privacy,
+            );
+            const metadata = sanitizeFlightMetadata(
+              input.metadata,
+              this.privacy,
+            );
+            delete metadata.ownerPid;
+            delete metadata.ownerId;
+            delete metadata.ownerIncarnation;
+            if (
+              input.kind === "trace.started" &&
+              input.source === "runtime"
+            ) {
+              metadata.ownerPid = process.pid;
+              if (CURRENT_PROCESS_INCARNATION) {
+                metadata.ownerIncarnation =
+                  CURRENT_PROCESS_INCARNATION;
+              }
+            }
+            const eventWithoutHash: Omit<FlightEvent, "contentHash"> = {
+              schema: FLIGHT_EVENT_SCHEMA,
+              id: privateIdentifier(
+                randomUUID(),
+                this.privacy,
+                "event",
+                "id",
+              )!,
+              sequence,
+              traceId,
+              parentId:
+                input.parentId === null
+                  ? null
+                  : privateIdentifier(
+                      input.parentId === undefined
+                        ? context?.parentId ?? undefined
+                        : input.parentId,
+                      this.privacy,
+                      "event",
+                      "parentId",
+                    ) ?? null,
+              sessionId: normalizeFlightSessionId(
+                input.sessionId ?? context?.sessionId,
+                this.identityKey!,
+                this.privacy.redactedValues,
+              ),
+              workspaceId: normalizeFlightWorkspaceId(
+                privateIdentifier(
+                  input.workspaceId ?? context?.workspaceId,
+                  this.privacy,
+                  "workspace",
+                  "workspaceId",
+                ),
+              ),
+              kind: privateIdentifier(
+                input.kind,
+                this.privacy,
+                "kind",
+                "kind",
+              )!,
+              source: privateIdentifier(
+                input.source,
+                this.privacy,
+                "source",
+                "source",
+              )!,
+              status: input.status ?? "info",
+              timestamp,
+              durationMs: input.durationMs,
+              providerId: privateIdentifier(
+                input.providerId,
+                this.privacy,
+                "provider",
+                "providerId",
+              ),
+              model:
+                sanitizeFlightMetadata(
+                  { model: input.model },
+                  this.privacy,
+                ).model === input.model &&
+                sanitizeFlightValue(input.model, this.privacy) === input.model
+                  ? normalizeFlightModelId(input.model)
+                  : undefined,
+              agentName: privateIdentifier(
+                input.agentName,
+                this.privacy,
+                "agent",
+                "agentName",
+              ),
+              toolName: privateIdentifier(
+                input.toolName,
+                this.privacy,
+                "tool",
+                "toolName",
+              ),
+              metadata,
+            };
+            if (sanitizedPayload !== undefined)
+              eventWithoutHash.payload = sanitizedPayload;
+            const persisted: FlightEvent = {
+              ...eventWithoutHash,
+              contentHash: computeFlightEventHash(eventWithoutHash),
+            };
+            await this.ledger!.append(persisted);
+            return persisted;
+          });
+          break;
+        } catch (error) {
+          if (isTraceSequenceConflict(error) && !this.closed) {
+            this.sequenceByTrace.delete(traceId);
+            conflictAttempt += 1;
+            await new Promise((resolve) =>
+              setTimeout(resolve, Math.min(conflictAttempt, 10)),
+            );
+            continue;
+          }
+          throw error;
+        }
+      }
+      if (!event) {
+        throw new Error("Flight Recorder is closed.");
+      }
+      try {
+        this.retainedEventCount = await this.ledger!.count();
+        await this.enforceRetention(
+          input.kind === "trace.completed" || input.kind === "trace.failed",
+        );
+      } catch (error) {
+        // The event is already durable. Retention health must be surfaced, but
+        // callers still need its ID for child causality and its true sequence.
+        this.noteError(error);
+      }
+      return event;
+    } catch (error) {
+      this.noteError(error);
+      return null;
+    } finally {
+      if (!context || context.traceId !== traceId) {
+        this.sequenceByTrace.delete(traceId);
+      }
+      this.activeMutations -= 1;
+      if (this.activeMutations === 0) {
+        for (const resolve of this.mutationIdleWaiters) resolve();
+        this.mutationIdleWaiters.clear();
+      }
+    }
+  }
+
+  async exportTrace(traceId: string): Promise<FlightExport | null> {
+    return this.export({ traceId });
+  }
+
+  async query(query: FlightEventQuery = {}): Promise<FlightEvent[]> {
+    const ledger = this.requireInspectionLedger();
+    try {
+        return await ledger.query(
+          normalizeFlightQuery(query, this.identityKey!, this.privacy),
+        );
+    } catch (error) {
+      this.noteError(error);
+      throw error;
+    }
+  }
+
+  async export(query: FlightEventQuery = {}): Promise<FlightExport | null> {
+    const ledger = this.requireInspectionLedger();
+    try {
+      return await ledger.export(
+        normalizeFlightQuery(query, this.identityKey!, this.privacy),
+      );
+    } catch (error) {
+      this.noteError(error);
+      throw error;
+    }
+  }
+
+  async import(
+    data: FlightExport,
+    options: { replace?: boolean } = {},
+  ): Promise<number> {
+    if (this.closed || this.closing) {
+      throw new Error("Flight Recorder close is in progress.");
+    }
+    const ledger = this.requireInspectionLedger();
+    if (this.clearing && !this.currentTrace()) {
+      throw new Error("Flight Recorder clear is in progress.");
+    }
+    this.activeMutations += 1;
+    try {
+      for (const event of data.events) {
+        for (const [key, prefix] of [
+          ["id", "event"],
+          ["kind", "kind"],
+          ["source", "source"],
+          ["traceId", "trace"],
+          ["parentId", "event"],
+          ["providerId", "provider"],
+          ["agentName", "agent"],
+          ["toolName", "tool"],
+        ] as const) {
+          const value = event[key];
+          if (
+            typeof value === "string" &&
+            privateIdentifier(value, this.privacy, prefix, key) !== value
+          ) {
+            throw new Error(
+              `Flight Recorder import ${key} violates active privacy policy.`,
+            );
+          }
+        }
+        if (
+          event.sessionId !== undefined &&
+          normalizeFlightSessionId(
+            event.sessionId,
+            this.identityKey!,
+            this.privacy.redactedValues,
+          ) !== event.sessionId
+        ) {
+          throw new Error(
+            "Flight Recorder import sessionId violates active privacy policy.",
+          );
+        }
+        if (
+          event.workspaceId !== undefined &&
+          normalizeFlightWorkspaceId(
+            privateIdentifier(
+              event.workspaceId,
+              this.privacy,
+              "workspace",
+              "workspaceId",
+            ),
+          ) !== event.workspaceId
+        ) {
+          throw new Error(
+            "Flight Recorder import workspaceId violates active privacy policy.",
+          );
+        }
+        if (
+          event.model !== undefined &&
+          (sanitizeFlightMetadata(
+            { model: event.model },
+            this.privacy,
+          ).model !== event.model ||
+            sanitizeFlightValue(event.model, this.privacy) !== event.model)
+        ) {
+          throw new Error(
+            "Flight Recorder import model violates active privacy policy.",
+          );
+        }
+        if (
+          !isDeepStrictEqual(
+            sanitizeFlightMetadata(event.metadata, this.privacy),
+            event.metadata,
+          )
+        ) {
+          throw new Error(
+            "Flight Recorder import metadata violates active privacy policy.",
+          );
+        }
+        if (Object.hasOwn(event, "payload")) {
+          if (this.privacy.recordIO !== true) {
+            throw new Error(
+              "Flight Recorder import contains payload IO while recordIO is disabled.",
+            );
+          }
+          if (
+            !isDeepStrictEqual(
+              sanitizeFlightPayload(event.payload, {
+                ...this.privacy,
+                recordIO: true,
+              }),
+              event.payload,
+            )
+          ) {
+            throw new Error(
+              "Flight Recorder import payload violates active privacy policy.",
+            );
+          }
+        }
+      }
+      const imported = await ledger.import(data, options);
+      for (const event of data.events)
+        this.sequenceByTrace.delete(event.traceId);
+      this.retainedEventCount = await ledger.count();
+      this.nextRetentionCheckCount = this.options.retentionEvents + 1;
+      return imported;
+    } catch (error) {
+      this.noteError(error);
+      throw error;
+    } finally {
+      this.activeMutations -= 1;
+      if (this.activeMutations === 0) {
+        for (const resolve of this.mutationIdleWaiters) resolve();
+        this.mutationIdleWaiters.clear();
+      }
+    }
+  }
+
+  async clear(): Promise<boolean> {
+    if (this.currentTrace()) {
+      throw new Error(
+        "Flight Recorder cannot clear from inside an active trace.",
+      );
+    }
+    if (this.clearOperation) return this.clearOperation;
+    const operation = this.clearOnce();
+    this.clearOperation = operation;
+    try {
+      return await operation;
+    } finally {
+      if (this.clearOperation === operation) {
+        this.clearOperation = null;
+      }
+    }
+  }
+
+  private async clearOnce(): Promise<boolean> {
+    const ledger = this.requireInspectionLedger();
+    if (this.closing) {
+      throw new Error("Flight Recorder close is in progress.");
+    }
+    if (this.currentTrace()) {
+      throw new Error(
+        "Flight Recorder cannot clear from inside an active trace.",
+      );
+    }
+    this.clearing = true;
+    try {
+      await this.waitForActiveTraces();
+      await this.waitForMutations();
+      await ledger.clear();
+      this.sequenceByTrace.clear();
+      this.retainedEventCount = 0;
+      this.nextRetentionCheckCount = this.options.retentionEvents + 1;
+      return true;
+    } catch (error) {
+      this.noteError(error);
+      throw error;
+    } finally {
+      this.clearing = false;
+    }
+  }
+
+  async health(): Promise<FlightRecorderHealth> {
+    let eventCount = 0;
+    if (this.initialized && this.ledger) {
+      try {
+        eventCount = await this.ledger.count();
+      } catch (error) {
+        this.noteError(error);
+      }
+    }
+    return {
+      enabled: this.options.enabled,
+      initialized: this.initialized,
+      eventCount,
+      errorCount: this.errorCount,
+      lastError: this.lastError,
+      databasePath: this.options.inMemory
+        ? ":memory:"
+        : (this.options.databasePath ?? DEFAULT_DB),
+    };
+  }
+
+  private noteError(error: unknown): void {
+    this.errorCount += 1;
+    this.lastError = errorText(error);
+  }
+
+  private async waitForActiveTraces(): Promise<void> {
+    if (this.activeTraceOperations === 0) return;
+    await new Promise<void>((resolve) => {
+      this.traceIdleWaiters.add(resolve);
+    });
+  }
+
+  private async waitForMutations(): Promise<void> {
+    if (this.activeMutations === 0) return;
+    await new Promise<void>((resolve) => {
+      this.mutationIdleWaiters.add(resolve);
+    });
+  }
+
+  private async releaseStartOwnership(eventId: string): Promise<void> {
+    try {
+      await this.ledger?.releaseEventOwnership?.(eventId);
+    } catch (error) {
+      this.noteError(error);
+    }
+  }
+
+  private async enforceRetention(force = false): Promise<void> {
+    const highWater = this.options.retentionEvents;
+    if (
+      highWater < 0 ||
+      this.retainedEventCount <= highWater ||
+      (!force && this.retainedEventCount < this.nextRetentionCheckCount)
+    ) {
+      return;
+    }
+    if (this.retentionMaintenance) {
+      await this.retentionMaintenance;
+      if (!force || this.retainedEventCount <= highWater) {
+        return;
+      }
+    }
+
+    const batch = Math.max(1, Math.ceil(highWater * RETENTION_BATCH_RATIO));
+    const target = highWater > 100 ? Math.max(0, highWater - batch) : highWater;
+    const maintenance = (async () => {
+      const deleted = this.ledger!.pruneRuntime
+        ? await this.ledger!.pruneRuntime(target)
+        : await this.ledger!.prune(target);
+      this.retainedEventCount = Math.max(
+        0,
+        this.retainedEventCount - deleted,
+      );
+      this.nextRetentionCheckCount =
+        this.retainedEventCount > highWater
+          ? this.retainedEventCount + batch
+          : highWater + 1;
+    })();
+    this.retentionMaintenance = maintenance;
+    try {
+      await maintenance;
+    } finally {
+      if (this.retentionMaintenance === maintenance) {
+        this.retentionMaintenance = null;
+      }
+    }
+  }
+
+  private requireInspectionLedger(): FlightLedger {
+    if (!this.options.enabled) {
+      throw new Error("Flight Recorder is disabled.");
+    }
+    if (!this.initialized || !this.ledger) {
+      throw new Error(
+        `Flight Recorder is unavailable${this.lastError ? `: ${this.lastError}` : "."}`,
+      );
+    }
+    return this.ledger;
+  }
+
+  /**
+   * Serialize sequence assignment per trace without blocking unrelated traces.
+   */
+  private async withTraceSequence<T>(
+    traceId: string,
+    operation: (sequence: number) => Promise<T>,
+  ): Promise<T> {
+    const previous = this.sequenceLocks.get(traceId) ?? Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current);
+    this.sequenceLocks.set(traceId, tail);
+
+    await previous;
+    try {
+      let sequence = this.sequenceByTrace.get(traceId);
+      if (sequence === undefined) {
+        sequence = await this.loadLastSequence(traceId);
+      }
+      const next = sequence + 1;
+      const result = await operation(next);
+      this.sequenceByTrace.set(traceId, next);
+      return result;
+    } finally {
+      release();
+      if (this.sequenceLocks.get(traceId) === tail) {
+        this.sequenceLocks.delete(traceId);
+      }
+    }
+  }
+
+  private async loadLastSequence(traceId: string): Promise<number> {
+    if (this.ledger?.lastSequence) {
+      return this.ledger.lastSequence(traceId);
+    }
+    const latest = await this.ledger!.query({
+      traceId,
+      order: "desc",
+      limit: 1,
+    });
+    return latest[0]?.sequence ?? 0;
+  }
+}
+
+function normalizeFlightQuery(
+  query: FlightEventQuery,
+  identityKey: string,
+  privacy: FlightRecorderPrivacy,
+): FlightEventQuery {
+  return {
+    ...query,
+    ...(query.traceId === undefined
+      ? {}
+      : {
+          traceId: isCanonicalPrivateIdentifier(query.traceId, "trace")
+            ? query.traceId
+            : privateIdentifier(
+                query.traceId,
+                privacy,
+                "trace",
+                "traceId",
+              ),
+        }),
+    ...(query.sessionId === undefined
+      ? {}
+      : {
+          sessionId: normalizeFlightSessionId(
+            query.sessionId,
+            identityKey,
+            privacy.redactedValues,
+          ),
+        }),
+    ...(query.workspaceId === undefined
+      ? {}
+      : {
+          workspaceId: normalizeFlightWorkspaceId(
+            privateIdentifier(
+              query.workspaceId,
+              privacy,
+              "workspace",
+              "workspaceId",
+            ),
+          ),
+        }),
+    ...(query.source === undefined
+      ? {}
+      : {
+          source: privateIdentifier(
+            query.source,
+            privacy,
+            "source",
+            "source",
+          ),
+        }),
+    ...(query.providerId === undefined
+      ? {}
+      : {
+          providerId: privateIdentifier(
+            query.providerId,
+            privacy,
+            "provider",
+            "providerId",
+          ),
+        }),
+    ...(query.agentName === undefined
+      ? {}
+      : {
+          agentName: privateIdentifier(
+            query.agentName,
+            privacy,
+            "agent",
+            "agentName",
+          ),
+        }),
+    ...(query.toolName === undefined
+      ? {}
+      : {
+          toolName: privateIdentifier(
+            query.toolName,
+            privacy,
+            "tool",
+            "toolName",
+          ),
+        }),
+  };
+}
+
+let globalRecorder = new FlightRecorder({ enabled: false });
+
+export function getFlightRecorder(): FlightRecorder {
+  return globalRecorder;
+}
+
+export function setFlightRecorder(recorder: FlightRecorder): FlightRecorder {
+  const previous = globalRecorder;
+  recorderGeneration += 1;
+  globalRecorder = recorder;
+  environmentRecorder = Promise.resolve(recorder);
+  return previous;
+}
+
+export async function withFlightTrace<T>(
+  context: Partial<FlightTraceContext>,
+  operation: () => Promise<T>,
+): Promise<T> {
+  return globalRecorder.runTrace(context, operation);
+}
+
+/**
+ * Configure the process-global recorder once from environment variables.
+ *
+ * Summary events are enabled by default for the actual product. Vitest and
+ * other test processes remain disabled unless explicitly opted in, preventing
+ * imports from writing into a developer's real ~/.openrappter directory.
+ *
+ * Raw IO remains opt-in even when the recorder itself is enabled.
+ */
+export function ensureFlightRecorderFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): Promise<FlightRecorder> {
+  if (environmentRecorder) return environmentRecorder;
+
+  const generation = recorderGeneration;
+  environmentRecorder = (async () => {
+    const enabled =
+      env.OPENRAPPTER_FLIGHT_RECORDER === "1" ||
+      (env.OPENRAPPTER_FLIGHT_RECORDER !== "0" && env.NODE_ENV !== "test");
+    const retention = Number.parseInt(
+      env.OPENRAPPTER_FLIGHT_RETENTION ?? String(DEFAULT_RETENTION),
+      10,
+    );
+    const recorder = new FlightRecorder({
+      enabled,
+      ...(env.OPENRAPPTER_FLIGHT_DB?.trim()
+        ? { databasePath: env.OPENRAPPTER_FLIGHT_DB }
+        : {}),
+      retentionEvents:
+        Number.isSafeInteger(retention) && retention >= 0
+          ? retention
+          : DEFAULT_RETENTION,
+      privacy: {
+        recordIO: env.OPENRAPPTER_FLIGHT_RECORD_IO === "1",
+        maxPayloadBytes: env.OPENRAPPTER_FLIGHT_MAX_PAYLOAD
+          ? Number.parseInt(env.OPENRAPPTER_FLIGHT_MAX_PAYLOAD, 10)
+          : undefined,
+      },
+    });
+    await recorder.initialize();
+    if (generation === recorderGeneration) {
+      globalRecorder = recorder;
+      return recorder;
+    }
+    await recorder.close();
+    return globalRecorder;
+  })();
+
+  return environmentRecorder;
+}
+
+/** Test-only reset for processes that need to exercise env bootstrap twice. */
+export function resetFlightRecorderEnvironmentForTests(): void {
+  environmentRecorder = null;
+}

--- a/typescript/src/flight-recorder/redaction.test.ts
+++ b/typescript/src/flight-recorder/redaction.test.ts
@@ -1,0 +1,995 @@
+import { describe, expect, it } from "vitest";
+import {
+  DEFAULT_EXCLUDED_PATH_PATTERNS,
+  DEFAULT_REDACTED_KEYS,
+  isExcludedFlightPath,
+  sanitizeFlightMetadata,
+  sanitizeFlightPayload,
+  sanitizeFlightValue,
+  summarizeFlightError,
+} from "./redaction.js";
+
+const githubToken = (): string =>
+  ["ghp", "0123456789abcdefghijklmnopqrstuv"].join("_");
+const awsKey = (): string => ["AKIA", "0123456789ABCDEF"].join("");
+const bearer = (): string => ["Bearer", "header.payload.signature"].join(" ");
+
+describe("flight recorder redaction", () => {
+  it("exports non-empty immutable-typed defaults with positive and negative controls", () => {
+    expect(DEFAULT_REDACTED_KEYS.has("token")).toBe(true);
+    expect(DEFAULT_REDACTED_KEYS.has("apiKey")).toBe(true);
+    expect(DEFAULT_REDACTED_KEYS.has("identityKey")).toBe(true);
+    expect(DEFAULT_REDACTED_KEYS.has("displayName")).toBe(false);
+    expect(DEFAULT_EXCLUDED_PATH_PATTERNS.length).toBeGreaterThan(0);
+    expect(isExcludedFlightPath("/work/.env.local")).toBe(true);
+    expect(isExcludedFlightPath("/work/flight.db.identity-key")).toBe(true);
+    expect(isExcludedFlightPath("/work/src/index.ts")).toBe(false);
+  });
+
+  it("drops payload IO unless recordIO is explicitly true", () => {
+    const payload = { ordinary: "survives only when opted in" };
+    expect(sanitizeFlightPayload(payload)).toBeUndefined();
+    expect(sanitizeFlightPayload(payload, { recordIO: false })).toBeUndefined();
+    expect(sanitizeFlightPayload(payload, { recordIO: true })).toEqual(payload);
+  });
+
+  it("always sanitizes metadata independently of recordIO", () => {
+    const secret = githubToken();
+    const metadata = { apiKey: secret, operation: "recent-edits" };
+    expect(JSON.stringify(metadata)).toContain(secret);
+
+    const result = sanitizeFlightMetadata(metadata, { recordIO: false });
+
+    expect(result).toEqual({ apiKey: "[redacted]", operation: "recent-edits" });
+    expect(JSON.stringify(result)).not.toContain(secret);
+    expect(sanitizeFlightMetadata(undefined)).toEqual({});
+  });
+
+  it("recursively redacts separator-insensitive and case-insensitive secret keys", () => {
+    const value = "not-secret-shaped-by-value";
+    const input = {
+      TOKEN: value,
+      auth: {
+        Api_Key: value,
+        "private-key": value,
+        refreshToken: value,
+        SESSION_TOKEN: value,
+      },
+      list: [{ Credential: value }, { authorization: value }],
+      cookieJar: value,
+      passwordHash: value,
+    };
+
+    const result = sanitizeFlightValue(input) as Record<string, unknown>;
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain(value);
+    expect(result.TOKEN).toBe("[redacted]");
+    expect(result.list).toEqual([
+      { Credential: "[redacted]" },
+      { authorization: "[redacted]" },
+    ]);
+  });
+
+  it("structurally sanitizes JSON object and array strings", () => {
+    expect(
+      sanitizeFlightValue(
+        '{"password":"ordinary-secret","nested":[{"token":"other-secret"}]}',
+      ),
+    ).toEqual({
+      password: "[redacted]",
+      nested: [{ token: "[redacted]" }],
+    });
+    const escaped =
+      'HTTP 400 body="{\\"password\\":\\"escaped-secret\\"}"';
+    const sanitized = sanitizeFlightValue(escaped);
+    expect(sanitized).not.toContain("escaped-secret");
+    expect(sanitized).toContain("[redacted]");
+    const unicodeEscaped = String.raw`"\u007b\"password\":\"unicode-secret\"\u007d"`;
+    const unicodeSanitized = sanitizeFlightValue(unicodeEscaped);
+    expect(unicodeSanitized).not.toContain("unicode-secret");
+    expect(unicodeSanitized).toContain("[redacted]");
+    const doubleEncoded = JSON.stringify(unicodeEscaped);
+    const doubleSanitized = sanitizeFlightValue(doubleEncoded);
+    expect(doubleSanitized).not.toContain("unicode-secret");
+    expect(doubleSanitized).toContain("[redacted]");
+    const primitiveSecret = String.raw`"\u0067\u0068\u0070_aaaaaaaaaaaaaaaaaaaa"`;
+    const primitiveSanitized = sanitizeFlightValue(primitiveSecret);
+    expect(primitiveSanitized).not.toContain("aaaaaaaaaaaaaaaaaaaa");
+    expect(primitiveSanitized).toContain("[redacted]");
+    expect(
+      sanitizeFlightValue(
+        '{"password":"ordinary-private-value", trailing}',
+      ),
+    ).toBe("[redacted]");
+    expect(
+      sanitizeFlightValue('{"value":9007199254740993}'),
+    ).toEqual({ value: "9007199254740993n" });
+  });
+
+  it("bounds structural string work before payload limits apply", () => {
+    const unmatched = "{".repeat(8_000);
+    expect(sanitizeFlightValue(unmatched)).toBe(unmatched);
+    expect(sanitizeFlightValue("{".repeat(70_000))).toBe(
+      "[truncated:70000]",
+    );
+  });
+
+  it("defers disabled payloads and bounds aggregate traversal", () => {
+    let invoked = false;
+    expect(
+      sanitizeFlightPayload(
+        () => {
+          invoked = true;
+          throw new Error("disabled payload should remain lazy");
+        },
+        { recordIO: false },
+      ),
+    ).toBeUndefined();
+    expect(invoked).toBe(false);
+
+    let elementReads = 0;
+    const huge = new Proxy(new Array(200_000).fill("x"), {
+      get(target, property, receiver) {
+        if (typeof property === "string" && /^\d+$/.test(property)) {
+          elementReads += 1;
+        }
+        return Reflect.get(target, property, receiver);
+      },
+    });
+    expect(
+      sanitizeFlightPayload(huge, {
+        recordIO: true,
+        maxPayloadBytes: 100,
+      }),
+    ).toBe("[truncated:budget]");
+    expect(elementReads).toBe(0);
+
+    let getterReads = 0;
+    const dynamic = Object.create(null);
+    Object.defineProperty(dynamic, "items", {
+      enumerable: true,
+      get() {
+        getterReads += 1;
+        return getterReads === 1
+          ? ["safe"]
+          : new Array(20_000).fill("expanded");
+      },
+    });
+    expect(sanitizeFlightValue(dynamic)).toEqual({ items: ["safe"] });
+    expect(getterReads).toBe(1);
+  });
+
+  it("charges repeated aliases for every emitted occurrence", () => {
+    const shared = new Array(1_000).fill("x");
+    const aliases = new Array(1_000).fill(shared);
+
+    expect(sanitizeFlightValue(aliases)).toBe("[truncated:budget]");
+  });
+
+  it("sorts unordered collections with locale-independent UTF-16 order", () => {
+    expect(sanitizeFlightValue(new Set(["ä", "z"]))).toEqual([
+      "z",
+      "ä",
+    ]);
+    expect(
+      sanitizeFlightValue(
+        new Map<unknown, unknown>([
+          ["ä", 1],
+          ["z", 2],
+        ]),
+      ),
+    ).toEqual([
+      ["z", 2],
+      ["ä", 1],
+    ]);
+    expect(sanitizeFlightValue(new Set([1e-5, 1e-6]))).toEqual([
+      1e-6,
+      1e-5,
+    ]);
+  });
+
+  it("redacts credentials embedded in property names without collisions", () => {
+    const secretKey = "password=ordinary-secret-value";
+    const result = sanitizeFlightValue({
+      "[redacted]": "control",
+      [secretKey]: "sensitive",
+    }) as Record<string, unknown>;
+
+    expect(JSON.stringify(result)).not.toContain(secretKey);
+    expect(result).toEqual({
+      "[redacted]": "control",
+      "[redacted]#2": "[redacted]",
+    });
+    expect(
+      sanitizeFlightValue(
+        { "exact-property-secret": "value" },
+        { redactedValues: ["exact-property-secret"] },
+      ),
+    ).toEqual({ "[redacted]": "[redacted]" });
+    expect(
+      sanitizeFlightValue({
+        "pass%77ord": "ordinary-private-value",
+      }),
+    ).toEqual({ password: "[redacted]" });
+    expect(
+      sanitizeFlightValue(
+        { prefixALPHABETAsuffix: "value" },
+        { redactedValues: ["ALPHABETA"] },
+      ),
+    ).toEqual({ "[redacted]": "value" });
+    expect(
+      sanitizeFlightValue({
+        "%5Bexcluded-path%5D": "encoded",
+        "[excluded-path]": "literal",
+      }),
+    ).toEqual({
+      "[excluded-path]": "encoded",
+      "[excluded-path]#2": "literal",
+    });
+    expect(
+      sanitizeFlightValue({
+        "%FF": 1,
+        "ÿ": 2,
+      }),
+    ).toEqual({
+      "�": 1,
+      "ÿ": 2,
+    });
+    const identityKey = "ab".repeat(32);
+    const encodedIdentity = [...identityKey]
+      .map((character) =>
+        `%${character.charCodeAt(0).toString(16).padStart(2, "0")}`,
+      )
+      .join("");
+    expect(
+      sanitizeFlightValue(encodedIdentity, {
+        redactedValues: [identityKey],
+      }),
+    ).toBe("[redacted]");
+  });
+
+  it("supports operator-supplied redacted keys without redacting near misses", () => {
+    const result = sanitizeFlightValue(
+      { signingPin: "1234", pin: "ordinary", displayName: "Ada" },
+      { redactedKeys: ["signing_pin"] },
+    );
+
+    expect(result).toEqual({
+      displayName: "Ada",
+      pin: "ordinary",
+      signingPin: "[redacted]",
+    });
+  });
+
+  it("redacts secret-shaped string values while preserving explicit negative controls", () => {
+    const values = {
+      github: githubToken(),
+      aws: awsKey(),
+      bearer: bearer(),
+      uri: ["postgresql://user", "pw@example.test/app"].join(":"),
+      connection: ["Server=db;", "Password=hunter2;", "Database=app"].join(""),
+      pem: [
+        "-----BEGIN PRIVATE KEY-----",
+        "ZmFrZS1ub3QtYS1yZWFsLWtleQ==",
+        "-----END PRIVATE KEY-----",
+      ].join("\n"),
+      dsa: [
+        "-----BEGIN DSA PRIVATE KEY-----",
+        "ZmFrZS1kc2Eta2V5",
+        "-----END DSA PRIVATE KEY-----",
+      ].join("\n"),
+      passwordOnlyUrl: "redis://:supersecret@host/0",
+    };
+    const input = {
+      values: Object.values(values),
+      ordinary: "AKIA-short-is-safe",
+    };
+    expect(input.values).toEqual(Object.values(values));
+    expect(input.values.every((secret) => secret.length > 10)).toBe(true);
+
+    const result = sanitizeFlightValue(input) as {
+      values: unknown[];
+      ordinary: string;
+    };
+
+    expect(result.values).toEqual(
+      Object.values(values).map(() => "[redacted]"),
+    );
+    expect(result.ordinary).toBe("AKIA-short-is-safe");
+    expect(
+      sanitizeFlightValue(
+        "https://example.test/path?token=ordinary-secret-value",
+      ),
+    ).toBe("[redacted]");
+    expect(
+      sanitizeFlightValue(
+        "https://example.test/path?session_token=ordinary-secret-value",
+      ),
+    ).toBe("[redacted]");
+    expect(
+      sanitizeFlightValue(
+        "https://example.test/path?%74oken=ordinary-secret-value",
+      ),
+    ).toBe("[redacted]");
+    expect(
+      sanitizeFlightValue(
+        "/callback?session_token=ordinary-secret-value",
+      ),
+    ).toBe("[redacted]");
+    expect(
+      sanitizeFlightValue(
+        "//host/path?%74oken=ordinary-secret-value",
+      ),
+    ).toBe("[redacted]");
+    expect(
+      sanitizeFlightValue(
+        "https://example.test/cb#token=ordinary-secret-value",
+      ),
+    ).toBe("[redacted]");
+    let deeplyEncoded = "%74oken";
+    for (let index = 0; index < 65; index += 1) {
+      deeplyEncoded = deeplyEncoded.replaceAll("%", "%25");
+    }
+    expect(
+      sanitizeFlightValue(
+        `https://example.test/?${deeplyEncoded}=ordinary-secret-value`,
+      ),
+    ).toBe("[redacted]");
+    expect(
+      sanitizeFlightValue('prefix {"a":1.0,"b":1e-7}'),
+    ).toBe('prefix {"a":1,"b":1e-7}');
+  });
+
+  it("redacts embedded bearer tokens and credentials with near-miss controls", () => {
+    const embeddedBearer = `HTTP 401: Authorization: ${bearer()} response body denied`;
+    const embeddedCredential =
+      "provider failed: client_secret=abcdefgh12345678 while connecting";
+    const controls = [
+      "HTTP 401: Authorization header missing; bearer token absent",
+      "provider failed: client_secret field was not configured",
+      "postgresql://example.test/app has no embedded password",
+    ];
+
+    expect(embeddedBearer).toContain(bearer());
+    expect(embeddedCredential).toContain("abcdefgh12345678");
+    expect(sanitizeFlightValue(embeddedBearer)).toBe("[redacted]");
+    expect(sanitizeFlightValue(embeddedCredential)).toBe("[redacted]");
+    expect(controls.map((value) => sanitizeFlightValue(value))).toEqual(
+      controls,
+    );
+  });
+
+  it("redacts secrets adjacent to non-ASCII letters", () => {
+    const token = githubToken();
+    const auth = bearer();
+    for (const value of [
+      `é${token}`,
+      `${token}é`,
+      `é${auth}`,
+    ]) {
+      expect(sanitizeFlightValue(value)).toBe("[redacted]");
+    }
+  });
+
+  it("reproduces the Copilot MITM recent-edit privacy failure without a secret-named key", () => {
+    const leakedToken = githubToken();
+    const recentEdit = {
+      kind: "recent-edit",
+      file: "src/provider.ts",
+      patch: `const copiedValue = "${leakedToken}";`,
+      linesChanged: 1,
+    };
+    expect(recentEdit.patch).toContain(leakedToken);
+
+    const sanitized = sanitizeFlightMetadata({ recentEdit });
+    const serialized = JSON.stringify(sanitized);
+
+    expect(serialized).not.toContain(leakedToken);
+    expect(serialized).toContain("[redacted]");
+    expect(serialized).toContain("linesChanged");
+  });
+
+  it("excludes default sensitive paths but keeps surrounding object shape", () => {
+    const input = {
+      files: [
+        "/repo/.env",
+        "/repo/.env.local",
+        "/home/me/.aws/credentials",
+        "/home/me/.ssh/id_ed25519",
+        "/keys/client.pem",
+        "/keys/client.key",
+        "/keys/client.p12",
+        "/home/me/.copilot_token",
+        "/repo/service-account.json",
+        "/home/me/.git-credentials",
+        "/repo/src/index.ts",
+      ],
+      count: 11,
+    };
+
+    const result = sanitizeFlightValue(input) as typeof input;
+
+    expect(result.files.slice(0, 10)).toEqual(
+      Array.from({ length: 10 }, () => "[excluded-path]"),
+    );
+    expect(result.files[10]).toBe("/repo/src/index.ts");
+    expect(result.count).toBe(11);
+  });
+
+  it("redacts sibling content when an object identifies an excluded file", () => {
+    const result = sanitizeFlightValue({
+      path: "/repo/.env",
+      content: "PRIVATE_VALUE=not-pattern-sensitive",
+      bytes: [1, 2, 3],
+      language: "dotenv",
+    });
+
+    expect(result).toEqual({
+      bytes: "[excluded-path]",
+      content: "[excluded-path]",
+      language: "dotenv",
+      path: "[excluded-path]",
+    });
+    expect(
+      sanitizeFlightValue({
+        name: ".env",
+        content: "PRIVATE_VALUE=ordinary",
+        contents: "PRIVATE_VALUE=second",
+        value: "PRIVATE_VALUE=third",
+      }),
+    ).toEqual({
+      content: "[excluded-path]",
+      contents: "[excluded-path]",
+      name: "[excluded-path]",
+      value: "[excluded-path]",
+    });
+    for (const uri of [
+      "file:///repo/.env?version=1",
+      "file:///repo/%2Eenv#fragment",
+    ]) {
+      expect(
+        sanitizeFlightValue({
+          uri,
+          content: "PRIVATE_VALUE=ordinary",
+        }),
+      ).toEqual({
+        content: "[excluded-path]",
+        uri: "[excluded-path]",
+      });
+      expect(
+        sanitizeFlightValue(
+          new Map([
+            ["uri", uri],
+            ["content", "PRIVATE_VALUE=ordinary"],
+          ]),
+        ),
+      ).toEqual([
+        ["content", "[excluded-path]"],
+        ["uri", "[excluded-path]"],
+      ]);
+    }
+    expect(
+      sanitizeFlightValue({
+        path: new URL("file:///repo/.env"),
+        content: "PRIVATE_VALUE=ordinary",
+      }),
+    ).toEqual({
+      content: "[excluded-path]",
+      path: "[excluded-path]",
+    });
+    expect(
+      sanitizeFlightValue({
+        sourcePath: "/repo/.env",
+        content: "PRIVATE_VALUE=ordinary",
+      }),
+    ).toEqual({
+      content: "[excluded-path]",
+      sourcePath: "[excluded-path]",
+    });
+    for (const locator of [
+      "sourceUri",
+      "documentPath",
+    ]) {
+      expect(
+        sanitizeFlightValue({
+          [locator]: "/repo/.env",
+          content: "PRIVATE_VALUE=ordinary",
+        }),
+      ).toEqual({
+        content: "[excluded-path]",
+        [locator]: "[excluded-path]",
+      });
+    }
+    expect(
+      sanitizeFlightValue({
+        textDocument: { uri: "file:///repo/.env" },
+        contentChanges: [{ text: "PRIVATE_VALUE=ordinary" }],
+      }),
+    ).toEqual({
+      textDocument: { uri: "[excluded-path]" },
+      contentChanges: "[excluded-path]",
+    });
+    expect(
+      sanitizeFlightValue({
+        "%2Eenv": "PRIVATE_VALUE=ordinary",
+      }),
+    ).toEqual({
+      "[excluded-path]": "[excluded-path]",
+    });
+    expect(
+      sanitizeFlightValue({
+        "%252Eenv": "PRIVATE_VALUE=ordinary",
+      }),
+    ).toEqual({
+      "[excluded-path]": "[excluded-path]",
+    });
+    let descriptor: Record<string, unknown> = {
+      uri: "file:///repo/.env",
+    };
+    for (let depth = 0; depth < 18; depth += 1) {
+      descriptor = { nested: descriptor };
+    }
+    expect(
+      sanitizeFlightValue({
+        descriptor,
+        content: "PRIVATE_VALUE=ordinary",
+      }),
+    ).toMatchObject({
+      content: "[excluded-path]",
+    });
+    expect(
+      sanitizeFlightValue({
+        path: "/repo/.env",
+        language: { raw: "PRIVATE_VALUE=ordinary" },
+        size: { raw: 42 },
+        content: "PRIVATE_VALUE=ordinary",
+      }),
+    ).toEqual({
+      content: "[excluded-path]",
+      language: "[excluded-path]",
+      path: "[excluded-path]",
+      size: "[excluded-path]",
+    });
+    expect(
+      sanitizeFlightValue({
+        sourcePath: "vscode-remote://host/%ZZ/private/%2Eenv",
+        content: "PRIVATE_VALUE=ordinary",
+      }),
+    ).toEqual({
+      content: "[excluded-path]",
+      sourcePath: "[excluded-path]",
+    });
+    expect(
+      sanitizeFlightValue({
+        sourcePath: "/repo/%252Eenv",
+        content: "PRIVATE_VALUE=ordinary",
+      }),
+    ).toEqual({
+      content: "[excluded-path]",
+      sourcePath: "[excluded-path]",
+    });
+    expect(
+      sanitizeFlightValue({
+        sourcePath:
+          "vscode-remote://ssh-remote+host/home/alice/%2Eenv",
+        content: "PRIVATE_VALUE=ordinary",
+      }),
+    ).toEqual({
+      content: "[excluded-path]",
+      sourcePath: "[excluded-path]",
+    });
+  });
+
+  it("honors operator path patterns including stateful global regexes", () => {
+    const privacy = { excludedPathPatterns: [/private-workspace/gi] };
+
+    expect(isExcludedFlightPath("/private-workspace/a.txt", privacy)).toBe(
+      true,
+    );
+    expect(isExcludedFlightPath("/private-workspace/b.txt", privacy)).toBe(
+      true,
+    );
+    expect(isExcludedFlightPath("/public/a.txt", privacy)).toBe(false);
+    expect(
+      sanitizeFlightValue(
+        { first: "/private-workspace/a.txt", second: "/public/a.txt" },
+        privacy,
+      ),
+    ).toEqual({ first: "[excluded-path]", second: "/public/a.txt" });
+  });
+
+  it("replaces circular recurrences and preserves repeated non-circular references", () => {
+    const shared = { label: "shared" };
+    const input: Record<string, unknown> = { first: shared, second: shared };
+    input.self = input;
+
+    const result = sanitizeFlightValue(input);
+
+    expect(result).toEqual({
+      first: { label: "shared" },
+      second: { label: "shared" },
+      self: "[circular]",
+    });
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it("densifies sparse arrays so the hashed value matches stored JSON", () => {
+    const sparse = Array(2) as unknown[];
+    sparse[1] = "present";
+
+    const result = sanitizeFlightValue({ sparse }) as {
+      sparse: unknown[];
+    };
+
+    expect(result.sparse).toEqual([null, "present"]);
+    expect(Object.hasOwn(result.sparse, 0)).toBe(true);
+  });
+
+  it("converts dates, buffers, typed arrays, arrays, maps, sets and errors", () => {
+    const error = new Error("ordinary failure");
+    Object.assign(error, { code: "E_TEST" });
+    const result = sanitizeFlightValue({
+      array: [1, undefined, 3],
+      buffer: Buffer.from([1, 2, 3]),
+      date: new Date("2025-01-02T03:04:05.000Z"),
+      error,
+      map: new Map<unknown, unknown>([
+        ["z", 2],
+        ["apiKey", githubToken()],
+        ["a", 1],
+      ]),
+      set: new Set(["z", "a"]),
+      typed: new Uint16Array([4, 5]),
+    }) as Record<string, unknown>;
+
+    expect(result.array).toEqual([1, null, 3]);
+    expect(result.buffer).toEqual([1, 2, 3]);
+    expect(result.date).toBe("2025-01-02T03:04:05.000Z");
+    expect(result.typed).toEqual([4, 5]);
+    expect(result.set).toEqual(["a", "z"]);
+    expect(result.map).toEqual([
+      ["a", 1],
+      ["apiKey", "[redacted]"],
+      ["z", 2],
+    ]);
+    expect(result.error).toMatchObject({
+      name: "Error",
+      message: "ordinary failure",
+      code: "E_TEST",
+    });
+
+    expect(() => JSON.stringify(result)).not.toThrow();
+  });
+
+  it("turns hostile error getters into an unserializable marker", () => {
+    const hostile = Object.create(Error.prototype);
+    for (const key of ["name", "message", "stack"]) {
+      Object.defineProperty(hostile, key, {
+        get() {
+          throw new Error(`blocked ${key}`);
+        },
+      });
+    }
+
+    const sanitized = {
+      name: "[unserializable]",
+      message: "[unserializable]",
+      stack: "[unserializable]",
+    };
+    expect(sanitizeFlightValue(hostile)).toEqual(sanitized);
+    expect(
+      sanitizeFlightPayload({ error: hostile }, { recordIO: true }),
+    ).toEqual({ error: sanitized });
+  });
+
+  it("structurally sanitizes prefixed JSON in error messages and stacks", () => {
+    const secret = "ordinary-error-secret";
+    const error = new Error(
+      `HTTP 400: ${JSON.stringify({ password: secret })}`,
+    );
+    const result = sanitizeFlightValue(error);
+    const serialized = JSON.stringify(result);
+
+    expect(serialized).not.toContain(secret);
+    expect(serialized).toContain("[redacted]");
+    expect(sanitizeFlightValue(result)).toEqual(result);
+
+    const nested = sanitizeFlightValue(
+      new Error(
+        'Error: {not-json: {"password":"nested-error-secret"}}',
+      ),
+    );
+    expect(JSON.stringify(nested)).not.toContain("nested-error-secret");
+    expect(JSON.stringify(nested)).toContain("[redacted]");
+  });
+
+  it("stringifies unsafe integers so cross-runtime hashes cannot hide precision loss", () => {
+    const unsafe = Number.MAX_SAFE_INTEGER + 1;
+    expect(Number.isSafeInteger(unsafe)).toBe(false);
+    expect(
+      sanitizeFlightValue({ unsafe, safe: Number.MAX_SAFE_INTEGER }),
+    ).toEqual({
+      safe: Number.MAX_SAFE_INTEGER,
+      unsafe: `${unsafe}n`,
+    });
+  });
+
+  it("produces deterministic JSON-compatible output for unordered collections", () => {
+    const first = sanitizeFlightValue({
+      map: new Map([
+        ["b", 2],
+        ["a", 1],
+      ]),
+      set: new Set(["b", "a"]),
+    });
+    const second = sanitizeFlightValue({
+      set: new Set(["a", "b"]),
+      map: new Map([
+        ["a", 1],
+        ["b", 2],
+      ]),
+    });
+
+    expect(JSON.stringify(first)).toBe(JSON.stringify(second));
+  });
+
+  it("redacts prototype-pollution keys without polluting the returned object", () => {
+    const input = JSON.parse(
+      '{"safe":"yes","__proto__":{"polluted":true},"constructor":"bad","prototype":"bad"}',
+    ) as Record<string, unknown>;
+
+    const result = sanitizeFlightValue(input) as Record<string, unknown>;
+
+    expect(result.safe).toBe("yes");
+    expect(result["[redacted]"]).toBe("[redacted]");
+    expect(result["[redacted]#2"]).toBe("[redacted]");
+    expect(result["[redacted]#3"]).toBe("[redacted]");
+    expect(Object.hasOwn(result, "__proto__")).toBe(false);
+    expect(Object.hasOwn(result, "constructor")).toBe(false);
+    expect(Object.hasOwn(result, "prototype")).toBe(false);
+    expect(({} as Record<string, unknown>).polluted).toBeUndefined();
+  });
+
+  it("redacts secret and path-shaped property names without collisions", () => {
+    const secretKey = githubToken();
+    const pathKey = "/Users/alice/.ssh/id_ed25519";
+    const input = Object.fromEntries([
+      ["[redacted]", "reserved"],
+      ["[redacted]#2", "reserved-two"],
+      ["[excluded-path]", "reserved-path"],
+      [secretKey, "secret-key-value"],
+      [pathKey, "path-key-value"],
+      ["constructor", "prototype-value"],
+      ["apiKey", "field-value"],
+      ["safe", "ordinary"],
+    ]);
+    const reversed = Object.fromEntries(Object.entries(input).reverse());
+
+    const result = sanitizeFlightValue(input) as Record<string, unknown>;
+    const reversedResult = sanitizeFlightValue(reversed);
+    const serialized = JSON.stringify(result);
+
+    expect(reversedResult).toEqual(result);
+    expect(Object.keys(result)).toHaveLength(Object.keys(input).length);
+    expect(serialized).not.toContain(secretKey);
+    expect(serialized).not.toContain(pathKey);
+    expect(result["[redacted]"]).toBe("reserved");
+    expect(result["[redacted]#2"]).toBe("reserved-two");
+    expect(result["[redacted]#3"]).toBe("[redacted]");
+    expect(result["[redacted]#4"]).toBe("secret-key-value");
+    expect(result["[excluded-path]"]).toBe("reserved-path");
+    expect(result["[excluded-path]#2"]).toBe("[excluded-path]");
+    expect(result.apiKey).toBe("[redacted]");
+    expect(result.safe).toBe("ordinary");
+    expect(Object.hasOwn(result, "constructor")).toBe(false);
+  });
+
+  it("excludes contents stored under bare sensitive filenames", () => {
+    const result = sanitizeFlightValue({
+      "server.p12": { bytes: [1, 2, 3] },
+      "service-account.json": { client_email: "service@example.test" },
+      "/Users/alice/client-secret.pem": { private: "secret" },
+    }) as Record<string, unknown>;
+
+    expect(result).toEqual({
+      "[excluded-path]": "[excluded-path]",
+      "[excluded-path]#2": "[excluded-path]",
+      "[excluded-path]#3": "[excluded-path]",
+    });
+    expect(JSON.stringify(result)).not.toContain("service@example.test");
+    expect(JSON.stringify(result)).not.toContain("client-secret.pem");
+  });
+
+  it("does not mutate original objects, arrays, maps or sets", () => {
+    const nested = { apiKey: githubToken(), path: "/repo/.env" };
+    const input = {
+      nested,
+      array: [nested],
+      map: new Map([["secret", nested]]),
+      set: new Set([nested]),
+    };
+    const originalToken = nested.apiKey;
+
+    const result = sanitizeFlightValue(input);
+
+    expect(result).not.toBe(input);
+    expect(nested).toEqual({ apiKey: originalToken, path: "/repo/.env" });
+    expect(input.array[0]).toBe(nested);
+    expect(input.map.get("secret")).toBe(nested);
+    expect(input.set.has(nested)).toBe(true);
+  });
+
+  it("enforces payload bytes after redaction and returns a valid truncation marker", () => {
+    const input = {
+      password: "x".repeat(2_000),
+      ordinary: "y".repeat(200),
+    };
+    const result = sanitizeFlightPayload(input, {
+      recordIO: true,
+      maxPayloadBytes: 80,
+    });
+    const serialized = JSON.stringify(result);
+
+    expect(result).toMatch(/^\[truncated:\d+\]$/);
+    expect(serialized).toBe(JSON.stringify(result));
+    expect(Buffer.byteLength(serialized, "utf8")).toBeLessThanOrEqual(80);
+    expect(serialized).not.toContain("x".repeat(100));
+  });
+
+  it("uses the 16 KiB default payload cap with a below-limit negative control", () => {
+    const below = { text: "a".repeat(1_000) };
+    const above = { text: "b".repeat(17_000) };
+
+    expect(sanitizeFlightPayload(below, { recordIO: true })).toEqual(below);
+    expect(sanitizeFlightPayload(above, { recordIO: true })).toMatch(
+      /^\[truncated:\d+\]$/,
+    );
+  });
+
+  it("returns an unserializable marker rather than throwing on hostile values", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        ownKeys() {
+          throw new Error("no enumeration");
+        },
+      },
+    );
+
+    expect(() =>
+      sanitizeFlightPayload(hostile, { recordIO: true }),
+    ).not.toThrow();
+    expect(sanitizeFlightPayload(hostile, { recordIO: true })).toBe(
+      "[unserializable]",
+    );
+  });
+
+  it("summarizes provider errors without retaining message tokens or response bodies", () => {
+    const token = githubToken();
+    const bearerToken = bearer();
+    const body = '{"customer":"private response body"}';
+    const message = `HTTP 401 Authorization: ${bearerToken}; token=${token}; body=${body}`;
+    const error = Object.assign(new Error(message), {
+      code: "ERR_PROVIDER_AUTH",
+      status: 401,
+    });
+    expect(error.message).toContain(token);
+    expect(error.message).toContain(bearerToken);
+    expect(error.message).toContain(body);
+
+    const first = summarizeFlightError(error);
+    const second = summarizeFlightError(error);
+    const serialized = JSON.stringify(first);
+
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({
+      errorName: "Error",
+      errorCode: "ERR_PROVIDER_AUTH",
+      httpStatus: 401,
+      messageChars: message.length,
+    });
+    expect(first.messageHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(serialized).not.toContain(token);
+    expect(serialized).not.toContain(bearerToken);
+    expect(serialized).not.toContain(body);
+    expect(serialized).not.toContain("HTTP 401");
+  });
+
+  it("summarizes Error-like objects while omitting raw and nested values", () => {
+    const errorLike = {
+      name: "ProviderError",
+      code: "E_UPSTREAM",
+      statusCode: 503,
+      message: "upstream response was unavailable",
+      stack: "raw stack must never persist",
+      body: { raw: "raw body must never persist" },
+      nested: { authorization: bearer() },
+    };
+
+    const result = summarizeFlightError(errorLike);
+
+    expect(result).toMatchObject({
+      errorName: "ProviderError",
+      errorCode: "E_UPSTREAM",
+      httpStatus: 503,
+      messageChars: errorLike.message.length,
+    });
+    expect(Object.keys(result).sort()).toEqual([
+      "errorCode",
+      "errorName",
+      "httpStatus",
+      "messageChars",
+      "messageHash",
+    ]);
+    expect(JSON.stringify(result)).not.toContain("upstream response");
+    expect(JSON.stringify(result)).not.toContain("raw stack");
+    expect(JSON.stringify(result)).not.toContain("raw body");
+  });
+
+  it("summarizes string errors with a stable hash and no raw string", () => {
+    const raw = `request failed with ${githubToken()}`;
+
+    const first = summarizeFlightError(raw);
+    const second = summarizeFlightError(raw);
+
+    expect(first).toEqual(second);
+    expect(first).toMatchObject({
+      errorName: "Error",
+      messageChars: raw.length,
+    });
+    expect(first.messageHash).toMatch(/^[a-f0-9]{64}$/);
+    expect(JSON.stringify(first)).not.toContain(raw);
+    expect(JSON.stringify(first)).not.toContain(githubToken());
+  });
+
+  it("omits unsafe error codes and invalid HTTP statuses", () => {
+    const secretCode = githubToken();
+    const result = summarizeFlightError({
+      name: "Unsafe Name With Spaces",
+      code: secretCode,
+      status: 99,
+      statusCode: 700,
+      message: "ordinary",
+    });
+
+    expect(result.errorName).toBe("Error");
+    expect(result.errorCode).toBeUndefined();
+    expect(result.httpStatus).toBeUndefined();
+    expect(JSON.stringify(result)).not.toContain(secretCode);
+  });
+
+  it("never throws while summarizing a hostile Proxy", () => {
+    const hostile = new Proxy(
+      {},
+      {
+        get() {
+          throw new Error("blocked");
+        },
+      },
+    );
+
+    expect(() => summarizeFlightError(hostile)).not.toThrow();
+    expect(summarizeFlightError(hostile)).toEqual({
+      errorName: "Error",
+      messageHash:
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      messageChars: 0,
+    });
+  });
+
+  it("preserves ordinary nested diagnostic data unchanged", () => {
+    const input = {
+      provider: {
+        model: "gpt-4.1",
+        durationMs: 42,
+        usage: { inputTokens: 120, outputTokens: 30 },
+      },
+      files: ["src/index.ts", "README.md"],
+      success: true,
+    };
+
+    expect(sanitizeFlightValue(input)).toEqual(input);
+    expect(sanitizeFlightMetadata(input)).toEqual(input);
+  });
+});

--- a/typescript/src/flight-recorder/redaction.test.ts
+++ b/typescript/src/flight-recorder/redaction.test.ts
@@ -270,14 +270,14 @@ describe("flight recorder redaction", () => {
       uri: ["postgresql://user", "pw@example.test/app"].join(":"),
       connection: ["Server=db;", "Password=hunter2;", "Database=app"].join(""),
       pem: [
-        "-----BEGIN PRIVATE KEY-----",
+        ["-----BEGIN", " PRIVATE KEY-----"].join(""),
         "ZmFrZS1ub3QtYS1yZWFsLWtleQ==",
-        "-----END PRIVATE KEY-----",
+        ["-----END", " PRIVATE KEY-----"].join(""),
       ].join("\n"),
       dsa: [
-        "-----BEGIN DSA PRIVATE KEY-----",
+        ["-----BEGIN DSA", " PRIVATE KEY-----"].join(""),
         "ZmFrZS1kc2Eta2V5",
-        "-----END DSA PRIVATE KEY-----",
+        ["-----END DSA", " PRIVATE KEY-----"].join(""),
       ].join("\n"),
       passwordOnlyUrl: "redis://:supersecret@host/0",
     };

--- a/typescript/src/flight-recorder/redaction.ts
+++ b/typescript/src/flight-recorder/redaction.ts
@@ -1,0 +1,1321 @@
+import { createHash } from "node:crypto";
+import type { FlightRecorderPrivacy } from "./types.js";
+
+const REDACTED = "[redacted]";
+const EXCLUDED_PATH = "[excluded-path]";
+const CIRCULAR = "[circular]";
+const UNSERIALIZABLE = "[unserializable]";
+const DEFAULT_MAX_PAYLOAD_BYTES = 16 * 1024;
+const MAX_SANITIZE_STRING_BYTES = 64 * 1024;
+const MAX_EMBEDDED_JSON_PARSE_CHARS = MAX_SANITIZE_STRING_BYTES * 4;
+const MAX_EMBEDDED_JSON_DEPTH = 4;
+const MAX_SANITIZE_NODES = 10_000;
+const MAX_SANITIZE_BYTES = 256 * 1024;
+const TRAVERSAL_LIMIT = "[truncated:budget]";
+
+export const DEFAULT_REDACTED_KEYS: ReadonlySet<string> = new Set([
+  "token",
+  "secret",
+  "password",
+  "credential",
+  "authorization",
+  "api_key",
+  "apiKey",
+  "apikey",
+  "private_key",
+  "privateKey",
+  "privatekey",
+  "cookie",
+  "session_token",
+  "sessionToken",
+  "sessiontoken",
+  "access_token",
+  "accessToken",
+  "accesstoken",
+  "refresh_token",
+  "refreshToken",
+  "refreshtoken",
+  "identityKey",
+  "identity_key",
+  "OPENRAPPTER_FLIGHT_ID_KEY",
+  "__proto__",
+  "constructor",
+  "prototype",
+]);
+
+export const DEFAULT_EXCLUDED_PATH_PATTERNS: readonly RegExp[] = [
+  /(?:^|[\\/])\.env(?:\.[^\\/]+)?(?:$|[\\/])/i,
+  /(?:^|[\\/])(?:\.git-credentials|credentials?|application_default_credentials|service[-_.]?account|client[-_.]?secret)(?:\.[^\\/]*)?$/i,
+  /\.(?:pem|key|p12)(?:$|[?#])/i,
+  /(?:^|[\\/])\.ssh(?:[\\/]|$)/i,
+  /(?:^|[\\/])\.aws[\\/]credentials(?:$|[\\/])/i,
+  /(?:^|[\\/])\.copilot_token(?:$|[\\/])/i,
+  /\.identity-key(?:\.\d+\.[0-9a-f-]+\.tmp)?(?:$|[?#])/i,
+];
+
+const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
+  /\b(?:gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{16,})\b/i,
+  /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/,
+  /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/i,
+  /\b[a-z][a-z0-9+.-]*:\/\/[^/\s:@]*:[^@\s/]+@/i,
+  /\b(?:password|pwd)\s*=\s*[^;\s]+/i,
+  /\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|credential)\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{8,}/i,
+  /[?&](?:token|secret|password|credential|authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)=/i,
+  /(?:^|[{,\s])["']?(?:password|pwd|token|secret|credential|authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]/i,
+  /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/i,
+];
+
+function normalizedKey(key: string): string {
+  return key.toLowerCase().replace(/[^a-z0-9]/g, "");
+}
+
+function normalizeUnicodeScalars(value: string): string {
+  let normalized = "";
+  for (let index = 0; index < value.length; index += 1) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const next = value.charCodeAt(index + 1);
+      if (next >= 0xdc00 && next <= 0xdfff) {
+        normalized += value[index] + value[index + 1];
+        index += 1;
+      } else {
+        normalized += "\ufffd";
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      normalized += "\ufffd";
+    } else {
+      normalized += value[index];
+    }
+  }
+  return normalized;
+}
+
+function isPrototypePollutionKey(key: string): boolean {
+  if (key === "__proto__") return true;
+  const normalized = normalizedKey(key);
+  return normalized === "constructor" || normalized === "prototype";
+}
+
+function isSensitiveKey(key: string, privacy?: FlightRecorderPrivacy): boolean {
+  if (isPrototypePollutionKey(key)) return true;
+
+  const normalized = normalizedKey(key);
+  const words = key
+    .replace(/([a-z0-9])([A-Z])/g, "$1 $2")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+  if (
+    words.some(
+      (word) =>
+        word === "token" ||
+        word === "secret" ||
+        word.startsWith("password") ||
+        word.startsWith("credential") ||
+        word === "authorization" ||
+        word.startsWith("cookie"),
+    )
+  ) {
+    return true;
+  }
+
+  if (
+    [
+      "apikey",
+      "privatekey",
+      "sessiontoken",
+      "accesstoken",
+      "refreshtoken",
+      "identitykey",
+    ].some((candidate) => normalized.includes(candidate))
+  ) {
+    return true;
+  }
+
+  return (privacy?.redactedKeys ?? []).some(
+    (candidate) => normalizedKey(candidate) === normalized,
+  );
+}
+
+function testPattern(pattern: RegExp, value: string): boolean {
+  pattern.lastIndex = 0;
+  const matched = pattern.test(value);
+  pattern.lastIndex = 0;
+  return matched;
+}
+
+function decodeValidPercentEscapes(value: string): string {
+  let current = value;
+  for (let pass = 0; pass < 32; pass += 1) {
+    const decoded = current.replace(/(?:%[0-9a-f]{2})+/gi, (encoded) => {
+      try {
+        return decodeURIComponent(encoded);
+      } catch {
+        return new TextDecoder().decode(
+          Uint8Array.from(
+            [...encoded.matchAll(/%([0-9a-f]{2})/gi)],
+            (match) => Number.parseInt(match[1], 16),
+          ),
+        );
+      }
+    });
+    if (decoded === current) return decoded;
+    current = decoded;
+  }
+  return REDACTED;
+}
+
+export function isExcludedFlightPath(
+  value: string,
+  privacy?: FlightRecorderPrivacy,
+): boolean {
+  const patterns = [
+    ...DEFAULT_EXCLUDED_PATH_PATTERNS,
+    ...(privacy?.excludedPathPatterns ?? []),
+  ];
+  const candidates = new Set<string>([
+    value,
+    value.replace(/[?#].*$/, ""),
+    decodeValidPercentEscapes(value),
+    decodeValidPercentEscapes(value).replace(/[?#].*$/, ""),
+  ]);
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value)) {
+    try {
+      const url = new URL(value);
+      const pathname = decodeValidPercentEscapes(url.pathname);
+      candidates.add(pathname);
+      candidates.add(pathname.replace(/[?#].*$/, ""));
+    } catch {
+      try {
+        candidates.add(
+          decodeValidPercentEscapes(
+            value.replace(/^[a-z][a-z0-9+.-]*:\/\//i, ""),
+          ),
+        );
+      } catch {
+        // Malformed percent encoding remains covered by the raw candidate.
+      }
+    }
+  }
+  return [...candidates].some((candidate) =>
+    patterns.some((pattern) => testPattern(pattern, candidate)),
+  );
+}
+
+function isSecretShapedString(
+  value: string,
+  privacy?: FlightRecorderPrivacy,
+): boolean {
+  const candidates = new Set([
+    value,
+    decodeValidPercentEscapes(value),
+  ]);
+  return [...candidates].some(
+    (candidateValue) =>
+      candidateValue === REDACTED ||
+      uriHasSensitiveQueryKey(candidateValue, privacy) ||
+      (privacy?.redactedValues ?? []).some(
+        (candidate) =>
+          candidate.length > 0 &&
+          (/^[0-9a-f]{64}$/i.test(candidate)
+            ? candidateValue
+                .toLowerCase()
+                .includes(candidate.toLowerCase())
+            : candidateValue.includes(candidate)),
+      ) ||
+      SECRET_VALUE_PATTERNS.some((pattern) =>
+        testPattern(pattern, candidateValue),
+      ),
+  );
+}
+
+function uriHasSensitiveQueryKey(
+  value: string,
+  privacy?: FlightRecorderPrivacy,
+): boolean {
+  if (!value.includes("?") && !value.includes("#")) return false;
+  try {
+    const url = new URL(value, "https://openrappter.invalid");
+    const keys = [...url.searchParams.keys()];
+    const fragment = decodeValidPercentEscapes(
+      url.hash.replace(/^#/, ""),
+    );
+    if (fragment) {
+      keys.push(...new URLSearchParams(fragment).keys());
+    }
+    for (const key of keys) {
+      if (isSensitiveKey(decodeValidPercentEscapes(key), privacy))
+        return true;
+    }
+  } catch {
+    return false;
+  }
+  return false;
+}
+
+function isSecretShapedKey(
+  value: string,
+  privacy?: FlightRecorderPrivacy,
+): boolean {
+  return (
+    (privacy?.redactedValues ?? []).some(
+      (candidate) =>
+        candidate.length > 0 &&
+        (/^[0-9a-f]{64}$/i.test(candidate)
+          ? value.toLowerCase().includes(candidate.toLowerCase())
+          : value.includes(candidate)),
+    ) ||
+    SECRET_VALUE_PATTERNS.some((pattern) => testPattern(pattern, value))
+  );
+}
+
+function flightPathString(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (value instanceof URL) return value.toString();
+  return undefined;
+}
+
+function isFileLocatorKey(key: string): boolean {
+  const normalized = normalizedKey(decodeValidPercentEscapes(key));
+  return [
+    "path",
+    "sourcepath",
+    "file",
+    "filename",
+    "filepath",
+    "name",
+    "uri",
+    "url",
+  ].includes(normalized) ||
+    normalized.endsWith("path") ||
+    normalized.endsWith("uri") ||
+    normalized.endsWith("url") ||
+    normalized.endsWith("filename");
+}
+
+function containsExcludedFileLocator(
+  value: unknown,
+  privacy?: FlightRecorderPrivacy,
+  ancestors = new WeakSet<object>(),
+  depth = 0,
+): boolean {
+  if (
+    value === null ||
+    typeof value !== "object" ||
+    depth > 16 ||
+    ancestors.has(value)
+  ) {
+    return depth > 16;
+  }
+
+  ancestors.add(value);
+  try {
+    if (value instanceof Map) {
+      for (const [key, entryValue] of value) {
+        if (
+          typeof key === "string" &&
+          isFileLocatorKey(key) &&
+          flightPathString(entryValue) !== undefined &&
+          isExcludedFlightPath(flightPathString(entryValue)!, privacy)
+        ) return true;
+        if (
+          containsExcludedFileLocator(
+            entryValue,
+            privacy,
+            ancestors,
+            depth + 1,
+          )
+        ) return true;
+      }
+      return false;
+    }
+    if (Array.isArray(value) || value instanceof Set) {
+      for (const entry of value) {
+        if (
+          containsExcludedFileLocator(
+            entry,
+            privacy,
+            ancestors,
+            depth + 1,
+          )
+        ) return true;
+      }
+      return false;
+    }
+    for (const [key, entryValue] of Object.entries(value)) {
+      if (
+        isFileLocatorKey(key) &&
+        flightPathString(entryValue) !== undefined &&
+        isExcludedFlightPath(flightPathString(entryValue)!, privacy)
+      ) return true;
+      if (
+        containsExcludedFileLocator(
+          entryValue,
+          privacy,
+          ancestors,
+          depth + 1,
+        )
+      ) return true;
+    }
+    return false;
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+function isSafeFileMetadataField(
+  key: string,
+  value: unknown,
+  privacy?: FlightRecorderPrivacy,
+): boolean {
+  const normalized = normalizedKey(key);
+  if (["size", "length"].includes(normalized)) {
+    return (
+      typeof value === "number" &&
+      Number.isFinite(value) &&
+      value >= 0
+    );
+  }
+  if (
+    ["language", "mime", "mimetype", "extension"].includes(normalized)
+  ) {
+    return (
+      typeof value === "string" &&
+      value.length <= 256 &&
+      sanitizeString(value, privacy) === value
+    );
+  }
+  return false;
+}
+
+function stableJson(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? "";
+  } catch {
+    return String(value);
+  }
+}
+
+function compareStableJson(left: unknown, right: unknown): number {
+  const leftJson = stableJson(left);
+  const rightJson = stableJson(right);
+  return leftJson < rightJson ? -1 : leftJson > rightJson ? 1 : 0;
+}
+
+interface TraversalLimits {
+  maxNodes: number;
+  maxBytes: number;
+}
+
+const SNAPSHOT_LIMIT = Symbol("snapshot-limit");
+
+function snapshotForSanitization(
+  value: unknown,
+  limits: TraversalLimits,
+): unknown {
+  const seen = new WeakMap<object, unknown>();
+  let nodes = 0;
+  let bytes = 0;
+
+  const visit = (current: unknown): unknown => {
+    nodes += 1;
+    if (nodes > limits.maxNodes) throw SNAPSHOT_LIMIT;
+    if (typeof current === "string") {
+      bytes += Buffer.byteLength(current, "utf8");
+      if (bytes > limits.maxBytes) throw SNAPSHOT_LIMIT;
+      return current;
+    }
+    if (
+      current === null ||
+      (typeof current !== "object" && typeof current !== "function")
+    ) {
+      return current;
+    }
+    const prior = seen.get(current);
+    if (prior !== undefined) return prior;
+
+    if (current instanceof Date) return new Date(current.getTime());
+    if (current instanceof RegExp)
+      return new RegExp(current.source, current.flags);
+    if (current instanceof URL) return current.toString();
+    if (current instanceof ArrayBuffer) {
+      bytes += current.byteLength;
+      if (bytes > limits.maxBytes) throw SNAPSHOT_LIMIT;
+      return current.slice(0);
+    }
+    if (ArrayBuffer.isView(current)) {
+      bytes += current.byteLength;
+      if (bytes > limits.maxBytes) throw SNAPSHOT_LIMIT;
+      return sanitizeTypedArray(current);
+    }
+    if (Array.isArray(current)) {
+      if (nodes + current.length > limits.maxNodes) throw SNAPSHOT_LIMIT;
+      const clone: unknown[] = [];
+      seen.set(current, clone);
+      for (let index = 0; index < current.length; index += 1) {
+        clone.push(visit(current[index]));
+      }
+      return clone;
+    }
+    if (current instanceof Map) {
+      if (nodes + current.size * 2 > limits.maxNodes) throw SNAPSHOT_LIMIT;
+      const clone = new Map<unknown, unknown>();
+      seen.set(current, clone);
+      for (const [key, entryValue] of current) {
+        clone.set(visit(key), visit(entryValue));
+      }
+      return clone;
+    }
+    if (current instanceof Set) {
+      if (nodes + current.size > limits.maxNodes) throw SNAPSHOT_LIMIT;
+      const clone = new Set<unknown>();
+      seen.set(current, clone);
+      for (const entry of current) clone.add(visit(entry));
+      return clone;
+    }
+    if (current instanceof Error) {
+      const clone: Record<string, unknown> = Object.create(null);
+      seen.set(current, clone);
+      for (const key of ["name", "message", "stack", "code", "cause"]) {
+        try {
+          const entry = (current as unknown as Record<string, unknown>)[key];
+          if (entry !== undefined) clone[key] = visit(entry);
+        } catch {
+          clone[key] = UNSERIALIZABLE;
+        }
+      }
+      return clone;
+    }
+
+    const clone: Record<string, unknown> = Object.create(null);
+    seen.set(current, clone);
+    let keys: string[];
+    try {
+      keys = Object.keys(current);
+    } catch {
+      return UNSERIALIZABLE;
+    }
+    if (nodes + keys.length > limits.maxNodes) throw SNAPSHOT_LIMIT;
+    for (const key of keys) {
+      nodes += 1;
+      bytes += Buffer.byteLength(key, "utf8");
+      if (nodes > limits.maxNodes || bytes > limits.maxBytes) {
+        throw SNAPSHOT_LIMIT;
+      }
+      try {
+        clone[key] = visit(
+          (current as Record<string, unknown>)[key],
+        );
+      } catch (error) {
+        if (error === SNAPSHOT_LIMIT) throw error;
+        clone[key] = UNSERIALIZABLE;
+      }
+    }
+    return clone;
+  };
+
+  return visit(value);
+}
+
+function isWithinTraversalBudget(
+  value: unknown,
+  limits: TraversalLimits,
+): boolean {
+  const stack: Array<
+    | { value: unknown }
+    | { exit: object }
+  > = [{ value }];
+  const ancestors = new WeakSet<object>();
+  let nodes = 0;
+  let bytes = 0;
+
+  while (stack.length > 0) {
+    const frame = stack.pop()!;
+    if ("exit" in frame) {
+      ancestors.delete(frame.exit);
+      continue;
+    }
+    const current = frame.value;
+    nodes += 1;
+    if (nodes > limits.maxNodes) return false;
+    if (typeof current === "string") {
+      bytes += Buffer.byteLength(current, "utf8");
+      if (bytes > limits.maxBytes) return false;
+      continue;
+    }
+    if (
+      current === null ||
+      (typeof current !== "object" && typeof current !== "function")
+    ) {
+      continue;
+    }
+    if (current instanceof ArrayBuffer) {
+      bytes += current.byteLength;
+      if (bytes > limits.maxBytes) return false;
+      continue;
+    }
+    if (ArrayBuffer.isView(current)) {
+      bytes += current.byteLength;
+      if (bytes > limits.maxBytes) return false;
+      continue;
+    }
+    if (ancestors.has(current)) continue;
+    ancestors.add(current);
+    stack.push({ exit: current });
+
+    if (Array.isArray(current)) {
+      if (current.length + nodes > limits.maxNodes) return false;
+      for (let index = current.length - 1; index >= 0; index -= 1) {
+        stack.push({ value: current[index] });
+      }
+      continue;
+    }
+    if (current instanceof Map) {
+      if (current.size * 2 + nodes > limits.maxNodes) return false;
+      for (const [key, entryValue] of current) {
+        stack.push({ value: key }, { value: entryValue });
+      }
+      continue;
+    }
+    if (current instanceof Set) {
+      if (current.size + nodes > limits.maxNodes) return false;
+      for (const entry of current) stack.push({ value: entry });
+      continue;
+    }
+    if (current instanceof Error) {
+      for (const key of ["name", "message", "stack"] as const) {
+        try {
+          const entry = current[key];
+          if (entry !== undefined) stack.push({ value: entry });
+        } catch {
+          stack.push({ value: UNSERIALIZABLE });
+        }
+      }
+      const error = current as Error & {
+        cause?: unknown;
+        code?: unknown;
+      };
+      if ("cause" in error) stack.push({ value: error.cause });
+      if ("code" in error) stack.push({ value: error.code });
+      continue;
+    }
+
+    try {
+      for (const key in current as Record<string, unknown>) {
+        if (!Object.hasOwn(current, key)) continue;
+        nodes += 1;
+        bytes += Buffer.byteLength(key, "utf8");
+        if (nodes > limits.maxNodes || bytes > limits.maxBytes) return false;
+        stack.push({
+          value: (current as Record<string, unknown>)[key],
+        });
+      }
+    } catch {
+      return true;
+    }
+  }
+  return true;
+}
+
+function sanitizeBoundedValue(
+  value: unknown,
+  privacy: FlightRecorderPrivacy | undefined,
+  limits: TraversalLimits,
+): unknown {
+  try {
+    const snapshot = snapshotForSanitization(value, limits);
+    if (!isWithinTraversalBudget(snapshot, limits)) return TRAVERSAL_LIMIT;
+    return sanitizeRecursive(snapshot, privacy, new WeakSet());
+  } catch (error) {
+    if (error === SNAPSHOT_LIMIT) return TRAVERSAL_LIMIT;
+    return UNSERIALIZABLE;
+  }
+}
+
+interface EmbeddedJsonRange {
+  kind: "container" | "string";
+  start: number;
+  end: number;
+  children: EmbeddedJsonRange[];
+}
+
+interface EmbeddedJsonBudget {
+  remaining: number;
+  exhausted: boolean;
+}
+
+function oversizedStringMarker(value: string): string | undefined {
+  const byteCount = Buffer.byteLength(value, "utf8");
+  return byteCount > MAX_SANITIZE_STRING_BYTES
+    ? `[truncated:${byteCount}]`
+    : undefined;
+}
+
+function collectEmbeddedJsonRanges(value: string): EmbeddedJsonRange[] {
+  const completed: EmbeddedJsonRange[] = [];
+  const stack: Array<{ opening: "{" | "["; start: number }> = [];
+  let stringStart = -1;
+  let escaped = false;
+
+  for (let index = 0; index < value.length; index += 1) {
+    const character = value[index];
+    if (stringStart >= 0) {
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        completed.push({
+          kind: "string",
+          start: stringStart,
+          end: index,
+          children: [],
+        });
+        stringStart = -1;
+      }
+      continue;
+    }
+
+    if (character === '"') {
+      stringStart = index;
+      continue;
+    }
+    if (character === "{" || character === "[") {
+      stack.push({ opening: character, start: index });
+      continue;
+    }
+    if (character !== "}" && character !== "]") continue;
+    const expected = character === "}" ? "{" : "[";
+    const opening = stack.at(-1);
+    if (!opening || opening.opening !== expected) continue;
+    stack.pop();
+    completed.push({
+      kind: "container",
+      start: opening.start,
+      end: index,
+      children: [],
+    });
+  }
+
+  completed.sort(
+    (left, right) => left.start - right.start || right.end - left.end,
+  );
+  const roots: EmbeddedJsonRange[] = [];
+  const parents: EmbeddedJsonRange[] = [];
+  for (const range of completed) {
+    while (
+      parents.length > 0 &&
+      !(
+        parents.at(-1)!.start < range.start &&
+        range.end < parents.at(-1)!.end
+      )
+    ) {
+      parents.pop();
+    }
+    const parent = parents.at(-1);
+    if (parent) {
+      parent.children.push(range);
+    } else {
+      roots.push(range);
+    }
+    parents.push(range);
+  }
+  return roots;
+}
+
+function protectUnsafeJsonIntegers(value: string): string {
+  let output = "";
+  let inString = false;
+  let escaped = false;
+  for (let index = 0; index < value.length; ) {
+    const character = value[index];
+    if (inString) {
+      output += character;
+      if (escaped) {
+        escaped = false;
+      } else if (character === "\\") {
+        escaped = true;
+      } else if (character === '"') {
+        inString = false;
+      }
+      index += 1;
+      continue;
+    }
+    if (character === '"') {
+      inString = true;
+      output += character;
+      index += 1;
+      continue;
+    }
+    if (character === "-" || /[0-9]/.test(character)) {
+      const match =
+        /^-?(?:0|[1-9][0-9]*)(?:\.[0-9]+)?(?:[eE][+-]?[0-9]+)?/.exec(
+          value.slice(index),
+        );
+      if (match) {
+        const token = match[0];
+        if (!/[.eE]/.test(token)) {
+          try {
+            const integer = BigInt(token);
+            if (
+              integer > BigInt(Number.MAX_SAFE_INTEGER) ||
+              integer < BigInt(Number.MIN_SAFE_INTEGER)
+            ) {
+              output += JSON.stringify(`${token}n`);
+              index += token.length;
+              continue;
+            }
+          } catch {
+            // Native parsing reports malformed numeric tokens.
+          }
+        }
+        output += token;
+        index += token.length;
+        continue;
+      }
+    }
+    output += character;
+    index += 1;
+  }
+  return output;
+}
+
+function parseLosslessJson(value: string): unknown {
+  return JSON.parse(protectUnsafeJsonIntegers(value));
+}
+
+function sanitizeEmbeddedJson(
+  value: string,
+  privacy?: FlightRecorderPrivacy,
+  depth = 0,
+  budget: EmbeddedJsonBudget = {
+    remaining: Math.min(
+      MAX_EMBEDDED_JSON_PARSE_CHARS,
+      Math.max(value.length * 4, 1_024),
+    ),
+    exhausted: false,
+  },
+): string {
+  const oversized = oversizedStringMarker(value);
+  if (oversized) return oversized;
+  if (depth > MAX_EMBEDDED_JSON_DEPTH) return REDACTED;
+
+  const ranges = collectEmbeddedJsonRanges(value);
+  const renderRange = (range: EmbeddedJsonRange): string => {
+    const candidate = value.slice(range.start, range.end + 1);
+    budget.remaining -= candidate.length;
+    if (budget.remaining < 0) {
+      budget.exhausted = true;
+      return "";
+    }
+
+    try {
+      const parsed = parseLosslessJson(candidate);
+      if (
+        range.kind === "container" &&
+        parsed !== null &&
+        typeof parsed === "object"
+      ) {
+        return (
+          JSON.stringify(
+            sanitizeRecursive(parsed, privacy, new WeakSet()),
+          ) ?? UNSERIALIZABLE
+        );
+      }
+      if (
+        range.kind === "string" &&
+        typeof parsed === "string"
+      ) {
+        const nested = sanitizeEmbeddedJson(
+          parsed,
+          privacy,
+          depth + 1,
+          budget,
+        );
+        return JSON.stringify(
+          sanitizeScalarString(nested, privacy),
+        );
+      }
+    } catch {
+      // Invalid outer syntax falls through to its completed child ranges.
+    }
+
+    let rendered = "";
+    let cursor = range.start;
+    for (const child of range.children) {
+      rendered += value.slice(cursor, child.start);
+      rendered += renderRange(child);
+      cursor = child.end + 1;
+    }
+    return rendered + value.slice(cursor, range.end + 1);
+  };
+
+  let output = "";
+  let cursor = 0;
+  for (const range of ranges) {
+    output += value.slice(cursor, range.start);
+    output += renderRange(range);
+    cursor = range.end + 1;
+  }
+  output += value.slice(cursor);
+  return budget.exhausted
+    ? `[truncated:${Buffer.byteLength(value, "utf8")}]`
+    : output;
+}
+
+function sanitizeString(
+  value: string,
+  privacy?: FlightRecorderPrivacy,
+): string {
+  value = normalizeUnicodeScalars(value);
+  const oversized = oversizedStringMarker(value);
+  if (oversized) return oversized;
+  return sanitizeScalarString(
+    sanitizeEmbeddedJson(value, privacy),
+    privacy,
+  );
+}
+
+function sanitizeScalarString(
+  value: string,
+  privacy?: FlightRecorderPrivacy,
+): string {
+  if (isExcludedFlightPath(value, privacy)) return EXCLUDED_PATH;
+  if (isSecretShapedString(value, privacy)) return REDACTED;
+  return value;
+}
+
+function unsafePropertyKeyMarker(
+  key: string,
+  privacy?: FlightRecorderPrivacy,
+): string | undefined {
+  key = decodeValidPercentEscapes(normalizeUnicodeScalars(key));
+  if (key === REDACTED) return REDACTED;
+  if (isPrototypePollutionKey(key)) return REDACTED;
+  if (isSecretShapedKey(key, privacy)) return REDACTED;
+  const pathLike =
+    key.includes("/") ||
+    key.includes("\\") ||
+    key.startsWith(".") ||
+    /\.[a-z0-9]+$/i.test(key) ||
+    /^(?:application_default_credentials|client[-_.]?secret)$/i.test(
+      key,
+    );
+  if (pathLike && isExcludedFlightPath(key, privacy)) return EXCLUDED_PATH;
+  // Non-path field names such as `Credential` keep their useful schema key and
+  // redact the value.
+  if (isSensitiveKey(key, privacy)) return undefined;
+  return undefined;
+}
+
+function planSanitizedPropertyKeys(
+  keys: string[],
+  privacy?: FlightRecorderPrivacy,
+): Map<string, string> {
+  const ordered = [...keys].sort((left, right) =>
+    left < right ? -1 : left > right ? 1 : 0,
+  );
+  const reserved = new Set(
+    ordered
+      .map((key) =>
+        decodeValidPercentEscapes(normalizeUnicodeScalars(key)),
+      )
+      .filter(
+        (key) => unsafePropertyKeyMarker(key, privacy) === undefined,
+      ),
+  );
+  const assigned = new Set<string>();
+  const plan = new Map<string, string>();
+
+  for (const key of ordered) {
+    const normalized = decodeValidPercentEscapes(
+      normalizeUnicodeScalars(key),
+    );
+    const marker = unsafePropertyKeyMarker(normalized, privacy);
+    if (marker === undefined && !assigned.has(normalized)) {
+      plan.set(key, normalized);
+      assigned.add(normalized);
+      continue;
+    }
+    const base = marker ?? normalized;
+    let candidate = base;
+    let suffix = 2;
+    while (reserved.has(candidate) || assigned.has(candidate)) {
+      candidate = `${base}#${suffix}`;
+      suffix += 1;
+    }
+    plan.set(key, candidate);
+    assigned.add(candidate);
+  }
+  return plan;
+}
+
+function sanitizeTypedArray(value: ArrayBufferView): unknown[] {
+  if (value instanceof DataView) {
+    return Array.from(
+      new Uint8Array(value.buffer, value.byteOffset, value.byteLength),
+    );
+  }
+
+  return Array.from(value as unknown as ArrayLike<number | bigint>, (entry) =>
+    typeof entry === "bigint" ? `${entry}n` : entry,
+  );
+}
+
+function sanitizeRecursive(
+  value: unknown,
+  privacy: FlightRecorderPrivacy | undefined,
+  ancestors: WeakSet<object>,
+): unknown {
+  if (value === null) return null;
+
+  switch (typeof value) {
+    case "string": {
+      const oversized = oversizedStringMarker(value);
+      if (oversized) return oversized;
+      const trimmed = value.trim();
+      if (
+        (trimmed.startsWith("{") && trimmed.endsWith("}")) ||
+        (trimmed.startsWith("[") && trimmed.endsWith("]"))
+      ) {
+        try {
+          const parsed = parseLosslessJson(value);
+          if (parsed !== null && typeof parsed === "object") {
+            return sanitizeRecursive(parsed, privacy, ancestors);
+          }
+        } catch {
+          // Invalid or truncated JSON remains a sanitized string.
+        }
+      }
+      return sanitizeString(value, privacy);
+    }
+    case "number":
+      if (!Number.isFinite(value)) return null;
+      return Number.isInteger(value) && !Number.isSafeInteger(value)
+        ? `${value}n`
+        : value;
+    case "boolean":
+      return value;
+    case "bigint":
+      return `${value}n`;
+    case "undefined":
+      return null;
+    case "function":
+    case "symbol":
+      return UNSERIALIZABLE;
+  }
+
+  if (ancestors.has(value)) return CIRCULAR;
+  ancestors.add(value);
+
+  try {
+    if (value instanceof Date) {
+      return Number.isNaN(value.getTime())
+        ? "[invalid-date]"
+        : value.toISOString();
+    }
+
+    if (value instanceof RegExp) return value.toString();
+
+    if (value instanceof URL) {
+      return sanitizeString(value.toString(), privacy);
+    }
+
+    if (value instanceof ArrayBuffer) {
+      return Array.from(new Uint8Array(value));
+    }
+
+    if (ArrayBuffer.isView(value)) return sanitizeTypedArray(value);
+
+    if (Array.isArray(value)) {
+      return Array.from(value, (entry) =>
+        sanitizeRecursive(entry, privacy, ancestors),
+      );
+    }
+
+    if (value instanceof Map) {
+      const fileLocator = containsExcludedFileLocator(value, privacy);
+      const stringKeyPlan = planSanitizedPropertyKeys(
+        Array.from(value.keys()).filter(
+          (key): key is string => typeof key === "string",
+        ),
+        privacy,
+      );
+      const entries = Array.from(value.entries(), ([key, entryValue]) => {
+        const classifiedKey =
+          typeof key === "string"
+            ? decodeValidPercentEscapes(normalizeUnicodeScalars(key))
+            : undefined;
+        const keyMarker =
+          classifiedKey !== undefined
+            ? unsafePropertyKeyMarker(classifiedKey, privacy)
+            : undefined;
+        const sanitizedKey =
+          typeof key === "string"
+            ? stringKeyPlan.get(key)!
+            : sanitizeRecursive(key, privacy, ancestors);
+        const sanitizedValue =
+          keyMarker === EXCLUDED_PATH
+            ? EXCLUDED_PATH
+            : typeof key === "string" &&
+                isFileLocatorKey(key) &&
+                flightPathString(entryValue) !== undefined &&
+                isExcludedFlightPath(flightPathString(entryValue)!, privacy)
+              ? EXCLUDED_PATH
+            : fileLocator &&
+                typeof key === "string" &&
+                !isSafeFileMetadataField(key, entryValue, privacy) &&
+                !isFileLocatorKey(key) &&
+                !containsExcludedFileLocator(entryValue, privacy)
+              ? EXCLUDED_PATH
+            : classifiedKey !== undefined &&
+                isSensitiveKey(classifiedKey, privacy)
+            ? REDACTED
+            : sanitizeRecursive(entryValue, privacy, ancestors);
+        return [sanitizedKey, sanitizedValue] as [unknown, unknown];
+      });
+      entries.sort((left, right) => compareStableJson(left[0], right[0]));
+      return entries;
+    }
+
+    if (value instanceof Set) {
+      const entries = Array.from(value, (entry) =>
+        sanitizeRecursive(entry, privacy, ancestors),
+      );
+      entries.sort(compareStableJson);
+      return entries;
+    }
+
+    if (value instanceof Error) {
+      const entries: Array<[string, unknown]> = [
+        ["name", sanitizeString(value.name, privacy)],
+        ["message", sanitizeString(value.message, privacy)],
+      ];
+      if (value.stack)
+        entries.push(["stack", sanitizeString(value.stack, privacy)]);
+      const errorWithCause = value as Error & {
+        cause?: unknown;
+        code?: unknown;
+      };
+      if ("code" in errorWithCause) {
+        entries.push([
+          "code",
+          sanitizeRecursive(errorWithCause.code, privacy, ancestors),
+        ]);
+      }
+      if ("cause" in errorWithCause) {
+        entries.push([
+          "cause",
+          sanitizeRecursive(errorWithCause.cause, privacy, ancestors),
+        ]);
+      }
+      return Object.fromEntries(entries);
+    }
+
+    const keyPlan = planSanitizedPropertyKeys(Object.keys(value), privacy);
+    const record = value as Record<string, unknown>;
+    const excludedFileObject = containsExcludedFileLocator(record, privacy);
+    const entries: Array<[string, unknown]> = [];
+    for (const [key, sanitizedKey] of keyPlan) {
+      const classifiedKey = decodeValidPercentEscapes(
+        normalizeUnicodeScalars(key),
+      );
+      if (
+        unsafePropertyKeyMarker(classifiedKey, privacy) === EXCLUDED_PATH
+      ) {
+        entries.push([sanitizedKey, EXCLUDED_PATH]);
+        continue;
+      }
+      if (isSensitiveKey(classifiedKey, privacy)) {
+        entries.push([sanitizedKey, REDACTED]);
+        continue;
+      }
+      let entryValue: unknown;
+      try {
+        entryValue = record[key];
+      } catch {
+        entryValue = UNSERIALIZABLE;
+      }
+      const locator = isFileLocatorKey(key)
+        ? flightPathString(entryValue)
+        : undefined;
+      if (locator !== undefined && isExcludedFlightPath(locator, privacy)) {
+        entries.push([sanitizedKey, EXCLUDED_PATH]);
+        continue;
+      }
+      if (
+        excludedFileObject &&
+        !isSafeFileMetadataField(key, entryValue, privacy) &&
+        !isFileLocatorKey(key) &&
+        !containsExcludedFileLocator(entryValue, privacy)
+      ) {
+        entries.push([sanitizedKey, EXCLUDED_PATH]);
+        continue;
+      }
+
+      entries.push([
+        sanitizedKey,
+        sanitizeRecursive(entryValue, privacy, ancestors),
+      ]);
+    }
+    return Object.fromEntries(entries);
+  } finally {
+    ancestors.delete(value);
+  }
+}
+
+export function sanitizeFlightValue(
+  value: unknown,
+  privacy?: FlightRecorderPrivacy,
+): unknown {
+  return sanitizeBoundedValue(value, privacy, {
+    maxNodes: MAX_SANITIZE_NODES,
+    maxBytes: MAX_SANITIZE_BYTES,
+  });
+}
+
+export function sanitizeFlightMetadata(
+  metadata: Record<string, unknown> | undefined,
+  privacy?: FlightRecorderPrivacy,
+): Record<string, unknown> {
+  if (!metadata) return {};
+
+  const sanitized = sanitizeFlightValue(metadata, privacy);
+  if (sanitized && typeof sanitized === "object" && !Array.isArray(sanitized)) {
+    return sanitized as Record<string, unknown>;
+  }
+  return { value: sanitized };
+}
+
+function safeErrorProperty(error: unknown, key: string): unknown {
+  if (
+    (typeof error !== "object" || error === null) &&
+    typeof error !== "function"
+  ) {
+    return undefined;
+  }
+  try {
+    return (error as Record<string, unknown>)[key];
+  } catch {
+    return undefined;
+  }
+}
+
+function safeErrorName(error: unknown): string {
+  const name = safeErrorProperty(error, "name");
+  if (
+    typeof name === "string" &&
+    /^[A-Za-z][A-Za-z0-9_.:-]{0,63}$/.test(name) &&
+    !isSecretShapedString(name) &&
+    !isExcludedFlightPath(name)
+  ) {
+    return name;
+  }
+  return "Error";
+}
+
+function safeErrorCode(error: unknown): string | number | boolean | undefined {
+  const code = safeErrorProperty(error, "code");
+  if (typeof code === "boolean") return code;
+  if (
+    typeof code === "number" &&
+    Number.isFinite(code) &&
+    String(code).length <= 32
+  ) {
+    return code;
+  }
+  if (
+    typeof code === "string" &&
+    /^[A-Za-z0-9_.:-]{1,64}$/.test(code) &&
+    !isSecretShapedString(code) &&
+    !isExcludedFlightPath(code)
+  ) {
+    return code;
+  }
+  return undefined;
+}
+
+function safeHttpStatus(error: unknown): number | undefined {
+  for (const key of ["status", "statusCode"]) {
+    const status = safeErrorProperty(error, key);
+    if (
+      typeof status === "number" &&
+      Number.isInteger(status) &&
+      status >= 100 &&
+      status <= 599
+    ) {
+      return status;
+    }
+  }
+  return undefined;
+}
+
+export function summarizeFlightError(error: unknown): Record<string, unknown> {
+  try {
+    const messageValue =
+      typeof error === "string" ? error : safeErrorProperty(error, "message");
+    const rawMessage = typeof messageValue === "string" ? messageValue : "";
+    const summary: Record<string, unknown> = {
+      errorName: safeErrorName(error),
+      messageHash: createHash("sha256").update(rawMessage).digest("hex"),
+      messageChars: rawMessage.length,
+    };
+
+    const errorCode = safeErrorCode(error);
+    if (errorCode !== undefined) summary.errorCode = errorCode;
+
+    const httpStatus = safeHttpStatus(error);
+    if (httpStatus !== undefined) summary.httpStatus = httpStatus;
+
+    return summary;
+  } catch {
+    return {
+      errorName: "Error",
+      messageHash:
+        "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      messageChars: 0,
+    };
+  }
+}
+
+export function sanitizeFlightPayload(
+  payload: unknown,
+  privacy?: FlightRecorderPrivacy,
+): unknown | undefined {
+  if (privacy?.recordIO !== true) return undefined;
+
+  const configuredLimit = privacy.maxPayloadBytes ?? DEFAULT_MAX_PAYLOAD_BYTES;
+  const maxPayloadBytes =
+    Number.isFinite(configuredLimit) && configuredLimit >= 0
+      ? Math.floor(configuredLimit)
+      : DEFAULT_MAX_PAYLOAD_BYTES;
+  if (maxPayloadBytes < 4) return `[truncated:${maxPayloadBytes}]`;
+
+  const resolved =
+    typeof payload === "function"
+      ? (payload as () => unknown)()
+      : payload;
+  const sanitized = sanitizeBoundedValue(resolved, privacy, {
+    maxNodes: Math.max(
+      64,
+      Math.min(MAX_SANITIZE_NODES, maxPayloadBytes * 2 + 64),
+    ),
+    maxBytes: Math.max(
+      MAX_SANITIZE_STRING_BYTES,
+      Math.min(MAX_SANITIZE_BYTES, maxPayloadBytes * 4 + 1_024),
+    ),
+  });
+  let serialized: string;
+  try {
+    const result = JSON.stringify(sanitized);
+    if (result === undefined) return UNSERIALIZABLE;
+    serialized = result;
+  } catch {
+    return UNSERIALIZABLE;
+  }
+
+  const serializedBytes = Buffer.byteLength(serialized, "utf8");
+
+  if (serializedBytes <= maxPayloadBytes) return sanitized;
+  return `[truncated:${serializedBytes}]`;
+}

--- a/typescript/src/flight-recorder/runtime-integration.test.ts
+++ b/typescript/src/flight-recorder/runtime-integration.test.ts
@@ -1,0 +1,985 @@
+import { afterEach, describe, expect, it } from "vitest";
+import { Assistant } from "../agents/Assistant.js";
+import { BasicAgent } from "../agents/BasicAgent.js";
+import { matchAndExecuteAgent } from "../chat.js";
+import type { AgentMetadata } from "../agents/types.js";
+import { CopilotCliDirectProvider } from "../providers/copilot-cli-direct.js";
+import { ProviderRegistry } from "../providers/registry.js";
+import type {
+  LLMProvider,
+  Message,
+  ProviderResponse,
+  StreamDelta,
+} from "../providers/types.js";
+import {
+  FlightRecorder,
+  getFlightRecorder,
+  setFlightRecorder,
+} from "./recorder.js";
+import {
+  normalizeFlightSessionId,
+  normalizeFlightWorkspaceId,
+} from "./integrity.js";
+import type {
+  FlightEvent,
+  FlightEventQuery,
+  FlightExport,
+  FlightLedger,
+} from "./types.js";
+
+const TEST_IDENTITY_KEY = "22".repeat(32);
+
+class MemoryFlightLedger implements FlightLedger {
+  events: FlightEvent[] = [];
+
+  async initialize(): Promise<void> {}
+  async close(): Promise<void> {}
+
+  async append(event: FlightEvent): Promise<void> {
+    this.events.push(event);
+  }
+
+  async query(query: FlightEventQuery = {}): Promise<FlightEvent[]> {
+    return this.events.filter((event) => {
+      if (query.traceId && event.traceId !== query.traceId) return false;
+      if (query.sessionId && event.sessionId !== query.sessionId) return false;
+      if (query.source && event.source !== query.source) return false;
+      if (query.providerId && event.providerId !== query.providerId)
+        return false;
+      if (query.agentName && event.agentName !== query.agentName) return false;
+      if (query.toolName && event.toolName !== query.toolName) return false;
+      if (query.status && event.status !== query.status) return false;
+      if (query.kind) {
+        const kinds = Array.isArray(query.kind) ? query.kind : [query.kind];
+        if (!kinds.includes(event.kind)) return false;
+      }
+      return true;
+    });
+  }
+
+  async count(): Promise<number> {
+    return this.events.length;
+  }
+
+  async prune(keep: number): Promise<number> {
+    const remove = Math.max(0, this.events.length - keep);
+    this.events.splice(0, remove);
+    return remove;
+  }
+
+  async export(query: FlightEventQuery = {}): Promise<FlightExport> {
+    return {
+      schema: "openrappter-flight-export/1.0",
+      exportedAt: new Date().toISOString(),
+      events: await this.query(query),
+    };
+  }
+
+  async import(
+    data: FlightExport,
+    options?: { replace?: boolean },
+  ): Promise<number> {
+    if (options?.replace) this.events = [];
+    this.events.push(...data.events);
+    return data.events.length;
+  }
+
+  async clear(): Promise<void> {
+    this.events = [];
+  }
+}
+
+class RecordedAgent extends BasicAgent {
+  constructor(name = "Recorded") {
+    const metadata: AgentMetadata = {
+      name,
+      description: "Returns a deterministic result",
+      parameters: {
+        type: "object",
+        properties: {
+          query: { type: "string", description: "Input query" },
+        },
+        required: [],
+      },
+    };
+    super(name, metadata);
+  }
+
+  async perform(kwargs: Record<string, unknown>): Promise<string> {
+    return JSON.stringify({ status: "success", query: kwargs.query ?? null });
+  }
+}
+
+class ErrorResultAgent extends RecordedAgent {
+  override async perform(): Promise<string> {
+    return JSON.stringify({ status: "error", message: "command failed" });
+  }
+}
+
+class SecretResultAgent extends RecordedAgent {
+  override async perform(): Promise<string> {
+    return JSON.stringify({
+      status: "success",
+      password: "result-secret-value",
+    });
+  }
+}
+
+class FileResultAgent extends RecordedAgent {
+  override async perform(): Promise<string> {
+    return JSON.stringify({
+      status: "success",
+      path: "/repo/.env",
+      content: "PRIVATE_VALUE=ordinary",
+    });
+  }
+}
+
+function provider(
+  id: string,
+  chat: LLMProvider["chat"],
+  options: {
+    available?: boolean;
+    chatStream?: LLMProvider["chatStream"];
+  } = {},
+): LLMProvider {
+  return {
+    id,
+    name: id,
+    chat,
+    chatStream: options.chatStream,
+    isAvailable: async () => options.available ?? true,
+  };
+}
+
+function assistant(
+  llm: LLMProvider,
+  agents: BasicAgent[] = [],
+  workspaceDir = "/workspace/openrappter",
+): Assistant {
+  return new Assistant(new Map(agents.map((agent) => [agent.name, agent])), {
+    provider: llm,
+    model: "test-model",
+    workspaceDir,
+    loadWorkspaceContext: false,
+    loadMemoryContext: false,
+    useTwin: false,
+  });
+}
+
+let previousRecorder: FlightRecorder | undefined;
+let installedRecorder: FlightRecorder | undefined;
+
+function installRecorder(
+  enabled = true,
+  privacy?: { recordIO?: boolean },
+): MemoryFlightLedger {
+  const ledger = new MemoryFlightLedger();
+  installedRecorder = new FlightRecorder(
+    { enabled, identityKey: TEST_IDENTITY_KEY, privacy },
+    ledger,
+  );
+  previousRecorder = setFlightRecorder(installedRecorder);
+  return ledger;
+}
+
+afterEach(async () => {
+  if (previousRecorder) {
+    setFlightRecorder(previousRecorder);
+  }
+  if (installedRecorder) {
+    await installedRecorder.close();
+  }
+  previousRecorder = undefined;
+  installedRecorder = undefined;
+});
+
+describe("Flight Recorder runtime integration", () => {
+  it("keeps provider, tool, and agent events in one ordered Assistant trace", async () => {
+    const ledger = installRecorder();
+    const agent = new RecordedAgent();
+    let calls = 0;
+    const llm = provider("fixture-provider", async () => {
+      calls += 1;
+      if (calls === 1) {
+        return {
+          content: null,
+          tool_calls: [
+            {
+              id: "tool-1",
+              type: "function",
+              function: { name: "Recorded", arguments: '{"query":"safe"}' },
+            },
+          ],
+        };
+      }
+      return {
+        content: "done",
+        tool_calls: null,
+        usage: { input_tokens: 12, output_tokens: 3 },
+      };
+    });
+
+    const result = await assistant(llm, [agent]).getResponse(
+      "run it",
+      undefined,
+      "private memory must not enter metadata",
+      "conversation-145",
+    );
+
+    expect(result.content).toBe("done");
+    const runtimeEvents = ledger.events.filter(
+      (event) =>
+        event.kind.startsWith("provider.") ||
+        event.kind.startsWith("tool.") ||
+        event.kind.startsWith("agent."),
+    );
+    expect(runtimeEvents.length).toBeGreaterThan(0);
+    expect(new Set(runtimeEvents.map((event) => event.traceId))).toHaveLength(
+      1,
+    );
+    expect(
+      runtimeEvents.some(
+        (event) => event.kind === "provider.attempt.completed",
+      ),
+    ).toBe(true);
+    expect(
+      runtimeEvents.some((event) => event.kind === "tool.call.completed"),
+    ).toBe(true);
+    expect(
+      runtimeEvents.some((event) => event.kind === "agent.execute.completed"),
+    ).toBe(true);
+    expect(
+      ledger.events.every((event, index) => event.sequence === index + 1),
+    ).toBe(true);
+    expect(
+      ledger.events.every(
+        (event) =>
+          event.sessionId ===
+          normalizeFlightSessionId(
+            "conversation-145",
+            TEST_IDENTITY_KEY,
+          ),
+      ),
+    ).toBe(true);
+    expect(
+      ledger.events.every(
+        (event) =>
+          event.workspaceId ===
+          normalizeFlightWorkspaceId("/workspace/openrappter"),
+      ),
+    ).toBe(true);
+    expect(JSON.stringify(ledger.events)).not.toContain(
+      "/workspace/openrappter",
+    );
+    expect(
+      JSON.stringify(ledger.events.map((event) => event.metadata)),
+    ).not.toContain("private memory must not enter metadata");
+
+    const root = ledger.events.find((event) => event.kind === "trace.started")!;
+    const providerStarted = ledger.events.find(
+      (event) => event.kind === "provider.attempt.started",
+    )!;
+    const providerCompleted = ledger.events.find(
+      (event) => event.kind === "provider.attempt.completed",
+    )!;
+    const toolStarted = ledger.events.find(
+      (event) => event.kind === "tool.call.started",
+    )!;
+    const agentStarted = ledger.events.find(
+      (event) => event.kind === "agent.execute.started",
+    )!;
+    const agentContext = ledger.events.find(
+      (event) =>
+        event.kind === "context.assembled" && event.source === "basic-agent",
+    )!;
+    const agentCompleted = ledger.events.find(
+      (event) => event.kind === "agent.execute.completed",
+    )!;
+    const toolCompleted = ledger.events.find(
+      (event) => event.kind === "tool.call.completed",
+    )!;
+    const traceCompleted = ledger.events.find(
+      (event) => event.kind === "trace.completed",
+    )!;
+
+    expect(providerStarted.parentId).toBe(root.id);
+    expect(providerCompleted.parentId).toBe(providerStarted.id);
+    expect(toolStarted.parentId).toBe(providerCompleted.id);
+    expect(agentStarted.parentId).toBe(toolStarted.id);
+    expect(agentContext.parentId).toBe(agentStarted.id);
+    expect(agentCompleted.parentId).toBe(agentStarted.id);
+    expect(toolCompleted.parentId).toBe(toolStarted.id);
+    expect(traceCompleted.parentId).toBe(root.id);
+  });
+
+  it("isolates concurrent Assistant turns by trace and session identity", async () => {
+    const ledger = installRecorder();
+    const llm = provider("concurrent-provider", async (messages) => {
+      const text = messages.at(-1)?.content ?? "";
+      await new Promise((resolve) =>
+        setTimeout(resolve, text === "slow" ? 15 : 1),
+      );
+      return { content: text, tool_calls: null };
+    });
+    const instance = assistant(llm);
+
+    const [slow, fast] = await Promise.all([
+      instance.getResponse("slow", undefined, undefined, "session-slow"),
+      instance.getResponse("fast", undefined, undefined, "session-fast"),
+    ]);
+
+    expect([slow.content, fast.content]).toEqual(["slow", "fast"]);
+    const traceBySession = new Map<string, Set<string>>();
+    for (const event of ledger.events) {
+      const sessionId = event.sessionId ?? "";
+      const traces = traceBySession.get(sessionId) ?? new Set<string>();
+      traces.add(event.traceId);
+      traceBySession.set(sessionId, traces);
+    }
+    const slowSession = normalizeFlightSessionId(
+      "session-slow",
+      TEST_IDENTITY_KEY,
+    )!;
+    const fastSession = normalizeFlightSessionId(
+      "session-fast",
+      TEST_IDENTITY_KEY,
+    )!;
+    expect(traceBySession.get(slowSession)?.size).toBe(1);
+    expect(traceBySession.get(fastSession)?.size).toBe(1);
+    const slowTrace = [...(traceBySession.get(slowSession) ?? [])][0];
+    const fastTrace = [...(traceBySession.get(fastSession) ?? [])][0];
+    expect(slowTrace).not.toBe(fastTrace);
+    expect(
+      ledger.events.every((event) =>
+        event.traceId === slowTrace
+          ? event.sessionId ===
+            normalizeFlightSessionId("session-slow", TEST_IDENTITY_KEY)
+          : event.sessionId ===
+            normalizeFlightSessionId("session-fast", TEST_IDENTITY_KEY),
+      ),
+    ).toBe(true);
+  });
+
+  it("records provider failure and preserves the original Assistant error", async () => {
+    const ledger = installRecorder();
+    const original = new TypeError("provider exploded");
+    const llm = provider("failing-provider", async () => {
+      throw original;
+    });
+
+    let caught: unknown;
+    try {
+      await assistant(llm).getResponse(
+        "fail",
+        undefined,
+        undefined,
+        "failure-session",
+      );
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(caught).toBe(original);
+    const failed = ledger.events.find(
+      (event) => event.kind === "provider.attempt.failed",
+    );
+    expect(failed?.providerId).toBe("failing-provider");
+    expect(failed?.metadata.errorName).toBe("TypeError");
+    expect(failed?.metadata.messageChars).toBe("provider exploded".length);
+    expect(failed?.metadata.messageHash).toMatch(/^[0-9a-f]{64}$/);
+    expect(JSON.stringify(failed)).not.toContain("provider exploded");
+    expect(ledger.events.at(-1)?.kind).toBe("trace.failed");
+  });
+
+  it("never persists provider response bodies or embedded credentials in default metadata", async () => {
+    const ledger = installRecorder();
+    const githubToken = `ghp_${"s".repeat(32)}`;
+    const bearer = `Bearer ${"t".repeat(32)}`;
+    const original = new Error(
+      `HTTP 401 body={"token":"${githubToken}"} Authorization: ${bearer}`,
+    );
+    const llm = provider("secret-failure-provider", async () => {
+      throw original;
+    });
+
+    await expect(
+      assistant(llm).getResponse(
+        "fail safely",
+        undefined,
+        undefined,
+        "secret-failure",
+      ),
+    ).rejects.toBe(original);
+
+    const persisted = JSON.stringify(ledger.events);
+    expect(persisted).not.toContain(githubToken);
+    expect(persisted).not.toContain(bearer);
+    expect(persisted).not.toContain("body=");
+    const failed = ledger.events.find(
+      (event) => event.kind === "provider.attempt.failed",
+    );
+    expect(failed?.metadata).toMatchObject({
+      errorName: "Error",
+      messageChars: original.message.length,
+    });
+    expect(failed?.metadata.messageHash).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("records failover rungs, unavailable providers, and final selection", async () => {
+    const ledger = installRecorder();
+    const registry = new ProviderRegistry();
+    registry.register(
+      provider(
+        "offline",
+        async () => {
+          throw new Error("must not run");
+        },
+        { available: false },
+      ),
+    );
+    registry.register(
+      provider("primary", async () => {
+        throw new Error("primary failed");
+      }),
+    );
+    registry.register(
+      provider("backup", async () => {
+        await getFlightRecorder().record({
+          kind: "provider.nested",
+          source: "backup-provider",
+        });
+        return {
+          content: "backup answer",
+          tool_calls: null,
+          model: "backup-resolved",
+        };
+      }),
+    );
+
+    const response = await registry.chatWithFailover(
+      ["missing", "offline", "primary", "backup"],
+      [{ role: "user", content: "hello" }],
+      { model: "requested-model" },
+      { maxRetries: 1, retryDelayMs: 0 },
+    );
+
+    expect(response.content).toBe("backup answer");
+    const failures = ledger.events.filter(
+      (event) => event.kind === "provider.attempt.failed",
+    );
+    expect(
+      failures.some(
+        (event) =>
+          event.providerId === "missing" && event.metadata.reason === "missing",
+      ),
+    ).toBe(true);
+    expect(
+      failures.some(
+        (event) =>
+          event.providerId === "offline" &&
+          event.metadata.reason === "unavailable",
+      ),
+    ).toBe(true);
+    expect(failures.some((event) => event.providerId === "primary")).toBe(true);
+    const startedProviders = ledger.events
+      .filter((event) => event.kind === "provider.attempt.started")
+      .map((event) => event.providerId);
+    expect(startedProviders).toEqual(["primary", "primary", "backup"]);
+    const selected = ledger.events.find(
+      (event) => event.kind === "provider.selected",
+    );
+    expect(selected?.providerId).toBe("backup");
+    expect(selected?.model).toBe("backup-resolved");
+    expect(selected?.metadata.rung).toBe(4);
+    expect(selected?.metadata.attempt).toBe(1);
+    const backupStarted = ledger.events.find(
+      (event) =>
+        event.kind === "provider.attempt.started" &&
+        event.providerId === "backup",
+    )!;
+    const backupCompleted = ledger.events.find(
+      (event) =>
+        event.kind === "provider.attempt.completed" &&
+        event.providerId === "backup",
+    )!;
+    expect(backupCompleted.parentId).toBe(backupStarted.id);
+    expect(
+      ledger.events.find((event) => event.kind === "provider.nested")
+        ?.parentId,
+    ).toBe(backupStarted.id);
+    expect(selected?.parentId).toBe(backupCompleted.id);
+  });
+
+  it("is behaviorally inert and appends no events when disabled", async () => {
+    const ledger = installRecorder(false);
+    const llm = provider("disabled-provider", async () => ({
+      content: "unchanged",
+      tool_calls: null,
+    }));
+
+    const result = await assistant(llm).getResponse(
+      "hello",
+      undefined,
+      undefined,
+      "disabled-session",
+    );
+
+    expect(result).toEqual({
+      content: "unchanged",
+      agentLogs: [],
+      model: undefined,
+      requestedModel: "test-model",
+    });
+    expect(ledger.events).toEqual([]);
+  });
+
+  it("records streaming provider lifecycle without changing deltas", async () => {
+    const ledger = installRecorder();
+    const deltas: string[] = [];
+    const stream = async function* (
+      _messages: Message[],
+    ): AsyncGenerator<StreamDelta> {
+      yield { content: "hel", done: false };
+      yield { content: "lo", done: false };
+      yield { done: true, model: "actual-stream-model" };
+    };
+    const llm = provider(
+      "stream-provider",
+      async (): Promise<ProviderResponse> => ({
+        content: null,
+        tool_calls: null,
+      }),
+      { chatStream: stream },
+    );
+
+    const result = await assistant(llm).getResponseStreaming(
+      "stream",
+      (delta) => deltas.push(delta),
+      "stream-session",
+    );
+
+    expect(result.content).toBe("hello");
+    expect(deltas).toEqual(["hel", "lo"]);
+    const started = ledger.events.find(
+      (event) => event.kind === "provider.attempt.started",
+    );
+    const completed = ledger.events.find(
+      (event) => event.kind === "provider.attempt.completed",
+    );
+    expect(started?.metadata.streaming).toBe(true);
+    expect(completed?.metadata.streaming).toBe(true);
+    expect(completed?.model).toBe("actual-stream-model");
+    expect(started?.traceId).toBe(completed?.traceId);
+  });
+
+  it("structures streaming tool history before payload redaction", async () => {
+    const ledger = installRecorder(true, { recordIO: true });
+    let round = 0;
+    const stream = async function* (): AsyncGenerator<StreamDelta> {
+      round += 1;
+      if (round === 1) {
+        yield {
+          done: false,
+          tool_calls: [
+            {
+              index: 0,
+              id: "stream-call",
+              type: "function",
+              function: {
+                name: "FileTool",
+                arguments: JSON.stringify({ path: "/repo/.env" }),
+              },
+            },
+          ],
+        };
+        yield { done: true };
+        return;
+      }
+      yield { content: "done", done: false };
+      yield { done: true };
+    };
+    const llm = provider(
+      "stream-history",
+      async () => ({ content: null, tool_calls: null }),
+      { chatStream: stream },
+    );
+    const instance = assistant(llm, [new FileResultAgent("FileTool")]);
+
+    await instance.getResponseStreaming(
+      "read",
+      () => {},
+      "stream-history-session",
+    );
+
+    const persisted = JSON.stringify(ledger.events);
+    expect(persisted).not.toContain("PRIVATE_VALUE=ordinary");
+    expect(persisted).not.toContain("/repo/.env");
+    expect(persisted).toContain("[excluded-path]");
+  });
+
+  it("does not report auto-routing policy as the model that answered", async () => {
+    const ledger = installRecorder();
+    const llm = provider("auto-provider", async () => ({
+      content: "answer",
+      tool_calls: null,
+    }));
+    const instance = new Assistant(new Map(), {
+      provider: llm,
+      model: "auto",
+      loadWorkspaceContext: false,
+      loadMemoryContext: false,
+      useTwin: false,
+    });
+
+    await instance.getResponse(
+      "route it",
+      undefined,
+      undefined,
+      "auto-session",
+    );
+
+    const completed = ledger.events.find(
+      (event) => event.kind === "provider.attempt.completed",
+    );
+    expect(completed?.model).toBeUndefined();
+    expect(completed?.metadata.modelPolicy).toBe("auto");
+  });
+
+  it("records a concrete provider-reported model instead of the auto policy", async () => {
+    const ledger = installRecorder();
+    const llm = provider("resolved-provider", async () => ({
+      content: "answer",
+      tool_calls: null,
+      model: "resolved-model-v2",
+    }));
+    const instance = new Assistant(new Map(), {
+      provider: llm,
+      model: "auto",
+      loadWorkspaceContext: false,
+      loadMemoryContext: false,
+      useTwin: false,
+    });
+
+    await instance.getResponse(
+      "route it",
+      undefined,
+      undefined,
+      "resolved-session",
+    );
+
+    const completed = ledger.events.find(
+      (event) => event.kind === "provider.attempt.completed",
+    );
+    expect(completed?.model).toBe("resolved-model-v2");
+    expect(completed?.metadata.modelPolicy).toBe("auto");
+  });
+
+  it("preserves Copilot CLI auto policy when no Assistant model is explicitly set", async () => {
+    const ledger = installRecorder();
+    let receivedModel = "";
+    const cli = new CopilotCliDirectProvider({
+      runner: async (_executable, args) => {
+        receivedModel = args[args.indexOf("--model") + 1];
+        return { stdout: "cli answer", stderr: "" };
+      },
+    });
+
+    const instance = new Assistant(new Map(), {
+      provider: cli,
+      loadWorkspaceContext: false,
+      loadMemoryContext: false,
+      useTwin: false,
+    });
+
+    expect(instance.getModel()).toBe("auto");
+    const response = await instance.getResponse(
+      "use auto",
+      undefined,
+      undefined,
+      "cli-auto-session",
+    );
+    expect(response.content).toBe("cli answer");
+    expect(receivedModel).toBe("auto");
+    const completed = ledger.events.find(
+      (event) => event.kind === "provider.attempt.completed",
+    );
+    expect(completed?.model).toBeUndefined();
+    expect(completed?.metadata.modelPolicy).toBe("auto");
+  });
+
+  it("disables MCP child recording when the recorder cannot share storage", async () => {
+    installRecorder();
+    let childEnvironment: NodeJS.ProcessEnv | undefined;
+    const cli = new CopilotCliDirectProvider({
+      runner: async (_executable, _args, options) => {
+        childEnvironment = options.env;
+        return { stdout: "answer", stderr: "" };
+      },
+    });
+
+    await getFlightRecorder().runTrace(
+      { traceId: "mcp-parent-trace", sessionId: "private-session" },
+      async () => {
+        const parent = await getFlightRecorder().record({
+          kind: "provider.attempt.started",
+          source: "test",
+        });
+        await getFlightRecorder().withParent(parent?.id, () =>
+          cli.chat([{ role: "user", content: "hello" }]),
+        );
+      },
+    );
+
+    expect(childEnvironment).toMatchObject({
+      OPENRAPPTER_FLIGHT_RECORDER: "0",
+    });
+    expect(childEnvironment?.OPENRAPPTER_INVOCATION_REQUEST_ID).toMatch(
+      /^[0-9a-f-]{36}$/i,
+    );
+  });
+
+  it("updates model policy atomically when a live provider swap falls back to CLI auto", async () => {
+    const ledger = installRecorder();
+    const sdk = provider("copilot-sdk", async () => ({
+      content: "sdk",
+      tool_calls: null,
+      model: "gpt-4.1",
+    }));
+    let receivedModel = "";
+    const cli = new CopilotCliDirectProvider({
+      runner: async (_executable, args) => {
+        receivedModel = args[args.indexOf("--model") + 1];
+        return { stdout: "cli answer", stderr: "" };
+      },
+    });
+    const instance = new Assistant(new Map(), {
+      provider: sdk,
+      model: "gpt-4.1",
+      loadWorkspaceContext: false,
+      loadMemoryContext: false,
+      useTwin: false,
+    });
+
+    instance.setProvider(cli, "auto");
+    const response = await instance.getResponse(
+      "fallback",
+      undefined,
+      undefined,
+      "swapped-session",
+    );
+
+    expect(response.content).toBe("cli answer");
+    expect(instance.getModel()).toBe("auto");
+    expect(receivedModel).toBe("auto");
+    const completed = ledger.events.find(
+      (event) => event.kind === "provider.attempt.completed",
+    );
+    expect(completed?.providerId).toBe("copilot-cli-direct");
+    expect(completed?.model).toBeUndefined();
+    expect(completed?.metadata.modelPolicy).toBe("auto");
+  });
+
+  it("records keyword-routed CLI agent calls as tool-to-agent causal trees", async () => {
+    const ledger = installRecorder();
+    const agent = new RecordedAgent("Shell");
+
+    const result = await getFlightRecorder().runTrace(
+      { traceId: "keyword-route", sessionId: "cli" },
+      () => matchAndExecuteAgent("run ls", new Map([["Shell", agent]])),
+    );
+
+    expect(result).toContain('"status":"success"');
+    const events = ledger.events.filter(
+      (event) => event.traceId === "keyword-route",
+    );
+    const root = events.find((event) => event.kind === "trace.started")!;
+    const toolStarted = events.find((event) => event.kind === "tool.call.started")!;
+    const agentStarted = events.find((event) => event.kind === "agent.execute.started")!;
+    const toolCompleted = events.find(
+      (event) => event.kind === "tool.call.completed",
+    )!;
+    expect(toolStarted.parentId).toBe(root.id);
+    expect(agentStarted.parentId).toBe(toolStarted.id);
+    expect(toolCompleted.parentId).toBe(toolStarted.id);
+  });
+
+  it("records error-shaped agent results as failed agent and tool events", async () => {
+    const ledger = installRecorder();
+    const agent = new ErrorResultAgent("Shell");
+
+    const result = await getFlightRecorder().runTrace(
+      { traceId: "error-result", sessionId: "cli" },
+      () => matchAndExecuteAgent("run command", new Map([["Shell", agent]])),
+    );
+
+    expect(result).not.toBeNull();
+    expect(JSON.parse(result!).status).toBe("error");
+    const events = ledger.events.filter(
+      (event) => event.traceId === "error-result",
+    );
+    expect(
+      events.find((event) => event.kind === "agent.execute.failed")?.status,
+    ).toBe("error");
+    expect(
+      events.find((event) => event.kind === "tool.call.failed")?.status,
+    ).toBe("error");
+    expect(
+      events.some((event) => event.kind === "agent.execute.completed"),
+    ).toBe(false);
+  });
+
+  it("records successful standalone agent results as structured payloads", async () => {
+    const ledger = installRecorder(true, { recordIO: true });
+    const agent = new SecretResultAgent("StandaloneSecret");
+
+    await agent.execute({ query: "run" });
+
+    const completed = ledger.events.find(
+      (event) => event.kind === "agent.execute.completed",
+    )!;
+    expect(completed.payload).toEqual({
+      result: {
+        password: "[redacted]",
+        status: "success",
+      },
+    });
+  });
+
+  it("records parsed tool arguments as structured redacted data", async () => {
+    const ledger = installRecorder(true, { recordIO: true });
+    const agent = new RecordedAgent("SafeTool");
+    const llm = provider("tool-provider", async () => ({
+      content: null,
+      tool_calls: [
+        {
+          id: "call-1",
+          type: "function",
+          function: {
+            name: "SafeTool",
+            arguments: JSON.stringify({
+              password: "correct horse battery staple",
+              api_key: "ordinary-secret-value",
+            }),
+          },
+        },
+      ],
+    }));
+    const instance = assistant(llm, [agent]);
+
+    await instance.getResponse("run", undefined, undefined, "tool-privacy");
+
+    const started = ledger.events.find(
+      (event) => event.kind === "tool.call.started",
+    )!;
+    expect(started.payload).toEqual({
+      arguments: {
+        api_key: "[redacted]",
+        password: "[redacted]",
+      },
+    });
+    expect(JSON.stringify(started)).not.toContain(
+      "correct horse battery staple",
+    );
+  });
+
+  it("redacts structured tool results in provider history and keyword routes", async () => {
+    const ledger = installRecorder(true, { recordIO: true });
+    const agent = new SecretResultAgent("Shell");
+    let round = 0;
+    const llm = provider("history-provider", async () => {
+      round += 1;
+      return round === 1
+        ? {
+            content: null,
+            tool_calls: [
+              {
+                id: "call-1",
+                type: "function",
+                function: {
+                  name: "Shell",
+                  arguments: JSON.stringify({
+                    password: "argument-secret-value",
+                  }),
+                },
+              },
+            ],
+          }
+        : { content: "done", tool_calls: null };
+    });
+    await assistant(llm, [agent]).getResponse(
+      "run",
+      undefined,
+      undefined,
+      "history-privacy",
+    );
+    await getFlightRecorder().runTrace(
+      { traceId: "keyword-secret" },
+      () => matchAndExecuteAgent("run command", new Map([["Shell", agent]])),
+    );
+
+    const persisted = JSON.stringify(ledger.events);
+    expect(persisted).not.toContain("argument-secret-value");
+    expect(persisted).not.toContain("result-secret-value");
+    expect(persisted).toContain("[redacted]");
+  });
+
+  it("redacts unknown-agent structured arguments", async () => {
+    const ledger = installRecorder(true, { recordIO: true });
+    let round = 0;
+    const llm = provider("unknown-tool-provider", async () => {
+      round += 1;
+      return round === 1
+        ? {
+            content: null,
+            tool_calls: [
+              {
+                id: "missing-call",
+                type: "function",
+                function: {
+                  name: "Missing",
+                  arguments: JSON.stringify({
+                    password: "ordinary-secret-value",
+                  }),
+                },
+              },
+            ],
+          }
+        : { content: "done", tool_calls: null };
+    });
+
+    await assistant(llm).getResponse(
+      "run",
+      undefined,
+      undefined,
+      "unknown-tool",
+    );
+
+    const persisted = JSON.stringify(ledger.events);
+    expect(persisted).not.toContain("ordinary-secret-value");
+    expect(persisted).toContain("[redacted]");
+  });
+
+  it("creates a root trace and summarizes context for standalone agent execution", async () => {
+    const ledger = installRecorder();
+    const agent = new RecordedAgent("Standalone");
+    agent.sloshFilter = { exclude: ["memory_echoes"] };
+    agent.sloshPrivacy = { redact: ["query_signals.hints"] };
+
+    const result = await agent.execute({
+      query: "standalone",
+      upstream_slush: { source_agent: "upstream" },
+    });
+
+    expect(JSON.parse(result).status).toBe("success");
+    expect(ledger.events[0].kind).toBe("trace.started");
+    expect(ledger.events.at(-1)?.kind).toBe("trace.completed");
+    const context = ledger.events.find(
+      (event) => event.kind === "context.assembled",
+    );
+    expect(context?.source).toBe("basic-agent");
+    expect(context?.metadata.filterExclude).toEqual(["memory_echoes"]);
+    expect(context?.metadata.privacyRedactCount).toBe(1);
+    expect(context?.metadata.hasUpstream).toBe(true);
+  });
+});

--- a/typescript/src/flight-recorder/types.ts
+++ b/typescript/src/flight-recorder/types.ts
@@ -1,0 +1,151 @@
+/**
+ * Flight Recorder v1 — provider-neutral durable event contract.
+ *
+ * The envelope is intentionally smaller than an OpenTelemetry span and more
+ * privacy-aware than a chat transcript. It records enough to explain and
+ * replay a run without persisting raw prompts, responses, tool arguments, or
+ * file contents unless an operator explicitly opts in.
+ */
+
+export const FLIGHT_EVENT_SCHEMA = "openrappter-event/1.0" as const;
+
+export type FlightEventStatus =
+  | "started"
+  | "success"
+  | "error"
+  | "decision"
+  | "info";
+
+export type FlightEventKind =
+  | "trace.started"
+  | "trace.completed"
+  | "trace.failed"
+  | "context.assembled"
+  | "provider.attempt.started"
+  | "provider.attempt.completed"
+  | "provider.attempt.failed"
+  | "provider.selected"
+  | "agent.execute.started"
+  | "agent.execute.completed"
+  | "agent.execute.failed"
+  | "tool.call.started"
+  | "tool.call.completed"
+  | "tool.call.failed"
+  | "recorder.error"
+  | (string & {});
+
+export interface FlightEventInput {
+  kind: FlightEventKind;
+  source: string;
+  status?: FlightEventStatus;
+  traceId?: string;
+  parentId?: string | null;
+  sessionId?: string;
+  workspaceId?: string;
+  providerId?: string;
+  model?: string;
+  agentName?: string;
+  toolName?: string;
+  timestamp?: string;
+  durationMs?: number;
+  metadata?: Record<string, unknown>;
+  /**
+   * Potentially sensitive IO. The recorder drops this field by default and
+   * sanitizes it recursively only when recordIO is explicitly enabled.
+   */
+  payload?: unknown;
+}
+
+export interface FlightEvent extends Omit<FlightEventInput, "timestamp"> {
+  schema: typeof FLIGHT_EVENT_SCHEMA;
+  id: string;
+  sequence: number;
+  traceId: string;
+  parentId: string | null;
+  timestamp: string;
+  status: FlightEventStatus;
+  metadata: Record<string, unknown>;
+  payload?: unknown;
+  /** SHA-256 of the canonical persisted event body (excluding this field). */
+  contentHash: string;
+}
+
+export interface FlightEventQuery {
+  traceId?: string;
+  sessionId?: string;
+  workspaceId?: string;
+  kind?: FlightEventKind | FlightEventKind[];
+  source?: string;
+  providerId?: string;
+  agentName?: string;
+  toolName?: string;
+  status?: FlightEventStatus;
+  since?: string;
+  until?: string;
+  /** Trace queries default to sequence order; cross-trace queries use time. */
+  order?: "asc" | "desc";
+  limit?: number;
+  offset?: number;
+}
+
+export interface FlightRecorderPrivacy {
+  /** Persist payload IO. False by default. */
+  recordIO?: boolean;
+  /** Maximum serialized payload bytes after redaction. Default 16 KiB. */
+  maxPayloadBytes?: number;
+  /** Additional case-insensitive key names to redact recursively. */
+  redactedKeys?: string[];
+  /** Additional exact secret values to redact wherever they occur. */
+  redactedValues?: string[];
+  /** Additional path patterns to exclude entirely. */
+  excludedPathPatterns?: RegExp[];
+}
+
+export interface FlightRecorderOptions {
+  enabled?: boolean;
+  databasePath?: string;
+  inMemory?: boolean;
+  privacy?: FlightRecorderPrivacy;
+  /** Maximum retained events. Oldest are pruned after append. Default 10,000. */
+  retentionEvents?: number;
+  /** 32-byte hex HMAC key for opaque session identities. */
+  identityKey?: string;
+}
+
+export interface FlightRecorderHealth {
+  enabled: boolean;
+  initialized: boolean;
+  eventCount: number;
+  errorCount: number;
+  lastError?: string;
+  databasePath?: string;
+}
+
+export interface FlightTraceContext {
+  traceId: string;
+  sessionId?: string;
+  workspaceId?: string;
+  parentId?: string | null;
+}
+
+export interface FlightExport {
+  schema: "openrappter-flight-export/1.0";
+  exportedAt: string;
+  events: FlightEvent[];
+}
+
+export interface FlightLedger {
+  initialize(): Promise<void>;
+  close(): Promise<void>;
+  append(event: FlightEvent): Promise<void>;
+  query(query?: FlightEventQuery): Promise<FlightEvent[]>;
+  count(): Promise<number>;
+  prune(keep: number): Promise<number>;
+  export(query?: FlightEventQuery): Promise<FlightExport>;
+  import(data: FlightExport, options?: { replace?: boolean }): Promise<number>;
+  clear(): Promise<void>;
+  lastSequence?(traceId: string): Promise<number>;
+  pruneRuntime?(keep: number): Promise<number>;
+  bindIdentityKey?(identityKey: string): Promise<void>;
+  releaseEventOwnership?(eventId: string): Promise<void>;
+}

--- a/typescript/src/flight-recorder/windows-storage.test.ts
+++ b/typescript/src/flight-recorder/windows-storage.test.ts
@@ -1,0 +1,110 @@
+import { existsSync, mkdtempSync, rmSync } from "node:fs";
+import { execFileSync } from "node:child_process";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, it } from "vitest";
+import { FlightRecorder } from "./recorder.js";
+
+interface AclSummary {
+  Protected: boolean;
+  Owner: string;
+  Access: Array<{
+    Identity: string;
+    Rights: string;
+    Inherited: boolean;
+  }>;
+}
+
+function readAcl(target: string): AclSummary {
+  const output = execFileSync(
+    "powershell.exe",
+    [
+      "-NoProfile",
+      "-NonInteractive",
+      "-Command",
+      [
+        "$acl = Get-Acl -LiteralPath $env:HF_TARGET",
+        "[pscustomobject]@{ Protected = $acl.AreAccessRulesProtected; Owner = $acl.Owner; Access = @($acl.Access | ForEach-Object { [pscustomobject]@{ Identity = $_.IdentityReference.Value; Rights = $_.FileSystemRights.ToString(); Inherited = $_.IsInherited } }) } | ConvertTo-Json -Depth 4 -Compress",
+      ].join("; "),
+    ],
+    {
+      encoding: "utf8",
+      env: { ...process.env, HF_TARGET: target },
+    },
+  );
+  return JSON.parse(output) as AclSummary;
+}
+
+describe.skipIf(process.platform !== "win32")(
+  "Flight Recorder Windows storage",
+  () => {
+    it("initializes private database, sidecars, owner, and identity files", async () => {
+      const directory = mkdtempSync(
+        path.join(os.tmpdir(), "openrappter-flight-win-"),
+      );
+      const databasePath = path.join(directory, "flight.db");
+      const recorder = new FlightRecorder({ enabled: true, databasePath });
+      try {
+        await recorder.initialize();
+        await recorder.runTrace({ traceId: "windows-storage" }, async () => {});
+
+        expect(existsSync(databasePath)).toBe(true);
+        expect(existsSync(`${databasePath}.identity-key`)).toBe(true);
+        expect(existsSync(`${databasePath}.owners`)).toBe(true);
+        expect((await recorder.health()).initialized).toBe(true);
+        for (const target of [
+          databasePath,
+          `${databasePath}-wal`,
+          `${databasePath}-shm`,
+          `${databasePath}.identity-key`,
+        ]) {
+          const acl = readAcl(target);
+          expect(acl.Protected).toBe(true);
+          expect(acl.Owner).toContain("\\");
+          expect(acl.Access).toHaveLength(1);
+          expect(acl.Access[0]).toMatchObject({
+            Identity: expect.stringContaining("\\"),
+            Rights: expect.stringContaining("FullControl"),
+            Inherited: false,
+          });
+        }
+      } finally {
+        await recorder.close();
+        rmSync(directory, { recursive: true, force: true });
+      }
+    });
+
+    it("materializes private WAL sidecars before a reopened ledger is ready", async () => {
+      const directory = mkdtempSync(
+        path.join(os.tmpdir(), "openrappter-flight-win-reopen-"),
+      );
+      const databasePath = path.join(directory, "flight.db");
+      const first = new FlightRecorder({ enabled: true, databasePath });
+      await first.initialize();
+      await first.close();
+      rmSync(`${databasePath}-wal`, { force: true });
+      rmSync(`${databasePath}-shm`, { force: true });
+
+      const second = new FlightRecorder({ enabled: true, databasePath });
+      try {
+        await second.initialize();
+        for (const target of [
+          `${databasePath}-wal`,
+          `${databasePath}-shm`,
+        ]) {
+          expect(existsSync(target)).toBe(true);
+          const acl = readAcl(target);
+          expect(acl.Protected).toBe(true);
+          expect(acl.Access).toHaveLength(1);
+          expect(acl.Access[0]).toMatchObject({
+            Rights: expect.stringContaining("FullControl"),
+            Inherited: false,
+          });
+        }
+      } finally {
+        await second.close();
+        rmSync(directory, { recursive: true, force: true });
+      }
+    });
+  },
+);

--- a/typescript/src/flight-recorder/windows-storage.test.ts
+++ b/typescript/src/flight-recorder/windows-storage.test.ts
@@ -24,7 +24,8 @@ function readAcl(target: string): AclSummary {
       "-NonInteractive",
       "-Command",
       [
-        "$acl = Get-Acl -LiteralPath $env:HF_TARGET",
+        "$item = if ([System.IO.Directory]::Exists($env:HF_TARGET)) { New-Object System.IO.DirectoryInfo($env:HF_TARGET) } else { New-Object System.IO.FileInfo($env:HF_TARGET) }",
+        "$acl = $item.GetAccessControl()",
         "[pscustomobject]@{ Protected = $acl.AreAccessRulesProtected; Owner = $acl.Owner; Access = @($acl.Access | ForEach-Object { [pscustomobject]@{ Identity = $_.IdentityReference.Value; Rights = $_.FileSystemRights.ToString(); Inherited = $_.IsInherited } }) } | ConvertTo-Json -Depth 4 -Compress",
       ].join("; "),
     ],

--- a/typescript/src/flight-recorder/windows-storage.test.ts
+++ b/typescript/src/flight-recorder/windows-storage.test.ts
@@ -4,6 +4,7 @@ import os from "node:os";
 import path from "node:path";
 import { describe, expect, it } from "vitest";
 import { FlightRecorder } from "./recorder.js";
+import { hardenPrivatePath } from "./permissions.js";
 
 interface AclSummary {
   Protected: boolean;
@@ -42,6 +43,7 @@ describe.skipIf(process.platform !== "win32")(
       const directory = mkdtempSync(
         path.join(os.tmpdir(), "openrappter-flight-win-"),
       );
+      hardenPrivatePath(directory, true);
       const databasePath = path.join(directory, "flight.db");
       const recorder = new FlightRecorder({ enabled: true, databasePath });
       try {
@@ -78,6 +80,7 @@ describe.skipIf(process.platform !== "win32")(
       const directory = mkdtempSync(
         path.join(os.tmpdir(), "openrappter-flight-win-reopen-"),
       );
+      hardenPrivatePath(directory, true);
       const databasePath = path.join(directory, "flight.db");
       const first = new FlightRecorder({ enabled: true, databasePath });
       await first.initialize();

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -1174,8 +1174,10 @@ export class GatewayServer {
                 sessionId: result.sessionId,
                 agentLogs: result.agentLogs
                   ?? (result.toolCalls ? [JSON.stringify(result.toolCalls)] : []),
-                model: this.backendStatus?.model,
-                requestedModel: this.backendStatus?.requestedModel,
+                model: result.model,
+                requestedModel:
+                  result.requestedModel ??
+                  this.backendStatus?.requestedModel,
                 // Lets the envelope explain an unattributed model instead of
                 // reporting the bare word "unknown".
                 backendKind: this.backendStatus?.kind,

--- a/typescript/src/gateway/types.ts
+++ b/typescript/src/gateway/types.ts
@@ -185,6 +185,8 @@ export interface AgentResponse {
   usage?: TokenUsage;
   finishReason?: 'stop' | 'tool_calls' | 'length' | 'error';
   agentLogs?: string[];
+  model?: string;
+  requestedModel?: string;
 }
 
 export interface ToolCallResult {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -18,12 +18,22 @@ import { registerTelephonyCommands } from './telephony/cli.js';
 import { registerTwinCommands } from './twin/index.js';
 import { registerCronCommand } from './cli/cron.js';
 import { registerRappterCommand } from './cli/rappters.js';
+import { registerFlightRecorderCommand } from './cli/flight-recorder.js';
 import { portTypedOnCommandLine } from './infra/cli-port.js';
+import {
+  ensureFlightRecorderFromEnv,
+  getFlightRecorder,
+} from './flight-recorder/index.js';
+import { chatWithFlightRecorder } from './providers/recorded-chat.js';
 
 const execAsync = promisify(exec);
 
 const EMOJI = '🦖';
 const NAME = 'openrappter';
+const GATEWAY_LIFECYCLE_LOCK = path.join(
+  HOME_DIR,
+  'gateway-lifecycle.pid',
+);
 
 // Initialize agent registry
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
@@ -81,6 +91,10 @@ async function startGatewayInProcess(opts?: {
   instance?: string;
   releaseProcessLock?: () => void;
 }): Promise<{ port: number; cleanup: () => Promise<void> }> {
+  // launchd runs `node` directly with a fixed environment, so hydrate the
+  // managed .env before the recorder snapshots and caches its configuration.
+  await hydrateManagedEnv();
+  await ensureFlightRecorderFromEnv();
   const { GatewayServer } = await import('./gateway/server.js');
   const { Assistant } = await import('./agents/Assistant.js');
   const { ChannelRegistry } = await import('./channels/registry.js');
@@ -100,13 +114,6 @@ async function startGatewayInProcess(opts?: {
     readIMessageConfig,
   } = await import('./channels/imessage-gateway.js');
   const { listBundledSkills } = await import('./skills/bundled.js');
-
-  // launchd runs `node` directly with a fixed environment, so a supervised
-  // gateway never sees ~/.openrappter/.env — the wrapper script is what sources
-  // it for interactive commands. Without this the Copilot provider starts with
-  // no credential and the iMessage model preflight fails forever, while
-  // `diagnose` (run under the wrapper) reports the token as configured. #44
-  await hydrateManagedEnv();
 
   const port = opts?.port ?? parseInt(process.env.OPENRAPPTER_PORT ?? '18790', 10);
   const token = process.env.OPENRAPPTER_TOKEN || undefined;
@@ -188,7 +195,7 @@ async function startGatewayInProcess(opts?: {
     description: `a local-first AI assistant. Your name is ${calledName}`
       + `${vitals.designation ? ` and your full designation is ${vitals.designation}` : ''}. `
       + 'You have shell, memory, and skill agents.',
-    model: process.env.OPENRAPPTER_MODEL,
+    model: backend.model ?? process.env.OPENRAPPTER_MODEL,
     githubToken: githubToken ?? undefined,
     workspaceDir: process.env.OPENRAPPTER_WORKSPACE_DIR,
     // Which rappter this is. Reached the lock, the port and the channels
@@ -342,10 +349,17 @@ async function startGatewayInProcess(opts?: {
       const controller = new AbortController();
       imessageModelProbeController = controller;
       try {
-        const response = await imessageProvider.chat([{
-          role: 'user',
-          content: 'Reply exactly OPENRAPPTER_MODEL_READY and nothing else.',
-        }], { signal: controller.signal });
+        const response = await chatWithFlightRecorder({
+          provider: imessageProvider,
+          messages: [{
+            role: 'user',
+            content: 'Reply exactly OPENRAPPTER_MODEL_READY and nothing else.',
+          }],
+          options: { model: imessageModel, signal: controller.signal },
+          source: 'imessage-model-preflight',
+          scope: { sessionId: 'imessage-model-preflight' },
+          attributes: { phase: 'readiness-probe' },
+        });
         if (response.content?.trim() !== 'OPENRAPPTER_MODEL_READY') {
           throw new Error('unexpected model probe response');
         }
@@ -481,6 +495,8 @@ async function startGatewayInProcess(opts?: {
       sessionId: req.sessionId ?? 'default',
       content: result.content,
       agentLogs: result.agentLogs,
+      model: result.model,
+      requestedModel: result.requestedModel,
       finishReason: 'stop' as const,
     };
   });
@@ -616,7 +632,10 @@ async function startGatewayInProcess(opts?: {
         const next = await reselect({ githubToken: token, model: process.env.OPENRAPPTER_MODEL });
         if (next.provider) {
           surgeonService.setProvider(next.provider);
-          assistant.setProvider?.(next.provider);
+          assistant.setProvider?.(
+            next.provider,
+            next.model ?? (next.kind === 'copilot-cli' ? 'auto' : assistant.getModel()),
+          );
           log(`${EMOJI} Stored Copilot profile is stale — switched to ${next.kind}`);
         } else {
           log(`${EMOJI} Stored Copilot profile is stale and no backend can answer`);
@@ -852,6 +871,7 @@ async function startGatewayInProcess(opts?: {
 
     const oldModel = assistant.getModel();
     assistant.setModel(params.model);
+    process.env.OPENRAPPTER_MODEL = params.model;
 
     // Persist to .env so it survives restarts
     try {
@@ -1096,6 +1116,10 @@ program
       return;
     }
 
+    if (!options.web && !options.daemon) {
+      await ensureFlightRecorderFromEnv();
+    }
+
     // Initialize agents
     await registry.discoverAgents();
 
@@ -1158,9 +1182,64 @@ program
         console.log(`${EMOJI} Web UI assets available: ${webRoot}`);
         return;
       }
-      const { port } = await startGatewayInProcess({
-        webRoot,
-        port: options.port,
+      const {
+        acquireLock,
+        releaseLock,
+        gatewayLockFileFor,
+        gatewayPortFor,
+        writeGatewayEndpoint,
+      } = await import('./infra/gateway-lock.js');
+      const { declareCurrentInstance } = await import(
+        './infra/current-instance.js'
+      );
+      const lockInstance = (options.instance as string | undefined)
+        ?? process.env.OPENRAPPTER_INSTANCE;
+      declareCurrentInstance(lockInstance);
+      const explicitPort = options.port
+        ? Number(options.port)
+        : (process.env.OPENRAPPTER_PORT
+          ? Number(process.env.OPENRAPPTER_PORT)
+          : undefined);
+      const lockPort = gatewayPortFor({
+        instance: lockInstance,
+        port: explicitPort,
+      });
+      const lockFile = gatewayLockFileFor({
+        instance: lockInstance,
+        port: lockPort,
+      });
+      if (!acquireLock({ filePath: GATEWAY_LIFECYCLE_LOCK })) {
+        throw new Error('Another gateway lifecycle operation is in progress.');
+      }
+      try {
+        if (!acquireLock({ filePath: lockFile })) {
+          throw new Error(
+            `Another OpenRappter gateway owns the runtime lock (${lockFile}).`,
+          );
+        }
+      } finally {
+        releaseLock({ filePath: GATEWAY_LIFECYCLE_LOCK });
+      }
+      let handedOff = false;
+      let started: Awaited<ReturnType<typeof startGatewayInProcess>>;
+      try {
+        started = await startGatewayInProcess({
+          webRoot,
+          port: lockPort,
+          ...(lockInstance ? { instance: lockInstance } : {}),
+          releaseProcessLock: () =>
+            releaseLock({ filePath: lockFile }),
+        });
+        handedOff = true;
+      } finally {
+        if (!handedOff) releaseLock({ filePath: lockFile });
+      }
+      const { port } = started;
+      writeGatewayEndpoint({
+        ...(lockInstance ? { instance: lockInstance } : {}),
+        port,
+        pid: process.pid,
+        startedAt: new Date().toISOString(),
       });
       const url = `http://127.0.0.1:${port}`;
       console.log(`${EMOJI} Web UI: ${url}`);
@@ -1194,12 +1273,21 @@ program
         : (process.env.OPENRAPPTER_PORT ? Number(process.env.OPENRAPPTER_PORT) : undefined);
       const lockPort = gatewayPortFor({ instance: lockInstance, port: explicitPort });
       const lockFile = gatewayLockFileFor({ instance: lockInstance, port: lockPort });
-      if (!acquireLock({ filePath: lockFile })) {
-        console.error(
-          `${EMOJI} Another OpenRappter gateway already owns this instance's runtime lock (${lockFile}).`,
-        );
+      if (!acquireLock({ filePath: GATEWAY_LIFECYCLE_LOCK })) {
+        console.error(`${EMOJI} Another gateway lifecycle operation is in progress.`);
         process.exitCode = 1;
         return;
+      }
+      try {
+        if (!acquireLock({ filePath: lockFile })) {
+          console.error(
+            `${EMOJI} Another OpenRappter gateway already owns this instance's runtime lock (${lockFile}).`,
+          );
+          process.exitCode = 1;
+          return;
+        }
+      } finally {
+        releaseLock({ filePath: GATEWAY_LIFECYCLE_LOCK });
       }
       let lockHandedToGateway = false;
       let startupFailed = false;
@@ -2115,6 +2203,29 @@ program
   .description('Clear all credentials, config, and cached tokens for a fresh start')
   .option('-y, --yes', 'Skip confirmation')
   .action(async (options) => {
+    const listGatewayLockFiles = (): string[] => {
+      const lockFiles = [path.join(HOME_DIR, 'gateway.pid')];
+      const instancesDir = path.join(HOME_DIR, 'instances');
+      try {
+        for (const entry of fs.readdirSync(instancesDir, {
+          withFileTypes: true,
+        })) {
+          if (entry.isDirectory()) {
+            lockFiles.push(
+              path.join(instancesDir, entry.name, 'gateway.pid'),
+            );
+          }
+        }
+      } catch {
+        // No twins have been created.
+      }
+      return lockFiles;
+    };
+    const resetEnv = await loadEnv();
+    const recorderDatabase =
+      process.env.OPENRAPPTER_FLIGHT_DB
+      || resetEnv.OPENRAPPTER_FLIGHT_DB
+      || path.join(HOME_DIR, 'flight-recorder.db');
     const filesToDelete = [
       { path: ENV_FILE, label: '.env (credentials)' },
       { path: CONFIG_FILE, label: 'config.json' },
@@ -2122,6 +2233,9 @@ program
       { path: path.join(HOME_DIR, 'credentials', 'github-token.json'), label: 'cached GitHub token' },
       { path: path.join(HOME_DIR, 'memory.json'), label: 'memory store' },
       { path: path.join(HOME_DIR, 'sessions.json'), label: 'sessions' },
+      { path: recorderDatabase, label: 'Flight Recorder database' },
+      { path: `${recorderDatabase}-wal`, label: 'Flight Recorder WAL' },
+      { path: `${recorderDatabase}-shm`, label: 'Flight Recorder shared memory' },
     ];
 
     console.log(`\n${EMOJI} This will delete:\n`);
@@ -2143,21 +2257,111 @@ program
       }
     }
 
-    let deleted = 0;
-    for (const f of filesToDelete) {
-      try {
-        if (fs.existsSync(f.path)) {
-          fs.unlinkSync(f.path);
-          console.log(chalk.green(`  ✓ Deleted ${f.label}`));
-          deleted++;
+    const { acquireLock, readGatewayLockOwner, releaseLock } = await import(
+      './infra/gateway-lock.js'
+    );
+    const acquiredLocks: string[] = [];
+    let releaseRecorderBarrier: (() => void) | undefined;
+    try {
+      if (!acquireLock({ filePath: GATEWAY_LIFECYCLE_LOCK })) {
+        throw new Error(
+          'Refusing reset because a gateway lifecycle operation is in progress.',
+        );
+      }
+      acquiredLocks.push(GATEWAY_LIFECYCLE_LOCK);
+      for (const filePath of listGatewayLockFiles()) {
+        if (!acquireLock({ filePath })) {
+          const owner = readGatewayLockOwner({ filePath });
+          throw new Error(
+            `Refusing reset because the authoritative gateway lock ${
+              filePath
+            } is held${
+              owner.pid ? ` by PID ${owner.pid}` : ''
+            }.`,
+          );
         }
-      } catch (err) {
-        console.error(chalk.red(`  ✗ Failed to delete ${f.label}: ${(err as Error).message}`));
+        acquiredLocks.push(filePath);
+      }
+
+      const {
+        acquireRecorderResetBarrier,
+        listLiveRecorderOwners,
+        removeRecorderIdentityArtifacts,
+        removeRecorderOwnerDirectory,
+      } = await import('./flight-recorder/process-owner.js');
+      releaseRecorderBarrier = acquireRecorderResetBarrier(
+        recorderDatabase,
+      );
+      await getFlightRecorder().close();
+      for (const recorderPath of [
+        recorderDatabase,
+        `${recorderDatabase}-wal`,
+        `${recorderDatabase}-shm`,
+        `${recorderDatabase}.identity-key`,
+      ]) {
+        try {
+          if (fs.lstatSync(recorderPath).isSymbolicLink()) {
+            throw new Error(
+              `Refusing reset because Flight Recorder storage is symlinked: ${recorderPath}`,
+            );
+          }
+        } catch (error) {
+          if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+        }
+      }
+      const liveRecorders = listLiveRecorderOwners(recorderDatabase);
+      if (liveRecorders.length > 0) {
+        throw new Error(
+          `Refusing reset while Flight Recorder PID(s) ${
+            liveRecorders.join(', ')
+          } are active.`,
+        );
+      }
+      let deleted = 0;
+      for (const f of filesToDelete) {
+        try {
+          if (fs.existsSync(f.path)) {
+            fs.unlinkSync(f.path);
+            console.log(chalk.green(`  ✓ Deleted ${f.label}`));
+            deleted++;
+          }
+        } catch (err) {
+          console.error(chalk.red(`  ✗ Failed to delete ${f.label}: ${(err as Error).message}`));
+        }
+      }
+      const recorderFiles = [
+        recorderDatabase,
+        `${recorderDatabase}-wal`,
+        `${recorderDatabase}-shm`,
+      ];
+      const recorderRemnants = recorderFiles.filter((file) =>
+        fs.existsSync(file)
+      );
+      if (recorderRemnants.length > 0) {
+        throw new Error(
+          `Reset could not remove Flight Recorder storage: ${
+            recorderRemnants.join(', ')
+          }. The identity key was preserved.`,
+        );
+      }
+      const deletedIdentityArtifacts =
+        removeRecorderIdentityArtifacts(recorderDatabase);
+      if (deletedIdentityArtifacts > 0) {
+        deleted += deletedIdentityArtifacts;
+        console.log(chalk.green(
+          `  ✓ Deleted ${deletedIdentityArtifacts} Flight Recorder identity artifact(s)`,
+        ));
+      }
+      removeRecorderOwnerDirectory(recorderDatabase);
+
+      console.log(`\n${EMOJI} Reset complete (${deleted} files removed).`);
+      console.log(`  Run ${chalk.bold('openrappter onboard')} to set up again.\n`);
+    } finally {
+      releaseRecorderBarrier?.();
+      for (const filePath of acquiredLocks.reverse()) {
+        releaseLock({ filePath });
       }
     }
-
-    console.log(`\n${EMOJI} Reset complete (${deleted} files removed).`);
-    console.log(`  Run ${chalk.bold('openrappter onboard')} to set up again.\n`);
   });
 
 // Status command
@@ -2316,5 +2520,7 @@ registerTwinCommands(program);
 registerCronCommand(program);
 // Seeing and creating the rappters on this device. #107
 registerRappterCommand(program);
+registerFlightRecorderCommand(program);
 
+await hydrateManagedEnv();
 program.parse();

--- a/typescript/src/mcp/server.ts
+++ b/typescript/src/mcp/server.ts
@@ -51,18 +51,25 @@ export interface McpServerOptions {
   name?: string;
   /** Server version (defaults to the package version) */
   version?: string;
+  executeAgent?: (
+    name: string,
+    args: Record<string, unknown>,
+    operation: () => Promise<string>,
+  ) => Promise<string>;
 }
 
 export class McpServer {
   private agents = new Map<string, BasicAgent>();
   private serverInfo: McpServerInfo;
   private initialized = false;
+  private readonly executeAgent?: McpServerOptions["executeAgent"];
 
   constructor(options?: McpServerOptions) {
     this.serverInfo = {
       name: options?.name ?? 'openrappter',
       version: options?.version ?? VERSION,
     };
+    this.executeAgent = options?.executeAgent;
   }
 
   /** Register an agent as an MCP tool */
@@ -156,7 +163,10 @@ export class McpServer {
     }
 
     try {
-      const resultStr = await agent.execute(args);
+      const operation = () => agent.execute(args);
+      const resultStr = this.executeAgent
+        ? await this.executeAgent(toolName, args, operation)
+        : await operation();
       // The CLI backend runs its tool loop inside itself, so the Assistant loop
       // never sees these calls and `agent_logs` came back empty even when an
       // agent had demonstrably run. Journal it here — this is the only place
@@ -190,39 +200,39 @@ export class McpServer {
   }
 
   /** Start the stdio transport — reads JSON-RPC from stdin, writes to stdout */
-  async serve(): Promise<void> {
-    const rl = createInterface({ input: process.stdin, terminal: false });
+  async serve(input: NodeJS.ReadableStream = process.stdin): Promise<void> {
+    const rl = createInterface({ input, terminal: false });
+    const pending = new Set<Promise<void>>();
 
-    rl.on('line', async (line) => {
-      const trimmed = line.trim();
-      if (!trimmed) return;
+    rl.on('line', (line) => {
+      const task = (async () => {
+        const trimmed = line.trim();
+        if (!trimmed) return;
 
-      let request: JsonRpcRequest;
-      try {
-        request = JSON.parse(trimmed);
-      } catch {
-        const errorResponse: JsonRpcResponse = {
-          jsonrpc: '2.0',
-          id: null,
-          error: { code: -32700, message: 'Parse error' },
-        };
-        this.writeLine(JSON.stringify(errorResponse));
-        return;
-      }
+        let request: JsonRpcRequest;
+        try {
+          request = JSON.parse(trimmed);
+        } catch {
+          const errorResponse: JsonRpcResponse = {
+            jsonrpc: '2.0',
+            id: null,
+            error: { code: -32700, message: 'Parse error' },
+          };
+          this.writeLine(JSON.stringify(errorResponse));
+          return;
+        }
 
-      // Handle notifications (no id) — just ignore
-      if (request.id === undefined || request.id === null) {
-        // It's a notification, no response needed
-        // But handle 'notifications/initialized' silently
-        return;
-      }
+        if (request.id === undefined || request.id === null) return;
 
-      const response = await this.handleRequest(request);
-      this.writeLine(JSON.stringify(response));
+        const response = await this.handleRequest(request);
+        this.writeLine(JSON.stringify(response));
+      })();
+      pending.add(task);
+      void task.finally(() => pending.delete(task));
     });
 
-    // Wait until stdin closes
     await new Promise<void>((resolve) => rl.on('close', resolve));
+    await Promise.allSettled([...pending]);
   }
 
   private writeLine(data: string): void {

--- a/typescript/src/mcp/stdio.ts
+++ b/typescript/src/mcp/stdio.ts
@@ -22,21 +22,110 @@ import { fileURLToPath } from 'url';
 import { AgentRegistry } from '../agents/AgentRegistry.js';
 import { createMcpServer } from './server.js';
 import { VERSION } from '../version.js';
+import { ensureFlightRecorderFromEnv } from '../flight-recorder/index.js';
+import { agentResultIsError } from '../agents/result-status.js';
+import { sanitizeFlightValue } from '../flight-recorder/redaction.js';
 
 const HERE = path.dirname(fileURLToPath(import.meta.url));
 
 async function main(): Promise<void> {
+  const recorder = await ensureFlightRecorderFromEnv();
   const registry = new AgentRegistry(
     path.join(HERE, '..', 'agents'),
     process.env.OPENRAPPTER_AGENTS_DIR ?? path.join(os.homedir(), '.openrappter', 'agents'),
   );
 
   const agents = await registry.getAllAgents();
-  const server = createMcpServer({ name: 'openrappter', version: VERSION });
+  const traceId = process.env.OPENRAPPTER_FLIGHT_TRACE_ID;
+  const executeAgent = async (
+    name: string,
+    args: Record<string, unknown>,
+    operation: () => Promise<string>,
+  ): Promise<string> => {
+    const runTool = async (): Promise<string> => {
+      const startedAt = performance.now();
+      const started = await recorder.record({
+        kind: 'tool.call.started',
+        source: 'mcp-stdio',
+        status: 'started',
+        toolName: name,
+        metadata: {
+          route: 'copilot-cli-mcp',
+          argumentKeys: Object.keys(args).sort(),
+        },
+        payload: { arguments: args },
+      });
+      return recorder.withParent(started?.id ?? null, async () => {
+        try {
+          const result = await operation();
+          const failed = agentResultIsError(result);
+          let structuredResult: unknown = sanitizeFlightValue(result);
+          try {
+            structuredResult = sanitizeFlightValue(JSON.parse(result));
+          } catch {
+            // Non-JSON output remains a sanitized string.
+          }
+          await recorder.record({
+            kind: failed ? 'tool.call.failed' : 'tool.call.completed',
+            source: 'mcp-stdio',
+            status: failed ? 'error' : 'success',
+            toolName: name,
+            durationMs: performance.now() - startedAt,
+            metadata: {
+              route: 'copilot-cli-mcp',
+              ...(failed ? { resultStatus: 'error' } : {}),
+            },
+            payload: { result: structuredResult },
+            parentId: started?.id,
+          });
+          return result;
+        } catch (error) {
+          await recorder.record({
+            kind: 'tool.call.failed',
+            source: 'mcp-stdio',
+            status: 'error',
+            toolName: name,
+            durationMs: performance.now() - startedAt,
+            metadata: { route: 'copilot-cli-mcp' },
+            payload: { error },
+            parentId: started?.id,
+          });
+          throw error;
+        }
+      });
+    };
+    if (traceId) {
+      return recorder.runTrace(
+        {
+          traceId,
+          parentId: process.env.OPENRAPPTER_FLIGHT_PARENT_ID ?? null,
+          sessionId: process.env.OPENRAPPTER_FLIGHT_SESSION_ID,
+          workspaceId: process.env.OPENRAPPTER_FLIGHT_WORKSPACE_ID,
+        },
+        runTool,
+      );
+    }
+    return recorder.runTrace(
+      {
+        sessionId: process.env.OPENRAPPTER_FLIGHT_SESSION_ID,
+        workspaceId: process.env.OPENRAPPTER_FLIGHT_WORKSPACE_ID,
+      },
+      runTool,
+    );
+  };
+  const server = createMcpServer({
+    name: 'openrappter',
+    version: VERSION,
+    executeAgent,
+  });
   server.registerAgents(Array.from(agents.values()));
 
   process.stderr.write(`[openrappter-mcp] serving ${agents.size} agents\n`);
-  await server.serve();
+  try {
+    await server.serve();
+  } finally {
+    await recorder.close();
+  }
 }
 
 main().catch((err) => {

--- a/typescript/src/providers/__tests__/copilot-stream.test.ts
+++ b/typescript/src/providers/__tests__/copilot-stream.test.ts
@@ -140,7 +140,7 @@ describe('CopilotProvider.chatStream', () => {
   it('yields content deltas with done: false', async () => {
     mockFetchSSE([
       'data: {"choices":[{"delta":{"role":"assistant"},"finish_reason":null}]}\n\n',
-      'data: {"choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
+      'data: {"model":"actual-model","choices":[{"delta":{"content":"Hello"},"finish_reason":null}]}\n\n',
       'data: {"choices":[{"delta":{"content":" there"},"finish_reason":null}]}\n\n',
       'data: {"choices":[{"delta":{},"finish_reason":"stop"}]}\n\n',
       'data: [DONE]\n\n',
@@ -158,6 +158,7 @@ describe('CopilotProvider.chatStream', () => {
     expect(contentDeltas[0].content).toBe('Hello');
     expect(contentDeltas[1].content).toBe(' there');
     expect(contentDeltas.every(d => d.done === false)).toBe(true);
+    expect(deltas.at(-1)?.model).toBe('actual-model');
   });
 
   it('assembles tool call chunks across deltas', async () => {

--- a/typescript/src/providers/anthropic.ts
+++ b/typescript/src/providers/anthropic.ts
@@ -9,15 +9,21 @@ import type {
   ProviderResponse,
   ToolCall,
   Tool,
-} from './types.js';
+} from "./types.js";
 
-const ANTHROPIC_API_URL = 'https://api.anthropic.com/v1/messages';
-const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const ANTHROPIC_API_URL = "https://api.anthropic.com/v1/messages";
+const DEFAULT_MODEL = "claude-sonnet-4-20250514";
 const DEFAULT_MAX_TOKENS = 4096;
 
 interface AnthropicMessage {
-  role: 'user' | 'assistant';
-  content: string | Array<{ type: 'text'; text: string } | { type: 'tool_use'; id: string; name: string; input: unknown } | { type: 'tool_result'; tool_use_id: string; content: string }>;
+  role: "user" | "assistant";
+  content:
+    | string
+    | Array<
+        | { type: "text"; text: string }
+        | { type: "tool_use"; id: string; name: string; input: unknown }
+        | { type: "tool_result"; tool_use_id: string; content: string }
+      >;
 }
 
 interface AnthropicTool {
@@ -28,9 +34,12 @@ interface AnthropicTool {
 
 interface AnthropicResponse {
   id: string;
-  type: 'message';
-  role: 'assistant';
-  content: Array<{ type: 'text'; text: string } | { type: 'tool_use'; id: string; name: string; input: unknown }>;
+  type: "message";
+  role: "assistant";
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "tool_use"; id: string; name: string; input: unknown }
+  >;
   model: string;
   stop_reason: string;
   usage: {
@@ -40,8 +49,8 @@ interface AnthropicResponse {
 }
 
 export class AnthropicProvider implements LLMProvider {
-  id = 'anthropic';
-  name = 'Anthropic Claude';
+  id = "anthropic";
+  name = "Anthropic Claude";
 
   private apiKey: string | null = null;
 
@@ -53,14 +62,17 @@ export class AnthropicProvider implements LLMProvider {
     return !!this.apiKey;
   }
 
-  async chat(messages: Message[], options?: ChatOptions): Promise<ProviderResponse> {
+  async chat(
+    messages: Message[],
+    options?: ChatOptions,
+  ): Promise<ProviderResponse> {
     if (!this.apiKey) {
-      throw new Error('Anthropic API key not configured');
+      throw new Error("Anthropic API key not configured");
     }
 
     // Extract system message
-    const systemMessage = messages.find((m) => m.role === 'system');
-    const otherMessages = messages.filter((m) => m.role !== 'system');
+    const systemMessage = messages.find((m) => m.role === "system");
+    const otherMessages = messages.filter((m) => m.role !== "system");
 
     // Convert messages to Anthropic format
     const anthropicMessages = this.convertMessages(otherMessages);
@@ -89,11 +101,11 @@ export class AnthropicProvider implements LLMProvider {
     }
 
     const response = await fetch(ANTHROPIC_API_URL, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'x-api-key': this.apiKey,
-        'anthropic-version': '2023-06-01',
+        "Content-Type": "application/json",
+        "x-api-key": this.apiKey,
+        "anthropic-version": "2023-06-01",
       },
       body: JSON.stringify(body),
     });
@@ -111,38 +123,44 @@ export class AnthropicProvider implements LLMProvider {
     const result: AnthropicMessage[] = [];
 
     for (const msg of messages) {
-      if (msg.role === 'user') {
-        result.push({ role: 'user', content: msg.content });
-      } else if (msg.role === 'assistant') {
+      if (msg.role === "user") {
+        result.push({ role: "user", content: msg.content });
+      } else if (msg.role === "assistant") {
         if (msg.tool_calls && msg.tool_calls.length > 0) {
           // Assistant message with tool calls
           result.push({
-            role: 'assistant',
+            role: "assistant",
             content: msg.tool_calls.map((tc) => ({
-              type: 'tool_use' as const,
+              type: "tool_use" as const,
               id: tc.id,
               name: tc.function.name,
               input: JSON.parse(tc.function.arguments),
             })),
           });
         } else {
-          result.push({ role: 'assistant', content: msg.content });
+          result.push({ role: "assistant", content: msg.content });
         }
-      } else if (msg.role === 'tool' && msg.tool_call_id) {
+      } else if (msg.role === "tool" && msg.tool_call_id) {
         // Tool result - append to last user message or create new
         const lastMsg = result[result.length - 1];
-        if (lastMsg?.role === 'user' && Array.isArray(lastMsg.content)) {
-          (lastMsg.content as Array<{ type: 'tool_result'; tool_use_id: string; content: string }>).push({
-            type: 'tool_result',
+        if (lastMsg?.role === "user" && Array.isArray(lastMsg.content)) {
+          (
+            lastMsg.content as Array<{
+              type: "tool_result";
+              tool_use_id: string;
+              content: string;
+            }>
+          ).push({
+            type: "tool_result",
             tool_use_id: msg.tool_call_id,
             content: msg.content,
           });
         } else {
           result.push({
-            role: 'user',
+            role: "user",
             content: [
               {
-                type: 'tool_result',
+                type: "tool_result",
                 tool_use_id: msg.tool_call_id,
                 content: msg.content,
               },
@@ -168,12 +186,12 @@ export class AnthropicProvider implements LLMProvider {
     const toolCalls: ToolCall[] = [];
 
     for (const block of data.content) {
-      if (block.type === 'text') {
+      if (block.type === "text") {
         content = block.text;
-      } else if (block.type === 'tool_use') {
+      } else if (block.type === "tool_use") {
         toolCalls.push({
           id: block.id,
-          type: 'function',
+          type: "function",
           function: {
             name: block.name,
             arguments: JSON.stringify(block.input),
@@ -185,6 +203,7 @@ export class AnthropicProvider implements LLMProvider {
     return {
       content,
       tool_calls: toolCalls.length > 0 ? toolCalls : null,
+      model: data.model,
       usage: {
         input_tokens: data.usage.input_tokens,
         output_tokens: data.usage.output_tokens,

--- a/typescript/src/providers/copilot-cli-direct.test.ts
+++ b/typescript/src/providers/copilot-cli-direct.test.ts
@@ -57,4 +57,24 @@ describe('CopilotCliDirectProvider', () => {
     expect(args).toContain('--no-ask-user');
     expect(args).not.toContain('--allow-all-tools');
   });
+
+  it('honors an explicit per-call model without claiming unreported identity', async () => {
+    const runner = vi.fn<CopilotCliDirectRunner>(
+      async () => ({ stdout: "answer", stderr: "" }),
+    );
+    const provider = new CopilotCliDirectProvider({
+      cliPath: "/usr/local/bin/copilot",
+      model: "auto",
+      runner,
+    });
+
+    const response = await provider.chat(
+      [{ role: "user", content: "hello" }],
+      { model: "gpt-5.6-sol" },
+    );
+
+    const args = runner.mock.calls[0][1];
+    expect(args[args.indexOf("--model") + 1]).toBe("gpt-5.6-sol");
+    expect(response.model).toBeUndefined();
+  });
 });

--- a/typescript/src/providers/copilot-cli-direct.ts
+++ b/typescript/src/providers/copilot-cli-direct.ts
@@ -11,6 +11,7 @@
  */
 
 import { execFile, execSync } from 'child_process';
+import { randomUUID } from 'crypto';
 import { promisify } from 'util';
 import { existsSync } from 'fs';
 import { homedir } from 'os';
@@ -18,7 +19,11 @@ import { join } from 'path';
 import type { LLMProvider, Message, ChatOptions, ProviderResponse } from './types.js';
 import { writeMcpBridgeConfig, toolArgsFor, copilotHomeDir, type McpBridgeConfig } from './copilot-cli-mcp.js';
 import { resolveLocalCopilotCliPath } from './copilot-cli-local.js';
-import { invocationsSince } from '../agents/invocation-journal.js';
+import {
+  invocationsSince,
+  trimJournal,
+} from '../agents/invocation-journal.js';
+import { getFlightRecorder } from '../flight-recorder/recorder.js';
 
 const execFileAsync = promisify(execFile);
 
@@ -76,7 +81,11 @@ export interface CopilotCliDirectOptions {
 export type CopilotCliDirectRunner = (
   executable: string,
   args: string[],
-  options: { timeout: number; maxBuffer: number },
+  options: {
+    timeout: number;
+    maxBuffer: number;
+    env?: NodeJS.ProcessEnv;
+  },
 ) => Promise<{ stdout: string; stderr: string }>;
 
 export class CopilotCliDirectProvider implements LLMProvider {
@@ -97,14 +106,27 @@ export class CopilotCliDirectProvider implements LLMProvider {
     this.model = config?.model?.trim() || 'auto';
     this.timeoutMs = config?.timeoutMs ?? 120_000;
     this.runner = config?.runner ?? (
-      async (executable, args, options) => execFileAsync(
-        executable,
-        args,
-        // Without an enriched PATH the CLI cannot find `node` (it is a
-        // `#!/usr/bin/env node` script), so a daemon started outside a shell
-        // fails before it ever reaches Copilot.
-        { ...options, env: { ...process.env, PATH: resolveSpawnPath() } },
-      )
+      async (executable, args, options) => {
+        const {
+          OPENRAPPTER_FLIGHT_ID_KEY: _privateIdentityKey,
+          ...safeEnvironment
+        } = process.env;
+        return execFileAsync(
+          executable,
+          args,
+          {
+            ...options,
+            env: {
+              ...safeEnvironment,
+              ...options.env,
+              PATH: resolveSpawnPath({
+                ...safeEnvironment,
+                ...options.env,
+              }),
+            },
+          },
+        );
+      }
     );
   }
 
@@ -176,14 +198,26 @@ export class CopilotCliDirectProvider implements LLMProvider {
 
   async isAvailable(): Promise<boolean> {
     try {
-      await execFileAsync(this.cliPath, ['--version'], { timeout: 10_000 });
+      const {
+        OPENRAPPTER_FLIGHT_ID_KEY: _privateIdentityKey,
+        ...safeEnvironment
+      } = process.env;
+      await execFileAsync(this.cliPath, ['--version'], {
+        timeout: 10_000,
+        env: safeEnvironment,
+      });
       return true;
     } catch { return false; }
   }
 
-  async chat(messages: Message[], _options?: ChatOptions): Promise<ProviderResponse> {
+  async chat(messages: Message[], options?: ChatOptions): Promise<ProviderResponse> {
     const startedAt = Date.now();
+    const requestId = randomUUID();
+    trimJournal();
     const prompt = this.buildPrompt(messages);
+    const model = options?.model?.trim() || this.model;
+    const traceEnvironment =
+      getFlightRecorder().childProcessEnvironment();
     try {
       const { stdout } = await this.runner(
         this.cliPath,
@@ -198,18 +232,36 @@ export class CopilotCliDirectProvider implements LLMProvider {
           '--no-custom-instructions',
           '--no-ask-user',
           '--model',
-          this.model,
+          model,
           ...this.toolArgs(),
         ],
-        { timeout: this.timeoutMs, maxBuffer: 20 * 1024 * 1024 },
+        {
+          timeout: this.timeoutMs,
+          maxBuffer: 20 * 1024 * 1024,
+          env: {
+            ...traceEnvironment,
+            OPENRAPPTER_INVOCATION_REQUEST_ID: requestId,
+          },
+        },
       );
       const content = this.cleanOutput(stdout);
       // Tools ran inside the CLI, so there are no tool_calls to hand back — but
       // they reached the agents through our MCP server, which journalled them.
       // Reporting them is what makes `agent_logs` true for this backend.
-      const ranAgents = this.exposeAgents ? invocationsSince(startedAt) : [];
-      return { content: content || null, tool_calls: null, agent_logs: ranAgents };
+      const correlatedInvocations = invocationsSince(
+        startedAt,
+        requestId,
+      );
+      const ranAgents = this.exposeAgents
+        ? correlatedInvocations
+        : [];
+      return {
+        content: content || null,
+        tool_calls: null,
+        agent_logs: ranAgents,
+      };
     } catch (error) {
+      invocationsSince(startedAt, requestId);
       const err = error as NodeJS.ErrnoException & { stderr?: string };
       if (err.stderr?.includes('No authentication information found')) {
         throw new Error('Copilot CLI is not authenticated');

--- a/typescript/src/providers/copilot.ts
+++ b/typescript/src/providers/copilot.ts
@@ -8,12 +8,20 @@
  *   GITHUB_TOKEN → Copilot API token (cached) → OpenAI-compatible API
  */
 
-import type { LLMProvider, Message, ChatOptions, ProviderResponse, Tool, ToolCall, StreamDelta } from './types.js';
+import type {
+  LLMProvider,
+  Message,
+  ChatOptions,
+  ProviderResponse,
+  Tool,
+  ToolCall,
+  StreamDelta,
+} from "./types.js";
 import {
   resolveCopilotApiToken,
   clearCachedCopilotToken,
   type ResolvedCopilotToken,
-} from './copilot-token.js';
+} from "./copilot-token.js";
 
 // ── Default models ───────────────────────────────────────────────────────────
 
@@ -27,34 +35,34 @@ import {
  */
 export const COPILOT_DEFAULT_MODELS = [
   // GPT-4.1 family
-  'gpt-4.1',
-  'gpt-4.1-mini',
-  'gpt-4.1-nano',
+  "gpt-4.1",
+  "gpt-4.1-mini",
+  "gpt-4.1-nano",
   // GPT-4o family
-  'gpt-4o',
-  'gpt-4o-mini',
+  "gpt-4o",
+  "gpt-4o-mini",
   // Reasoning models
-  'o1',
-  'o1-mini',
-  'o3',
-  'o3-mini',
-  'o4-mini',
+  "o1",
+  "o1-mini",
+  "o3",
+  "o3-mini",
+  "o4-mini",
   // Claude (Copilot Pro / Business / Enterprise)
-  'claude-3.5-sonnet',
-  'claude-3.7-sonnet',
-  'claude-3.7-sonnet-thought',
-  'claude-sonnet-4',
+  "claude-3.5-sonnet",
+  "claude-3.7-sonnet",
+  "claude-3.7-sonnet-thought",
+  "claude-sonnet-4",
   // Gemini (Copilot Pro / Business / Enterprise)
-  'gemini-2.0-flash',
-  'gemini-2.5-pro',
+  "gemini-2.0-flash",
+  "gemini-2.5-pro",
 ] as const;
 
-export const COPILOT_DEFAULT_MODEL = 'gpt-4.1';
+export const COPILOT_DEFAULT_MODEL = "gpt-4.1";
 
 // ── OpenAI-compatible request/response types ─────────────────────────────────
 
 interface OpenAIMessage {
-  role: 'system' | 'user' | 'assistant' | 'tool';
+  role: "system" | "user" | "assistant" | "tool";
   content: string | null;
   tool_calls?: OpenAIToolCall[];
   tool_call_id?: string;
@@ -62,20 +70,25 @@ interface OpenAIMessage {
 
 interface OpenAIToolCall {
   id: string;
-  type: 'function';
+  type: "function";
   function: { name: string; arguments: string };
 }
 
 interface OpenAITool {
-  type: 'function';
-  function: { name: string; description: string; parameters: Record<string, unknown> };
+  type: "function";
+  function: {
+    name: string;
+    description: string;
+    parameters: Record<string, unknown>;
+  };
 }
 
 interface OpenAIChatResponse {
   id: string;
+  model?: string;
   choices: Array<{
     message: {
-      role: 'assistant';
+      role: "assistant";
       content: string | null;
       tool_calls?: OpenAIToolCall[];
     };
@@ -90,9 +103,11 @@ interface OpenAIChatResponse {
 
 // ── SSE Stream Parser ────────────────────────────────────────────────────────
 
-export async function* parseSSEStream(body: ReadableStream<Uint8Array>): AsyncGenerator<Record<string, unknown>> {
+export async function* parseSSEStream(
+  body: ReadableStream<Uint8Array>,
+): AsyncGenerator<Record<string, unknown>> {
   const decoder = new TextDecoder();
-  let buffer = '';
+  let buffer = "";
   const reader = body.getReader();
   try {
     for (;;) {
@@ -100,12 +115,12 @@ export async function* parseSSEStream(body: ReadableStream<Uint8Array>): AsyncGe
       if (done) break;
       buffer += decoder.decode(chunk, { stream: true });
       const lines = buffer.split(/\r?\n/);
-      buffer = lines.pop() ?? '';
+      buffer = lines.pop() ?? "";
       for (const line of lines) {
         const trimmed = line.trim();
-        if (!trimmed || trimmed.startsWith(':')) continue;
-        if (trimmed === 'data: [DONE]') return;
-        if (trimmed.startsWith('data: ')) {
+        if (!trimmed || trimmed.startsWith(":")) continue;
+        if (trimmed === "data: [DONE]") return;
+        if (trimmed.startsWith("data: ")) {
           yield JSON.parse(trimmed.slice(6));
         }
       }
@@ -134,8 +149,8 @@ function parseRetryAfter(header: string | null): number | null {
 // ── Provider ─────────────────────────────────────────────────────────────────
 
 export class CopilotProvider implements LLMProvider {
-  readonly id = 'copilot';
-  readonly name = 'GitHub Copilot';
+  readonly id = "copilot";
+  readonly name = "GitHub Copilot";
 
   private githubToken: string | null = null;
   private resolvedToken: ResolvedCopilotToken | null = null;
@@ -175,14 +190,17 @@ export class CopilotProvider implements LLMProvider {
   /** Get a valid Copilot API token, exchanging if needed */
   private async ensureToken(): Promise<ResolvedCopilotToken> {
     // Return cached token if still valid
-    if (this.resolvedToken && this.resolvedToken.expiresAt - Date.now() > 5 * 60 * 1000) {
+    if (
+      this.resolvedToken &&
+      this.resolvedToken.expiresAt - Date.now() > 5 * 60 * 1000
+    ) {
       return this.resolvedToken;
     }
 
     const githubToken = this.getGithubToken();
     if (!githubToken) {
       throw new Error(
-        'No GitHub token found. Set GITHUB_TOKEN, run `gh auth login`, or run `openrappter onboard`.',
+        "No GitHub token found. Set GITHUB_TOKEN, run `gh auth login`, or run `openrappter onboard`.",
       );
     }
 
@@ -208,9 +226,10 @@ export class CopilotProvider implements LLMProvider {
       if (attempt === RATE_LIMIT_MAX_RETRIES) return res;
 
       const retryMs =
-        parseRetryAfter(res.headers.get('Retry-After')) ??
+        parseRetryAfter(res.headers.get("Retry-After")) ??
         Math.min(
-          RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) + Math.random() * 1_000,
+          RATE_LIMIT_BASE_DELAY_MS * Math.pow(2, attempt) +
+            Math.random() * 1_000,
           RATE_LIMIT_MAX_DELAY_MS,
         );
 
@@ -218,10 +237,13 @@ export class CopilotProvider implements LLMProvider {
     }
 
     // unreachable, but satisfies tsc
-    throw new Error('Rate-limit retry loop exited unexpectedly');
+    throw new Error("Rate-limit retry loop exited unexpectedly");
   }
 
-  async chat(messages: Message[], options?: ChatOptions): Promise<ProviderResponse> {
+  async chat(
+    messages: Message[],
+    options?: ChatOptions,
+  ): Promise<ProviderResponse> {
     const { token, baseUrl } = await this.ensureToken();
     const model = options?.model ?? COPILOT_DEFAULT_MODEL;
 
@@ -239,14 +261,16 @@ export class CopilotProvider implements LLMProvider {
     };
 
     if (options?.tools && options.tools.length > 0) {
-      body.tools = options.tools.map((t: Tool): OpenAITool => ({
-        type: 'function',
-        function: {
-          name: t.function.name,
-          description: t.function.description,
-          parameters: t.function.parameters,
-        },
-      }));
+      body.tools = options.tools.map(
+        (t: Tool): OpenAITool => ({
+          type: "function",
+          function: {
+            name: t.function.name,
+            description: t.function.description,
+            parameters: t.function.parameters,
+          },
+        }),
+      );
     }
 
     if (options?.temperature != null) body.temperature = options.temperature;
@@ -255,53 +279,66 @@ export class CopilotProvider implements LLMProvider {
     const url = `${baseUrl}/chat/completions`;
 
     const res = await this.fetchWithRateRetry(url, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
-        'Accept': 'application/json',
-        'Editor-Version': 'vscode/1.95.0',
-        'User-Agent': 'GitHubCopilotChat/0.22.2024',
-        'Copilot-Integration-Id': 'vscode-chat',
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        Accept: "application/json",
+        "Editor-Version": "vscode/1.95.0",
+        "User-Agent": "GitHubCopilotChat/0.22.2024",
+        "Copilot-Integration-Id": "vscode-chat",
       },
       body: JSON.stringify(body),
     });
 
     if (!res.ok) {
-      const errBody = await res.text().catch(() => '');
+      const errBody = await res.text().catch(() => "");
       // On auth errors, invalidate the cached Copilot token and retry once.
       // The GitHub token may still be valid — just the short-lived Copilot API
       // token expired or was revoked server-side.
       if ((res.status === 401 || res.status === 403) && !options?._isRetry) {
         this.invalidateToken();
-        return this.chat(messages, { ...options, _isRetry: true } as ChatOptions);
+        return this.chat(messages, {
+          ...options,
+          _isRetry: true,
+        } as ChatOptions);
       }
-      throw new Error(`Copilot API error: HTTP ${res.status}${errBody ? ` — ${errBody}` : ''}`);
+      throw new Error(
+        `Copilot API error: HTTP ${res.status}${errBody ? ` — ${errBody}` : ""}`,
+      );
     }
 
     const data = (await res.json()) as OpenAIChatResponse;
     const choice = data.choices?.[0];
 
     if (!choice) {
-      throw new Error('Copilot API returned no choices');
+      throw new Error("Copilot API returned no choices");
     }
 
-    const toolCalls: ToolCall[] | null = choice.message.tool_calls?.map((tc) => ({
-      id: tc.id,
-      type: 'function' as const,
-      function: { name: tc.function.name, arguments: tc.function.arguments },
-    })) ?? null;
+    const toolCalls: ToolCall[] | null =
+      choice.message.tool_calls?.map((tc) => ({
+        id: tc.id,
+        type: "function" as const,
+        function: { name: tc.function.name, arguments: tc.function.arguments },
+      })) ?? null;
 
     return {
       content: choice.message.content,
       tool_calls: toolCalls,
+      model: data.model,
       usage: data.usage
-        ? { input_tokens: data.usage.prompt_tokens, output_tokens: data.usage.completion_tokens }
+        ? {
+            input_tokens: data.usage.prompt_tokens,
+            output_tokens: data.usage.completion_tokens,
+          }
         : undefined,
     };
   }
 
-  async *chatStream(messages: Message[], options?: ChatOptions): AsyncGenerator<StreamDelta> {
+  async *chatStream(
+    messages: Message[],
+    options?: ChatOptions,
+  ): AsyncGenerator<StreamDelta> {
     const { token, baseUrl } = await this.ensureToken();
     const model = options?.model ?? COPILOT_DEFAULT_MODEL;
 
@@ -319,14 +356,16 @@ export class CopilotProvider implements LLMProvider {
     };
 
     if (options?.tools && options.tools.length > 0) {
-      body.tools = options.tools.map((t: Tool): OpenAITool => ({
-        type: 'function',
-        function: {
-          name: t.function.name,
-          description: t.function.description,
-          parameters: t.function.parameters,
-        },
-      }));
+      body.tools = options.tools.map(
+        (t: Tool): OpenAITool => ({
+          type: "function",
+          function: {
+            name: t.function.name,
+            description: t.function.description,
+            parameters: t.function.parameters,
+          },
+        }),
+      );
     }
 
     if (options?.temperature != null) body.temperature = options.temperature;
@@ -335,39 +374,58 @@ export class CopilotProvider implements LLMProvider {
     const url = `${baseUrl}/chat/completions`;
 
     const res = await this.fetchWithRateRetry(url, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${token}`,
-        'Accept': 'text/event-stream',
-        'Editor-Version': 'vscode/1.95.0',
-        'User-Agent': 'GitHubCopilotChat/0.22.2024',
-        'Copilot-Integration-Id': 'vscode-chat',
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${token}`,
+        Accept: "text/event-stream",
+        "Editor-Version": "vscode/1.95.0",
+        "User-Agent": "GitHubCopilotChat/0.22.2024",
+        "Copilot-Integration-Id": "vscode-chat",
       },
       body: JSON.stringify(body),
     });
 
     if (!res.ok) {
-      const errBody = await res.text().catch(() => '');
+      const errBody = await res.text().catch(() => "");
       if ((res.status === 401 || res.status === 403) && !options?._isRetry) {
         this.invalidateToken();
-        yield* this.chatStream(messages, { ...options, _isRetry: true } as ChatOptions);
+        yield* this.chatStream(messages, {
+          ...options,
+          _isRetry: true,
+        } as ChatOptions);
         return;
       }
-      throw new Error(`Copilot API error: HTTP ${res.status}${errBody ? ` — ${errBody}` : ''}`);
+      throw new Error(
+        `Copilot API error: HTTP ${res.status}${errBody ? ` — ${errBody}` : ""}`,
+      );
     }
 
     if (!res.body) {
-      throw new Error('Copilot API returned no response body');
+      throw new Error("Copilot API returned no response body");
     }
 
     let lastFinishReason: string | undefined;
+    let reportedModel: string | undefined;
 
     for await (const event of parseSSEStream(res.body)) {
-      const choices = event.choices as Array<{
-        delta?: { content?: string; tool_calls?: Array<{ index: number; id?: string; type?: string; function?: { name?: string; arguments?: string } }> };
-        finish_reason?: string;
-      }> | undefined;
+      if (typeof event.model === "string" && event.model.trim()) {
+        reportedModel = event.model.trim();
+      }
+      const choices = event.choices as
+        | Array<{
+            delta?: {
+              content?: string;
+              tool_calls?: Array<{
+                index: number;
+                id?: string;
+                type?: string;
+                function?: { name?: string; arguments?: string };
+              }>;
+            };
+            finish_reason?: string;
+          }>
+        | undefined;
 
       const choice = choices?.[0];
       if (!choice) continue;
@@ -384,17 +442,24 @@ export class CopilotProvider implements LLMProvider {
 
       yield {
         content: delta.content ?? undefined,
-        tool_calls: delta.tool_calls?.map(tc => ({
+        model: reportedModel,
+        tool_calls: delta.tool_calls?.map((tc) => ({
           index: tc.index,
           id: tc.id,
-          type: tc.type as 'function' | undefined,
-          function: tc.function ? { name: tc.function.name, arguments: tc.function.arguments } : undefined,
+          type: tc.type as "function" | undefined,
+          function: tc.function
+            ? { name: tc.function.name, arguments: tc.function.arguments }
+            : undefined,
         })),
         done: false,
       };
     }
 
-    yield { done: true, finish_reason: lastFinishReason };
+    yield {
+      done: true,
+      finish_reason: lastFinishReason,
+      model: reportedModel,
+    };
   }
 
   async isAvailable(): Promise<boolean> {
@@ -410,6 +475,8 @@ export class CopilotProvider implements LLMProvider {
   }
 }
 
-export function createCopilotProvider(options?: { githubToken?: string }): LLMProvider {
+export function createCopilotProvider(options?: {
+  githubToken?: string;
+}): LLMProvider {
   return new CopilotProvider(options);
 }

--- a/typescript/src/providers/flight-io.ts
+++ b/typescript/src/providers/flight-io.ts
@@ -1,0 +1,55 @@
+import { sanitizeFlightValue } from "../flight-recorder/redaction.js";
+import type {
+  Message,
+  ProviderResponse,
+  ToolCall,
+} from "./types.js";
+
+export function flightStructuredValue(value: unknown): unknown {
+  return sanitizeFlightValue(value);
+}
+
+export function flightLogResult(value: string): string {
+  const sanitized = flightStructuredValue(value);
+  if (typeof sanitized === "string") return sanitized;
+  try {
+    return JSON.stringify(sanitized) ?? "[unserializable]";
+  } catch {
+    return "[unserializable]";
+  }
+}
+
+export function formatFlightAgentLog(
+  agent: string,
+  result: string,
+  failed = false,
+): string {
+  return `[${agent}] ${failed ? "ERROR: " : ""}${flightLogResult(result)}`;
+}
+
+export function sanitizeFlightAgentLog(value: string): string {
+  const match = /^\[([^\]]+)\]\s*([\s\S]*)$/.exec(value);
+  if (!match) return flightLogResult(value);
+  const failed = match[2].startsWith("ERROR: ");
+  return formatFlightAgentLog(
+    match[1],
+    failed ? match[2].slice("ERROR: ".length) : match[2],
+    failed,
+  );
+}
+
+export function flightToolCalls(
+  calls: ToolCall[] | null | undefined,
+): unknown {
+  return calls;
+}
+
+export function flightMessages(messages: Message[]): unknown[] {
+  return messages;
+}
+
+export function flightProviderResponse(
+  response: ProviderResponse,
+): Record<string, unknown> {
+  return { ...response };
+}

--- a/typescript/src/providers/gemini.test.ts
+++ b/typescript/src/providers/gemini.test.ts
@@ -1,0 +1,34 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { GeminiProvider } from "./gemini.js";
+
+const originalFetch = globalThis.fetch;
+
+afterEach(() => {
+  globalThis.fetch = originalFetch;
+  vi.restoreAllMocks();
+});
+
+describe("GeminiProvider", () => {
+  it("reports the successful response modelVersion instead of the request alias", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        modelVersion: "gemini-2.0-flash-001",
+        candidates: [{ content: { parts: [{ text: "answer" }] } }],
+        usageMetadata: {
+          promptTokenCount: 2,
+          candidatesTokenCount: 1,
+        },
+      }),
+    }) as unknown as typeof fetch;
+    const provider = new GeminiProvider("test-key");
+
+    const response = await provider.chat(
+      [{ role: "user", content: "hello" }],
+      { model: "gemini-2.0-flash" },
+    );
+
+    expect(response.content).toBe("answer");
+    expect(response.model).toBe("gemini-2.0-flash-001");
+  });
+});

--- a/typescript/src/providers/gemini.ts
+++ b/typescript/src/providers/gemini.ts
@@ -1,8 +1,13 @@
-import type { LLMProvider, Message, ChatOptions, ProviderResponse } from './types.js';
+import type {
+  LLMProvider,
+  Message,
+  ChatOptions,
+  ProviderResponse,
+} from "./types.js";
 
 export class GeminiProvider implements LLMProvider {
-  readonly id = 'gemini';
-  readonly name = 'Google Gemini';
+  readonly id = "gemini";
+  readonly name = "Google Gemini";
   private apiKey?: string;
 
   constructor(apiKey?: string) {
@@ -11,19 +16,19 @@ export class GeminiProvider implements LLMProvider {
 
   async chat(
     messages: Message[],
-    options?: ChatOptions
+    options?: ChatOptions,
   ): Promise<ProviderResponse> {
     const apiKey = this.apiKey || process.env.GEMINI_API_KEY;
     if (!apiKey) {
-      throw new Error('Gemini API key not configured');
+      throw new Error("Gemini API key not configured");
     }
 
-    const model = options?.model || 'gemini-2.0-flash';
+    const model = options?.model || "gemini-2.0-flash";
     const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`;
 
     // Convert OpenAI-style messages to Gemini format
     const contents = messages.map((msg) => ({
-      role: msg.role === 'assistant' ? 'model' : 'user',
+      role: msg.role === "assistant" ? "model" : "user",
       parts: [{ text: msg.content }],
     }));
 
@@ -36,9 +41,9 @@ export class GeminiProvider implements LLMProvider {
     };
 
     const response = await fetch(url, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify(requestBody),
     });
@@ -59,15 +64,20 @@ export class GeminiProvider implements LLMProvider {
         candidatesTokenCount?: number;
         totalTokenCount?: number;
       };
+      modelVersion?: string;
     };
 
     // Extract the generated text from Gemini response
     const candidate = data.candidates?.[0];
-    const text = candidate?.content?.parts?.[0]?.text || '';
+    const text = candidate?.content?.parts?.[0]?.text || "";
 
     return {
       content: text,
       tool_calls: null,
+      model:
+        typeof data.modelVersion === "string" && data.modelVersion.trim()
+          ? data.modelVersion.trim()
+          : undefined,
       usage: {
         input_tokens: data.usageMetadata?.promptTokenCount || 0,
         output_tokens: data.usageMetadata?.candidatesTokenCount || 0,

--- a/typescript/src/providers/ollama.ts
+++ b/typescript/src/providers/ollama.ts
@@ -8,14 +8,14 @@ import type {
   ChatOptions,
   ProviderResponse,
   EmbeddingOptions,
-} from './types.js';
+} from "./types.js";
 
-const DEFAULT_OLLAMA_URL = 'http://localhost:11434';
-const DEFAULT_MODEL = 'llama3.2';
-const DEFAULT_EMBEDDING_MODEL = 'nomic-embed-text';
+const DEFAULT_OLLAMA_URL = "http://localhost:11434";
+const DEFAULT_MODEL = "llama3.2";
+const DEFAULT_EMBEDDING_MODEL = "nomic-embed-text";
 
 interface OllamaMessage {
-  role: 'system' | 'user' | 'assistant';
+  role: "system" | "user" | "assistant";
   content: string;
 }
 
@@ -23,7 +23,7 @@ interface OllamaChatResponse {
   model: string;
   created_at: string;
   message: {
-    role: 'assistant';
+    role: "assistant";
     content: string;
   };
   done: boolean;
@@ -51,21 +51,22 @@ interface OllamaListResponse {
 }
 
 export class OllamaProvider implements LLMProvider {
-  id = 'ollama';
-  name = 'Ollama (Local)';
+  id = "ollama";
+  name = "Ollama (Local)";
 
   private baseUrl: string;
   private defaultModel: string;
 
   constructor(options?: { baseUrl?: string; model?: string }) {
-    this.baseUrl = options?.baseUrl ?? process.env.OLLAMA_URL ?? DEFAULT_OLLAMA_URL;
+    this.baseUrl =
+      options?.baseUrl ?? process.env.OLLAMA_URL ?? DEFAULT_OLLAMA_URL;
     this.defaultModel = options?.model ?? DEFAULT_MODEL;
   }
 
   async isAvailable(): Promise<boolean> {
     try {
       const response = await fetch(`${this.baseUrl}/api/tags`, {
-        method: 'GET',
+        method: "GET",
         signal: AbortSignal.timeout(5000),
       });
       return response.ok;
@@ -86,12 +87,15 @@ export class OllamaProvider implements LLMProvider {
     return data.models;
   }
 
-  async chat(messages: Message[], options?: ChatOptions): Promise<ProviderResponse> {
+  async chat(
+    messages: Message[],
+    options?: ChatOptions,
+  ): Promise<ProviderResponse> {
     // Convert messages to Ollama format (no tool support in basic Ollama)
     const ollamaMessages: OllamaMessage[] = messages
-      .filter((m) => m.role !== 'tool')
+      .filter((m) => m.role !== "tool")
       .map((msg) => ({
-        role: msg.role === 'tool' ? 'user' : msg.role,
+        role: msg.role === "tool" ? "user" : msg.role,
         content: msg.content,
       }));
 
@@ -106,9 +110,9 @@ export class OllamaProvider implements LLMProvider {
     }
 
     const response = await fetch(`${this.baseUrl}/api/chat`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
       },
       body: JSON.stringify(body),
     });
@@ -123,6 +127,7 @@ export class OllamaProvider implements LLMProvider {
     return {
       content: data.message.content,
       tool_calls: null, // Ollama doesn't support tool calling natively
+      model: data.model,
       usage: {
         input_tokens: data.prompt_eval_count ?? 0,
         output_tokens: data.eval_count ?? 0,
@@ -130,16 +135,19 @@ export class OllamaProvider implements LLMProvider {
     };
   }
 
-  async embed(texts: string[], options?: EmbeddingOptions): Promise<number[][]> {
+  async embed(
+    texts: string[],
+    options?: EmbeddingOptions,
+  ): Promise<number[][]> {
     const model = options?.model ?? DEFAULT_EMBEDDING_MODEL;
     const embeddings: number[][] = [];
 
     // Ollama processes embeddings one at a time
     for (const text of texts) {
       const response = await fetch(`${this.baseUrl}/api/embeddings`, {
-        method: 'POST',
+        method: "POST",
         headers: {
-          'Content-Type': 'application/json',
+          "Content-Type": "application/json",
         },
         body: JSON.stringify({
           model,
@@ -149,7 +157,9 @@ export class OllamaProvider implements LLMProvider {
 
       if (!response.ok) {
         const error = await response.text();
-        throw new Error(`Ollama Embeddings API error: ${response.status} - ${error}`);
+        throw new Error(
+          `Ollama Embeddings API error: ${response.status} - ${error}`,
+        );
       }
 
       const data = (await response.json()) as OllamaEmbeddingResponse;

--- a/typescript/src/providers/openai.ts
+++ b/typescript/src/providers/openai.ts
@@ -8,19 +8,19 @@ import type {
   ChatOptions,
   ProviderResponse,
   EmbeddingOptions,
-} from './types.js';
+} from "./types.js";
 
-const OPENAI_API_URL = 'https://api.openai.com/v1';
-const DEFAULT_MODEL = 'gpt-4o';
-const DEFAULT_EMBEDDING_MODEL = 'text-embedding-3-small';
+const OPENAI_API_URL = "https://api.openai.com/v1";
+const DEFAULT_MODEL = "gpt-4o";
+const DEFAULT_EMBEDDING_MODEL = "text-embedding-3-small";
 const DEFAULT_MAX_TOKENS = 4096;
 
 interface OpenAIMessage {
-  role: 'system' | 'user' | 'assistant' | 'tool';
+  role: "system" | "user" | "assistant" | "tool";
   content: string;
   tool_calls?: Array<{
     id: string;
-    type: 'function';
+    type: "function";
     function: { name: string; arguments: string };
   }>;
   tool_call_id?: string;
@@ -28,17 +28,17 @@ interface OpenAIMessage {
 
 interface OpenAIResponse {
   id: string;
-  object: 'chat.completion';
+  object: "chat.completion";
   created: number;
   model: string;
   choices: Array<{
     index: number;
     message: {
-      role: 'assistant';
+      role: "assistant";
       content: string | null;
       tool_calls?: Array<{
         id: string;
-        type: 'function';
+        type: "function";
         function: { name: string; arguments: string };
       }>;
     };
@@ -52,9 +52,9 @@ interface OpenAIResponse {
 }
 
 interface OpenAIEmbeddingResponse {
-  object: 'list';
+  object: "list";
   data: Array<{
-    object: 'embedding';
+    object: "embedding";
     index: number;
     embedding: number[];
   }>;
@@ -66,8 +66,8 @@ interface OpenAIEmbeddingResponse {
 }
 
 export class OpenAIProvider implements LLMProvider {
-  id = 'openai';
-  name = 'OpenAI';
+  id = "openai";
+  name = "OpenAI";
 
   private apiKey: string | null = null;
 
@@ -79,9 +79,12 @@ export class OpenAIProvider implements LLMProvider {
     return !!this.apiKey;
   }
 
-  async chat(messages: Message[], options?: ChatOptions): Promise<ProviderResponse> {
+  async chat(
+    messages: Message[],
+    options?: ChatOptions,
+  ): Promise<ProviderResponse> {
     if (!this.apiKey) {
-      throw new Error('OpenAI API key not configured');
+      throw new Error("OpenAI API key not configured");
     }
 
     const openaiMessages: OpenAIMessage[] = messages.map((msg) => ({
@@ -106,9 +109,9 @@ export class OpenAIProvider implements LLMProvider {
     }
 
     const response = await fetch(`${OPENAI_API_URL}/chat/completions`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(body),
@@ -125,6 +128,7 @@ export class OpenAIProvider implements LLMProvider {
     return {
       content: choice.message.content,
       tool_calls: choice.message.tool_calls ?? null,
+      model: data.model,
       usage: {
         input_tokens: data.usage.prompt_tokens,
         output_tokens: data.usage.completion_tokens,
@@ -132,9 +136,12 @@ export class OpenAIProvider implements LLMProvider {
     };
   }
 
-  async embed(texts: string[], options?: EmbeddingOptions): Promise<number[][]> {
+  async embed(
+    texts: string[],
+    options?: EmbeddingOptions,
+  ): Promise<number[][]> {
     if (!this.apiKey) {
-      throw new Error('OpenAI API key not configured');
+      throw new Error("OpenAI API key not configured");
     }
 
     const body: Record<string, unknown> = {
@@ -147,9 +154,9 @@ export class OpenAIProvider implements LLMProvider {
     }
 
     const response = await fetch(`${OPENAI_API_URL}/embeddings`, {
-      method: 'POST',
+      method: "POST",
       headers: {
-        'Content-Type': 'application/json',
+        "Content-Type": "application/json",
         Authorization: `Bearer ${this.apiKey}`,
       },
       body: JSON.stringify(body),
@@ -157,7 +164,9 @@ export class OpenAIProvider implements LLMProvider {
 
     if (!response.ok) {
       const error = await response.text();
-      throw new Error(`OpenAI Embeddings API error: ${response.status} - ${error}`);
+      throw new Error(
+        `OpenAI Embeddings API error: ${response.status} - ${error}`,
+      );
     }
 
     const data = (await response.json()) as OpenAIEmbeddingResponse;

--- a/typescript/src/providers/recorded-chat.test.ts
+++ b/typescript/src/providers/recorded-chat.test.ts
@@ -1,0 +1,332 @@
+import { afterEach, describe, expect, it } from "vitest";
+import {
+  FlightRecorder,
+  setFlightRecorder,
+} from "../flight-recorder/recorder.js";
+import { normalizeFlightSessionId } from "../flight-recorder/integrity.js";
+import type { LLMProvider } from "./types.js";
+import { chatWithFlightRecorder } from "./recorded-chat.js";
+
+let recorder: FlightRecorder | undefined;
+let previous: FlightRecorder | undefined;
+
+afterEach(async () => {
+  if (previous) setFlightRecorder(previous);
+  await recorder?.close();
+  recorder = undefined;
+  previous = undefined;
+});
+
+async function installRecorder(
+  options: ConstructorParameters<typeof FlightRecorder>[0] = {},
+): Promise<FlightRecorder> {
+  recorder = new FlightRecorder({
+    enabled: true,
+    inMemory: true,
+    ...options,
+  });
+  await recorder.initialize();
+  previous = setFlightRecorder(recorder);
+  return recorder;
+}
+
+describe("chatWithFlightRecorder", () => {
+  it("records a standalone provider attempt without changing the response", async () => {
+    const active = await installRecorder();
+    const response = {
+      content: "answer",
+      tool_calls: null,
+      model: "resolved-model",
+    };
+    const provider: LLMProvider = {
+      id: "recorded-provider",
+      name: "Recorded Provider",
+      async chat() {
+        return response;
+      },
+      async isAvailable() {
+        return true;
+      },
+    };
+
+    const result = await chatWithFlightRecorder({
+      provider,
+      messages: [{ role: "user", content: "private prompt" }],
+      options: { model: "auto" },
+      source: "recorded-chat-test",
+      scope: { sessionId: "conversation-id" },
+      attributes: { phase: "probe" },
+    });
+
+    expect(result).toBe(response);
+    const events = await active.query();
+    const root = events.find((event) => event.kind === "trace.started")!;
+    const started = events.find(
+      (event) => event.kind === "provider.attempt.started",
+    )!;
+    const completed = events.find(
+      (event) => event.kind === "provider.attempt.completed",
+    )!;
+    expect(started.parentId).toBe(root.id);
+    expect(completed.parentId).toBe(started.id);
+    expect(completed.model).toBe("resolved-model");
+    expect(completed.metadata).toMatchObject({
+      phase: "probe",
+      modelPolicy: "auto",
+    });
+    expect(JSON.stringify(events)).not.toContain("private prompt");
+  });
+
+  it("records provider failure and rethrows the identical error", async () => {
+    const active = await installRecorder();
+    const original = new Error("private provider failure");
+    const provider: LLMProvider = {
+      id: "failing-provider",
+      name: "Failing Provider",
+      async chat() {
+        throw original;
+      },
+      async isAvailable() {
+        return true;
+      },
+    };
+
+    await expect(
+      chatWithFlightRecorder({
+        provider,
+        messages: [{ role: "user", content: "private prompt" }],
+        source: "recorded-chat-test",
+      }),
+    ).rejects.toBe(original);
+
+    const failed = (await active.query()).find(
+      (event) => event.kind === "provider.attempt.failed",
+    )!;
+    expect(failed.providerId).toBe("failing-provider");
+    expect(failed.metadata.errorName).toBe("Error");
+    expect(JSON.stringify(failed)).not.toContain(original.message);
+  });
+
+  it("durably records provider failures with hostile error getters", async () => {
+    const active = await installRecorder({
+      identityKey: "88".repeat(32),
+      privacy: { recordIO: true },
+    });
+    const hostile = Object.create(Error.prototype);
+    for (const key of ["name", "message", "stack"]) {
+      Object.defineProperty(hostile, key, {
+        get() {
+          throw new Error(`blocked ${key}`);
+        },
+      });
+    }
+    const provider: LLMProvider = {
+      id: "hostile-provider",
+      name: "Hostile Provider",
+      async chat() {
+        throw hostile;
+      },
+      async isAvailable() {
+        return true;
+      },
+    };
+
+    await expect(
+      chatWithFlightRecorder({
+        provider,
+        messages: [{ role: "user", content: "hello" }],
+        source: "recorded-chat-test",
+      }),
+    ).rejects.toBe(hostile);
+
+    const failed = (await active.query()).find(
+      (event) => event.kind === "provider.attempt.failed",
+    );
+    expect(failed).toBeDefined();
+    expect(failed?.payload).toMatchObject({
+      error: {
+        name: "[unserializable]",
+        message: "[unserializable]",
+        stack: "[unserializable]",
+      },
+    });
+  });
+
+  it("does not mislabel an unanswered model policy as concrete identity", async () => {
+    const active = await installRecorder();
+    const provider: LLMProvider = {
+      id: "fallback-provider",
+      name: "Fallback Provider",
+      async chat() {
+        return { content: "fallback answer", tool_calls: null };
+      },
+      async isAvailable() {
+        return true;
+      },
+    };
+
+    await chatWithFlightRecorder({
+      provider,
+      messages: [{ role: "user", content: "hello" }],
+      options: { model: "gpt-5.6-sol" },
+      source: "recorded-chat-test",
+    });
+
+    const completed = (await active.query()).find(
+      (event) => event.kind === "provider.attempt.completed",
+    )!;
+    expect(completed.model).toBeUndefined();
+    expect(completed.metadata.modelPolicy).toBe("gpt-5.6-sol");
+  });
+
+  it("redacts structured tool arguments in provider responses", async () => {
+    const active = await installRecorder();
+    const provider: LLMProvider = {
+      id: "tool-provider",
+      name: "Tool Provider",
+      async chat() {
+        return {
+          content: null,
+          tool_calls: [
+            {
+              id: "call-1",
+              type: "function",
+              function: {
+                name: "Missing",
+                arguments: JSON.stringify({
+                  password: "ordinary-secret-value",
+                }),
+              },
+            },
+          ],
+        };
+      },
+      async isAvailable() {
+        return true;
+      },
+    };
+
+    const privateRecorder = new FlightRecorder({
+      enabled: true,
+      inMemory: true,
+      identityKey: "55".repeat(32),
+      privacy: { recordIO: true },
+    });
+
+    await privateRecorder.initialize();
+    const current = setFlightRecorder(privateRecorder);
+    try {
+      await chatWithFlightRecorder({
+        provider,
+        messages: [{ role: "user", content: "hello" }],
+        source: "recorded-chat-test",
+      });
+      const persisted = JSON.stringify(await privateRecorder.query());
+      expect(persisted).not.toContain("ordinary-secret-value");
+      expect(persisted).toContain("[redacted]");
+    } finally {
+      setFlightRecorder(current);
+      await privateRecorder.close();
+    }
+    expect((await active.health()).eventCount).toBe(0);
+  });
+
+  it("redacts JSON provider content and agent log results", async () => {
+    const privateRecorder = new FlightRecorder({
+      enabled: true,
+      inMemory: true,
+      identityKey: "66".repeat(32),
+      privacy: { recordIO: true },
+    });
+
+    await privateRecorder.initialize();
+    const current = setFlightRecorder(privateRecorder);
+    const provider: LLMProvider = {
+      id: "json-provider",
+      name: "JSON Provider",
+      async chat() {
+        return {
+          content: JSON.stringify({
+            password: "ordinary-secret-value",
+          }),
+          tool_calls: null,
+          agent_logs: [
+            `[Shell] ${JSON.stringify({
+              password: "tool-result-secret",
+            })}`,
+            `[Shell] ERROR: ${JSON.stringify({
+              password: "tool-error-secret",
+            })}`,
+          ],
+        };
+      },
+      async isAvailable() {
+        return true;
+      },
+    };
+    try {
+      await chatWithFlightRecorder({
+        provider,
+        messages: [
+          {
+            role: "user",
+            content: JSON.stringify({
+              password: "user-json-secret",
+            }),
+          },
+        ],
+        source: "recorded-chat-test",
+      });
+      const persisted = JSON.stringify(await privateRecorder.query());
+      expect(persisted).not.toContain("ordinary-secret-value");
+      expect(persisted).not.toContain("tool-result-secret");
+      expect(persisted).not.toContain("tool-error-secret");
+      expect(persisted).not.toContain("user-json-secret");
+      expect(persisted).toContain("[redacted]");
+    } finally {
+      setFlightRecorder(current);
+      await privateRecorder.close();
+    }
+  });
+
+  it("applies supplied scope inside an existing trace", async () => {
+    const active = await installRecorder({
+      identityKey: "55".repeat(32),
+    });
+    const provider: LLMProvider = {
+      id: "scoped-provider",
+      name: "Scoped Provider",
+      async chat() {
+        return { content: "answer", tool_calls: null };
+      },
+      async isAvailable() {
+        return true;
+      },
+    };
+
+    await active.runTrace(
+      { traceId: "outer-trace", sessionId: "outer-session" },
+      async () => {
+        await chatWithFlightRecorder({
+          provider,
+          messages: [{ role: "user", content: "hello" }],
+          source: "recorded-chat-test",
+          scope: { sessionId: "voice-thread-42" },
+        });
+      },
+    );
+
+    const scoped = (await active.query()).filter(
+      (event) => event.providerId === "scoped-provider",
+    );
+    expect(scoped).not.toHaveLength(0);
+    expect(new Set(scoped.map((event) => event.sessionId))).toEqual(
+      new Set([
+        normalizeFlightSessionId(
+          "voice-thread-42",
+          "55".repeat(32),
+        ),
+      ]),
+    );
+  });
+});

--- a/typescript/src/providers/recorded-chat.ts
+++ b/typescript/src/providers/recorded-chat.ts
@@ -1,0 +1,119 @@
+import {
+  getFlightRecorder,
+  summarizeFlightError,
+} from "../flight-recorder/index.js";
+import type { FlightTraceContext } from "../flight-recorder/types.js";
+import type {
+  ChatOptions,
+  LLMProvider,
+  Message,
+  ProviderResponse,
+} from "./types.js";
+import {
+  flightMessages,
+  flightProviderResponse,
+} from "./flight-io.js";
+
+export interface RecordedChatRequest {
+  provider: LLMProvider;
+  messages: Message[];
+  options?: ChatOptions;
+  source: string;
+  scope?: Partial<FlightTraceContext>;
+  attributes?: Record<string, unknown>;
+}
+
+export async function chatWithFlightRecorder(
+  request: RecordedChatRequest,
+): Promise<ProviderResponse> {
+  const recorder = getFlightRecorder();
+  const attempt = async (): Promise<ProviderResponse> => {
+    const startedAt = performance.now();
+    const modelPolicy = request.options?.model;
+    const started = await recorder.record({
+      kind: "provider.attempt.started",
+      source: request.source,
+      status: "started",
+      providerId: request.provider.id,
+      metadata: {
+        ...request.attributes,
+        messageCount: request.messages.length,
+        toolCount: request.options?.tools?.length ?? 0,
+        streaming: false,
+        ...(modelPolicy === undefined ? {} : { modelPolicy }),
+      },
+      payload: () => ({ messages: flightMessages(request.messages) }),
+    });
+
+    return recorder.withParent(started?.id ?? null, async () => {
+      try {
+        const response = await request.provider.chat(
+          request.messages,
+          request.options,
+        );
+        await recorder.record({
+          kind: "provider.attempt.completed",
+          source: request.source,
+          status: "success",
+          providerId: request.provider.id,
+          model: response.model,
+          durationMs: performance.now() - startedAt,
+          metadata: {
+            ...request.attributes,
+            messageCount: request.messages.length,
+            toolCount: request.options?.tools?.length ?? 0,
+            streaming: false,
+            ...(modelPolicy === undefined ? {} : { modelPolicy }),
+            toolCallsOccurred: Boolean(response.tool_calls?.length),
+            ...(response.usage ? { usage: response.usage } : {}),
+          },
+          payload: () => ({
+            messages: flightMessages(request.messages),
+            response: flightProviderResponse(response),
+          }),
+        });
+        return response;
+      } catch (error) {
+        await recorder.record({
+          kind: "provider.attempt.failed",
+          source: request.source,
+          status: "error",
+          providerId: request.provider.id,
+          durationMs: performance.now() - startedAt,
+          metadata: {
+            ...request.attributes,
+            messageCount: request.messages.length,
+            toolCount: request.options?.tools?.length ?? 0,
+            streaming: false,
+            ...(modelPolicy === undefined ? {} : { modelPolicy }),
+            ...summarizeFlightError(error),
+          },
+          payload: () => ({
+            messages: flightMessages(request.messages),
+            error,
+          }),
+        });
+        throw error;
+      }
+    });
+  };
+
+  if (recorder.currentTrace()) {
+    if (!request.scope || Object.keys(request.scope).length === 0) {
+      return attempt();
+    }
+    const current = recorder.currentTrace()!;
+    return recorder.runTrace(
+      {
+        ...request.scope,
+        traceId: request.scope.traceId ?? current.traceId,
+        parentId:
+          request.scope.parentId === undefined
+            ? current.parentId ?? null
+            : request.scope.parentId,
+      },
+      attempt,
+    );
+  }
+  return recorder.runTrace(request.scope ?? {}, attempt);
+}

--- a/typescript/src/providers/registry.ts
+++ b/typescript/src/providers/registry.ts
@@ -9,10 +9,17 @@ import type {
   ProviderResponse,
   EmbeddingOptions,
   ProviderConfig,
-} from './types.js';
-import { createAnthropicProvider } from './anthropic.js';
-import { createOpenAIProvider } from './openai.js';
-import { createOllamaProvider } from './ollama.js';
+} from "./types.js";
+import { createAnthropicProvider } from "./anthropic.js";
+import { createOpenAIProvider } from "./openai.js";
+import { createOllamaProvider } from "./ollama.js";
+import { getFlightRecorder } from "../flight-recorder/recorder.js";
+import { normalizeFlightModelId } from "../flight-recorder/integrity.js";
+import {
+  flightMessages,
+  flightProviderResponse,
+} from "./flight-io.js";
+import { summarizeFlightError } from "../flight-recorder/redaction.js";
 
 export interface FailoverOptions {
   maxRetries?: number;
@@ -87,31 +94,152 @@ export class ProviderRegistry {
     providerChain: string[],
     messages: Message[],
     options?: ChatOptions,
-    failoverOptions?: FailoverOptions
+    failoverOptions?: FailoverOptions,
+  ): Promise<ProviderResponse> {
+    const recorder = getFlightRecorder();
+    const operation = () =>
+      this.chatWithFailoverWithinTrace(
+        providerChain,
+        messages,
+        options,
+        failoverOptions,
+      );
+    if (recorder.currentTrace()) {
+      return operation();
+    }
+    return recorder.runTrace({}, operation);
+  }
+
+  private async chatWithFailoverWithinTrace(
+    providerChain: string[],
+    messages: Message[],
+    options?: ChatOptions,
+    failoverOptions?: FailoverOptions,
   ): Promise<ProviderResponse> {
     const opts = { ...DEFAULT_FAILOVER_OPTIONS, ...failoverOptions };
     const errors: Error[] = [];
+    const recorder = getFlightRecorder();
 
-    for (const providerId of providerChain) {
+    for (const [rungIndex, providerId] of providerChain.entries()) {
+      const rung = rungIndex + 1;
       const provider = this.providers.get(providerId);
 
       if (!provider) {
-        errors.push(new Error(`Provider '${providerId}' not found`));
+        const error = new Error(`Provider '${providerId}' not found`);
+        errors.push(error);
+        await recorder.record({
+          kind: "provider.attempt.failed",
+          source: "provider-registry",
+          status: "error",
+          providerId,
+          metadata: {
+            rung,
+            modelPolicy: options?.model,
+            reason: "missing",
+            ...summarizeFlightError(error),
+          },
+        });
         continue;
       }
 
       // Skip unavailable providers if configured
       if (opts.skipUnavailable && !(await provider.isAvailable())) {
-        errors.push(new Error(`Provider '${providerId}' is not available`));
+        const error = new Error(`Provider '${providerId}' is not available`);
+        errors.push(error);
+        await recorder.record({
+          kind: "provider.attempt.failed",
+          source: "provider-registry",
+          status: "error",
+          providerId,
+          metadata: {
+            rung,
+            modelPolicy: options?.model,
+            reason: "unavailable",
+            ...summarizeFlightError(error),
+          },
+        });
         continue;
       }
 
       // Try with retries
       for (let attempt = 0; attempt <= (opts.maxRetries ?? 0); attempt++) {
+        const started = performance.now();
+        const startedEvent = await recorder.record({
+          kind: "provider.attempt.started",
+          source: "provider-registry",
+          status: "started",
+          providerId,
+          metadata: {
+            rung,
+            attempt: attempt + 1,
+            modelPolicy: options?.model,
+            messageCount: messages.length,
+            toolCount: options?.tools?.length ?? 0,
+          },
+          payload: () => ({ messages: flightMessages(messages) }),
+        });
         try {
-          return await provider.chat(messages, options);
+          const response = await recorder.withParent(
+            startedEvent?.id ?? null,
+            () => provider.chat(messages, options),
+          );
+          const completedEvent = await recorder.record({
+            kind: "provider.attempt.completed",
+            source: "provider-registry",
+            status: "success",
+            providerId,
+            model: normalizeFlightModelId(response.model),
+            durationMs: performance.now() - started,
+            metadata: {
+              rung,
+              attempt: attempt + 1,
+              modelPolicy: options?.model,
+              messageCount: messages.length,
+              toolCount: options?.tools?.length ?? 0,
+              toolCallsOccurred: Boolean(response.tool_calls?.length),
+              ...(response.usage ? { usage: response.usage } : {}),
+            },
+            payload: () => ({
+              messages: flightMessages(messages),
+              response: flightProviderResponse(response),
+            }),
+            parentId: startedEvent?.id,
+          });
+          await recorder.record({
+            kind: "provider.selected",
+            source: "provider-registry",
+            status: "decision",
+            providerId,
+            model: normalizeFlightModelId(response.model),
+            metadata: {
+              rung,
+              attempt: attempt + 1,
+              modelPolicy: options?.model,
+            },
+            parentId: completedEvent?.id,
+          });
+          return response;
         } catch (error) {
-          errors.push(error as Error);
+          const providerError = error as Error;
+          errors.push(providerError);
+          await recorder.record({
+            kind: "provider.attempt.failed",
+            source: "provider-registry",
+            status: "error",
+            providerId,
+            durationMs: performance.now() - started,
+            metadata: {
+              rung,
+              attempt: attempt + 1,
+              modelPolicy: options?.model,
+              ...summarizeFlightError(providerError),
+            },
+            payload: () => ({
+              messages: flightMessages(messages),
+              error: providerError,
+            }),
+            parentId: startedEvent?.id,
+          });
 
           // Don't retry on last attempt
           if (attempt < (opts.maxRetries ?? 0)) {
@@ -122,7 +250,22 @@ export class ProviderRegistry {
     }
 
     // All providers failed
-    const errorMessages = errors.map((e) => e.message).join('; ');
+    const errorMessages = errors.map((e) => e.message).join("; ");
+    const terminalError = new Error(`All providers failed: ${errorMessages}`);
+    await recorder.record({
+      kind: "provider.attempt.failed",
+      source: "provider-registry",
+      status: "error",
+      providerId: providerChain.at(-1),
+      metadata: {
+        terminal: true,
+        modelPolicy: options?.model,
+        providerChain,
+        errorCount: errors.length,
+        ...summarizeFlightError(terminalError),
+      },
+      payload: { error: terminalError },
+    });
     throw new Error(`All providers failed: ${errorMessages}`);
   }
 
@@ -133,7 +276,7 @@ export class ProviderRegistry {
     providerChain: string[],
     texts: string[],
     options?: EmbeddingOptions,
-    failoverOptions?: FailoverOptions
+    failoverOptions?: FailoverOptions,
   ): Promise<number[][]> {
     const opts = { ...DEFAULT_FAILOVER_OPTIONS, ...failoverOptions };
     const errors: Error[] = [];
@@ -147,7 +290,9 @@ export class ProviderRegistry {
       }
 
       if (!provider.embed) {
-        errors.push(new Error(`Provider '${providerId}' does not support embeddings`));
+        errors.push(
+          new Error(`Provider '${providerId}' does not support embeddings`),
+        );
         continue;
       }
 
@@ -169,7 +314,7 @@ export class ProviderRegistry {
       }
     }
 
-    const errorMessages = errors.map((e) => e.message).join('; ');
+    const errorMessages = errors.map((e) => e.message).join("; ");
     throw new Error(`All embedding providers failed: ${errorMessages}`);
   }
 
@@ -195,22 +340,26 @@ export function createDefaultRegistry(): ProviderRegistry {
 /**
  * Create a registry from provider configs
  */
-export function createRegistryFromConfigs(configs: ProviderConfig[]): ProviderRegistry {
+export function createRegistryFromConfigs(
+  configs: ProviderConfig[],
+): ProviderRegistry {
   const registry = new ProviderRegistry();
 
   for (const config of configs) {
-    const apiKey = config.auth.token ?? (config.auth.token_env ? process.env[config.auth.token_env] : undefined);
+    const apiKey =
+      config.auth.token ??
+      (config.auth.token_env ? process.env[config.auth.token_env] : undefined);
 
     let provider: LLMProvider | null = null;
 
     switch (config.provider) {
-      case 'anthropic':
+      case "anthropic":
         provider = createAnthropicProvider(apiKey);
         break;
-      case 'openai':
+      case "openai":
         provider = createOpenAIProvider(apiKey);
         break;
-      case 'ollama':
+      case "ollama":
         provider = createOllamaProvider();
         break;
       default:

--- a/typescript/src/providers/types.ts
+++ b/typescript/src/providers/types.ts
@@ -3,7 +3,7 @@
  */
 
 export interface Message {
-  role: 'system' | 'user' | 'assistant' | 'tool';
+  role: "system" | "user" | "assistant" | "tool";
   content: string;
   tool_calls?: ToolCall[];
   tool_call_id?: string;
@@ -18,7 +18,7 @@ export interface Message {
 
 export interface ToolCall {
   id: string;
-  type: 'function';
+  type: "function";
   function: {
     name: string;
     arguments: string;
@@ -26,7 +26,7 @@ export interface ToolCall {
 }
 
 export interface Tool {
-  type: 'function';
+  type: "function";
   function: {
     name: string;
     description: string;
@@ -37,6 +37,8 @@ export interface Tool {
 export interface ProviderResponse {
   content: string | null;
   tool_calls: ToolCall[] | null;
+  /** Concrete model reported by the provider, when the provider reveals it. */
+  model?: string;
   usage?: {
     input_tokens: number;
     output_tokens: number;
@@ -65,10 +67,12 @@ export interface ChatOptions {
 
 export interface StreamDelta {
   content?: string;
+  /** Concrete provider-reported model, when present in the stream. */
+  model?: string;
   tool_calls?: Array<{
     index: number;
     id?: string;
-    type?: 'function';
+    type?: "function";
     function?: { name?: string; arguments?: string };
   }>;
   done: boolean;
@@ -98,7 +102,10 @@ export interface LLMProvider {
   /**
    * Stream a chat response when supported.
    */
-  chatStream?(messages: Message[], options?: ChatOptions): AsyncGenerator<StreamDelta>;
+  chatStream?(
+    messages: Message[],
+    options?: ChatOptions,
+  ): AsyncGenerator<StreamDelta>;
 
   /**
    * Generate embeddings for texts (optional)
@@ -119,7 +126,7 @@ export interface ProviderConfig {
   provider: string;
   model: string;
   auth: {
-    type: 'api-key' | 'oauth';
+    type: "api-key" | "oauth";
     token_env?: string;
     token?: string;
   };

--- a/typescript/src/surgeon/service.test.ts
+++ b/typescript/src/surgeon/service.test.ts
@@ -8,6 +8,11 @@ import type {
   Message,
   ProviderResponse,
 } from '../providers/types.js';
+import {
+  FlightRecorder,
+  setFlightRecorder,
+} from '../flight-recorder/recorder.js';
+import type { FlightEvent } from '../flight-recorder/types.js';
 import { SurgeonService } from './service.js';
 import type { SurgeonPatientSnapshot } from './types.js';
 
@@ -221,16 +226,33 @@ describe('SurgeonService', () => {
     });
     expect(approved.status).toBe('approved');
 
-    const recovered = await service.operate({
-      caseId: consultationResult.case.id,
-      procedureId: procedure!.id,
-      digest: procedure!.digest,
-    });
+    const recorder = new FlightRecorder({ enabled: true, inMemory: true });
+    await recorder.initialize();
+    const previous = setFlightRecorder(recorder);
+    let recovered: Awaited<ReturnType<SurgeonService['operate']>>;
+    let operationEvents: FlightEvent[] = [];
+    try {
+      recovered = await service.operate({
+        caseId: consultationResult.case.id,
+        procedureId: procedure!.id,
+        digest: procedure!.digest,
+      });
+      operationEvents = await recorder.query();
+    } finally {
+      setFlightRecorder(previous);
+      await recorder.close();
+    }
 
     expect(executeProcedure).toHaveBeenCalledOnce();
     expect(recovered.status).toBe('recovered');
     expect(recovered.outcome?.status).toBe('recovered');
     expect(recovered.outcome?.evidence).toContain('Shell agent completed the bounded repair');
+    expect(new Set(operationEvents.map(event => event.traceId)).size).toBe(1);
+    expect(operationEvents.map(event => event.kind)).toContain(
+      'provider.attempt.completed',
+    );
+    expect(operationEvents[0].kind).toBe('trace.started');
+    expect(operationEvents.at(-1)?.kind).toBe('trace.completed');
   });
 
   it('never reports recovery when no OpenRappter tool actually ran', async () => {
@@ -476,12 +498,29 @@ describe('SurgeonService', () => {
       inspectPatient: async () => patient(),
     });
 
-    const result = await service.consult({ userInput: 'Inspect the patient.' });
+    const recorder = new FlightRecorder({ enabled: true, inMemory: true });
+    await recorder.initialize();
+    const previous = setFlightRecorder(recorder);
+    let result;
+    let events: FlightEvent[] = [];
+    try {
+      result = await service.consult({ userInput: 'Inspect the patient.' });
+      events = await recorder.query();
+    } finally {
+      setFlightRecorder(previous);
+      await recorder.close();
+    }
 
     expect(result.case.status).toBe('needs_attention');
     expect(result.turn.kind).toBe('error');
     expect(result.turn.response).toMatch(/could not be validated/i);
     expect(result.turn.options[0].value).toContain('try the examination again');
     expect(provider.messages).toHaveLength(2);
+    expect(new Set(events.map(event => event.traceId)).size).toBe(1);
+    expect(
+      events.filter(event => event.kind === 'provider.attempt.completed'),
+    ).toHaveLength(2);
+    expect(events[0].kind).toBe('trace.started');
+    expect(events.at(-1)?.kind).toBe('trace.completed');
   });
 });

--- a/typescript/src/surgeon/service.ts
+++ b/typescript/src/surgeon/service.ts
@@ -2,6 +2,8 @@ import { createHash, randomUUID } from 'crypto';
 import fs from 'fs';
 import path from 'path';
 import { CopilotCliDirectProvider } from '../providers/copilot-cli-direct.js';
+import { chatWithFlightRecorder } from '../providers/recorded-chat.js';
+import { getFlightRecorder } from '../flight-recorder/index.js';
 import type { LLMProvider, Message } from '../providers/types.js';
 import type {
   SurgeonCase,
@@ -148,6 +150,21 @@ export class SurgeonService {
     const current = request.caseId
       ? this.requireCase(request.caseId)
       : this.createCase(patient);
+    const recorder = getFlightRecorder();
+    const operation = () =>
+      this.consultWithinTrace(userInput, patient, current);
+    if (recorder.currentTrace()) return operation();
+    return recorder.runTrace(
+      { sessionId: `surgeon_${current.id}` },
+      operation,
+    );
+  }
+
+  private async consultWithinTrace(
+    userInput: string,
+    patient: SurgeonPatientSnapshot,
+    current: SurgeonCase,
+  ): Promise<SurgeonConsultResult> {
     this.assertCaseNotInSurgery(current);
     if (this.consultingCases.has(current.id)) {
       throw new Error('This patient case is already being examined');
@@ -157,25 +174,36 @@ export class SurgeonService {
     let candidate;
     let parsed;
     try {
-      candidate = await this.provider.chat(
-        this.consultMessages(current, patient, userInput),
-        { model: process.env.OPENRAPPTER_SURGEON_MODEL ?? 'auto' },
-      );
+      candidate = await chatWithFlightRecorder({
+        provider: this.provider,
+        messages: this.consultMessages(current, patient, userInput),
+        options: { model: process.env.OPENRAPPTER_SURGEON_MODEL ?? 'auto' },
+        source: "surgeon-service",
+        scope: { sessionId: current.id },
+        attributes: { phase: "consult" },
+      });
       parsed = parseModelTurn(candidate.content);
 
       if (!parsed) {
-        const repair = await this.provider.chat([
-          { role: 'system', content: REPAIR_SYSTEM_PROMPT },
-          {
-            role: 'user',
-            content: JSON.stringify({
-              candidate: normalizeText(candidate.content ?? '', 9_000),
-              current_request: userInput,
-            }),
+        const repair = await chatWithFlightRecorder({
+          provider: this.provider,
+          messages: [
+            { role: 'system', content: REPAIR_SYSTEM_PROMPT },
+            {
+              role: 'user',
+              content: JSON.stringify({
+                candidate: normalizeText(candidate.content ?? '', 9_000),
+                current_request: userInput,
+              }),
+            },
+          ],
+          options: {
+            model: process.env.OPENRAPPTER_SURGEON_MODEL ?? 'auto',
+            temperature: 0,
           },
-        ], {
-          model: process.env.OPENRAPPTER_SURGEON_MODEL ?? 'auto',
-          temperature: 0,
+          source: "surgeon-service",
+          scope: { sessionId: current.id },
+          attributes: { phase: "repair" },
         });
         parsed = parseModelTurn(repair.content);
       }
@@ -261,6 +289,19 @@ export class SurgeonService {
 
   async operate(approval: SurgeonProcedureApproval): Promise<SurgeonCase> {
     const current = this.requireCase(approval.caseId);
+    const recorder = getFlightRecorder();
+    const operation = () => this.operateWithinTrace(approval, current);
+    if (recorder.currentTrace()) return operation();
+    return recorder.runTrace(
+      { sessionId: `surgeon_${current.id}` },
+      operation,
+    );
+  }
+
+  private async operateWithinTrace(
+    approval: SurgeonProcedureApproval,
+    current: SurgeonCase,
+  ): Promise<SurgeonCase> {
     const procedure = this.requireProcedure(current, approval);
     if (current.status === 'recovered' && procedure.status === 'recovered') {
       return cloneCase(current);
@@ -323,21 +364,28 @@ export class SurgeonService {
       current.updatedAt = this.timestamp();
       this.save();
 
-      const verificationResponse = await this.provider.chat([
-        { role: 'system', content: VERIFY_SYSTEM_PROMPT },
-        {
-          role: 'user',
-          content: JSON.stringify({
-            procedure: procedureForDigest(procedure),
-            executor_summary: normalizeText(evidence.summary, 6_000),
-            tool_evidence: evidence.agentLogs.map(entry => normalizeText(entry, 2_000)).slice(0, 30),
-            patient_before: current.patientAtDiagnosis,
-            patient_after: patientAfter,
-          }),
+      const verificationResponse = await chatWithFlightRecorder({
+        provider: this.provider,
+        messages: [
+          { role: 'system', content: VERIFY_SYSTEM_PROMPT },
+          {
+            role: 'user',
+            content: JSON.stringify({
+              procedure: procedureForDigest(procedure),
+              executor_summary: normalizeText(evidence.summary, 6_000),
+              tool_evidence: evidence.agentLogs.map(entry => normalizeText(entry, 2_000)).slice(0, 30),
+              patient_before: current.patientAtDiagnosis,
+              patient_after: patientAfter,
+            }),
+          },
+        ],
+        options: {
+          model: process.env.OPENRAPPTER_SURGEON_MODEL ?? 'auto',
+          temperature: 0,
         },
-      ], {
-        model: process.env.OPENRAPPTER_SURGEON_MODEL ?? 'auto',
-        temperature: 0,
+        source: "surgeon-service",
+        scope: { sessionId: current.id },
+        attributes: { phase: "verify" },
       });
       const verification = parseVerification(verificationResponse.content);
       if (!verification) {

--- a/typescript/src/telephony/reply.test.ts
+++ b/typescript/src/telephony/reply.test.ts
@@ -12,6 +12,10 @@
  */
 
 import { describe, expect, it, vi } from 'vitest';
+import {
+  FlightRecorder,
+  setFlightRecorder,
+} from '../flight-recorder/recorder.js';
 import type { LLMProvider, Message } from '../providers/types.js';
 import {
   GREETING,
@@ -86,6 +90,33 @@ describe('answering a person', () => {
     // The model was actually shown the message — the failure being fixed was
     // that it never was.
     expect(seen[0].at(-1)).toEqual({ role: 'user', content: 'Okay well list 10 things you can do' });
+  });
+
+  it('records the direct telephony provider call under the thread session', async () => {
+    const recorder = new FlightRecorder({ enabled: true, inMemory: true });
+    await recorder.initialize();
+    const previous = setFlightRecorder(recorder);
+    try {
+      const { provider } = fakeProvider('Recorded answer.');
+      const respond = createAssistantResponder({ provider });
+
+      expect(await respond(msg('Are you there?', 'private-thread'))).toBe(
+        'Recorded answer.',
+      );
+      const events = await recorder.query();
+      const started = events.find(
+        (event) => event.kind === 'provider.attempt.started',
+      )!;
+      const completed = events.find(
+        (event) => event.kind === 'provider.attempt.completed',
+      )!;
+      expect(started.source).toBe('telephony-reply');
+      expect(completed.parentId).toBe(started.id);
+      expect(JSON.stringify(events)).not.toContain('private-thread');
+    } finally {
+      setFlightRecorder(previous);
+      await recorder.close();
+    }
   });
 
   it('carries the thread so a follow-up has something to follow', async () => {

--- a/typescript/src/telephony/reply.ts
+++ b/typescript/src/telephony/reply.ts
@@ -38,6 +38,7 @@
  */
 
 import type { LLMProvider, Message } from '../providers/types.js';
+import { chatWithFlightRecorder } from '../providers/recorded-chat.js';
 
 /** One remembered turn in a thread. */
 export interface Turn {
@@ -258,7 +259,14 @@ export function createAssistantResponder(options: AssistantResponderOptions) {
     ];
 
     try {
-      const res = await provider.chat(messages, options.model ? { model: options.model } : undefined);
+      const res = await chatWithFlightRecorder({
+        provider,
+        messages,
+        options: options.model ? { model: options.model } : undefined,
+        source: "telephony-reply",
+        scope: { sessionId: message.threadId },
+        attributes: { phase: "compose" },
+      });
       const answer = toSms(res.content ?? '', maxChars);
       if (!answer) {
         log('[reply] model returned nothing usable — falling back to the greeting');

--- a/typescript/src/version.test.ts
+++ b/typescript/src/version.test.ts
@@ -8,7 +8,7 @@ describe('package version', () => {
       fs.readFileSync(new URL('../package.json', import.meta.url), 'utf8')
     ) as { version: string };
 
-    expect(metadata.version).toBe('1.11.0');
+    expect(metadata.version).toBe('1.12.0');
     expect(VERSION).toBe(metadata.version);
   });
 });


### PR DESCRIPTION
## Summary
- add a provider-neutral, cross-runtime SQLite Flight Recorder
- add privacy-safe event/export contracts, causal tracing, replay import/export, and CLI inspection
- harden retention, ownership, reset, Windows ACLs, process liveness, identity keys, canonical hashing, and package/release gates
- ship TypeScript/Python parity plus 1.12.0 docs and release notes

## Validation
- Flight Recorder acceptance gate: 16/16
- TypeScript build, lint, full regression, mutation, runtime, and packed-package smoke
- Python Flight Recorder, full regression, compile/import, and cross-runtime vectors
- required native Windows storage gate in release workflow

Closes #145.
References #146.