### PR TITLE
fix: harden autonomous desktop after buzzsaw

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -196,7 +196,7 @@ jobs:
         working-directory: typescript/desktop
         run: |
           npm ci --ignore-scripts
-          npm audit --omit=dev --audit-level=high
+          npm audit --audit-level=high
 
   # Explicit, fail-hard production dependency audit gate (Python side).
   # Installs only runtime dependencies (no [dev] extra) so the audit

--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Audit desktop production dependencies
         working-directory: typescript/desktop
-        run: npm audit --omit=dev --audit-level=high
+        run: npm audit --audit-level=high
 
       - name: Run real Electron smoke on Linux
         if: runner.os == 'Linux'
@@ -67,7 +67,6 @@ jobs:
         shell: pwsh
         run: |
           $env:OPENRAPPTER_DESKTOP_SMOKE = "1"
-          $env:OPENRAPPTER_DESKTOP_SMOKE_SCOPE = "boot"
           .\node_modules\.bin\electron.cmd .
 
       - name: Build unpacked macOS application

--- a/.github/workflows/release-bar.yml
+++ b/.github/workflows/release-bar.yml
@@ -21,6 +21,10 @@ jobs:
     outputs:
       version: ${{ steps.version.outputs.version }}
     steps:
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
+
       - name: Validate exact macOS release tag
         id: version
         shell: bash
@@ -35,6 +39,13 @@ jobs:
           fi
           printf 'version=%s\n' "$version" >> "$GITHUB_OUTPUT"
 
+      - name: Require release commit on main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
   build-and-release:
     name: Build & Release DMG
     needs: validate-tag
@@ -46,9 +57,9 @@ jobs:
       run:
         working-directory: macos
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
-      - uses: swift-actions/setup-swift@v2
+      - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a
         with:
           swift-version: '6.0'
 
@@ -194,7 +205,7 @@ jobs:
             "${NOTARY_KEY_PATH:-}"
 
       - name: Upload DMG as release asset
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           name: "OpenRappter Bar ${{ env.RELEASE_VERSION }}"
           body: |
@@ -223,3 +234,4 @@ jobs:
             macos/dist/OpenRappter-Bar-${{ env.RELEASE_VERSION }}.dmg
             macos/dist/OpenRappter-Bar-${{ env.RELEASE_VERSION }}.dmg.sha256
           fail_on_unmatched_files: true
+          overwrite_files: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,25 +22,34 @@ jobs:
     outputs:
       version: ${{ steps.validate.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+        with:
+          fetch-depth: 0
 
-      - uses: actions/setup-node@v4
+      - name: Require release commit on main
+        shell: bash
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin main
+          git merge-base --is-ancestor "$GITHUB_SHA" origin/main
+
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: typescript/package-lock.json
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
-
-      - name: Test deterministic preflight
-        run: node --test scripts/release-preflight.test.mjs
 
       # Install the TypeScript loader without running prepare (which builds).
       - name: Install TypeScript dependencies without build scripts
         working-directory: typescript
         run: npm ci --ignore-scripts
+
+      - name: Test deterministic preflight
+        run: node --test scripts/release-preflight.test.mjs
 
       - name: Validate tag and versions
         id: validate
@@ -70,15 +79,15 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: typescript/package-lock.json
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: pip
@@ -123,15 +132,15 @@ jobs:
     needs: preflight
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: typescript/package-lock.json
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: pip
@@ -163,15 +172,15 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: typescript/package-lock.json
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
           cache: pip
@@ -208,9 +217,9 @@ jobs:
     needs: preflight
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
@@ -231,7 +240,7 @@ jobs:
           npm ci
           npm run build
           npm test
-          npm audit --omit=dev --audit-level=high
+          npm audit --audit-level=high
 
       - name: Run real Electron smoke
         working-directory: typescript/desktop
@@ -255,9 +264,9 @@ jobs:
           - os: linux
             runner: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
@@ -301,9 +310,9 @@ jobs:
       - name: Build signed desktop distributions
         working-directory: typescript/desktop
         env:
-          CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.os == 'mac' && 'true' || 'false' }}
-          CSC_LINK: ${{ matrix.os == 'mac' && secrets.MACOS_CERTIFICATE_P12_BASE64 || '' }}
-          CSC_KEY_PASSWORD: ${{ matrix.os == 'mac' && secrets.MACOS_CERTIFICATE_PASSWORD || '' }}
+          CSC_IDENTITY_AUTO_DISCOVERY: ${{ matrix.os != 'linux' && 'true' || 'false' }}
+          CSC_LINK: ${{ matrix.os == 'mac' && secrets.MACOS_CERTIFICATE_P12_BASE64 || matrix.os == 'win' && secrets.WINDOWS_CERTIFICATE_P12_BASE64 || '' }}
+          CSC_KEY_PASSWORD: ${{ matrix.os == 'mac' && secrets.MACOS_CERTIFICATE_PASSWORD || matrix.os == 'win' && secrets.WINDOWS_CERTIFICATE_PASSWORD || '' }}
           APPLE_API_KEY: ${{ matrix.os == 'mac' && steps.notarization.outputs.path || '' }}
           APPLE_API_KEY_ID: ${{ matrix.os == 'mac' && secrets.APPLE_API_KEY_ID || '' }}
           APPLE_API_ISSUER: ${{ matrix.os == 'mac' && secrets.APPLE_API_ISSUER_ID || '' }}
@@ -317,7 +326,50 @@ jobs:
             test -n "$APPLE_API_KEY_ID"
             test -n "$APPLE_API_ISSUER"
           fi
+          if [ "${{ matrix.os }}" = "win" ]; then
+            test -n "$CSC_LINK"
+            test -n "$CSC_KEY_PASSWORD"
+          fi
           npx --no-install electron-builder --publish never
+
+      - name: Smoke packaged macOS application
+        if: matrix.os == 'mac'
+        working-directory: typescript/desktop
+        shell: bash
+        run: |
+          set -euo pipefail
+          app_binary="$(
+            find dist \
+              -maxdepth 5 \
+              -type f \
+              -path '*/OpenRappter.app/Contents/MacOS/OpenRappter' \
+              -print \
+              -quit
+          )"
+          test -n "$app_binary"
+          OPENRAPPTER_DESKTOP_SMOKE=1 "$app_binary"
+
+      - name: Smoke packaged Linux application
+        if: matrix.os == 'linux'
+        working-directory: typescript/desktop
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -x dist/linux-unpacked/openrappter
+          sudo chown root:root dist/linux-unpacked/chrome-sandbox
+          sudo chmod 4755 dist/linux-unpacked/chrome-sandbox
+          xvfb-run -a env OPENRAPPTER_DESKTOP_SMOKE=1 \
+            dist/linux-unpacked/openrappter
+
+      - name: Smoke packaged Windows application
+        if: matrix.os == 'win'
+        timeout-minutes: 5
+        working-directory: typescript/desktop
+        shell: pwsh
+        run: |
+          $env:OPENRAPPTER_DESKTOP_SMOKE = "1"
+          $env:OPENRAPPTER_DESKTOP_SMOKE_SCOPE = "boot"
+          .\dist\win-unpacked\OpenRappter.exe
 
       - name: Require signed and notarized macOS release
         if: matrix.os == 'mac'
@@ -337,13 +389,28 @@ jobs:
           spctl --assess --type execute --verbose=2 "$app_path"
           xcrun stapler validate "$app_path"
 
+      - name: Require signed Windows release
+        if: matrix.os == 'win'
+        shell: pwsh
+        run: |
+          $installers = Get-ChildItem typescript/desktop/dist/*.exe
+          if ($installers.Count -eq 0) {
+            throw "No Windows installer was produced."
+          }
+          foreach ($installer in $installers) {
+            $signature = Get-AuthenticodeSignature $installer.FullName
+            if ($signature.Status -ne "Valid") {
+              throw "Invalid Authenticode signature for $($installer.Name): $($signature.Status)"
+            }
+          }
+
       - name: Remove temporary notarization key
         if: always() && matrix.os == 'mac'
         shell: bash
         run: rm -f "${{ steps.notarization.outputs.path }}"
 
       - name: Upload desktop distributions
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: desktop-${{ matrix.os }}-${{ needs.preflight.outputs.version }}
           path: |
@@ -361,15 +428,15 @@ jobs:
     env:
       RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           cache: npm
           cache-dependency-path: typescript/package-lock.json
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
 
@@ -417,7 +484,7 @@ jobs:
           sha256sum --check SHA256SUMS
 
       - name: Upload immutable release artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         with:
           name: release-artifacts-${{ env.RELEASE_VERSION }}
           path: release-dist/
@@ -450,7 +517,7 @@ jobs:
     env:
       RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: release-artifacts-${{ env.RELEASE_VERSION }}
           path: release-dist
@@ -459,7 +526,7 @@ jobs:
         working-directory: release-dist
         run: sha256sum --check SHA256SUMS
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
 
@@ -477,7 +544,7 @@ jobs:
           "$RUNNER_TEMP/openrappter-npm-smoke/bin/openrappter" show --help \
             | grep -qi "show-and-tell"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065
         with:
           python-version: '3.12'
 
@@ -530,11 +597,11 @@ jobs:
     env:
       RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: release-artifacts-${{ env.RELEASE_VERSION }}
           path: release-dist
@@ -543,7 +610,7 @@ jobs:
         working-directory: release-dist
         run: sha256sum --check SHA256SUMS
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020
         with:
           node-version: 22
           registry-url: https://registry.npmjs.org
@@ -583,7 +650,7 @@ jobs:
 
       - name: Publish only missing PyPI artifacts with OIDC
         if: steps.pypi-state.outputs.state != 'matching'
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33
         with:
           packages-dir: pypi-dist/
 
@@ -670,7 +737,7 @@ jobs:
     env:
       RELEASE_VERSION: ${{ needs.preflight.outputs.version }}
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           name: release-artifacts-${{ env.RELEASE_VERSION }}
           path: release-dist
@@ -679,7 +746,7 @@ jobs:
         working-directory: release-dist
         run: sha256sum --check SHA256SUMS
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093
         with:
           pattern: desktop-*-${{ env.RELEASE_VERSION }}
           path: desktop-dist
@@ -695,12 +762,12 @@ jobs:
           sha256sum --check SHA256SUMS-DESKTOP
 
       - name: Create GitHub Release with generated notes
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65
         with:
           name: v${{ env.RELEASE_VERSION }}
           generate_release_notes: true
           fail_on_unmatched_files: true
-          overwrite_files: true
+          overwrite_files: false
           files: |
             release-dist/openrappter-${{ env.RELEASE_VERSION }}.tgz
             release-dist/openrappter-${{ env.RELEASE_VERSION }}-py3-none-any.whl

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,6 +106,8 @@ Package releases use one canonical workflow: `.github/workflows/release.yml`.
 A strict `vX.Y.Z` tag is accepted only when it matches:
 
 - `typescript/package.json` and both root versions in `typescript/package-lock.json`
+- `typescript/desktop/package.json` and both root versions in
+  `typescript/desktop/package-lock.json`
 - `python/pyproject.toml`
 - the TypeScript and Python runtime-reported versions
 
@@ -114,6 +116,7 @@ Update the npm metadata, then update the Python project version and
 
 ```bash
 npm version X.Y.Z --no-git-tag-version --prefix typescript
+npm version X.Y.Z --no-git-tag-version --prefix typescript/desktop
 node scripts/release-preflight.mjs --tag vX.Y.Z
 node --test scripts/release-preflight.test.mjs
 ```

--- a/docs/electron-desktop.md
+++ b/docs/electron-desktop.md
@@ -53,6 +53,9 @@ Electron Builder targets:
 - Linux: AppImage
 
 Production signing/notarization credentials remain external to the repository.
+macOS releases require the documented Apple certificate and notarization
+secrets. Windows releases require `WINDOWS_CERTIFICATE_P12_BASE64` and
+`WINDOWS_CERTIFICATE_PASSWORD`; unsigned `.exe` assets are rejected.
 
 ## Security boundary
 

--- a/macos/Sources/OpenRappterBar/Core/AppConstants.swift
+++ b/macos/Sources/OpenRappterBar/Core/AppConstants.swift
@@ -37,6 +37,9 @@ public enum AppConstants {
     public static var defaultPort: Int {
         DesktopGatewayDiscovery.current()?.port ?? 18790
     }
+    public static var defaultGatewayToken: String? {
+        DesktopGatewayDiscovery.current()?.token
+    }
     public static var defaultWebSocketURL: String {
         "ws://\(defaultHost):\(defaultPort)"
     }

--- a/macos/Sources/OpenRappterBar/Models/RpcTypes.swift
+++ b/macos/Sources/OpenRappterBar/Models/RpcTypes.swift
@@ -157,6 +157,28 @@ public enum RpcErrorCode {
     public static let rateLimited = -32001
 }
 
+public struct GatewayAuthLoginResponse: Codable, Sendable {
+    public let userCode: String
+    public let verificationUri: String
+    public let deviceCode: String
+}
+
+public struct GatewayAuthPollResponse: Codable, Sendable {
+    public let status: String
+    public let username: String?
+    public let error: String?
+}
+
+public struct GatewayAuthCancelResponse: Codable, Sendable {
+    public let ok: Bool
+    public let status: String
+}
+
+public struct GatewayAuthProfile: Codable, Sendable {
+    public let id: String
+    public let username: String?
+}
+
 // MARK: - Encoding Helpers
 
 public extension RpcRequestFrame {

--- a/macos/Sources/OpenRappterBar/Services/DesktopGatewayDiscovery.swift
+++ b/macos/Sources/OpenRappterBar/Services/DesktopGatewayDiscovery.swift
@@ -9,6 +9,7 @@ public struct DesktopGatewayEndpoint: Codable, Equatable {
     public let port: Int
     public let token: String
     public let pid: Int32
+    public let ownerPid: Int32?
     public let updatedAt: String
 }
 
@@ -35,7 +36,8 @@ public enum DesktopGatewayDiscovery {
                 of: #"^[0-9a-f]{64}$"#,
                 options: .regularExpression
             ) != nil,
-            processIsAlive(endpoint.pid)
+            processIsAlive(endpoint.pid),
+            endpoint.ownerPid.map(processIsAlive) ?? true
         else {
             return nil
         }

--- a/macos/Sources/OpenRappterBar/Services/GatewayConnection.swift
+++ b/macos/Sources/OpenRappterBar/Services/GatewayConnection.swift
@@ -116,6 +116,8 @@ public actor GatewayConnection: GatewayConnectionProtocol {
         host: String = AppConstants.defaultHost,
         port: Int = AppConstants.defaultPort,
         authToken: String? = nil,
+        desktopEndpoint: DesktopGatewayEndpoint? = nil,
+        discoverDesktopEndpoint: Bool = true,
         transportFactory: TransportFactory? = nil,
         reconnectDelayProvider: @escaping ReconnectDelayProvider = {
             GatewayConnection.backoffDelay(attempt: $0)
@@ -125,17 +127,21 @@ public actor GatewayConnection: GatewayConnectionProtocol {
         },
         postHandshakeHook: @escaping PostHandshakeHook = {}
     ) {
-        let desktop = DesktopGatewayDiscovery.current()
-        self.url = URL(string: "ws://\(host):\(port)")!
-        self.authToken = authToken ?? (
-            desktop?.host == host && desktop?.port == port
-                ? desktop?.token
+        let discoveredDesktop = discoverDesktopEndpoint
+            ? DesktopGatewayDiscovery.current()
+            : nil
+        let desktop = desktopEndpoint ?? (
+            authToken == nil
+                && discoveredDesktop?.host == host
+                && discoveredDesktop?.port == port
+                ? discoveredDesktop
                 : nil
         )
-        self.followsDesktopEndpoint =
-            authToken == nil
-            && desktop?.host == host
-            && desktop?.port == port
+        self.url = URL(
+            string: "ws://\(desktop?.host ?? host):\(desktop?.port ?? port)"
+        )!
+        self.authToken = desktop?.token ?? authToken
+        self.followsDesktopEndpoint = desktop != nil
         self.transportFactory = transportFactory ?? { url in URLSessionWebSocket(url: url) }
         self.reconnectDelayProvider = reconnectDelayProvider
         self.reconnectSleeper = reconnectSleeper

--- a/macos/Sources/OpenRappterBar/Services/GitHubAuthService.swift
+++ b/macos/Sources/OpenRappterBar/Services/GitHubAuthService.swift
@@ -4,7 +4,8 @@ import Security
 
 // MARK: - GitHub Auth Service
 
-/// Handles GitHub device code OAuth flow, token persistence (Keychain + .env), and user info.
+/// Uses Desktop gateway auth when attached, with local OAuth persistence as
+/// the standalone fallback.
 @Observable
 @MainActor
 public final class GitHubAuthService {
@@ -37,14 +38,64 @@ public final class GitHubAuthService {
     public var username: String?
 
     private var pollTask: Task<Void, Never>?
+    private var rpcClient: RpcClient?
+    private var authGeneration: UInt = 0
+    private var gatewayDeviceCode: String?
+    private var gatewayCancellationTask: Task<Void, Never>?
+    private var gatewayCancellationGeneration: UInt = 0
+
+    public var usingGatewayAuthentication: Bool {
+        rpcClient != nil
+    }
+
+    public func configure(rpcClient: RpcClient?) {
+        let previousRpcClient = self.rpcClient
+        pollTask?.cancel()
+        pollTask = nil
+        authGeneration &+= 1
+        let generation = authGeneration
+        self.rpcClient = rpcClient
+        cancelPendingGatewayFlow(
+            refreshGeneration: generation,
+            preferredRpcClient: previousRpcClient
+        )
+        refreshAuthStatus(generation: generation)
+    }
 
     // MARK: - Check Auth Status
 
     /// Check Keychain first, then fall back to .env. Migrates .env token to Keychain if found.
     public func checkAuthStatus() {
+        pollTask?.cancel()
+        pollTask = nil
+        authGeneration &+= 1
+        let generation = authGeneration
+        cancelPendingGatewayFlow(refreshGeneration: generation)
+        refreshAuthStatus(generation: generation)
+    }
+
+    private func refreshAuthStatus(generation: UInt) {
+        error = nil
+        username = nil
+        authState = .unknown
+        if let rpcClient {
+            Task {
+                do {
+                    let profile = try await rpcClient.activeGatewayAuthProfile()
+                    guard generation == authGeneration else { return }
+                    username = profile?.username ?? profile?.id
+                    authState = profile == nil ? .unauthenticated : .authenticated
+                } catch {
+                    guard generation == authGeneration else { return }
+                    self.error = error.localizedDescription
+                    authState = .unauthenticated
+                }
+            }
+            return
+        }
         if let token = readKeychain() {
             authState = .authenticated
-            fetchUsername(token: token)
+            fetchUsername(token: token, generation: generation)
             return
         }
 
@@ -52,7 +103,7 @@ public final class GitHubAuthService {
             // Migrate to Keychain
             saveKeychain(token: token)
             authState = .authenticated
-            fetchUsername(token: token)
+            fetchUsername(token: token, generation: generation)
             return
         }
 
@@ -62,16 +113,85 @@ public final class GitHubAuthService {
     // MARK: - Login (Device Code Flow)
 
     public func login() {
-        guard authState != .authenticating else { return }
+        guard authState != .authenticating, gatewayDeviceCode == nil else { return }
+        gatewayCancellationGeneration &+= 1
+        gatewayCancellationTask?.cancel()
+        gatewayCancellationTask = nil
+        pollTask?.cancel()
+        authGeneration &+= 1
+        let generation = authGeneration
         authState = .authenticating
         error = nil
         userCode = ""
         verificationURL = ""
 
+        if let rpcClient {
+            pollTask = Task {
+                do {
+                    let device = try await rpcClient.beginGatewayAuthentication()
+                    guard generation == authGeneration else {
+                        cancelDetachedGatewayFlow(
+                            deviceCode: device.deviceCode,
+                            preferredRpcClient: rpcClient
+                        )
+                        return
+                    }
+                    gatewayDeviceCode = device.deviceCode
+                    userCode = device.userCode
+                    verificationURL = device.verificationUri
+                    if let url = URL(string: device.verificationUri) {
+                        NSWorkspace.shared.open(url)
+                    }
+                    while !Task.isCancelled {
+                        let result: GatewayAuthPollResponse
+                        do {
+                            result = try await rpcClient.pollGatewayAuthentication(
+                                deviceCode: device.deviceCode
+                            )
+                        } catch is CancellationError {
+                            throw CancellationError()
+                        } catch {
+                            guard generation == authGeneration else { return }
+                            self.error = "Waiting for the Desktop gateway to reconnect…"
+                            try await Task.sleep(for: .seconds(1))
+                            continue
+                        }
+                        guard generation == authGeneration else { return }
+                        self.error = nil
+                        if result.status == "pending" {
+                            try await Task.sleep(for: .seconds(1))
+                            continue
+                        }
+                        if result.status == "success" {
+                            gatewayDeviceCode = nil
+                            username = result.username
+                            authState = .authenticated
+                            Log.auth.info("Gateway-managed GitHub authentication successful")
+                            return
+                        }
+                        gatewayDeviceCode = nil
+                        throw GitHubAuthError.gatewayFailed(
+                            result.error ?? "Gateway authentication failed"
+                        )
+                    }
+                } catch is CancellationError {
+                    if generation == authGeneration, authState == .authenticating {
+                        authState = .unauthenticated
+                    }
+                } catch {
+                    guard generation == authGeneration else { return }
+                    self.error = error.localizedDescription
+                    authState = .unauthenticated
+                }
+            }
+            return
+        }
+
         pollTask = Task {
             do {
                 // Step 1: Request device code
                 let deviceResponse = try await requestDeviceCode()
+                guard generation == authGeneration else { return }
                 userCode = deviceResponse.userCode
                 verificationURL = deviceResponse.verificationURI
 
@@ -86,18 +206,20 @@ public final class GitHubAuthService {
                     interval: deviceResponse.interval,
                     expiresIn: deviceResponse.expiresIn
                 )
+                guard generation == authGeneration else { return }
 
                 // Step 3: Persist
                 saveKeychain(token: token)
                 writeTokenToEnv(token: token)
                 authState = .authenticated
                 Log.auth.info("GitHub authentication successful")
-                fetchUsername(token: token)
+                fetchUsername(token: token, generation: generation)
             } catch is CancellationError {
-                if authState == .authenticating {
+                if generation == authGeneration, authState == .authenticating {
                     authState = .unauthenticated
                 }
             } catch {
+                guard generation == authGeneration else { return }
                 Log.auth.error("GitHub auth failed: \(error.localizedDescription)")
                 self.error = error.localizedDescription
                 authState = .unauthenticated
@@ -108,22 +230,149 @@ public final class GitHubAuthService {
     // MARK: - Cancel
 
     public func cancelLogin() {
+        authGeneration &+= 1
+        let generation = authGeneration
         pollTask?.cancel()
         pollTask = nil
-        authState = .unauthenticated
         userCode = ""
         verificationURL = ""
         error = nil
+        guard gatewayDeviceCode != nil else {
+            authState = .unauthenticated
+            return
+        }
+        authState = .unknown
+        cancelPendingGatewayFlow(
+            refreshGeneration: generation,
+            markCancelled: true
+        )
     }
 
     // MARK: - Logout
 
     public func logout() {
+        cancelPendingGatewayFlow()
+        authGeneration &+= 1
+        let generation = authGeneration
+        pollTask?.cancel()
+        pollTask = nil
+        if let rpcClient {
+            Task {
+                do {
+                    if let profile = try await rpcClient.activeGatewayAuthProfile() {
+                        try await rpcClient.removeGatewayAuthProfile(id: profile.id)
+                    }
+                    let nextProfile = try await rpcClient.activeGatewayAuthProfile()
+                    guard generation == authGeneration else { return }
+                    username = nextProfile?.username ?? nextProfile?.id
+                    error = nil
+                    authState = nextProfile == nil ? .unauthenticated : .authenticated
+                } catch {
+                    guard generation == authGeneration else { return }
+                    self.error = error.localizedDescription
+                }
+            }
+            return
+        }
         deleteKeychain()
         removeTokenFromEnv()
         username = nil
         authState = .unauthenticated
         Log.auth.info("GitHub token cleared")
+    }
+
+    private func cancelPendingGatewayFlow(
+        refreshGeneration: UInt? = nil,
+        markCancelled: Bool = false,
+        preferredRpcClient: RpcClient? = nil
+    ) {
+        guard let deviceCode = gatewayDeviceCode else { return }
+        gatewayCancellationGeneration &+= 1
+        let cancellationGeneration = gatewayCancellationGeneration
+        gatewayCancellationTask?.cancel()
+        let task = Task {
+            var preferredRpcClient = preferredRpcClient
+            defer {
+                if cancellationGeneration == gatewayCancellationGeneration {
+                    gatewayCancellationTask = nil
+                }
+            }
+            while !Task.isCancelled,
+                  cancellationGeneration == gatewayCancellationGeneration,
+                  gatewayDeviceCode == deviceCode {
+                guard let cancellationClient = preferredRpcClient ?? rpcClient else {
+                    gatewayDeviceCode = nil
+                    if markCancelled, refreshGeneration == authGeneration {
+                        authState = .unauthenticated
+                        error = "Desktop authentication cancellation could not be confirmed."
+                    }
+                    return
+                }
+                preferredRpcClient = nil
+                do {
+                    let result = try await cancellationClient.cancelGatewayAuthentication(
+                        deviceCode: deviceCode
+                    )
+                    guard cancellationGeneration == gatewayCancellationGeneration,
+                          gatewayDeviceCode == deviceCode else { return }
+                    gatewayDeviceCode = nil
+                    error = nil
+                    if let refreshGeneration,
+                       refreshGeneration == authGeneration {
+                        if markCancelled, result.status == "cancelled" {
+                            authState = .unauthenticated
+                        } else {
+                            refreshAuthStatus(generation: refreshGeneration)
+                        }
+                    }
+                    return
+                } catch {
+                    if rpcClient == nil {
+                        gatewayDeviceCode = nil
+                        if markCancelled, refreshGeneration == authGeneration {
+                            authState = .unauthenticated
+                            self.error = "Desktop authentication cancellation could not be confirmed."
+                        }
+                        return
+                    }
+                    if markCancelled, refreshGeneration == authGeneration {
+                        self.error = "Cancelling Desktop authentication…"
+                    }
+                    Log.auth.debug(
+                        "Gateway authentication cancellation will retry: \(error.localizedDescription)"
+                    )
+                    try? await Task.sleep(for: .seconds(1))
+                }
+            }
+        }
+        gatewayCancellationTask = task
+    }
+
+    private func cancelDetachedGatewayFlow(
+        deviceCode: String,
+        preferredRpcClient: RpcClient
+    ) {
+        Task {
+            var cancellationClientCandidate: RpcClient? = preferredRpcClient
+            while !Task.isCancelled {
+                guard let cancellationClient = cancellationClientCandidate ?? rpcClient else {
+                    return
+                }
+                cancellationClientCandidate = nil
+                do {
+                    _ = try await cancellationClient.cancelGatewayAuthentication(
+                        deviceCode: deviceCode
+                    )
+                    return
+                } catch {
+                    guard rpcClient != nil else { return }
+                    Log.auth.debug(
+                        "Detached gateway authentication cancellation will retry: \(error.localizedDescription)"
+                    )
+                    try? await Task.sleep(for: .seconds(1))
+                }
+            }
+        }
     }
 
     // MARK: - Device Code Request
@@ -224,7 +473,7 @@ public final class GitHubAuthService {
 
     // MARK: - Username Fetch
 
-    private func fetchUsername(token: String) {
+    private func fetchUsername(token: String, generation: UInt) {
         Task {
             do {
                 var request = URLRequest(url: URL(string: "https://api.github.com/user")!)
@@ -237,6 +486,7 @@ public final class GitHubAuthService {
                 }
                 if let json = try JSONSerialization.jsonObject(with: data) as? [String: Any],
                    let login = json["login"] as? String {
+                    guard generation == authGeneration else { return }
                     username = login
                 }
             } catch {
@@ -389,6 +639,7 @@ enum GitHubAuthError: Error, LocalizedError {
     case expired
     case denied
     case other(String, String?)
+    case gatewayFailed(String)
 
     var errorDescription: String? {
         switch self {
@@ -404,6 +655,8 @@ enum GitHubAuthError: Error, LocalizedError {
             return "Login was cancelled or denied"
         case .other(let code, let desc):
             return "GitHub error: \(code)\(desc.map { " — \($0)" } ?? "")"
+        case .gatewayFailed(let message):
+            return message
         }
     }
 }

--- a/macos/Sources/OpenRappterBar/Services/RpcClient.swift
+++ b/macos/Sources/OpenRappterBar/Services/RpcClient.swift
@@ -95,6 +95,66 @@ public struct RpcClient: RpcClientProtocol, Sendable {
         return try decodePayload(response)
     }
 
+    public func beginGatewayAuthentication() async throws -> GatewayAuthLoginResponse {
+        let response = try await connection.sendRequest(method: "auth.login")
+        return try decodePayload(response)
+    }
+
+    public func pollGatewayAuthentication(
+        deviceCode: String
+    ) async throws -> GatewayAuthPollResponse {
+        let response = try await connection.sendRequest(
+            method: "auth.poll",
+            params: ["deviceCode": AnyCodable(deviceCode)]
+        )
+        return try decodePayload(response)
+    }
+
+    public func cancelGatewayAuthentication(
+        deviceCode: String
+    ) async throws -> GatewayAuthCancelResponse {
+        let response = try await connection.sendRequest(
+            method: "auth.cancel",
+            params: ["deviceCode": AnyCodable(deviceCode)]
+        )
+        return try decodePayload(response)
+    }
+
+    public func activeGatewayAuthProfile() async throws -> GatewayAuthProfile? {
+        let response = try await connection.sendRequest(method: "auth.active")
+        guard response.ok else {
+            let detail = response.error ?? RpcErrorDetail(code: -1, message: "Unknown error")
+            throw GatewayConnectionError.serverError(
+                code: detail.code,
+                message: detail.message
+            )
+        }
+        guard response.payload != nil else { return nil }
+        return try decodePayload(response)
+    }
+
+    public func removeGatewayAuthProfile(id: String) async throws {
+        let response = try await connection.sendRequest(
+            method: "auth.remove",
+            params: ["id": AnyCodable(id)]
+        )
+        let result: [String: Bool] = try decodePayload(response)
+        guard result["ok"] == true else {
+            throw RpcClientError.decodingFailed("Gateway refused to remove auth profile")
+        }
+    }
+
+    public func switchGatewayAuthProfile(id: String) async throws {
+        let response = try await connection.sendRequest(
+            method: "auth.switch",
+            params: ["id": AnyCodable(id)]
+        )
+        let result: [String: Bool] = try decodePayload(response)
+        guard result["ok"] == true else {
+            throw RpcClientError.decodingFailed("Gateway refused to switch auth profile")
+        }
+    }
+
     public func sendChat(message: String, sessionKey: String? = nil) async throws -> ChatAccepted {
         var params: [String: AnyCodable] = [
             "message": AnyCodable(message)

--- a/macos/Sources/OpenRappterBar/ViewModels/AccountViewModel.swift
+++ b/macos/Sources/OpenRappterBar/ViewModels/AccountViewModel.swift
@@ -21,9 +21,17 @@ public final class AccountViewModel {
         authService.checkAuthStatus()
     }
 
+    public func configure(rpcClient: RpcClient?) {
+        authService.configure(rpcClient: rpcClient)
+    }
+
     /// Returns the coordinator-owned task so callers can await completion.
     @discardableResult
     public func restartGatewayAfterAuth() -> Task<Void, Never> {
+        guard !authService.usingGatewayAuthentication else {
+            Log.auth.info("Gateway-managed authentication updated without a restart")
+            return Task {}
+        }
         Log.auth.info("Restarting gateway to pick up new GitHub token")
         return restartGateway?() ?? Task {}
     }

--- a/macos/Sources/OpenRappterBar/ViewModels/AppViewModel.swift
+++ b/macos/Sources/OpenRappterBar/ViewModels/AppViewModel.swift
@@ -49,16 +49,23 @@ public enum ChatState: Sendable {
 @Observable
 @MainActor
 public final class AppViewModel {
-    public typealias ConnectionFactory = @MainActor (_ host: String, _ port: Int) -> GatewayConnection
+    public typealias ConnectionFactory = @MainActor (
+        _ host: String,
+        _ port: Int,
+        _ desktopEndpoint: DesktopGatewayEndpoint?
+    ) -> GatewayConnection
+    public typealias DesktopEndpointProvider = @MainActor () -> DesktopGatewayEndpoint?
 
     private struct GatewayEndpoint: Equatable {
         let host: String
         let port: Int
+        let desktopEndpoint: DesktopGatewayEndpoint?
     }
 
     private enum GatewayLifecycleOperation: Equatable {
         case start
         case stop
+        case desktopTakeover(GatewayEndpoint)
         case authenticationRestart(GatewayEndpoint)
     }
 
@@ -85,6 +92,7 @@ public final class AppViewModel {
 
     // Process
     public var processState: ProcessManager.ProcessState = .stopped
+    public private(set) var usesDesktopGateway = false
 
     // Heartbeat
     public var heartbeatHealth: HeartbeatHealth = .healthy
@@ -118,6 +126,7 @@ public final class AppViewModel {
     let eventBus: EventBus
     let sessionStore: SessionStore
     private let connectionFactory: ConnectionFactory
+    private let desktopEndpointProvider: DesktopEndpointProvider
 
     // Legacy chat state (forwarded from ChatViewModel for existing views)
     public var chatInput: String {
@@ -179,8 +188,16 @@ public final class AppViewModel {
         self.eventBus = bus
         self.processManager = ProcessManager()
         self.sessionStore = SessionStore()
-        self.connectionFactory = { host, port in
-            GatewayConnection(host: host, port: port)
+        self.connectionFactory = { host, port, desktopEndpoint in
+            GatewayConnection(
+                host: host,
+                port: port,
+                desktopEndpoint: desktopEndpoint,
+                discoverDesktopEndpoint: desktopEndpoint != nil
+            )
+        }
+        self.desktopEndpointProvider = {
+            DesktopGatewayDiscovery.current()
         }
         Task { await sessionStore.load() }
         // Start fleet live polling
@@ -191,6 +208,10 @@ public final class AppViewModel {
     /// Detect a running gateway and connect to it automatically.
     public func detectAndConnect(host: String = AppConstants.defaultHost, port: Int = AppConstants.defaultPort) {
         guard !isShuttingDown else { return }
+        if desktopEndpointProvider() != nil {
+            connectUsingPreferredGateway(fallbackHost: host, fallbackPort: port)
+            return
+        }
         gatewayLifecycleGeneration &+= 1
         let generation = gatewayLifecycleGeneration
         Task {
@@ -208,17 +229,90 @@ public final class AppViewModel {
         processManager: ProcessManager,
         eventBus: EventBus,
         sessionStore: SessionStore? = nil,
-        connectionFactory: @escaping ConnectionFactory = { host, port in
-            GatewayConnection(host: host, port: port)
-        }
+        connectionFactory: @escaping ConnectionFactory = { host, port, desktopEndpoint in
+            GatewayConnection(
+                host: host,
+                port: port,
+                desktopEndpoint: desktopEndpoint,
+                discoverDesktopEndpoint: desktopEndpoint != nil
+            )
+        },
+        desktopEndpointProvider: @escaping DesktopEndpointProvider = { nil }
     ) {
         self.processManager = processManager
         self.eventBus = eventBus
         self.sessionStore = sessionStore ?? SessionStore()
         self.connectionFactory = connectionFactory
+        self.desktopEndpointProvider = desktopEndpointProvider
     }
 
     // MARK: - Actions
+
+    /// Prefer Electron's private authenticated gateway and only fall back to
+    /// the standalone endpoint when no live desktop owner is available.
+    @discardableResult
+    public func connectUsingPreferredGateway(
+        fallbackHost: String = AppConstants.defaultHost,
+        fallbackPort: Int = AppConstants.defaultPort
+    ) -> Task<Void, Never> {
+        if let endpoint = desktopEndpointProvider() {
+            let gatewayEndpoint = GatewayEndpoint(
+                host: endpoint.host,
+                port: endpoint.port,
+                desktopEndpoint: endpoint
+            )
+            let operation = GatewayLifecycleOperation.desktopTakeover(gatewayEndpoint)
+            if gatewayLifecycleOperation == operation, let gatewayLifecycleTask {
+                return gatewayLifecycleTask
+            }
+
+            gatewayLifecycleGeneration &+= 1
+            let generation = gatewayLifecycleGeneration
+            let supersededLifecycle = gatewayLifecycleTask
+            supersededLifecycle?.cancel()
+            usesDesktopGateway = true
+            let task = Task { [weak self] in
+                guard let self else { return }
+                defer {
+                    if generation == self.gatewayLifecycleGeneration {
+                        self.gatewayLifecycleTask = nil
+                        self.gatewayLifecycleOperation = nil
+                    }
+                }
+                guard generation == self.gatewayLifecycleGeneration,
+                      !self.isShuttingDown,
+                      !Task.isCancelled else { return }
+
+                await self.disconnectFromGateway()
+                guard generation == self.gatewayLifecycleGeneration,
+                      !self.isShuttingDown,
+                      !Task.isCancelled else { return }
+
+                self.processState = .stopping
+                _ = await self.processManager.stop()
+                await supersededLifecycle?.value
+                guard generation == self.gatewayLifecycleGeneration,
+                      !self.isShuttingDown,
+                      !Task.isCancelled else { return }
+
+                self.processState = self.processManager.state
+                self.addActivity(type: .system, text: "Using OpenRappter Desktop gateway")
+                let connectionTask = self.connectToEndpoint(
+                    host: endpoint.host,
+                    port: endpoint.port,
+                    desktopEndpoint: endpoint
+                )
+                await connectionTask.value
+            }
+            gatewayLifecycleOperation = operation
+            gatewayLifecycleTask = task
+            return task
+        }
+        return connectToGateway(
+            host: fallbackHost,
+            port: fallbackPort
+        )
+    }
 
     /// Connect to the gateway.
     ///
@@ -232,8 +326,47 @@ public final class AppViewModel {
         host: String = AppConstants.defaultHost,
         port: Int = AppConstants.defaultPort
     ) -> Task<Void, Never> {
+        let supersededLifecycle = gatewayLifecycleTask
+        if supersededLifecycle != nil {
+            gatewayLifecycleGeneration &+= 1
+            gatewayLifecycleTask = nil
+            gatewayLifecycleOperation = nil
+            supersededLifecycle?.cancel()
+        }
+        usesDesktopGateway = false
+        if let supersededLifecycle {
+            let generation = gatewayLifecycleGeneration
+            let connectionIntentGeneration = connectGeneration
+            return Task { [weak self] in
+                guard let self else { return }
+                await supersededLifecycle.value
+                guard generation == self.gatewayLifecycleGeneration,
+                      connectionIntentGeneration == self.connectGeneration,
+                      !self.isShuttingDown,
+                      !Task.isCancelled else { return }
+                let connectionTask = self.connectToEndpoint(
+                    host: host,
+                    port: port,
+                    desktopEndpoint: nil
+                )
+                await connectionTask.value
+            }
+        }
+        return connectToEndpoint(host: host, port: port, desktopEndpoint: nil)
+    }
+
+    @discardableResult
+    private func connectToEndpoint(
+        host: String,
+        port: Int,
+        desktopEndpoint: DesktopGatewayEndpoint?
+    ) -> Task<Void, Never> {
         guard !isShuttingDown else { return Task {} }
-        let endpoint = GatewayEndpoint(host: host, port: port)
+        let endpoint = GatewayEndpoint(
+            host: host,
+            port: port,
+            desktopEndpoint: desktopEndpoint
+        )
         if let connectTask, connectEndpoint == endpoint {
             return connectTask
         }
@@ -248,6 +381,7 @@ public final class AppViewModel {
             await self.performConnect(
                 host: host,
                 port: port,
+                desktopEndpoint: desktopEndpoint,
                 generation: generation,
                 supersededTask: supersededTask
             )
@@ -263,6 +397,7 @@ public final class AppViewModel {
     private func performConnect(
         host: String,
         port: Int,
+        desktopEndpoint: DesktopGatewayEndpoint?,
         generation: UInt,
         supersededTask: Task<Void, Never>?
     ) async {
@@ -282,7 +417,7 @@ public final class AppViewModel {
 
         await supersededTask?.value
         guard generation == connectGeneration, !Task.isCancelled else { return }
-        let conn = connectionFactory(host, port)
+        let conn = connectionFactory(host, port, desktopEndpoint)
         connection = conn
 
         await conn.setStateHandler { [weak self, weak conn] state in
@@ -389,6 +524,9 @@ public final class AppViewModel {
     @discardableResult
     public func startGateway() -> Task<Void, Never> {
         guard !isShuttingDown else { return Task {} }
+        if usesDesktopGateway || desktopEndpointProvider() != nil {
+            return connectUsingPreferredGateway()
+        }
         if gatewayLifecycleOperation == .start, let gatewayLifecycleTask {
             return gatewayLifecycleTask
         }
@@ -415,7 +553,12 @@ public final class AppViewModel {
                       result != .superseded else { return }
                 self.processState = self.processManager.state
                 self.addActivity(type: .system, text: "Gateway started")
-                self.connectToGateway()
+                let connectionTask = self.connectToEndpoint(
+                    host: AppConstants.defaultHost,
+                    port: AppConstants.defaultPort,
+                    desktopEndpoint: nil
+                )
+                await connectionTask.value
             } catch {
                 guard generation == self.gatewayLifecycleGeneration,
                       !self.isShuttingDown,
@@ -431,6 +574,35 @@ public final class AppViewModel {
 
     @discardableResult
     public func stopGateway() -> Task<Void, Never> {
+        if usesDesktopGateway {
+            if gatewayLifecycleOperation == .stop, let gatewayLifecycleTask {
+                return gatewayLifecycleTask
+            }
+            gatewayLifecycleGeneration &+= 1
+            let generation = gatewayLifecycleGeneration
+            let supersededLifecycle = gatewayLifecycleTask
+            supersededLifecycle?.cancel()
+            let task = Task { [weak self] in
+                guard let self else { return }
+                defer {
+                    if generation == self.gatewayLifecycleGeneration {
+                        self.gatewayLifecycleTask = nil
+                        self.gatewayLifecycleOperation = nil
+                    }
+                }
+                guard generation == self.gatewayLifecycleGeneration else { return }
+                await self.disconnectFromGateway()
+                guard generation == self.gatewayLifecycleGeneration else { return }
+                _ = await self.processManager.stop()
+                await supersededLifecycle?.value
+                guard generation == self.gatewayLifecycleGeneration else { return }
+                self.processState = self.processManager.state
+                self.addActivity(type: .system, text: "Disconnected from OpenRappter Desktop")
+            }
+            gatewayLifecycleOperation = .stop
+            gatewayLifecycleTask = task
+            return task
+        }
         if gatewayLifecycleOperation == .stop, let gatewayLifecycleTask {
             return gatewayLifecycleTask
         }
@@ -471,7 +643,15 @@ public final class AppViewModel {
         port: Int = AppConstants.defaultPort
     ) -> Task<Void, Never> {
         guard !isShuttingDown else { return Task {} }
-        let endpoint = GatewayEndpoint(host: host, port: port)
+        if usesDesktopGateway {
+            addActivity(type: .system, text: "Desktop gateway authentication updated")
+            return Task {}
+        }
+        let endpoint = GatewayEndpoint(
+            host: host,
+            port: port,
+            desktopEndpoint: nil
+        )
         let operation = GatewayLifecycleOperation.authenticationRestart(endpoint)
         if gatewayLifecycleOperation == operation, let gatewayLifecycleTask {
             return gatewayLifecycleTask
@@ -511,7 +691,11 @@ public final class AppViewModel {
 
                 self.processState = self.processManager.state
                 self.addActivity(type: .system, text: "Gateway restarted after authentication")
-                let connectionTask = self.connectToGateway(host: host, port: port)
+                let connectionTask = self.connectToEndpoint(
+                    host: host,
+                    port: port,
+                    desktopEndpoint: nil
+                )
                 await connectionTask.value
             } catch {
                 guard generation == self.gatewayLifecycleGeneration,

--- a/macos/Sources/OpenRappterBar/ViewModels/SettingsViewModel.swift
+++ b/macos/Sources/OpenRappterBar/ViewModels/SettingsViewModel.swift
@@ -27,16 +27,25 @@ public final class SettingsViewModel {
         self.init(settingsStore: SettingsStore())
     }
 
-    public func configure(rpcClient: RpcClient) {
+    public func configure(
+        rpcClient: RpcClient,
+        useGatewayAuthentication: Bool = true
+    ) {
         self.rpcClient = rpcClient
+        accountViewModel.configure(
+            rpcClient: useGatewayAuthentication ? rpcClient : nil
+        )
         channelsViewModel.configure(rpcClient: rpcClient)
         cronViewModel.configure(rpcClient: rpcClient)
         skillsViewModel.configure(rpcClient: rpcClient)
         approvalViewModel.configure(rpcClient: rpcClient)
     }
 
-    public func clearConfiguration() {
+    public func clearConfiguration(clearAccountAuthentication: Bool = true) {
         rpcClient = nil
+        if clearAccountAuthentication {
+            accountViewModel.configure(rpcClient: nil)
+        }
         channelsViewModel.clearConfiguration()
         cronViewModel.clearConfiguration()
         skillsViewModel.clearConfiguration()

--- a/macos/Sources/OpenRappterBar/Views/BonesView.swift
+++ b/macos/Sources/OpenRappterBar/Views/BonesView.swift
@@ -236,19 +236,17 @@ public enum AgentInstaller {
     public static func install(
         filename: String,
         contents: String,
-        port: Int = AppConstants.defaultPort
+        port: Int = AppConstants.defaultPort,
+        token: String? = AppConstants.defaultGatewayToken
     ) async -> AgentDropResult {
-        guard let url = URL(string: "http://127.0.0.1:\(port)/agents/import") else {
+        guard let request = makeRequest(
+            filename: filename,
+            contents: contents,
+            port: port,
+            token: token
+        ) else {
             return .refused(reason: "Could not reach the daemon.")
         }
-        var request = URLRequest(url: url)
-        request.httpMethod = "POST"
-        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-        request.httpBody = try? JSONSerialization.data(withJSONObject: [
-            "filename": filename,
-            "contents": contents,
-        ])
-        request.timeoutInterval = 45
 
         do {
             let (data, _) = try await URLSession.shared.data(for: request)
@@ -266,6 +264,29 @@ public enum AgentInstaller {
         } catch {
             return .refused(reason: "openrappter is not running, so there is nothing to teach. Start it and drop again.")
         }
+    }
+
+    static func makeRequest(
+        filename: String,
+        contents: String,
+        port: Int,
+        token: String?
+    ) -> URLRequest? {
+        guard let url = URL(string: "http://127.0.0.1:\(port)/agents/import") else {
+            return nil
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        if let token, !token.isEmpty {
+            request.setValue(token, forHTTPHeaderField: "X-Gateway-Token")
+        }
+        request.httpBody = try? JSONSerialization.data(withJSONObject: [
+            "filename": filename,
+            "contents": contents,
+        ])
+        request.timeoutInterval = 45
+        return request
     }
 }
 

--- a/macos/Sources/OpenRappterBar/Views/Chat/ChatWindowManager.swift
+++ b/macos/Sources/OpenRappterBar/Views/Chat/ChatWindowManager.swift
@@ -80,7 +80,10 @@ public final class ChatWindowManager {
             }
 
             if auth.authState == .authenticated {
-                viewModel.chatViewModel.addSystemMessage("✅ Authenticated! Restarting gateway…")
+                let message = auth.usingGatewayAuthentication
+                    ? "✅ Authenticated through OpenRappter Desktop."
+                    : "✅ Authenticated! Restarting gateway…"
+                viewModel.chatViewModel.addSystemMessage(message)
                 await settingsViewModel.accountViewModel.restartGatewayAfterAuth().value
             } else if let error = auth.error {
                 viewModel.chatViewModel.addSystemMessage("❌ Auth failed: \(error)")
@@ -182,10 +185,9 @@ public final class ChatWindowManager {
                         onReauth: { [weak self] in self?.handleReauth() }
                     )
                     panel.contentView = NSHostingView(rootView: chatView)
-                    // Reconnect to gateway since daemon was just started
-                    self.viewModel.connectToGateway(
-                        host: self.settingsViewModel.settingsStore.host,
-                        port: self.settingsViewModel.settingsStore.port
+                    self.viewModel.connectUsingPreferredGateway(
+                        fallbackHost: self.settingsViewModel.settingsStore.host,
+                        fallbackPort: self.settingsViewModel.settingsStore.port
                     )
                 }
             )

--- a/macos/Sources/OpenRappterBar/Views/Settings/AccountSettingsView.swift
+++ b/macos/Sources/OpenRappterBar/Views/Settings/AccountSettingsView.swift
@@ -118,7 +118,16 @@ public struct AccountSettingsView: View {
                 }
             }
 
-            Button("Sign Out", role: .destructive) {
+            if authService.usingGatewayAuthentication {
+                Label("Managed securely by OpenRappter Desktop", systemImage: "macwindow")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+
+            Button(
+                authService.usingGatewayAuthentication ? "Remove Account" : "Sign Out",
+                role: .destructive
+            ) {
                 authService.logout()
             }
             .controlSize(.small)

--- a/macos/Sources/OpenRappterBar/Views/StatusMenuView.swift
+++ b/macos/Sources/OpenRappterBar/Views/StatusMenuView.swift
@@ -76,13 +76,18 @@ public struct StatusMenuView: View {
                 Text(viewModel.statusText)
                     .font(.caption)
                     .foregroundStyle(.secondary)
+                if viewModel.usesDesktopGateway {
+                    Text("OpenRappter Desktop gateway")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
             }
 
             Spacer()
 
             if viewModel.connectionState == .disconnected {
                 Button("Connect") {
-                    viewModel.connectToGateway()
+                    viewModel.connectUsingPreferredGateway()
                 }
                 .buttonStyle(.bordered)
                 .controlSize(.small)
@@ -93,7 +98,11 @@ public struct StatusMenuView: View {
 
     private var footerButtons: some View {
         HStack {
-            if viewModel.processState == .stopped {
+            if viewModel.usesDesktopGateway {
+                Label("Managed by Desktop", systemImage: "macwindow")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else if viewModel.processState == .stopped {
                 Button {
                     viewModel.startGateway()
                 } label: {

--- a/macos/Sources/OpenRappterBarApp/AppDelegate.swift
+++ b/macos/Sources/OpenRappterBarApp/AppDelegate.swift
@@ -94,27 +94,19 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         observeViewModel()
         registerAsLoginItem()
 
-        // Electron publishes a private endpoint. Prefer it over starting a
-        // competing gateway so the window and menu bar share one organism.
-        if let desktop = DesktopGatewayDiscovery.current() {
-            viewModel.connectToGateway(host: desktop.host, port: desktop.port)
-        } else if settingsViewModel.settingsStore.autoStartGateway {
-            viewModel.startGateway()
-        } else if settingsViewModel.settingsStore.autoConnect {
-            // Only auto-connect standalone when not auto-starting
-            // (startGateway already calls connectToGateway on success)
-            viewModel.connectToGateway(
-                host: settingsViewModel.settingsStore.host,
-                port: settingsViewModel.settingsStore.port
-            )
-        }
-
         // Configure settings ViewModel when RPC becomes available
         viewModel.onRpcClientReady = { [weak self] rpc in
-            self?.settingsViewModel.configure(rpcClient: rpc)
+            guard let self else { return }
+            self.settingsViewModel.configure(
+                rpcClient: rpc,
+                useGatewayAuthentication: self.viewModel.usesDesktopGateway
+            )
         }
         viewModel.onRpcClientInvalidated = { [weak self] in
-            self?.settingsViewModel.clearConfiguration()
+            guard let self else { return }
+            self.settingsViewModel.clearConfiguration(
+                clearAccountAuthentication: !self.viewModel.usesDesktopGateway
+            )
         }
 
         // Configure account auth with gateway restart capability
@@ -127,6 +119,22 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 )
             }
         )
+
+        // Electron publishes a private endpoint. Prefer it over starting a
+        // competing gateway so the window and menu bar share one organism.
+        if DesktopGatewayDiscovery.current() != nil {
+            viewModel.connectUsingPreferredGateway(
+                fallbackHost: settingsViewModel.settingsStore.host,
+                fallbackPort: settingsViewModel.settingsStore.port
+            )
+        } else if settingsViewModel.settingsStore.autoStartGateway {
+            viewModel.startGateway()
+        } else if settingsViewModel.settingsStore.autoConnect {
+            viewModel.connectUsingPreferredGateway(
+                fallbackHost: settingsViewModel.settingsStore.host,
+                fallbackPort: settingsViewModel.settingsStore.port
+            )
+        }
     }
 
     // MARK: - Termination
@@ -207,11 +215,13 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
             menu.addItem(NSMenuItem(title: "Disconnect", action: #selector(menuDisconnect), keyEquivalent: ""))
         }
 
-        // Gateway
-        if viewModel.processState == .stopped {
-            menu.addItem(NSMenuItem(title: "Start Gateway", action: #selector(menuStartGateway), keyEquivalent: ""))
-        } else if viewModel.processState == .running {
-            menu.addItem(NSMenuItem(title: "Stop Gateway", action: #selector(menuStopGateway), keyEquivalent: ""))
+        // Electron owns its gateway lifecycle; the Bar may only connect to it.
+        if !viewModel.usesDesktopGateway {
+            if viewModel.processState == .stopped {
+                menu.addItem(NSMenuItem(title: "Start Gateway", action: #selector(menuStartGateway), keyEquivalent: ""))
+            } else if viewModel.processState == .running {
+                menu.addItem(NSMenuItem(title: "Stop Gateway", action: #selector(menuStopGateway), keyEquivalent: ""))
+            }
         }
 
         menu.addItem(NSMenuItem.separator())
@@ -254,14 +264,18 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Menu Actions
 
     @objc private func menuConnect() {
-        viewModel.connectToGateway(
-            host: settingsViewModel.settingsStore.host,
-            port: settingsViewModel.settingsStore.port
+        viewModel.connectUsingPreferredGateway(
+            fallbackHost: settingsViewModel.settingsStore.host,
+            fallbackPort: settingsViewModel.settingsStore.port
         )
     }
 
     @objc private func menuDisconnect() {
-        Task { await viewModel.disconnectFromGateway() }
+        if viewModel.usesDesktopGateway {
+            viewModel.stopGateway()
+        } else {
+            Task { await viewModel.disconnectFromGateway() }
+        }
     }
 
     @objc private func menuStartGateway() {
@@ -315,7 +329,10 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
                 try? await Task.sleep(for: .seconds(1))
             }
             if auth.authState == .authenticated {
-                viewModel.chatViewModel.addSystemMessage("✅ Authenticated! Restarting gateway…")
+                let message = auth.usingGatewayAuthentication
+                    ? "✅ Authenticated through OpenRappter Desktop."
+                    : "✅ Authenticated! Restarting gateway…"
+                viewModel.chatViewModel.addSystemMessage(message)
                 await settingsViewModel.accountViewModel.restartGatewayAfterAuth().value
             }
             viewModel.chatViewModel.authFlowFinished(succeeded: auth.authState == .authenticated)
@@ -348,7 +365,16 @@ public final class AppDelegate: NSObject, NSApplicationDelegate {
         case .settings:
             NSApp.sendAction(Selector(("showSettingsWindow:")), to: nil, from: nil)
         case .connect(let host, let port):
-            viewModel.connectToGateway(host: host, port: port)
+            if let desktop = DesktopGatewayDiscovery.current(),
+               desktop.host == host,
+               desktop.port == port {
+                viewModel.connectUsingPreferredGateway(
+                    fallbackHost: host,
+                    fallbackPort: port
+                )
+            } else {
+                viewModel.connectToGateway(host: host, port: port)
+            }
         case .unknown:
             break
         }

--- a/macos/Tests/OpenRappterBarTests/AppViewModelTests.swift
+++ b/macos/Tests/OpenRappterBarTests/AppViewModelTests.swift
@@ -222,13 +222,139 @@ func runAppViewModelTests() async {
     }
 
     await suite("App ViewModel — lifecycle races") {
+        await test("desktop authority owns its gateway lifecycle") {
+            let mock = MockWebSocket()
+            let conn = GatewayConnection(transportFactory: { _ in mock })
+            let endpoint = DesktopGatewayEndpoint(
+                schema: "openrappter-desktop-endpoint/1.0",
+                host: "127.0.0.9",
+                port: 18888,
+                token: String(repeating: "a", count: 64),
+                pid: 42,
+                ownerPid: 43,
+                updatedAt: "2026-08-15T00:00:00Z"
+            )
+            var requestedEndpoint = ""
+            var requestedDesktopEndpoint: DesktopGatewayEndpoint?
+            var connectionFactoryCalls = 0
+            var discoveryCount = 0
+            let vm = AppViewModel(
+                processManager: ProcessManager(),
+                eventBus: EventBus(),
+                connectionFactory: { host, port, desktopEndpoint in
+                    connectionFactoryCalls += 1
+                    requestedEndpoint = "\(host):\(port)"
+                    requestedDesktopEndpoint = desktopEndpoint
+                    return conn
+                },
+                desktopEndpointProvider: {
+                    discoveryCount += 1
+                    return endpoint
+                }
+            )
+
+            mock.enqueueReceive(try makeHelloOk(requestId: "rpc-1"))
+            let connectTask = vm.connectUsingPreferredGateway(
+                fallbackHost: "standalone.local",
+                fallbackPort: 18790
+            )
+            _ = try await mock.waitForSentCount(2)
+            mock.enqueueReceive(try makeStatusResponse())
+            await connectTask.value
+
+            try expect(vm.usesDesktopGateway, "Desktop should remain the gateway authority")
+            try expectEqual(requestedEndpoint, "127.0.0.9:18888")
+            try expectEqual(requestedDesktopEndpoint, endpoint)
+            try expectEqual(discoveryCount, 1)
+            try expectEqual(vm.processState, .stopped)
+
+            await vm.stopGateway().value
+            try expectEqual(vm.connectionState, .disconnected)
+            try expect(vm.usesDesktopGateway, "Disconnecting must not claim desktop ownership")
+            try expectEqual(vm.processState, .stopped)
+
+            let explicitTask = vm.connectToGateway(
+                host: "standalone.local",
+                port: 18790
+            )
+            for _ in 0..<100 {
+                if connectionFactoryCalls >= 2 { break }
+                await Task.yield()
+            }
+            try expect(
+                !vm.usesDesktopGateway,
+                "An explicit standalone endpoint must clear Desktop authority"
+            )
+            try expectEqual(connectionFactoryCalls, 2)
+            try expectNil(
+                requestedDesktopEndpoint,
+                "Explicit standalone connects must not inherit a Desktop token"
+            )
+            await vm.disconnectFromGateway()
+            await explicitTask.value
+        }
+
+        await test("desktop takeover supersedes an in-flight standalone start") {
+            let detectorGate = TestGate()
+            var nodeResolverCalls = 0
+            let pm = ProcessManager(
+                nodePathResolver: {
+                    nodeResolverCalls += 1
+                    return "/bin/sh"
+                },
+                gatewayDetector: {
+                    await detectorGate.wait()
+                    return false
+                }
+            )
+            let endpoint = DesktopGatewayEndpoint(
+                schema: "openrappter-desktop-endpoint/1.0",
+                host: "127.0.0.1",
+                port: 18889,
+                token: String(repeating: "c", count: 64),
+                pid: 44,
+                ownerPid: 45,
+                updatedAt: "2026-08-15T00:00:00Z"
+            )
+            var discoveredEndpoint: DesktopGatewayEndpoint?
+            let mock = MockWebSocket()
+            let conn = GatewayConnection(transportFactory: { _ in mock })
+            let vm = AppViewModel(
+                processManager: pm,
+                eventBus: EventBus(),
+                connectionFactory: { _, _, _ in conn },
+                desktopEndpointProvider: { discoveredEndpoint }
+            )
+
+            let startTask = vm.startGateway()
+            await detectorGate.waitUntilEntered()
+            discoveredEndpoint = endpoint
+            let takeoverTask = vm.connectUsingPreferredGateway()
+            await detectorGate.open()
+
+            _ = try await mock.waitForSentCount(1)
+            mock.enqueueReceive(try makeHelloOk(requestId: "rpc-1"))
+            _ = try await mock.waitForSentCount(2)
+            mock.enqueueReceive(try makeStatusResponse())
+            await startTask.value
+            await takeoverTask.value
+
+            try expectEqual(nodeResolverCalls, 0)
+            try expectEqual(pm.state, .stopped)
+            try expect(vm.usesDesktopGateway, "Desktop should retain authority")
+            try expectEqual(vm.connectionState, .connected)
+            try expect(!vm.activities.contains { $0.text == "Gateway started" })
+
+            await vm.stopGateway().value
+        }
+
         await test("disconnect during handshake cancels and awaits the connect task") {
             let mock = MockWebSocket()
             let conn = GatewayConnection(transportFactory: { _ in mock })
             let vm = AppViewModel(
                 processManager: ProcessManager(),
                 eventBus: EventBus(),
-                connectionFactory: { _, _ in conn }
+                connectionFactory: { _, _, _ in conn }
             )
             var readyCount = 0
             vm.onRpcClientReady = { _ in readyCount += 1 }
@@ -257,7 +383,7 @@ func runAppViewModelTests() async {
             let vm = AppViewModel(
                 processManager: ProcessManager(),
                 eventBus: EventBus(),
-                connectionFactory: { _, _ in
+                connectionFactory: { _, _, _ in
                     factoryCalls += 1
                     return conn
                 }
@@ -291,7 +417,7 @@ func runAppViewModelTests() async {
             let vm = AppViewModel(
                 processManager: ProcessManager(),
                 eventBus: EventBus(),
-                connectionFactory: { host, port in
+                connectionFactory: { host, port, _ in
                     requestedEndpoints.append("\(host):\(port)")
                     defer { nextConnection += 1 }
                     return connections[nextConnection]
@@ -325,7 +451,7 @@ func runAppViewModelTests() async {
             let vm = AppViewModel(
                 processManager: ProcessManager(),
                 eventBus: EventBus(),
-                connectionFactory: { _, _ in conn }
+                connectionFactory: { _, _, _ in conn }
             )
             var disconnectTask: Task<Void, Never>?
             var invalidationCount = 0

--- a/macos/Tests/OpenRappterBarTests/BonesWindowTests.swift
+++ b/macos/Tests/OpenRappterBarTests/BonesWindowTests.swift
@@ -69,6 +69,19 @@ func runBonesWindowTests() async {
                        "the refusal must say why, got: \(refusal!)")
         }
 
+        await test("a drop authenticates to the discovered Desktop gateway") {
+            let request = AgentInstaller.makeRequest(
+                filename: "probe_agent.py",
+                contents: "print('safe')",
+                port: 18791,
+                token: String(repeating: "a", count: 64)
+            )
+            try expectEqual(
+                request?.value(forHTTPHeaderField: "X-Gateway-Token"),
+                String(repeating: "a", count: 64)
+            )
+        }
+
         await test("only .py and .js are treated as agents") {
             // The drop filter is what stands between a stray screenshot and an
             // attempt to execute it.

--- a/macos/Tests/OpenRappterBarTests/DesktopGatewayDiscoveryTests.swift
+++ b/macos/Tests/OpenRappterBarTests/DesktopGatewayDiscoveryTests.swift
@@ -19,6 +19,7 @@ func runDesktopGatewayDiscoveryTests() throws {
                 port: 18841,
                 token: String(repeating: "a", count: 64),
                 pid: ProcessInfo.processInfo.processIdentifier,
+                ownerPid: ProcessInfo.processInfo.processIdentifier,
                 updatedAt: ISO8601DateFormatter().string(from: Date())
             )
             let data = try JSONEncoder().encode(endpoint)

--- a/macos/Tests/OpenRappterBarTests/GatewayConnectionTests.swift
+++ b/macos/Tests/OpenRappterBarTests/GatewayConnectionTests.swift
@@ -162,6 +162,42 @@ func runGatewayConnectionTests() async throws {
             await conn.disconnect()
         }
 
+        await test("desktop endpoint snapshot carries its token into the handshake") {
+            let mock = MockWebSocket()
+            let endpoint = DesktopGatewayEndpoint(
+                schema: "openrappter-desktop-endpoint/1.0",
+                host: "127.0.0.1",
+                port: 18888,
+                token: String(repeating: "b", count: 64),
+                pid: 42,
+                ownerPid: 43,
+                updatedAt: "2026-08-15T00:00:00Z"
+            )
+            let connectedURLs = AsyncCollector<URL>()
+            let conn = GatewayConnection(
+                host: "stale.local",
+                port: 18790,
+                desktopEndpoint: endpoint,
+                transportFactory: { url in
+                    Task { await connectedURLs.append(url) }
+                    return mock
+                }
+            )
+            mock.enqueueReceive(try makeHelloOk())
+
+            try await conn.connect()
+
+            _ = try await mock.waitForSentCount(1)
+            let sent = mock.lastSentJSON()
+            let params = sent?["params"] as? [String: Any]
+            let auth = params?["auth"] as? [String: Any]
+            let urls = try await connectedURLs.waitForCount(1)
+            try expectEqual(urls.first?.absoluteString, "ws://127.0.0.1:18888")
+            try expectEqual(auth?["token"] as? String, endpoint.token)
+
+            await conn.disconnect()
+        }
+
         await test("events dispatch to handler") {
             let mock = MockWebSocket()
             let conn = GatewayConnection(transportFactory: { _ in mock })

--- a/macos/Tests/OpenRappterBarTests/RpcClientContractTests.swift
+++ b/macos/Tests/OpenRappterBarTests/RpcClientContractTests.swift
@@ -22,6 +22,16 @@ private func makeOkArrayResponse(id: String, payload: [[String: Any]]) throws ->
     return try JSONSerialization.data(withJSONObject: frame)
 }
 
+private func makeOkNullResponse(id: String) throws -> Data {
+    let frame: [String: Any] = [
+        "type": "res",
+        "id": id,
+        "ok": true,
+        "payload": NSNull(),
+    ]
+    return try JSONSerialization.data(withJSONObject: frame)
+}
+
 /// Connects a fresh mock-backed GatewayConnection (consumes request id
 /// "rpc-1" for the handshake) and returns it plus an RpcClient wrapping it,
 /// ready for a first RPC call at id "rpc-2".
@@ -70,6 +80,134 @@ private func withDeferredResponse<T: Sendable>(
 }
 
 func runRpcClientContractTests() async {
+    await suite("RpcClient Gateway Auth Contract") {
+        await test("auth login uses the gateway device-flow method") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let login = try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkResponse(id: "rpc-2", payload: [
+                    "userCode": "ABCD-EFGH",
+                    "verificationUri": "https://github.com/login/device",
+                    "deviceCode": "device-1",
+                ])
+            ) {
+                try await rpc.beginGatewayAuthentication()
+            }
+
+            try expectEqual(login.userCode, "ABCD-EFGH")
+            let sent = try await lastSentJSON(mock)
+            try expectEqual(sent?["method"] as? String, "auth.login")
+            await conn.disconnect()
+        }
+
+        await test("auth polling sends the gateway device code") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let poll = try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkResponse(id: "rpc-2", payload: [
+                    "status": "pending",
+                ])
+            ) {
+                try await rpc.pollGatewayAuthentication(deviceCode: "device-2")
+            }
+
+            try expectEqual(poll.status, "pending")
+            let sent = try await lastSentJSON(mock)
+            try expectEqual(sent?["method"] as? String, "auth.poll")
+            let params = sent?["params"] as? [String: Any]
+            try expectEqual(params?["deviceCode"] as? String, "device-2")
+            await conn.disconnect()
+        }
+
+        await test("auth cancellation targets the pending gateway flow") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let cancelled = try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkResponse(id: "rpc-2", payload: [
+                    "ok": true,
+                    "status": "cancelled",
+                ])
+            ) {
+                try await rpc.cancelGatewayAuthentication(deviceCode: "device-3")
+            }
+
+            try expect(cancelled.ok, "Gateway should acknowledge cancellation")
+            try expectEqual(cancelled.status, "cancelled")
+            let sent = try await lastSentJSON(mock)
+            try expectEqual(sent?["method"] as? String, "auth.cancel")
+            let params = sent?["params"] as? [String: Any]
+            try expectEqual(params?["deviceCode"] as? String, "device-3")
+            await conn.disconnect()
+        }
+
+        await test("active auth profile decodes the gateway authority") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let profile = try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkResponse(id: "rpc-2", payload: [
+                    "id": "octocat",
+                    "username": "octocat",
+                    "provider": "copilot",
+                    "type": "device-code",
+                    "default": true,
+                    "createdAt": "2026-08-15T00:00:00Z",
+                ])
+            ) {
+                try await rpc.activeGatewayAuthProfile()
+            }
+
+            try expectEqual(profile?.id, "octocat")
+            let sent = try await lastSentJSON(mock)
+            try expectEqual(sent?["method"] as? String, "auth.active")
+            await conn.disconnect()
+        }
+
+        await test("active auth profile accepts the gateway's null signed-out state") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let profile = try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkNullResponse(id: "rpc-2")
+            ) {
+                try await rpc.activeGatewayAuthProfile()
+            }
+
+            try expectNil(profile)
+            await conn.disconnect()
+        }
+
+        await test("auth removal and switching use gateway profile methods") {
+            let (removeConn, removeMock, removeRpc) = try await makeConnectedClient()
+            try await withDeferredResponse(
+                mock: removeMock,
+                response: try makeOkResponse(id: "rpc-2", payload: ["ok": true])
+            ) {
+                try await removeRpc.removeGatewayAuthProfile(id: "octocat")
+            }
+            var sent = try await lastSentJSON(removeMock)
+            try expectEqual(sent?["method"] as? String, "auth.remove")
+            try expectEqual(
+                (sent?["params"] as? [String: Any])?["id"] as? String,
+                "octocat"
+            )
+            await removeConn.disconnect()
+
+            let (switchConn, switchMock, switchRpc) = try await makeConnectedClient()
+            try await withDeferredResponse(
+                mock: switchMock,
+                response: try makeOkResponse(id: "rpc-2", payload: ["ok": true])
+            ) {
+                try await switchRpc.switchGatewayAuthProfile(id: "hubot")
+            }
+            sent = try await lastSentJSON(switchMock)
+            try expectEqual(sent?["method"] as? String, "auth.switch")
+            try expectEqual(
+                (sent?["params"] as? [String: Any])?["id"] as? String,
+                "hubot"
+            )
+            await switchConn.disconnect()
+        }
+    }
+
     await suite("RpcClient Channel Contract") {
         await test("listChannels maps canonical status DTOs into UI channels") {
             let (conn, mock, rpc) = try await makeConnectedClient()

--- a/python/openrappter/show_and_tell.py
+++ b/python/openrappter/show_and_tell.py
@@ -49,7 +49,8 @@ NAMED_KEYS = {
 }
 PRIVATE_CONTEXT = re.compile(
     r"\b(?:1password|bitwarden|keychain|password|passkey|credential|secret|"
-    r"token|private key|security code|sign[ -]?in|log[ -]?in)\b",
+    r"token|private key|security code|sign[ -]?in|log[ -]?in|incognito|"
+    r"inprivate|private browsing)\b",
     re.I,
 )
 _INITIALIZE_LOCK = threading.RLock()
@@ -619,6 +620,9 @@ class ShowAndTellStore:
             SET collector_runtime = ?, collector_pid = ?, collector_nonce = ?,
                 collector_started_at = ?, collector_heartbeat_at = ?, updated_at = ?
             WHERE id = ? AND state = 'recording'
+              AND collector_runtime IS NULL
+              AND collector_pid IS NULL
+              AND collector_nonce IS NULL
             """,
             (runtime, pid, nonce, now, now, now, session_id),
         )
@@ -1382,6 +1386,35 @@ def _title_from_intent(intent: str) -> str:
     return " ".join(words[:5]) or "Recorded workflow"
 
 
+def _event_narration(event: dict[str, Any]) -> str:
+    data = event.get("data") if isinstance(event.get("data"), dict) else {}
+    if event.get("type") == "session.note":
+        return _safe_text(data.get("note"), 1200)
+    if event.get("type") != "narration.transcribed":
+        return ""
+    direct = _safe_text(data.get("text"), 1200)
+    if direct:
+        return direct
+    segments = data.get("segments")
+    if not isinstance(segments, list):
+        return ""
+    return _safe_text(
+        " ".join(
+            str(segment.get("text", ""))
+            for segment in segments
+            if isinstance(segment, dict)
+        ),
+        1200,
+    )
+
+
+def _privacy_step(step: dict[str, Any]) -> dict[str, Any]:
+    return {
+        **step,
+        "url": privacy_reduced_url(step.get("url")),
+    }
+
+
 def build_deterministic_analysis(
     session: dict[str, Any],
     events: list[dict[str, Any]],
@@ -1389,10 +1422,9 @@ def build_deterministic_analysis(
 ) -> dict[str, Any]:
     note = next(
         (
-            _safe_text(event.get("data", {}).get("note"), 1000)
+            _event_narration(event)
             for event in events
-            if event.get("type") == "session.note"
-            and _safe_text(event.get("data", {}).get("note"), 1000)
+            if _event_narration(event)
         ),
         "",
     )
@@ -1479,8 +1511,8 @@ def build_deterministic_analysis(
                     "url": "",
                     "confidence": "medium",
                 }
-        elif event.get("type") == "session.note":
-            narration = _safe_text(data.get("note"), 1200)
+        elif event.get("type") in {"session.note", "narration.transcribed"}:
+            narration = _event_narration(event)
             if narration:
                 if steps:
                     steps[-1]["detail"] = _safe_text(
@@ -1577,7 +1609,7 @@ def revise_analysis(
     feedback: Any = None,
     approve: bool = False,
 ) -> dict[str, Any]:
-    steps = current["steps"]
+    steps = [_privacy_step(step) for step in current["steps"]]
     if isinstance(steps_json, str) and steps_json.strip():
         parsed = json.loads(steps_json)
         if not isinstance(parsed, list) or not parsed or len(parsed) > 60:
@@ -1585,7 +1617,7 @@ def revise_analysis(
         required = {"id", "title", "detail"}
         if any(not isinstance(step, dict) or not required.issubset(step) for step in parsed):
             raise ValueError("Every edited step requires id, title, and detail.")
-        steps = parsed
+        steps = [_privacy_step(step) for step in parsed]
     note = _safe_text(feedback, 2000)
     now = int(time.time() * 1000)
     revised = {
@@ -1615,15 +1647,18 @@ def _destination(root: Path, base_name: str, session_id: str, kind: str) -> Path
     _private_directory(root)
     candidate = root / base_name
     same_session = False
-    manifest = candidate / "manifest.json"
+    metadata_file = candidate / (
+        "manifest.json" if kind == "skill" else "automation.json"
+    )
     safe_candidate = (
         not candidate.exists()
         or (not candidate.is_symlink() and candidate.is_dir())
     )
-    if safe_candidate and kind == "skill" and manifest.exists():
+    if safe_candidate and metadata_file.exists():
         try:
             same_session = (
-                json.loads(manifest.read_text()).get("sourceSessionId") == session_id
+                json.loads(metadata_file.read_text()).get("sourceSessionId")
+                == session_id
             )
         except (OSError, json.JSONDecodeError):
             pass
@@ -1668,8 +1703,9 @@ def _render_skill(analysis: dict[str, Any], name: str) -> str:
         line = f"{index}. **{step['title']}** — {step['detail']}"
         if step.get("tool"):
             line += f" Prefer `{step['tool']}`."
-        if step.get("url"):
-            line += f" Destination: {step['url']}"
+        reduced_url = privacy_reduced_url(step.get("url"))
+        if reduced_url:
+            line += f" Destination: {reduced_url}"
         lines.append(line)
     lines.extend(
         [
@@ -1716,6 +1752,7 @@ def build_artifacts(
                 "description": analysis["intent"],
                 "tags": ["show-and-tell", "recorded-workflow"],
                 "sourceSessionId": analysis["sessionId"],
+                "sourceAnalysisRevision": analysis["revision"],
                 "generatedBy": "OpenRappter Show-and-Tell",
             },
             indent=2,
@@ -1756,6 +1793,7 @@ def build_artifacts(
                 "enabled": False,
                 "trigger": {"type": "manual"},
                 "sourceSessionId": analysis["sessionId"],
+                "sourceAnalysisRevision": analysis["revision"],
                 "steps": [
                     {
                         "id": step.get("id", f"s{index}"),
@@ -1763,7 +1801,11 @@ def build_artifacts(
                         "prompt": (
                             step["detail"]
                             + (f" Prefer {step['tool']}." if step.get("tool") else "")
-                            + (f" Use {step['url']}." if step.get("url") else "")
+                            + (
+                                f" Use {privacy_reduced_url(step.get('url'))}."
+                                if privacy_reduced_url(step.get("url"))
+                                else ""
+                            )
                         ),
                     }
                     for index, step in enumerate(analysis["steps"], 1)
@@ -1831,6 +1873,7 @@ def test_artifacts(store: ShowAndTellStore, session_id: str) -> dict[str, Any]:
         privacy_safe = not artifact_contains_sensitive_text(content)
         if artifact["kind"] == "skill":
             manifest_path = path.parent / "manifest.json"
+            revision_ok = False
             try:
                 manifest = manifest_path.read_text(encoding="utf-8")
                 parsed_manifest = json.loads(manifest)
@@ -1838,6 +1881,10 @@ def test_artifacts(store: ShowAndTellStore, session_id: str) -> dict[str, Any]:
                     parsed_manifest.get("sourceSessionId") == session_id
                     and parsed_manifest.get("name") == artifact["name"]
                     and not artifact_contains_sensitive_text(manifest)
+                )
+                revision_ok = (
+                    parsed_manifest.get("sourceAnalysisRevision")
+                    == (analysis or {}).get("revision")
                 )
                 checks.append(
                     {
@@ -1865,6 +1912,17 @@ def test_artifacts(store: ShowAndTellStore, session_id: str) -> dict[str, Any]:
                         "detail": f"Missing or invalid {manifest_path}",
                     }
                 )
+            checks.append(
+                {
+                    "name": "skill-analysis-revision",
+                    "ok": revision_ok,
+                    "detail": (
+                        "Skill matches the current analysis revision."
+                        if revision_ok
+                        else "Skill was built from an older analysis revision."
+                    ),
+                }
+            )
         checks.append(
             {
                 "name": f"{artifact['kind']}-integrity",
@@ -1890,13 +1948,29 @@ def test_artifacts(store: ShowAndTellStore, session_id: str) -> dict[str, Any]:
                     parsed.get("schema") == SHOW_AND_TELL_AUTOMATION_SCHEMA
                     and parsed.get("enabled") is False
                 )
+                revision_ok = (
+                    parsed.get("sourceAnalysisRevision")
+                    == (analysis or {}).get("revision")
+                )
             except json.JSONDecodeError:
                 shape_ok = False
+                revision_ok = False
             checks.append(
                 {
                     "name": "automation-shape",
                     "ok": shape_ok,
                     "detail": "Automation is versioned and disabled by default.",
+                }
+            )
+            checks.append(
+                {
+                    "name": "automation-analysis-revision",
+                    "ok": revision_ok,
+                    "detail": (
+                        "Automation matches the current analysis revision."
+                        if revision_ok
+                        else "Automation was built from an older analysis revision."
+                    ),
                 }
             )
     return {"ok": all(check["ok"] for check in checks), "checks": checks}

--- a/python/tests/test_show_and_tell.py
+++ b/python/tests/test_show_and_tell.py
@@ -16,6 +16,7 @@ from openrappter.show_and_tell import (
     is_private_context,
     safe_computer_action_data,
     privacy_reduced_url,
+    revise_analysis,
     run_collector,
 )
 import pytest
@@ -77,6 +78,20 @@ def test_event_sequence_is_shared_across_store_instances(tmp_path):
     assert [event["sequence"] for event in first.events(session["id"])] == [0, 1]
     first.close()
     second.close()
+
+
+def test_second_collector_cannot_replace_attached_owner(tmp_path):
+    store = ShowAndTellStore(tmp_path / "show")
+    session = store.create_session()
+    assert store.attach_collector(session["id"], "python", 101, "first")
+    assert not store.attach_collector(
+        session["id"], "typescript", 202, "second"
+    )
+    attached = store.get_session(session["id"])
+    assert attached["collectorRuntime"] == "python"
+    assert attached["collectorPid"] == 101
+    assert attached["collectorNonce"] == "first"
+    store.close()
 
 
 def test_stale_session_is_failed_before_replacement(tmp_path):
@@ -297,8 +312,25 @@ def test_full_flow_builds_portable_skill_and_disabled_automation(tmp_path, monke
     tested = json.loads(agent.perform(action="test", session_id=session_id))
     assert tested["status"] == "success"
     assert tested["ok"] is True
+    second_approval = seed_consent(store, "approve")
+    revised = json.loads(
+        agent.perform(
+            action="review",
+            session_id=session_id,
+            intent="Create a revised weekly project status report",
+            approve=True,
+            consent_token=second_approval,
+        )
+    )
+    assert revised["analysis"]["revision"] > analyzed["analysis"]["revision"]
+    stale = json.loads(agent.perform(action="test", session_id=session_id))
+    assert stale["status"] == "error"
+    assert any(
+        check["name"].endswith("-analysis-revision") and not check["ok"]
+        for check in stale["checks"]
+    )
     rebuilt = json.loads(
-        agent.perform(action="build", session_id=session_id, target="skill")
+        agent.perform(action="build", session_id=session_id, target="all")
     )
     assert rebuilt["status"] == "success"
     assert len([
@@ -568,6 +600,9 @@ def test_privacy_reduced_url_rejects_local_schemes_and_opaque_tokens():
     ) == "https://example.com/callback/:id"
     assert artifact_contains_sensitive_text(json.dumps({"url": jwt}))
     assert is_private_context("Safari", "Google Accounts", "/signin/oauth")
+    assert is_private_context("Google Chrome", "New Incognito Tab")
+    assert is_private_context("Microsoft Edge", "InPrivate browsing")
+    assert is_private_context("Safari", "Private Browsing")
 
 
 def test_deterministic_analysis_uses_semantic_events_not_frame_pixels():
@@ -662,12 +697,61 @@ def test_deterministic_analysis_keeps_narration_as_a_step():
                 "sessionId": "narrated-session",
                 "sequence": 0,
                 "timestamp": now,
-                "type": "session.note",
-                "source": "local-whisper-narration",
-                "data": {"note": "Summarize blockers before listing next steps."},
+                "type": "narration.transcribed",
+                "source": "local-whisper",
+                "data": {"text": "Summarize blockers before listing next steps."},
             }
         ],
     )
     assert analysis["steps"][0]["title"] == "Follow the narrated instruction"
     assert "Summarize blockers" in analysis["steps"][0]["detail"]
-    assert "event:0:session.note" in analysis["steps"][0]["evidence"]
+    assert "event:0:narration.transcribed" in analysis["steps"][0]["evidence"]
+
+
+def test_revise_analysis_privacy_reduces_step_urls():
+    now = int(time.time() * 1000)
+    revised = revise_analysis(
+        {
+            "schema": SHOW_AND_TELL_ANALYSIS_SCHEMA,
+            "sessionId": "session-1",
+            "revision": 1,
+            "title": "Research",
+            "intent": "Research safely",
+            "intentRationale": "Test",
+            "intentConfidence": "high",
+            "steps": [
+                {
+                    "id": "s1",
+                    "title": "Search",
+                    "detail": "Search for the report.",
+                    "kind": "action",
+                    "tool": "Browser or Web",
+                    "app": "Safari",
+                    "url": "https://example.com/start",
+                    "evidence": [],
+                    "confidence": "high",
+                }
+            ],
+            "feedbackLog": [],
+            "approved": False,
+            "approvedAt": None,
+            "createdAt": now,
+            "updatedAt": now,
+        },
+        steps_json=json.dumps(
+            [
+                {
+                    "id": "s1",
+                    "title": "Search",
+                    "detail": "Search for the report.",
+                    "kind": "action",
+                    "tool": "Browser or Web",
+                    "app": "Safari",
+                    "url": "https://example.com/search?q=confidential#private",
+                    "evidence": [],
+                    "confidence": "high",
+                }
+            ]
+        ),
+    )
+    assert revised["steps"][0]["url"] == "https://example.com/search"

--- a/scripts/release-preflight.test.mjs
+++ b/scripts/release-preflight.test.mjs
@@ -1,5 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 import path from 'node:path';
 import { readFileSync } from 'node:fs';
 import test from 'node:test';
@@ -19,6 +20,11 @@ import {
   validateReleaseState,
   waitForRegistryArtifacts,
 } from './release-preflight.mjs';
+
+const requireFromTypescript = createRequire(
+  new URL('../typescript/package.json', import.meta.url),
+);
+const { parse: parseYaml } = requireFromTypescript('yaml');
 
 const VERSION = '1.10.0';
 const PACKAGE_NAME = 'openrappter';
@@ -439,14 +445,19 @@ test('release workflows retain per-tag builds and globally serialize publication
   );
 });
 
-test('macOS workflow validates the tag before checkout and never injects output into shell', () => {
+test('macOS workflow validates tag provenance and never injects output into shell', () => {
   const workflow = readFileSync(
     new URL('../.github/workflows/release-bar.yml', import.meta.url),
     'utf8',
   );
   const validation = workflow.indexOf('- name: Validate exact macOS release tag');
-  const checkout = workflow.indexOf('- uses: actions/checkout@v4');
-  assert.ok(validation >= 0 && validation < checkout);
+  const checkout = workflow.search(/- uses: actions\/checkout@[0-9a-f]{40}/);
+  const provenance = workflow.indexOf('- name: Require release commit on main');
+  assert.ok(checkout >= 0 && validation > checkout && provenance > validation);
+  assert.match(
+    workflow,
+    /git merge-base --is-ancestor "\$GITHUB_SHA" origin\/main/,
+  );
   assert.ok(workflow.includes(
     '^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)-bar$',
   ));
@@ -491,7 +502,11 @@ test('registry publication reconciles exact artifacts and selects an explicit np
   assert.match(workflow, /"build==1\.5\.1"[\s\S]*"hatchling==1\.31\.0"/);
   assert.match(workflow, /python -m build --no-isolation/);
   assert.match(workflow, /overwrite: true/);
-  assert.match(workflow, /overwrite_files: true/);
+  assert.match(workflow, /overwrite_files: false/);
+  assert.match(
+    workflow,
+    /preflight:[\s\S]*?Require release commit on main[\s\S]*?git merge-base --is-ancestor "\$GITHUB_SHA" origin\/main/,
+  );
   assert.match(
     workflow,
     /publish-registries:[\s\S]*?needs: \[preflight, smoke-artifacts, build-electron-artifacts\]/,
@@ -516,6 +531,89 @@ test('registry publication reconciles exact artifacts and selects an explicit np
   assert.match(workflow, /desktop-dist\/\*\.dmg/);
   assert.match(workflow, /desktop-dist\/\*\.exe/);
   assert.match(workflow, /desktop-dist\/\*\.AppImage/);
+  assert.match(desktopJob, /WINDOWS_CERTIFICATE_P12_BASE64/);
+  assert.match(desktopJob, /Get-AuthenticodeSignature/);
+  assert.match(workflow, /npm audit --audit-level=high/);
+});
+
+test('parsed release workflow preserves the privileged dependency graph', () => {
+  const workflow = parseYaml(readFileSync(
+    new URL('../.github/workflows/release.yml', import.meta.url),
+    'utf8',
+  ));
+  assert.deepEqual(
+    workflow.jobs['publish-registries'].needs,
+    ['preflight', 'smoke-artifacts', 'build-electron-artifacts'],
+  );
+  assert.deepEqual(
+    workflow.jobs['github-release'].needs,
+    ['preflight', 'publish-registries', 'build-electron-artifacts'],
+  );
+  assert.equal(
+    workflow.jobs.preflight.steps.some(
+      (step) =>
+        step.name === 'Require release commit on main' &&
+        String(step.run).includes(
+          'git merge-base --is-ancestor "$GITHUB_SHA" origin/main',
+        ),
+    ),
+    true,
+  );
+  const desktopStepNames = workflow.jobs['build-electron-artifacts'].steps
+    .map((step) => step.name)
+    .filter(Boolean);
+  for (const stepName of [
+    'Smoke packaged macOS application',
+    'Smoke packaged Linux application',
+    'Smoke packaged Windows application',
+    'Require signed Windows release',
+  ]) {
+    assert.ok(desktopStepNames.includes(stepName), `missing ${stepName}`);
+  }
+});
+
+test('macOS Bar release assets are immutable on rerun', () => {
+  const workflow = parseYaml(readFileSync(
+    new URL('../.github/workflows/release-bar.yml', import.meta.url),
+    'utf8',
+  ));
+  const releaseStep = workflow.jobs['build-and-release'].steps.find(
+    (step) => step.name === 'Upload DMG as release asset',
+  );
+  assert.equal(releaseStep.with.overwrite_files, false);
+});
+
+test('Windows Electron CI runs the complete smoke scope', () => {
+  const workflow = readFileSync(
+    new URL('../.github/workflows/desktop.yml', import.meta.url),
+    'utf8',
+  );
+  const windowsSmoke = workflow.slice(
+    workflow.indexOf('- name: Run real Electron smoke on Windows'),
+    workflow.indexOf('- name: Build unpacked macOS application'),
+  );
+  assert.match(windowsSmoke, /OPENRAPPTER_DESKTOP_SMOKE = "1"/);
+  assert.doesNotMatch(windowsSmoke, /OPENRAPPTER_DESKTOP_SMOKE_SCOPE/);
+});
+
+test('privileged release actions are pinned to immutable commits', () => {
+  for (const workflowName of ['release.yml', 'release-bar.yml']) {
+    const workflow = readFileSync(
+      new URL(`../.github/workflows/${workflowName}`, import.meta.url),
+      'utf8',
+    );
+    const externalUses = [...workflow.matchAll(
+      /^\s*-?\s*uses:\s*([^./\s][^@\s]*)@([^\s#]+)\s*$/gm,
+    )];
+    assert.ok(externalUses.length > 0);
+    for (const [, action, ref] of externalUses) {
+      assert.match(
+        ref,
+        /^[0-9a-f]{40}$/,
+        `${action} in ${workflowName} is not pinned`,
+      );
+    }
+  }
 });
 
 test('generated macOS release notes use the live Homebrew tap', () => {

--- a/tools/show-and-tell-smoke.mjs
+++ b/tools/show-and-tell-smoke.mjs
@@ -61,6 +61,21 @@ try {
     }),
   );
   assert(stopped.session?.state === 'stopped', 'TypeScript collector did not stop cleanly.');
+  const events = await store.events(started.session.id);
+  const activation = events.find((event) => event.type === 'app.activate');
+  const browser = events.find((event) => event.type === 'browser.url');
+  assert(
+    activation?.source === 'context-collector' &&
+      activation.data.app === 'ShowAndTellTestApp' &&
+      activation.data.window === 'Synthetic collector window' &&
+      Number.isInteger(activation.sequence),
+    `TypeScript collector activation payload is incomplete: ${JSON.stringify(activation)}`,
+  );
+  assert(
+    browser?.data.url === 'https://example.test/workflow' &&
+      browser.sequence === activation.sequence + 1,
+    `TypeScript collector browser payload is incomplete: ${JSON.stringify(browser)}`,
+  );
   store.close();
 
   const pythonScript = `
@@ -89,10 +104,15 @@ started = json.loads(agent.perform(
 time.sleep(1.2)
 live = json.loads(agent.perform(action="status", session_id=started["session"]["id"]))
 stopped = json.loads(agent.perform(action="stop", session_id=started["session"]["id"]))
+events = store.events(started["session"]["id"])
+activation = next(event for event in events if event["type"] == "app.activate")
+browser = next(event for event in events if event["type"] == "browser.url")
 print(json.dumps({
     "started": started["status"],
     "healthy": live["collector_healthy"],
     "stopped": stopped["session"]["state"],
+    "activation": activation,
+    "browser": browser,
 }))
 agent.store.close()
 store.close()
@@ -109,7 +129,13 @@ store.close()
   assert(
     pythonResult.started === 'success' &&
       pythonResult.healthy === true &&
-      pythonResult.stopped === 'stopped',
+      pythonResult.stopped === 'stopped' &&
+      pythonResult.activation.source === 'context-collector' &&
+      pythonResult.activation.data.app === 'ShowAndTellTestApp' &&
+      pythonResult.activation.data.window === 'Synthetic collector window' &&
+      Number.isInteger(pythonResult.activation.sequence) &&
+      pythonResult.browser.data.url === 'https://example.test/workflow' &&
+      pythonResult.browser.sequence === pythonResult.activation.sequence + 1,
     `Python collector lifecycle failed: ${JSON.stringify(pythonResult)}`,
   );
 

--- a/typescript/desktop/package-lock.json
+++ b/typescript/desktop/package-lock.json
@@ -15,7 +15,7 @@
       },
       "devDependencies": {
         "@types/node": "^22.0.0",
-        "electron": "40.10.6",
+        "electron": "41.10.3",
         "electron-builder": "26.15.3"
       }
     },
@@ -2089,9 +2089,9 @@
       }
     },
     "node_modules/electron": {
-      "version": "40.10.6",
-      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron/-/electron-40.10.6.tgz",
-      "integrity": "sha1-TW/t3tmyp4nztC7OmyUZYRkth/k=",
+      "version": "41.10.3",
+      "resolved": "https://ms-feed-25.pkgs.visualstudio.com/1es-public/_packaging/npm-public/npm/registry/electron/-/electron-41.10.3.tgz",
+      "integrity": "sha1-o0/qvu7Mnb/BLzRH4l6ZgWO4/wE=",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",

--- a/typescript/desktop/package.json
+++ b/typescript/desktop/package.json
@@ -24,7 +24,7 @@
   },
   "devDependencies": {
     "@types/node": "^22.0.0",
-    "electron": "40.10.6",
+    "electron": "41.10.3",
     "electron-builder": "26.15.3"
   },
   "build": {

--- a/typescript/desktop/src/main.ts
+++ b/typescript/desktop/src/main.ts
@@ -40,6 +40,7 @@ import {
   VIBEVOICE_MODEL_LABEL,
   VibeVoiceService,
 } from './vibevoice.js';
+import { SECURE_RENDERER_PREFERENCES } from './window-security.js';
 
 const packageRoot = path.join(
   import.meta.dirname,
@@ -170,6 +171,10 @@ async function publishDesktopEndpoint(): Promise<void> {
     hardenPrivatePath(target: string, directory?: boolean): void;
   };
   const directory = path.join(os.homedir(), '.openrappter');
+  const gatewayPid = gatewayProcess?.pid;
+  if (!gatewayPid) {
+    throw new Error('Cannot publish a desktop endpoint before gateway readiness.');
+  }
   mkdirSync(directory, { recursive: true, mode: 0o700 });
   hardenPrivatePath(directory, true);
   endpointFile = path.join(directory, 'desktop-gateway.json');
@@ -181,7 +186,8 @@ async function publishDesktopEndpoint(): Promise<void> {
       host: '127.0.0.1',
       port: gatewayPort,
       token: gatewayToken,
-      pid: process.pid,
+      pid: gatewayPid,
+      ownerPid: process.pid,
       updatedAt: new Date().toISOString(),
     })}\n`,
     { mode: 0o600 },
@@ -251,8 +257,7 @@ async function focusWindow(view?: string): Promise<void> {
       (async () => {
         const app = document.querySelector('openrappter-app');
         if (!app) throw new Error('OpenRappter app surface is not mounted.');
-        app.currentView = ${JSON.stringify(view)};
-        app.requestUpdate();
+        app.navigate(${JSON.stringify(view)});
         await app.updateComplete;
       })()
     `);
@@ -361,6 +366,7 @@ async function ensureGateway(): Promise<void> {
         ...process.env,
         ELECTRON_RUN_AS_NODE: '1',
         OPENRAPPTER_DESKTOP: '1',
+        OPENRAPPTER_DESKTOP_OWNER_PID: String(process.pid),
         OPENRAPPTER_PORT: String(gatewayPort),
         OPENRAPPTER_TOKEN: gatewayToken,
         ...(smokeRoot
@@ -636,17 +642,12 @@ async function handleNarration(
   runtime.store.hardenFile(audioFile);
   await runtime.store.appendEvent(
     sessionId,
-    'session.note',
-    'local-whisper-narration',
-    { note: transcript.text },
-  );
-  await runtime.store.appendEvent(
-    sessionId,
     'narration.transcribed',
     'local-whisper',
     {
       model: transcript.model,
       language,
+      text: transcript.text,
       audioFile: path.posix.join('audio', filename),
       segments: transcript.segments,
     },
@@ -883,7 +884,8 @@ async function installAgentFromCommand(
     if (Buffer.byteLength(source, 'utf8') > 500_000) {
       throw new Error('Agent source exceeds the 500 KB desktop approval limit.');
     }
-    const capabilities = scanAgentCapabilities(filename, source);
+    const compiled = await compileAgentForImport(filename, source);
+    const capabilities = scanAgentCapabilities(compiled.filename, source);
     if (Date.now() > expiresAt) {
       throw new Error('Agent installation request expired before approval.');
     }
@@ -892,7 +894,7 @@ async function installAgentFromCommand(
       const approval = await dialog.showMessageBox(mainWindow!, {
         type: 'warning',
         title: 'Install a hot-loaded agent?',
-        message: `Install ${path.basename(filename)}?`,
+        message: `Install ${compiled.filename}?`,
         detail:
           `This code will run with your full user authority after verification. ` +
           `The capability list is a heuristic, not a sandbox.\n\n` +
@@ -910,7 +912,6 @@ async function installAgentFromCommand(
     if (Date.now() > expiresAt) {
       throw new Error('Agent installation request expired before import.');
     }
-    const compiled = await compileAgentForImport(filename, source);
     const response = await fetch(`${gatewayOrigin}/agents/import`, {
       method: 'POST',
       headers: {
@@ -1114,14 +1115,11 @@ function createWindow(): BrowserWindow {
     backgroundColor: '#050711',
     webPreferences: {
       preload: path.join(import.meta.dirname, 'preload.cjs'),
-      contextIsolation: true,
-      nodeIntegration: false,
-      sandbox: true,
-      webSecurity: true,
+      ...SECURE_RENDERER_PREFERENCES,
     },
   });
   window.removeMenu();
-  window.webContents.once('did-finish-load', () => {
+  window.webContents.on('did-finish-load', () => {
     rendererReady = true;
     startDesktopCommandPump();
   });
@@ -1134,6 +1132,19 @@ function createWindow(): BrowserWindow {
       event.preventDefault();
       if (/^https?:\/\//i.test(url)) void shell.openExternal(url);
     }
+  });
+  window.webContents.on('render-process-gone', (_event, details) => {
+    rendererReady = false;
+    if (
+      quitting ||
+      details.reason === 'clean-exit' ||
+      window.isDestroyed()
+    ) {
+      return;
+    }
+    setTimeout(() => {
+      if (!quitting && !window.isDestroyed()) window.webContents.reload();
+    }, 250);
   });
   window.once('ready-to-show', () => window.show());
   if (process.env.OPENRAPPTER_DESKTOP_SMOKE === '1') {
@@ -1161,8 +1172,7 @@ function createWindow(): BrowserWindow {
           )};
           let recorder = null;
           if (smokeScope !== 'boot') {
-            appElement.currentView = 'show-and-tell';
-            appElement.requestUpdate();
+            appElement.navigate('show-and-tell');
             await appElement.updateComplete;
             recorder = appElement.shadowRoot.querySelector(
               'openrappter-show-and-tell'
@@ -1376,7 +1386,12 @@ if (process.env.OPENRAPPTER_DESKTOP_SMOKE === '1') {
   console.log(`OPENRAPPTER_DESKTOP_SMOKE lock=${ownsInstanceLock}`);
 }
 if (!ownsInstanceLock) {
-  app.quit();
+  if (process.env.OPENRAPPTER_DESKTOP_SMOKE === '1') {
+    console.error('OPENRAPPTER_DESKTOP_SMOKE_ERROR instance lock unavailable');
+    app.exit(1);
+  } else {
+    app.quit();
+  }
 } else {
   if (process.env.OPENRAPPTER_DESKTOP_SMOKE === '1') {
     for (const eventName of ['ready', 'window-all-closed', 'before-quit', 'will-quit', 'quit']) {
@@ -1386,10 +1401,7 @@ if (!ownsInstanceLock) {
     }
   }
   app.on('second-instance', () => {
-    if (mainWindow) {
-      if (mainWindow.isMinimized()) mainWindow.restore();
-      mainWindow.focus();
-    }
+    void focusWindow().catch(showTrayError);
   });
 
   app.on('before-quit', (event) => {
@@ -1445,7 +1457,6 @@ if (!ownsInstanceLock) {
       const bootSmoke =
         process.env.OPENRAPPTER_DESKTOP_SMOKE === '1' &&
         process.env.OPENRAPPTER_DESKTOP_SMOKE_SCOPE === 'boot';
-      if (!bootSmoke) await publishDesktopEndpoint();
       session.defaultSession.webRequest.onBeforeSendHeaders(
         { urls: [`ws://127.0.0.1:${gatewayPort}/*`] },
         (details, callback) => {
@@ -1538,6 +1549,7 @@ if (!ownsInstanceLock) {
       if (process.env.OPENRAPPTER_DESKTOP_SMOKE === '1') {
         console.log('OPENRAPPTER_DESKTOP_SMOKE gateway-ready');
       }
+      if (!bootSmoke) await publishDesktopEndpoint();
       mainWindow = createWindow();
       if (!bootSmoke) createTray();
     } catch (error) {

--- a/typescript/desktop/src/main.ts
+++ b/typescript/desktop/src/main.ts
@@ -1375,7 +1375,6 @@ async function finishDesktopSmoke(exitCode: number): Promise<void> {
     stopOwnedGateway(),
     vibeVoiceService?.stop() ?? Promise.resolve(),
   ]);
-  app.exit(exitCode);
   process.exit(exitCode);
 }
 

--- a/typescript/desktop/src/main.ts
+++ b/typescript/desktop/src/main.ts
@@ -1376,6 +1376,7 @@ async function finishDesktopSmoke(exitCode: number): Promise<void> {
     vibeVoiceService?.stop() ?? Promise.resolve(),
   ]);
   app.exit(exitCode);
+  setImmediate(() => process.exit(exitCode));
 }
 
 if (process.env.OPENRAPPTER_DESKTOP_SMOKE === '1') {

--- a/typescript/desktop/src/main.ts
+++ b/typescript/desktop/src/main.ts
@@ -1375,7 +1375,28 @@ async function finishDesktopSmoke(exitCode: number): Promise<void> {
     stopOwnedGateway(),
     vibeVoiceService?.stop() ?? Promise.resolve(),
   ]);
+  if (commandTimer) clearInterval(commandTimer);
+  removeOwnedDesktopEndpoint();
+  if (smokeRoot && process.platform !== 'win32') {
+    rmSync(smokeRoot, { recursive: true, force: true });
+  }
+  const hardProcess = process as NodeJS.Process & {
+    reallyExit?: (code?: number) => never;
+  };
+  if (hardProcess.reallyExit) hardProcess.reallyExit(exitCode);
   process.exit(exitCode);
+}
+
+function removeOwnedDesktopEndpoint(): void {
+  if (!endpointFile) return;
+  try {
+    const endpoint = JSON.parse(
+      readFileSync(endpointFile, 'utf8'),
+    ) as { pid?: unknown };
+    if (endpoint.pid === process.pid) rmSync(endpointFile, { force: true });
+  } catch {
+    // A newer desktop process may own the endpoint.
+  }
 }
 
 if (process.env.OPENRAPPTER_DESKTOP_SMOKE === '1') {
@@ -1583,15 +1604,6 @@ if (!ownsInstanceLock) {
     if (smokeRoot) {
       rmSync(smokeRoot, { recursive: true, force: true });
     }
-    if (endpointFile) {
-      try {
-        const endpoint = JSON.parse(
-          readFileSync(endpointFile, 'utf8'),
-        ) as { pid?: unknown };
-        if (endpoint.pid === process.pid) rmSync(endpointFile, { force: true });
-      } catch {
-        // A newer desktop process may own the endpoint.
-      }
-    }
+    removeOwnedDesktopEndpoint();
   });
 }

--- a/typescript/desktop/src/main.ts
+++ b/typescript/desktop/src/main.ts
@@ -1376,7 +1376,7 @@ async function finishDesktopSmoke(exitCode: number): Promise<void> {
     vibeVoiceService?.stop() ?? Promise.resolve(),
   ]);
   app.exit(exitCode);
-  setImmediate(() => process.exit(exitCode));
+  process.exit(exitCode);
 }
 
 if (process.env.OPENRAPPTER_DESKTOP_SMOKE === '1') {

--- a/typescript/desktop/src/vibevoice.ts
+++ b/typescript/desktop/src/vibevoice.ts
@@ -238,6 +238,13 @@ export class VibeVoiceService {
       this.operation.catch(() => undefined),
       delay(10_000),
     ]);
+    await Promise.all(
+      [...this.activeChildren].map((child) => this.terminateChild(child)),
+    );
+    const lateServer = this.server;
+    this.server = null;
+    this.serverPort = null;
+    if (lateServer) await this.terminateChild(lateServer);
     this.update({
       state: this.isInstalled() ? 'starting' : 'missing',
       phase: 'idle',
@@ -395,6 +402,7 @@ export class VibeVoiceService {
     const port = await this.availablePort(
       39_000 + (randomBytes(2).readUInt16BE(0) % 10_000),
     );
+    this.assertGeneration(generation);
     const device = this.device();
     const child = spawn(
       this.venvPython(),
@@ -424,55 +432,55 @@ export class VibeVoiceService {
     );
     let spawnError: Error | null = null;
     let output = '';
-    const onData = (chunk: Buffer) => {
-      output = `${output}${chunk.toString()}`.slice(-8000);
-    };
-    child.stdout.on('data', onData);
-    child.stderr.on('data', onData);
-    child.once('error', (error) => {
-      spawnError = error;
-    });
-    this.server = child;
-    this.serverPort = port;
-    const deadline = Date.now() + 120_000;
-    while (Date.now() < deadline) {
-      this.assertGeneration(generation);
-      if (!this.childIsRunning(child)) {
-        this.server = null;
-        this.serverPort = null;
-        throw new Error(
-          `VibeVoice server exited (${
-            child.exitCode ?? child.signalCode ?? 'unknown'
-          }): ${output.slice(-1200)}`,
-        );
-      }
-      if (spawnError) {
-        this.server = null;
-        this.serverPort = null;
-        throw spawnError;
-      }
-      try {
-        if (await this.serverReady(port)) {
-          this.update({
-            state: 'ready',
-            phase: 'idle',
-            port,
-            device,
-            progress: 100,
-          });
-          return;
+    try {
+      const onData = (chunk: Buffer) => {
+        output = `${output}${chunk.toString()}`.slice(-8000);
+      };
+      child.stdout.on('data', onData);
+      child.stderr.on('data', onData);
+      child.once('error', (error) => {
+        spawnError = error;
+      });
+      this.server = child;
+      this.serverPort = port;
+      const deadline = Date.now() + 120_000;
+      while (Date.now() < deadline) {
+        this.assertGeneration(generation);
+        if (!this.childIsRunning(child)) {
+          throw new Error(
+            `VibeVoice server exited (${
+              child.exitCode ?? child.signalCode ?? 'unknown'
+            }): ${output.slice(-1200)}`,
+          );
         }
-      } catch {
-        // Model loading can take well over a minute on first start.
+        if (spawnError) throw spawnError;
+        try {
+          if (await this.serverReady(port)) {
+            this.update({
+              state: 'ready',
+              phase: 'idle',
+              port,
+              device,
+              progress: 100,
+            });
+            return;
+          }
+        } catch {
+          // Model loading can take well over a minute on first start.
+        }
+        await delay(500);
       }
-      await delay(500);
+      throw new Error(
+        `VibeVoice server did not become ready in two minutes: ${output.slice(-1200)}`,
+      );
+    } catch (error) {
+      if (this.server === child) {
+        this.server = null;
+        this.serverPort = null;
+      }
+      await this.terminateChild(child);
+      throw error;
     }
-    await this.terminateChild(child);
-    this.server = null;
-    this.serverPort = null;
-    throw new Error(
-      `VibeVoice server did not become ready in two minutes: ${output.slice(-1200)}`,
-    );
   }
 
   private async run(

--- a/typescript/desktop/src/window-security.ts
+++ b/typescript/desktop/src/window-security.ts
@@ -1,0 +1,6 @@
+export const SECURE_RENDERER_PREFERENCES = {
+  contextIsolation: true,
+  nodeIntegration: false,
+  sandbox: true,
+  webSecurity: true,
+} as const;

--- a/typescript/desktop/test/desktop-contract.test.mjs
+++ b/typescript/desktop/test/desktop-contract.test.mjs
@@ -127,7 +127,7 @@ test('desktop reuses the packaged OpenRappter gateway and core', () => {
   assert.match(main, /SMOKE_ERROR instance lock unavailable/);
   assert.match(main, /async function finishDesktopSmoke/);
   assert.match(main, /child\.kill\('SIGKILL'\)/);
-  assert.match(main, /await Promise\.allSettled[\s\S]*process\.exit\(exitCode\)/);
+  assert.match(main, /await Promise\.allSettled[\s\S]*hardProcess\.reallyExit\(exitCode\)/);
   assert.match(
     main,
     /OPENRAPPTER_DESKTOP_SMOKE === '1'[\s\S]*OPENRAPPTER_SMOKE_ERROR/,

--- a/typescript/desktop/test/desktop-contract.test.mjs
+++ b/typescript/desktop/test/desktop-contract.test.mjs
@@ -127,7 +127,7 @@ test('desktop reuses the packaged OpenRappter gateway and core', () => {
   assert.match(main, /SMOKE_ERROR instance lock unavailable/);
   assert.match(main, /async function finishDesktopSmoke/);
   assert.match(main, /child\.kill\('SIGKILL'\)/);
-  assert.match(main, /app\.exit\(exitCode\);\s*process\.exit\(exitCode\)/);
+  assert.match(main, /await Promise\.allSettled[\s\S]*process\.exit\(exitCode\)/);
   assert.match(
     main,
     /OPENRAPPTER_DESKTOP_SMOKE === '1'[\s\S]*OPENRAPPTER_SMOKE_ERROR/,

--- a/typescript/desktop/test/desktop-contract.test.mjs
+++ b/typescript/desktop/test/desktop-contract.test.mjs
@@ -21,12 +21,18 @@ const runtimeInstaller = readFileSync(
   new URL('../scripts/install-runtime.mjs', import.meta.url),
   'utf8',
 );
+const { SECURE_RENDERER_PREFERENCES } = await import(
+  '../dist/window-security.js'
+);
 
 test('desktop renderer is isolated and sandboxed', () => {
-  assert.match(main, /contextIsolation:\s*true/);
-  assert.match(main, /nodeIntegration:\s*false/);
-  assert.match(main, /sandbox:\s*true/);
-  assert.match(main, /webSecurity:\s*true/);
+  assert.deepEqual(SECURE_RENDERER_PREFERENCES, {
+    contextIsolation: true,
+    nodeIntegration: false,
+    sandbox: true,
+    webSecurity: true,
+  });
+  assert.match(main, /SECURE_RENDERER_PREFERENCES/);
 });
 
 test('signed macOS builds retain microphone and Apple Events capabilities', () => {
@@ -59,6 +65,8 @@ test('local tell and voice models bootstrap privately', () => {
   assert.match(vibevoice, /--no-access-log/);
   assert.match(vibevoice, /activeChildren/);
   assert.match(vibevoice, /lifecycleGeneration/);
+  assert.match(vibevoice, /this\.assertGeneration\(generation\);[\s\S]*const device/);
+  assert.match(vibevoice, /const lateServer = this\.server/);
   assert.match(vibevoice, /process\.kill\(-child\.pid/);
   assert.match(vibevoice, /taskkill\.exe/);
   assert.match(vibevoice, /'\/T'/);
@@ -76,6 +84,8 @@ test('desktop publishes one authenticated endpoint for tray and Swift Bar', () =
   assert.match(main, /Launch OpenRappter Bar/);
   assert.match(main, /app\.setLoginItemSettings/);
   assert.match(main, /async function waitForRenderer/);
+  assert.match(main, /render-process-gone/);
+  assert.match(main, /webContents\.on\('did-finish-load'/);
   assert.match(main, /await focusWindow\('chat'\)/);
   assert.match(main, /\.catch\(showTrayError\)/);
 });
@@ -114,6 +124,7 @@ test('desktop reuses the packaged OpenRappter gateway and core', () => {
   assert.match(main, /onBeforeSendHeaders/);
   assert.match(main, /Origin:\s*gatewayOrigin/);
   assert.match(main, /required\.every\(\(key\) => result\[key\] === true\)/);
+  assert.match(main, /SMOKE_ERROR instance lock unavailable/);
   assert.match(main, /async function finishDesktopSmoke/);
   assert.match(main, /child\.kill\('SIGKILL'\)/);
   assert.match(

--- a/typescript/desktop/test/desktop-contract.test.mjs
+++ b/typescript/desktop/test/desktop-contract.test.mjs
@@ -127,6 +127,7 @@ test('desktop reuses the packaged OpenRappter gateway and core', () => {
   assert.match(main, /SMOKE_ERROR instance lock unavailable/);
   assert.match(main, /async function finishDesktopSmoke/);
   assert.match(main, /child\.kill\('SIGKILL'\)/);
+  assert.match(main, /setImmediate\(\(\) => process\.exit\(exitCode\)\)/);
   assert.match(
     main,
     /OPENRAPPTER_DESKTOP_SMOKE === '1'[\s\S]*OPENRAPPTER_SMOKE_ERROR/,

--- a/typescript/desktop/test/desktop-contract.test.mjs
+++ b/typescript/desktop/test/desktop-contract.test.mjs
@@ -127,7 +127,7 @@ test('desktop reuses the packaged OpenRappter gateway and core', () => {
   assert.match(main, /SMOKE_ERROR instance lock unavailable/);
   assert.match(main, /async function finishDesktopSmoke/);
   assert.match(main, /child\.kill\('SIGKILL'\)/);
-  assert.match(main, /setImmediate\(\(\) => process\.exit\(exitCode\)\)/);
+  assert.match(main, /app\.exit\(exitCode\);\s*process\.exit\(exitCode\)/);
   assert.match(
     main,
     /OPENRAPPTER_DESKTOP_SMOKE === '1'[\s\S]*OPENRAPPTER_SMOKE_ERROR/,

--- a/typescript/scripts/package-smoke.mjs
+++ b/typescript/scripts/package-smoke.mjs
@@ -230,10 +230,15 @@ try {
       action: "stop",
       session_id: started.session.id,
     }));
+    const events = await store.events(started.session.id);
+    const activation = events.find((event) => event.type === "app.activate");
+    const browser = events.find((event) => event.type === "browser.url");
     process.stdout.write(JSON.stringify({
       started: started.status,
       healthy: live.collector_healthy,
       stopped: stopped.session.state,
+      activation,
+      browser,
     }));
     store.close();
   `;
@@ -255,7 +260,13 @@ try {
   if (
     showStatus.started !== "success" ||
     showStatus.healthy !== true ||
-    showStatus.stopped !== "stopped"
+    showStatus.stopped !== "stopped" ||
+    showStatus.activation?.source !== "context-collector" ||
+    showStatus.activation?.data?.app !== "ShowAndTellTestApp" ||
+    showStatus.activation?.data?.window !== "Synthetic collector window" ||
+    !Number.isInteger(showStatus.activation?.sequence) ||
+    showStatus.browser?.data?.url !== "https://example.test/workflow" ||
+    showStatus.browser?.sequence !== showStatus.activation.sequence + 1
   ) {
     throw new Error(
       `Installed Show-and-Tell worker failed:\n${showSmoke.stdout}`,
@@ -549,6 +560,38 @@ try {
       throw new Error(`Packaged reset left Flight Recorder state: ${resetPath}`);
     }
   }
+  } else {
+    const [{ FlightRecorder }, { hardenPrivatePath }] = await Promise.all([
+      import(pathToFileURL(
+        path.join(installedRoot, "dist", "flight-recorder", "recorder.js"),
+      ).href),
+      import(pathToFileURL(
+        path.join(installedRoot, "dist", "flight-recorder", "permissions.js"),
+      ).href),
+    ]);
+    const windowsFlightDir = path.join(scratch, "windows-flight-recorder");
+    mkdirSync(windowsFlightDir, { recursive: true });
+    hardenPrivatePath(windowsFlightDir, true);
+    const recorder = new FlightRecorder({
+      enabled: true,
+      databasePath: path.join(windowsFlightDir, "flight.db"),
+      retentionEvents: -1,
+    });
+    try {
+      await recorder.initialize();
+      await recorder.runTrace(
+        { traceId: "windows-package-smoke" },
+        async () => {},
+      );
+      const health = await recorder.health();
+      if (!health.initialized || health.eventCount < 2) {
+        throw new Error(
+          `Packaged Windows Flight Recorder did not persist a trace: ${JSON.stringify(health)}`,
+        );
+      }
+    } finally {
+      await recorder.close();
+    }
   }
 
   console.log(

--- a/typescript/scripts/package-smoke.mjs
+++ b/typescript/scripts/package-smoke.mjs
@@ -561,37 +561,46 @@ try {
     }
   }
   } else {
-    const [{ FlightRecorder }, { hardenPrivatePath }] = await Promise.all([
-      import(pathToFileURL(
-        path.join(installedRoot, "dist", "flight-recorder", "recorder.js"),
-      ).href),
-      import(pathToFileURL(
-        path.join(installedRoot, "dist", "flight-recorder", "permissions.js"),
-      ).href),
-    ]);
     const windowsFlightDir = path.join(scratch, "windows-flight-recorder");
     mkdirSync(windowsFlightDir, { recursive: true });
-    hardenPrivatePath(windowsFlightDir, true);
-    const recorder = new FlightRecorder({
-      enabled: true,
-      databasePath: path.join(windowsFlightDir, "flight.db"),
-      retentionEvents: -1,
-    });
-    try {
-      await recorder.initialize();
-      await recorder.runTrace(
-        { traceId: "windows-package-smoke" },
-        async () => {},
-      );
-      const health = await recorder.health();
-      if (!health.initialized || health.eventCount < 2) {
-        throw new Error(
-          `Packaged Windows Flight Recorder did not persist a trace: ${JSON.stringify(health)}`,
+    const recorderModule = pathToFileURL(
+      path.join(installedRoot, "dist", "flight-recorder", "recorder.js"),
+    ).href;
+    const permissionsModule = pathToFileURL(
+      path.join(installedRoot, "dist", "flight-recorder", "permissions.js"),
+    ).href;
+    const windowsFlightScript = `
+      import path from "node:path";
+      import { FlightRecorder } from ${JSON.stringify(recorderModule)};
+      import { hardenPrivatePath } from ${JSON.stringify(permissionsModule)};
+      const directory = ${JSON.stringify(windowsFlightDir)};
+      hardenPrivatePath(directory, true);
+      const recorder = new FlightRecorder({
+        enabled: true,
+        databasePath: path.join(directory, "flight.db"),
+        retentionEvents: -1,
+      });
+      try {
+        await recorder.initialize();
+        await recorder.runTrace(
+          { traceId: "windows-package-smoke" },
+          async () => {},
         );
+        const health = await recorder.health();
+        if (!health.initialized || health.eventCount < 2) {
+          throw new Error(
+            \`Packaged Windows Flight Recorder did not persist a trace: \${JSON.stringify(health)}\`,
+          );
+        }
+      } finally {
+        await recorder.close();
       }
-    } finally {
-      await recorder.close();
-    }
+    `;
+    run(
+      process.execPath,
+      ["--input-type=module", "--eval", windowsFlightScript],
+      { cwd: installRoot },
+    );
   }
 
   console.log(

--- a/typescript/src/__tests__/parity/mcp-server.test.ts
+++ b/typescript/src/__tests__/parity/mcp-server.test.ts
@@ -85,6 +85,20 @@ class FailAgent extends BasicAgent {
   }
 }
 
+class ContractFailAgent extends BasicAgent {
+  constructor() {
+    super('ContractFail', {
+      name: 'ContractFail',
+      description: 'Returns a structured contract error',
+      parameters: { type: 'object', properties: {}, required: [] },
+    });
+  }
+
+  async perform(): Promise<string> {
+    return JSON.stringify({ status: 'error', message: 'Contract failure' });
+  }
+}
+
 describe('McpServer', () => {
   let server: McpServer;
 
@@ -297,6 +311,24 @@ describe('McpServer', () => {
       const result = response.result as { content: { type: string; text: string }[]; isError: boolean };
       expect(result.isError).toBe(true);
       expect(result.content[0].text).toContain('Intentional failure');
+    });
+
+    it('marks structured agent errors as MCP tool errors', async () => {
+      server.registerAgent(new ContractFailAgent());
+      const response = await server.handleRequest({
+        jsonrpc: '2.0',
+        id: 'contract-error',
+        method: 'tools/call',
+        params: { name: 'ContractFail', arguments: {} },
+      });
+
+      expect(response.error).toBeUndefined();
+      const result = response.result as {
+        content: { type: string; text: string }[];
+        isError?: boolean;
+      };
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain('Contract failure');
     });
 
     it('should call tool with complex arguments', async () => {

--- a/typescript/src/__tests__/unit/assistant-config-whitelist.test.ts
+++ b/typescript/src/__tests__/unit/assistant-config-whitelist.test.ts
@@ -94,6 +94,43 @@ describe('AssistantConfig options survive the constructor', () => {
     expect(promptFor({})).not.toContain(marker);
   });
 
+  it('retains a disabled ambient-credential policy across token updates', async () => {
+    const priorToken = process.env.GITHUB_TOKEN;
+    process.env.GITHUB_TOKEN = 'ambient-policy-test';
+    try {
+      const assistant = new Assistant(new Map(), {
+        allowAmbientCredentials: false,
+      });
+
+      assistant.setGithubToken(null);
+      const provider = (assistant as unknown as {
+        provider: { isAvailable(): Promise<boolean> };
+      }).provider;
+      expect(await provider.isAvailable()).toBe(false);
+    } finally {
+      if (priorToken === undefined) delete process.env.GITHUB_TOKEN;
+      else process.env.GITHUB_TOKEN = priorToken;
+    }
+  });
+
+  it('does not let a global CLI preference bypass Desktop sign-out', async () => {
+    const priorBackend = process.env.OPENRAPPTER_AI_BACKEND;
+    process.env.OPENRAPPTER_AI_BACKEND = 'copilot-cli';
+    try {
+      const assistant = new Assistant(new Map(), {
+        allowAmbientCredentials: false,
+      });
+      const provider = (assistant as unknown as {
+        provider: { id: string; isAvailable(): Promise<boolean> };
+      }).provider;
+      expect(provider.id).toBe('copilot');
+      expect(await provider.isAvailable()).toBe(false);
+    } finally {
+      if (priorBackend === undefined) delete process.env.OPENRAPPTER_AI_BACKEND;
+      else process.env.OPENRAPPTER_AI_BACKEND = priorBackend;
+    }
+  });
+
   it('drops no declared option silently — pins the whitelist itself', () => {
     const here = dirname(fileURLToPath(import.meta.url));
     const source = readFileSync(join(here, '..', '..', 'agents', 'Assistant.ts'), 'utf8');

--- a/typescript/src/__tests__/unit/auth-methods.test.ts
+++ b/typescript/src/__tests__/unit/auth-methods.test.ts
@@ -1,0 +1,176 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { registerAuthMethods } from '../../gateway/methods/auth-methods.js';
+
+type Handler = (params: unknown, connection: unknown) => Promise<unknown>;
+
+const cleanup: string[] = [];
+
+afterEach(() => {
+  for (const directory of cleanup.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
+
+describe('auth.remove live token updates', () => {
+  it('publishes an explicit signed-out state from an empty persisted store', () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'openrappter-auth-empty-'));
+    cleanup.push(dataDir);
+    writeFileSync(join(dataDir, 'auth-profiles.json'), '[]', { mode: 0o600 });
+    const tokenUpdates: Array<string | null> = [];
+
+    registerAuthMethods(
+      { registerMethod() {} },
+      {
+        dataDir,
+        onAuthTokenUpdate: (token: string | null) => tokenUpdates.push(token),
+      },
+    );
+
+    expect(tokenUpdates).toEqual([null]);
+  });
+
+  it('activates the replacement profile and clears the final credential', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'openrappter-auth-methods-'));
+    cleanup.push(dataDir);
+    writeFileSync(
+      join(dataDir, 'auth-profiles.json'),
+      JSON.stringify([
+        {
+          id: 'first',
+          provider: 'copilot',
+          type: 'device-code',
+          token: 'token-first',
+          default: true,
+          createdAt: '2026-08-15T00:00:00.000Z',
+        },
+        {
+          id: 'second',
+          provider: 'copilot',
+          type: 'device-code',
+          token: 'token-second',
+          default: false,
+          createdAt: '2026-08-15T00:00:01.000Z',
+        },
+      ]),
+      { mode: 0o600 },
+    );
+
+    const methods = new Map<string, Handler>();
+    const tokenUpdates: Array<string | null> = [];
+    registerAuthMethods(
+      {
+        registerMethod(name, handler) {
+          methods.set(name, handler as Handler);
+        },
+      },
+      {
+        dataDir,
+        onAuthTokenUpdate: (token: string | null) => tokenUpdates.push(token),
+      },
+    );
+
+    expect(tokenUpdates).toEqual(['token-first']);
+    tokenUpdates.length = 0;
+
+    await methods.get('auth.remove')?.({ id: 'first' }, {});
+    expect(tokenUpdates).toEqual(['token-second']);
+
+    tokenUpdates.length = 0;
+    await methods.get('auth.remove')?.({ id: 'second' }, {});
+    expect(tokenUpdates).toEqual([null]);
+  });
+
+  it('cancels the detached device flow before it can save a profile', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'openrappter-auth-cancel-'));
+    cleanup.push(dataDir);
+    const methods = new Map<string, Handler>();
+    const tokenUpdates: Array<string | null> = [];
+    let observedSignal: AbortSignal | undefined;
+
+    registerAuthMethods(
+      {
+        registerMethod(name, handler) {
+          methods.set(name, handler as Handler);
+        },
+      },
+      {
+        dataDir,
+        requestDeviceCode: async () => ({
+          device_code: 'cancel-device',
+          user_code: 'CANCEL-ME',
+          verification_uri: 'https://github.com/login/device',
+          expires_in: 900,
+          interval: 1,
+        }),
+        pollForAccessToken: async (params: { signal?: AbortSignal }) => {
+          observedSignal = params.signal;
+          await new Promise<never>((_, reject) => {
+            params.signal?.addEventListener(
+              'abort',
+              () => reject(new DOMException('cancelled', 'AbortError')),
+              { once: true },
+            );
+          });
+          throw new Error('unreachable');
+        },
+        onAuthTokenUpdate: (token: string | null) => tokenUpdates.push(token),
+      },
+    );
+
+    await methods.get('auth.login')?.({}, {});
+    const result = await methods.get('auth.cancel')?.(
+      { deviceCode: 'cancel-device' },
+      {},
+    );
+    await Promise.resolve();
+
+    expect(result).toEqual({ ok: true, status: 'cancelled' });
+    expect(observedSignal?.aborted).toBe(true);
+    expect(tokenUpdates).toEqual([]);
+    expect(await methods.get('auth.active')?.({}, {})).toBeNull();
+  });
+
+  it('reports completion instead of pretending a persisted login was cancelled', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'openrappter-auth-complete-'));
+    cleanup.push(dataDir);
+    const methods = new Map<string, Handler>();
+    const tokenUpdates: Array<string | null> = [];
+
+    registerAuthMethods(
+      {
+        registerMethod(name, handler) {
+          methods.set(name, handler as Handler);
+        },
+      },
+      {
+        dataDir,
+        requestDeviceCode: async () => ({
+          device_code: 'completed-device',
+          user_code: 'DONE-NOW',
+          verification_uri: 'https://github.com/login/device',
+          expires_in: 900,
+          interval: 1,
+        }),
+        pollForAccessToken: async () => 'completed-token',
+        fetchGitHubUsername: async () => 'completed-user',
+        onAuthTokenUpdate: (token: string | null) => tokenUpdates.push(token),
+      },
+    );
+
+    await methods.get('auth.login')?.({}, {});
+    await new Promise<void>((resolve) => setImmediate(resolve));
+    const result = await methods.get('auth.cancel')?.(
+      { deviceCode: 'completed-device' },
+      {},
+    );
+
+    expect(result).toEqual({ ok: false, status: 'completed' });
+    expect(await methods.get('auth.active')?.({}, {})).toMatchObject({
+      id: 'completed-user',
+    });
+    expect(tokenUpdates).toEqual(['completed-token']);
+  });
+});

--- a/typescript/src/__tests__/unit/copilot-check.test.ts
+++ b/typescript/src/__tests__/unit/copilot-check.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'fs';
 import { hasCopilotAvailable, resolveGithubToken } from '../../copilot-check.js';
 
 // Mock child_process exec
@@ -43,6 +44,10 @@ vi.mock('fs', async (importOriginal) => {
     ...actual,
     default: {
       ...actual,
+      existsSync: vi.fn().mockImplementation((filePath: string) => {
+        if (filePath.includes('auth-profiles.json')) return false;
+        return actual.existsSync(filePath);
+      }),
       readFileSync: vi.fn().mockImplementation((...args: unknown[]) => {
         const filePath = args[0] as string;
         // Block reads to credentials and .env files — let other fs reads through
@@ -52,6 +57,10 @@ vi.mock('fs', async (importOriginal) => {
         return actual.readFileSync(...(args as Parameters<typeof actual.readFileSync>));
       }),
     },
+    existsSync: vi.fn().mockImplementation((filePath: string) => {
+      if (filePath.includes('auth-profiles.json')) return false;
+      return actual.existsSync(filePath);
+    }),
     readFileSync: vi.fn().mockImplementation((...args: unknown[]) => {
       const filePath = args[0] as string;
       if (filePath.includes('github-token.json') || filePath.includes('.openrappter/.env')) {
@@ -70,6 +79,7 @@ beforeEach(() => {
   delete process.env.COPILOT_GITHUB_TOKEN;
   delete process.env.GH_TOKEN;
   delete process.env.GITHUB_TOKEN;
+  delete process.env.OPENRAPPTER_DESKTOP_OWNER_PID;
 });
 
 afterEach(() => {
@@ -124,6 +134,20 @@ describe('resolveGithubToken', () => {
   it('should return null when every discovered token fails validation', async () => {
     process.env.COPILOT_GITHUB_TOKEN = 'bad_stale_token';
     process.env.GH_TOKEN = 'bad_other_token';
+    expect(await resolveGithubToken()).toBeNull();
+  });
+
+  it('treats an explicit empty profile store as signed out', async () => {
+    process.env.GITHUB_TOKEN = 'ambient-token';
+    process.env.OPENRAPPTER_DESKTOP_OWNER_PID = '1234';
+    vi.mocked(fs.existsSync).mockImplementation((filePath) =>
+      String(filePath).includes('auth-profiles.json')
+    );
+    vi.mocked(fs.readFileSync).mockImplementation((filePath, ...args) => {
+      if (String(filePath).includes('auth-profiles.json')) return '[]';
+      throw new Error(`Unexpected read: ${String(filePath)} ${String(args)}`);
+    });
+
     expect(await resolveGithubToken()).toBeNull();
   });
 });

--- a/typescript/src/__tests__/unit/package-smoke-contract.test.ts
+++ b/typescript/src/__tests__/unit/package-smoke-contract.test.ts
@@ -1,0 +1,21 @@
+import { readFileSync } from 'node:fs';
+import { describe, expect, it } from 'vitest';
+
+describe('Windows package smoke cleanup', () => {
+  it('loads better-sqlite3 only in a child process', () => {
+    const source = readFileSync(
+      new URL('../../../scripts/package-smoke.mjs', import.meta.url),
+      'utf8',
+    );
+    const marker = source.indexOf('const windowsFlightDir');
+    const windowsBranch = source.slice(
+      source.lastIndexOf('} else {', marker),
+      source.indexOf('console.log(', marker),
+    );
+
+    expect(windowsBranch).toContain(
+      '["--input-type=module", "--eval", windowsFlightScript]',
+    );
+    expect(windowsBranch).not.toMatch(/\bimport\s*\(/);
+  });
+});

--- a/typescript/src/agents/Assistant.concurrent.test.ts
+++ b/typescript/src/agents/Assistant.concurrent.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { Assistant } from './Assistant.js';
+import type {
+  ChatOptions,
+  LLMProvider,
+  Message,
+  ProviderResponse,
+} from '../providers/types.js';
+
+describe('Assistant conversation serialization', () => {
+  it('does not expose a later user turn to an in-flight provider call', async () => {
+    const snapshots: Message[][] = [];
+    let releaseFirst!: () => void;
+    const firstBlocked = new Promise<void>((resolve) => {
+      releaseFirst = resolve;
+    });
+    const provider: LLMProvider = {
+      id: 'serialized-test',
+      name: 'Serialized test provider',
+      async isAvailable() {
+        return true;
+      },
+      async chat(
+        messages: Message[],
+        _options?: ChatOptions,
+      ): Promise<ProviderResponse> {
+        snapshots.push(messages.map((message) => ({ ...message })));
+        if (snapshots.length === 1) await firstBlocked;
+        return {
+          content: `reply-${snapshots.length}`,
+          tool_calls: null,
+        };
+      },
+    };
+    const assistant = new Assistant(new Map(), {
+      provider,
+      loadWorkspaceContext: false,
+      loadMemoryContext: false,
+    });
+
+    const first = assistant.getResponse(
+      'first',
+      undefined,
+      undefined,
+      'shared-session',
+    );
+    while (snapshots.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 1));
+    }
+    const second = assistant.getResponse(
+      'second',
+      undefined,
+      undefined,
+      'shared-session',
+    );
+    await new Promise((resolve) => setTimeout(resolve, 20));
+    expect(snapshots).toHaveLength(1);
+
+    releaseFirst();
+    await first;
+    await second;
+
+    expect(
+      snapshots[0].filter((message) => message.role === 'user')
+        .map((message) => message.content),
+    ).toEqual(['first']);
+    expect(
+      snapshots[1].filter((message) => message.role === 'user')
+        .map((message) => message.content),
+    ).toEqual(['first', 'second']);
+  });
+});

--- a/typescript/src/agents/Assistant.ts
+++ b/typescript/src/agents/Assistant.ts
@@ -79,6 +79,8 @@ export interface AssistantConfig {
   model?: string;
   /** GitHub token for Copilot API (falls back to env vars) */
   githubToken?: string;
+  /** Whether a missing explicit token may fall back to process credentials. */
+  allowAmbientCredentials?: boolean;
   /** Whether to stream deltas (default true) */
   streaming?: boolean;
   /**
@@ -151,6 +153,7 @@ export class Assistant {
       description: config?.description ?? "a helpful local-first AI assistant",
       model: config?.model ?? defaultModel,
       githubToken: config?.githubToken,
+      allowAmbientCredentials: config?.allowAmbientCredentials ?? true,
       streaming: config?.streaming ?? true,
       maxToolRounds: config?.maxToolRounds ?? PARITY_MAX_ROUNDS,
       loadWorkspaceContext: config?.loadWorkspaceContext ?? true,
@@ -171,10 +174,13 @@ export class Assistant {
       config?.provider ??
       // Prefer the GitHub Copilot CLI when explicitly selected: it owns its own
       // auth + refresh, so openrappter never runs the flaky device-code flow.
-      (process.env.OPENRAPPTER_AI_BACKEND === "copilot-cli"
+      (
+        process.env.OPENRAPPTER_AI_BACKEND === "copilot-cli"
+        && (config?.allowAmbientCredentials ?? true)
         ? new CopilotCliDirectProvider({ model: this.config.model })
         : new CopilotProvider({
             githubToken: config?.githubToken,
+            allowAmbientCredentials: config?.allowAmbientCredentials,
           }));
   }
 
@@ -203,10 +209,22 @@ export class Assistant {
   }
 
   /** Update the GitHub token at runtime (e.g. after device-code login) */
-  setGithubToken(token: string): void {
-    this.config.githubToken = token;
+  setGithubToken(
+    token: string | null,
+    allowAmbientCredentials?: boolean,
+  ): void {
+    const ambientPolicy =
+      allowAmbientCredentials
+      ?? this.config.allowAmbientCredentials
+      ?? true;
+    this.config.allowAmbientCredentials = ambientPolicy;
+    if (token) {
+      this.config.githubToken = token;
+    } else {
+      delete this.config.githubToken;
+    }
     if (this.provider instanceof CopilotProvider) {
-      this.provider.setGithubToken(token);
+      this.provider.setGithubToken(token, ambientPolicy);
     }
   }
 

--- a/typescript/src/agents/Assistant.ts
+++ b/typescript/src/agents/Assistant.ts
@@ -135,6 +135,7 @@ export class Assistant {
   private provider: LLMProvider;
   /** Maps conversation keys to message history for multi-turn continuity */
   private conversations: Map<string, Message[]> = new Map();
+  private conversationTails: Map<string, Promise<void>> = new Map();
   private workspaceDir: string;
   private cachedIdentity: AgentIdentity | null = null;
 
@@ -237,9 +238,34 @@ export class Assistant {
     signal?: AbortSignal,
   ): Promise<AssistantResponse> {
     const key = conversationKey ?? "default";
-    return this.runTurnTrace(key, () =>
-      this.getResponseWithinTrace(message, onDelta, memoryContext, key, signal),
+    return this.withConversationTurn(key, () =>
+      this.runTurnTrace(key, () =>
+        this.getResponseWithinTrace(message, onDelta, memoryContext, key, signal),
+      ),
     );
+  }
+
+  private async withConversationTurn<T>(
+    conversationKey: string,
+    operation: () => Promise<T>,
+  ): Promise<T> {
+    const previous = this.conversationTails.get(conversationKey) ??
+      Promise.resolve();
+    let release!: () => void;
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const tail = previous.then(() => current, () => current);
+    this.conversationTails.set(conversationKey, tail);
+    await previous.catch(() => undefined);
+    try {
+      return await operation();
+    } finally {
+      release();
+      if (this.conversationTails.get(conversationKey) === tail) {
+        this.conversationTails.delete(conversationKey);
+      }
+    }
   }
 
   private async getResponseWithinTrace(
@@ -425,8 +451,10 @@ export class Assistant {
     conversationKey?: string,
   ): Promise<AssistantResponse> {
     const key = conversationKey ?? "default";
-    return this.runTurnTrace(key, () =>
-      this.getResponseStreamingWithinTrace(message, onDelta, key),
+    return this.withConversationTurn(key, () =>
+      this.runTurnTrace(key, () =>
+        this.getResponseStreamingWithinTrace(message, onDelta, key),
+      ),
     );
   }
 
@@ -440,7 +468,12 @@ export class Assistant {
     const modelPolicy = this.config.model;
     const chatStream = provider.chatStream;
     if (!chatStream) {
-      return this.getResponse(message, onDelta, undefined, conversationKey);
+      return this.getResponseWithinTrace(
+        message,
+        onDelta,
+        undefined,
+        conversationKey,
+      );
     }
 
     const agentLogs: string[] = [];

--- a/typescript/src/agents/GoogleVoiceAgent.ts
+++ b/typescript/src/agents/GoogleVoiceAgent.ts
@@ -114,7 +114,17 @@ export async function defaultResponder(message: InboxMessage): Promise<string | 
  */
 async function defaultProvider(): Promise<LLMProvider | null> {
   const { selectBackend } = await import('../providers/backend-select.js');
-  const choice = await selectBackend({});
+  const {
+    hasAuthProfileAuthority,
+    resolveGithubToken,
+  } = await import('../copilot-check.js');
+  const profileAuthority = hasAuthProfileAuthority();
+  const githubToken = await resolveGithubToken();
+  const choice = await selectBackend({
+    githubToken: githubToken ?? undefined,
+    allowIndependentCli: !profileAuthority,
+    allowAmbientCredentials: !profileAuthority,
+  });
   return choice.provider;
 }
 

--- a/typescript/src/agents/__tests__/hot-load.test.ts
+++ b/typescript/src/agents/__tests__/hot-load.test.ts
@@ -147,6 +147,29 @@ describe('the refusals', () => {
     expect(agent!.metadata?.description).toBe('Version two.');
   }, 40_000);
 
+  it('removes agents that disappeared from a replaced Python file', async () => {
+    const first = Buffer.concat([
+      grailAgent('A', 'Alpha', 'Alpha version one.'),
+      Buffer.from('\n'),
+      grailAgent('B', 'Beta', 'Beta version one.'),
+    ]);
+    await importAgentFile('multi_agent.py', first, registry, { dir });
+    expect(await registry.getAgent('Alpha')).toBeDefined();
+    expect(await registry.getAgent('Beta')).toBeDefined();
+
+    await importAgentFile(
+      'multi_agent.py',
+      grailAgent('A', 'Alpha', 'Alpha version two.'),
+      registry,
+      { dir },
+    );
+
+    expect((await registry.getAgent('Alpha'))?.metadata?.description).toBe(
+      'Alpha version two.',
+    );
+    expect(await registry.getAgent('Beta')).toBeUndefined();
+  }, 40_000);
+
   it('re-reads an edit that CPython\'s bytecode cache would call unchanged', async () => {
     // The .pyc validity check is (mtime_seconds, size). Two versions of the same
     // agent that differ only in a same-length string, written inside one

--- a/typescript/src/agents/agent-import.ts
+++ b/typescript/src/agents/agent-import.ts
@@ -131,14 +131,29 @@ export async function importAgentFile(
     // ── Make it live ─────────────────────────────────────────────────────────
     // Forget first: a replaced file may define a different set of names, and a
     // stale entry would keep answering from the old code.
-    const replaced = found.agents.some(a => live.has(a.name));
-    for (const a of found.agents) registry.forget(a.name);
+    const ownedBefore = [...live.entries()]
+      .filter(([, agent]) =>
+        (agent as { sourceFile?: string }).sourceFile === target)
+      .map(([agentName]) => agentName);
+    const replaced = ownedBefore.length > 0;
+    for (const agentName of new Set([
+      ...ownedBefore,
+      ...found.agents.map((agent) => agent.name),
+    ])) {
+      registry.forget(agentName);
+    }
     await registry.reloadUserAgents();
 
     const after = await registry.getAllAgents();
     const missing = found.agents.filter(a => !after.has(a.name)).map(a => a.name);
     if (missing.length > 0) {
       await restore();
+      const failed = await registry.getAllAgents();
+      for (const [agentName, agent] of failed) {
+        if ((agent as { sourceFile?: string }).sourceFile === target) {
+          registry.forget(agentName);
+        }
+      }
       await registry.reloadUserAgents();
       return { status: 'error', error: `${name} loaded but did not register: ${missing.join(', ')}.` };
     }

--- a/typescript/src/auth/profiles.ts
+++ b/typescript/src/auth/profiles.ts
@@ -70,7 +70,12 @@ export class AuthProfileStore {
     if (provider) {
       return this.profiles.filter((p) => p.provider === provider);
     }
+
     return [...this.profiles];
+  }
+
+  hasPersistedState(): boolean {
+    return fs.existsSync(this.profilesPath);
   }
 
   setDefault(provider: string, id: string): boolean {

--- a/typescript/src/cli/show-and-tell.ts
+++ b/typescript/src/cli/show-and-tell.ts
@@ -5,6 +5,7 @@ import type { Command } from 'commander';
 
 import { ShowAndTellAgent } from '../agents/ShowAndTellAgent.js';
 import {
+  hasAuthProfileAuthority,
   resolveCopilotAuth,
   resolveGithubToken,
 } from '../copilot-check.js';
@@ -30,6 +31,8 @@ async function connectAnalysisProvider(agent: ShowAndTellAgent): Promise<void> {
   let backend = await selectBackend({
     githubToken: token ?? undefined,
     model: process.env.OPENRAPPTER_MODEL,
+    allowIndependentCli: !hasAuthProfileAuthority(),
+    allowAmbientCredentials: !hasAuthProfileAuthority(),
   });
   if (!backend.provider) {
     const auth = await resolveCopilotAuth();
@@ -37,6 +40,8 @@ async function connectAnalysisProvider(agent: ShowAndTellAgent): Promise<void> {
     backend = await selectBackend({
       githubToken: token ?? undefined,
       model: process.env.OPENRAPPTER_MODEL,
+      allowIndependentCli: !hasAuthProfileAuthority(),
+      allowAmbientCredentials: !hasAuthProfileAuthority(),
     });
   }
   if (!backend.provider) {

--- a/typescript/src/copilot-check.ts
+++ b/typescript/src/copilot-check.ts
@@ -29,8 +29,12 @@ function loadCachedGitHubToken(): string | null {
   return null;
 }
 
-/** Load a token from auth-profiles.json (saved by device-code flow via auth.login RPC) */
-function loadAuthProfileToken(): string | null {
+/** An existing profile store is authoritative, including an explicit empty store. */
+function loadAuthProfileState(): { authoritative: boolean; token: string | null } {
+  if (!fs.existsSync(AUTH_PROFILES_FILE)) {
+    return { authoritative: false, token: null };
+  }
+
   try {
     const data = fs.readFileSync(AUTH_PROFILES_FILE, 'utf-8');
     const profiles = JSON.parse(data) as Array<{
@@ -42,14 +46,23 @@ function loadAuthProfileToken(): string | null {
     const defaultCopilot = profiles.find(
       (p) => p.provider === 'copilot' && p.default && typeof p.token === 'string' && p.token.length > 10
     );
-    if (defaultCopilot?.token) return defaultCopilot.token;
+    if (defaultCopilot?.token) {
+      return { authoritative: true, token: defaultCopilot.token };
+    }
     // Fall back to any copilot profile with a real token
     const anyCopilot = profiles.find(
       (p) => p.provider === 'copilot' && typeof p.token === 'string' && p.token.length > 10
     );
-    if (anyCopilot?.token) return anyCopilot.token;
-  } catch { /* no auth profiles */ }
-  return null;
+    if (anyCopilot?.token) {
+      return { authoritative: true, token: anyCopilot.token };
+    }
+  } catch { /* a corrupt explicit store must not restore ambient credentials */ }
+  return { authoritative: true, token: null };
+}
+
+export function hasAuthProfileAuthority(): boolean {
+  return Boolean(process.env.OPENRAPPTER_DESKTOP_OWNER_PID)
+    && loadAuthProfileState().authoritative;
 }
 
 /** Save a GitHub token to the credentials file */
@@ -68,65 +81,62 @@ export async function hasCopilotAvailable(): Promise<boolean> {
 }
 
 /**
- * Resolve a GitHub token from (in priority order):
- * 1. COPILOT_GITHUB_TOKEN env var (explicit Copilot token always wins)
- * 2. Cached credentials file (~/.openrappter/credentials/github-token.json)
- * 3. Auth profiles store (~/.openrappter/auth-profiles.json — copilot provider)
- * 4. ~/.openrappter/.env file (saved by onboard/installer device code flow)
- * 5. GH_TOKEN / GITHUB_TOKEN env vars (may be from gh CLI — different OAuth app)
- * 6. gh CLI token (least preferred — usually doesn't have Copilot access)
- *
- * Note: Steps 2-4 are prioritized over generic env vars because the
- * onboard/installer device code flow produces tokens with Copilot access,
- * while GH_TOKEN/GITHUB_TOKEN from gh CLI typically do not.
+ * A Desktop-owned gateway treats auth-profiles.json as the sole account
+ * authority, including an empty store created by explicit sign-out. Standalone
+ * runtimes retain legacy env, credential-cache, .env, and gh CLI discovery.
  */
 export async function resolveGithubToken(): Promise<string | null> {
   // Collect all candidate tokens in priority order, validate the first one that works
   const candidates: { token: string; source: string }[] = [];
+  const profileState = loadAuthProfileState();
+  const profileIsAuthoritative =
+    Boolean(process.env.OPENRAPPTER_DESKTOP_OWNER_PID)
+    && profileState.authoritative;
 
-  // 1. Explicit Copilot token always wins
-  if (process.env.COPILOT_GITHUB_TOKEN) {
-    candidates.push({ token: process.env.COPILOT_GITHUB_TOKEN, source: 'env:COPILOT_GITHUB_TOKEN' });
-  }
+  if (profileIsAuthoritative) {
+    if (profileState.token) {
+      candidates.push({ token: profileState.token, source: 'auth-profile' });
+    }
+  } else {
+    // Legacy discovery remains available until the first profile-store action.
+    if (process.env.COPILOT_GITHUB_TOKEN) {
+      candidates.push({ token: process.env.COPILOT_GITHUB_TOKEN, source: 'env:COPILOT_GITHUB_TOKEN' });
+    }
 
-  // 2. Cached credentials file (saved by device code flow or onboard)
-  const cached = loadCachedGitHubToken();
-  if (cached) candidates.push({ token: cached, source: 'credentials' });
+    const cached = loadCachedGitHubToken();
+    if (cached) candidates.push({ token: cached, source: 'credentials' });
+    if (profileState.token) {
+      candidates.push({ token: profileState.token, source: 'auth-profile' });
+    }
 
-  // 3. Auth profiles store (saved by auth.login RPC or web UI device-code flow)
-  const profileToken = loadAuthProfileToken();
-  if (profileToken) candidates.push({ token: profileToken, source: 'auth-profile' });
-
-  // 4. ~/.openrappter/.env file (saved by installer/onboard — has Copilot access)
-  try {
-    const envFile = path.join(os.homedir(), '.openrappter', '.env');
-    const data = fs.readFileSync(envFile, 'utf-8');
-    for (const line of data.split(/\r?\n/)) {
-      const trimmed = line.trim();
-      const prefixes = ['COPILOT_GITHUB_TOKEN=', 'GITHUB_TOKEN='];
-      for (const prefix of prefixes) {
-        if (trimmed.startsWith(prefix)) {
-          let val = trimmed.slice(prefix.length).trim();
-          if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
-            val = val.slice(1, -1);
-          }
-          if (val.length > 0) {
-            candidates.push({ token: val, source: `env-file:${prefix.replace('=', '')}` });
+    try {
+      const envFile = path.join(os.homedir(), '.openrappter', '.env');
+      const data = fs.readFileSync(envFile, 'utf-8');
+      for (const line of data.split(/\r?\n/)) {
+        const trimmed = line.trim();
+        const prefixes = ['COPILOT_GITHUB_TOKEN=', 'GITHUB_TOKEN='];
+        for (const prefix of prefixes) {
+          if (trimmed.startsWith(prefix)) {
+            let val = trimmed.slice(prefix.length).trim();
+            if ((val.startsWith('"') && val.endsWith('"')) || (val.startsWith("'") && val.endsWith("'"))) {
+              val = val.slice(1, -1);
+            }
+            if (val.length > 0) {
+              candidates.push({ token: val, source: `env-file:${prefix.replace('=', '')}` });
+            }
           }
         }
       }
-    }
-  } catch { /* no .env file */ }
+    } catch { /* no .env file */ }
 
-  // 5. Generic env vars (may not have Copilot access)
-  const envToken = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
-  if (envToken) candidates.push({ token: envToken, source: 'env:GH_TOKEN|GITHUB_TOKEN' });
+    const envToken = process.env.GH_TOKEN ?? process.env.GITHUB_TOKEN;
+    if (envToken) candidates.push({ token: envToken, source: 'env:GH_TOKEN|GITHUB_TOKEN' });
 
-  // 6. gh CLI token (least preferred — usually different OAuth app)
-  try {
-    const { stdout } = await execAsync('gh auth token 2>/dev/null');
-    if (stdout.trim()) candidates.push({ token: stdout.trim(), source: 'gh-cli' });
-  } catch { /* gh not available */ }
+    try {
+      const { stdout } = await execAsync('gh auth token 2>/dev/null');
+      if (stdout.trim()) candidates.push({ token: stdout.trim(), source: 'gh-cli' });
+    } catch { /* gh not available */ }
+  }
 
   // Deduplicate by token value, preserving priority order
   const seen = new Set<string>();

--- a/typescript/src/desktop-control/desktop-control.test.ts
+++ b/typescript/src/desktop-control/desktop-control.test.ts
@@ -2,7 +2,7 @@ import { mkdtempSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 
 import { DesktopControlAgent } from '../agents/DesktopControlAgent.js';
 import { DesktopCommandQueue } from './queue.js';
@@ -70,6 +70,42 @@ describe('DesktopCommandQueue', () => {
       });
       const result = JSON.parse(await pending);
       expect(result.ui_results[0].result.view).toBe('agents');
+    } finally {
+      if (prior === undefined) {
+        delete process.env.OPENRAPPTER_DESKTOP_CONTROL_DIR;
+      } else {
+        process.env.OPENRAPPTER_DESKTOP_CONTROL_DIR = prior;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('turns a failed UI command into a failed agent result', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'desktop-result-error-'));
+    const prior = process.env.OPENRAPPTER_DESKTOP_CONTROL_DIR;
+    process.env.OPENRAPPTER_DESKTOP_CONTROL_DIR = root;
+    try {
+      vi.resetModules();
+      const { dispatchAgentUiCommands: dispatchFresh } = await import(
+        './result.js'
+      );
+      const consumer = new DesktopCommandQueue(root);
+      const pending = dispatchFresh(JSON.stringify({
+        status: 'success',
+        ui_commands: [{ action: 'navigate', view: 'agents' }],
+      }));
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const command = consumer.claimNext();
+      consumer.complete(command!, {
+        status: 'error',
+        error: 'renderer unavailable',
+      });
+      const result = JSON.parse(await pending);
+      expect(result.status).toBe('error');
+      expect(result.ui_results[0]).toMatchObject({
+        status: 'error',
+        error: 'renderer unavailable',
+      });
     } finally {
       if (prior === undefined) {
         delete process.env.OPENRAPPTER_DESKTOP_CONTROL_DIR;

--- a/typescript/src/desktop-control/result.ts
+++ b/typescript/src/desktop-control/result.ts
@@ -74,5 +74,10 @@ export async function dispatchAgentUiCommands(result: string): Promise<string> {
     }
   }
   parsed.ui_results = outcomes;
+  const failures = outcomes.filter((outcome) => outcome.status === 'error');
+  if (failures.length > 0) {
+    parsed.status = 'error';
+    parsed.error = 'One or more requested desktop UI commands failed.';
+  }
   return JSON.stringify(parsed);
 }

--- a/typescript/src/gateway/methods/auth-methods.ts
+++ b/typescript/src/gateway/methods/auth-methods.ts
@@ -6,6 +6,7 @@
  *   auth.active    — Get the current active profile
  *   auth.login     — Start device code flow (returns user_code + URL)
  *   auth.pollLogin — Poll for device code completion, save on success
+ *   auth.cancel    — Cancel a pending device code flow
  *   auth.switch    — Set a different profile as default
  *   auth.remove    — Remove a saved profile
  */
@@ -41,7 +42,9 @@ const pendingFlows = new Map<
     expiresAt: number;
     intervalMs: number;
     resolved: boolean;
+    controller: AbortController;
     token?: string;
+    username?: string;
     error?: string;
   }
 >();
@@ -70,12 +73,25 @@ export function registerAuthMethods(
   _deps?: Record<string, unknown>
 ): void {
   const store = new AuthProfileStore(_deps?.dataDir as string | undefined);
+  const requestDeviceCodeImpl = (
+    _deps?.requestDeviceCode ?? requestDeviceCode
+  ) as typeof requestDeviceCode;
+  const pollForAccessTokenImpl = (
+    _deps?.pollForAccessToken ?? pollForAccessToken
+  ) as typeof pollForAccessToken;
+  const fetchGitHubUsernameImpl = (
+    _deps?.fetchGitHubUsername ?? fetchGitHubUsername
+  ) as typeof fetchGitHubUsername;
 
   // If a profile already exists, notify the caller so the provider can use it
-  const onTokenUpdate = _deps?.onAuthTokenUpdate as ((token: string) => void) | undefined;
+  const onTokenUpdate = _deps?.onAuthTokenUpdate as (
+    (token: string | null) => void
+  ) | undefined;
   const existingProfile = store.get('copilot');
   if (existingProfile?.token && onTokenUpdate) {
     onTokenUpdate(existingProfile.token);
+  } else if (store.hasPersistedState() && onTokenUpdate) {
+    onTokenUpdate(null);
   }
 
   // ── auth.profiles — list all saved profiles ────────────────────────────────
@@ -109,9 +125,10 @@ export function registerAuthMethods(
   server.registerMethod<void, { userCode: string; verificationUri: string; deviceCode: string }>(
     'auth.login',
     async () => {
-      const device = await requestDeviceCode();
+      const device = await requestDeviceCodeImpl();
       const expiresAt = Date.now() + device.expires_in * 1000;
       const intervalMs = Math.max(1000, device.interval * 1000);
+      const controller = new AbortController();
 
       // Store the pending flow
       pendingFlows.set(device.device_code, {
@@ -119,35 +136,40 @@ export function registerAuthMethods(
         expiresAt,
         intervalMs,
         resolved: false,
+        controller,
       });
 
       // Start polling in the background
-      pollForAccessToken({
+      pollForAccessTokenImpl({
         deviceCode: device.device_code,
         intervalMs,
         expiresAt,
+        signal: controller.signal,
       })
         .then(async (token) => {
           const flow = pendingFlows.get(device.device_code);
-          if (flow) {
-            flow.token = token;
-            flow.resolved = true;
+          if (!flow) return;
 
-            // Fetch username and save profile
-            const username = (await fetchGitHubUsername(token)) ?? `account-${Date.now()}`;
-            // Remove existing profile with same username to avoid duplicates
-            store.remove('copilot', username);
-            store.add({
-              id: username,
-              provider: 'copilot',
-              type: 'device-code',
-              token,
-              default: true,
-            });
+          // Fetch username and save profile before publishing success. A
+          // cancellation can remove the flow while this request is in flight.
+          const username = (
+            await fetchGitHubUsernameImpl(token)
+          ) ?? `account-${Date.now()}`;
+          if (pendingFlows.get(device.device_code) !== flow) return;
+          store.remove('copilot', username);
+          store.add({
+            id: username,
+            provider: 'copilot',
+            type: 'device-code',
+            token,
+            default: true,
+          });
+          flow.token = token;
+          flow.username = username;
+          flow.resolved = true;
 
-            // Notify the running provider so it picks up the new token
-            if (onTokenUpdate) onTokenUpdate(token);
-          }
+          // Notify the running provider so it picks up the new token
+          if (onTokenUpdate) onTokenUpdate(token);
         })
         .catch((err) => {
           const flow = pendingFlows.get(device.device_code);
@@ -190,11 +212,25 @@ export function registerAuthMethods(
       }
 
       // Determine the username that was saved
-      const username = flow.token
-        ? (await fetchGitHubUsername(flow.token)) ?? 'unknown'
-        : 'unknown';
+      return { status: 'success', username: flow.username ?? 'unknown' };
+    }
+  );
 
-      return { status: 'success', username };
+  // ── auth.cancel — stop a pending login flow ────────────────────────────────
+  server.registerMethod<
+    { deviceCode: string },
+    { ok: boolean; status: 'cancelled' | 'completed' | 'missing' }
+  >(
+    'auth.cancel',
+    async (params) => {
+      const flow = pendingFlows.get(params.deviceCode);
+      if (!flow) return { ok: false, status: 'missing' };
+      pendingFlows.delete(params.deviceCode);
+      if (flow.resolved && flow.token) {
+        return { ok: false, status: 'completed' };
+      }
+      flow.controller.abort();
+      return { ok: true, status: 'cancelled' };
     }
   );
 
@@ -215,7 +251,11 @@ export function registerAuthMethods(
   server.registerMethod<{ id: string }, { ok: boolean }>(
     'auth.remove',
     async (params) => {
+      const activeProfileId = store.get('copilot')?.id;
       const ok = store.remove('copilot', params.id);
+      if (ok && activeProfileId === params.id && onTokenUpdate) {
+        onTokenUpdate(store.get('copilot')?.token ?? null);
+      }
       return { ok };
     }
   );

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -171,7 +171,7 @@ export class GatewayServer {
   private rappterManager?: RappterManager;
 
   // Callback to update the running Copilot provider token after auth.login
-  private onAuthTokenUpdate?: (token: string) => void;
+  private onAuthTokenUpdate?: (token: string | null) => void;
 
   // External handlers
   private agentHandler?: (
@@ -420,7 +420,7 @@ export class GatewayServer {
    * Register a callback invoked when auth.login or auth.switch provides a new token.
    * Use this to update the running Copilot provider without a restart.
    */
-  setAuthTokenCallback(cb: (token: string) => void): void {
+  setAuthTokenCallback(cb: (token: string | null) => void): void {
     this.onAuthTokenUpdate = cb;
   }
 
@@ -2297,7 +2297,7 @@ export class GatewayServer {
 
     // Auth profile methods (device-code login, switch, remove)
     registerAuthMethods(this, {
-      onAuthTokenUpdate: (token: string) => this.onAuthTokenUpdate?.(token),
+      onAuthTokenUpdate: (token: string | null) => this.onAuthTokenUpdate?.(token),
       dataDir: this.dataDir,
     });
 

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -21,6 +21,7 @@ import { registerRappterCommand } from './cli/rappters.js';
 import { registerFlightRecorderCommand } from './cli/flight-recorder.js';
 import { registerShowAndTellCommand } from './cli/show-and-tell.js';
 import { portTypedOnCommandLine } from './infra/cli-port.js';
+import { watchOwnerProcess } from './infra/owner-watch.js';
 import {
   ensureFlightRecorderFromEnv,
   getFlightRecorder,
@@ -1305,6 +1306,12 @@ program
           releaseProcessLock: () => releaseLock({ filePath: lockFile }),
         });
         lockHandedToGateway = true;
+        const desktopOwnerPid = Number.parseInt(
+          process.env.OPENRAPPTER_DESKTOP_OWNER_PID ?? '',
+          10,
+        );
+        watchOwnerProcess(desktopOwnerPid, () =>
+          cleanup().finally(() => process.exit(0)));
         if (
           process.env.OPENRAPPTER_NODE_ID
           && process.env.OPENRAPPTER_LAUNCHD !== '1'

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -10,7 +10,7 @@ import { fileURLToPath } from 'url';
 import { AgentRegistry } from './agents/index.js';
 import type { AgentInfo } from './agents/types.js';
 import { ensureHomeDir, loadEnv, saveEnv, hydrateManagedEnv, loadConfig, saveConfig, resolvedConfigSources, HOME_DIR, CONFIG_FILE, ENV_FILE } from './env.js';
-import { hasCopilotAvailable, autoAuthIfNeeded, resolveCopilotAuth, resolveGithubToken, saveGitHubToken } from './copilot-check.js';
+import { hasAuthProfileAuthority, hasCopilotAvailable, autoAuthIfNeeded, resolveCopilotAuth, resolveGithubToken, saveGitHubToken } from './copilot-check.js';
 import type { CopilotAuthOutcome } from './copilot-check.js';
 import { chat, displayResult } from './chat.js';
 import { VERSION } from './version.js';
@@ -153,6 +153,7 @@ async function startGatewayInProcess(opts?: {
   // token is not a *missing* one.
   const auth = await resolveCopilotAuth({ silent: opts?.silent });
   const githubToken = auth.status === 'authenticated' ? auth.token : null;
+  const desktopProfileAuthority = hasAuthProfileAuthority();
   for (const line of describeCopilotAuth(auth)) {
     if (auth.status === 'authenticated') log(line); else console.warn(line);
   }
@@ -168,19 +169,26 @@ async function startGatewayInProcess(opts?: {
   const backend = await selectBackend({
     githubToken: githubToken ?? undefined,
     model: process.env.OPENRAPPTER_MODEL,
+    allowIndependentCli: !desktopProfileAuthority,
+    allowAmbientCredentials: !desktopProfileAuthority,
   });
   log(`${EMOJI} AI backend: ${backend.kind} — ${backend.reason}`);
   // Give the agent-writer a model. Without one it silently falls back to a
   // scaffold that echoes its input, so the surgeon reported "installed X" for
   // an agent that does not implement anything. The registry constructs agents
   // with no provider, so it has to be handed over after selection.
+  const providerAwareAgents = [
+    agents.get('LearnNew') ?? agents.get('LearnNewAgent'),
+    agents.get('ShowAndTell'),
+  ];
+  const updateAgentProviders = (provider: unknown): void => {
+    for (const agent of providerAwareAgents) {
+      (agent as { setProvider?: (value: unknown) => void } | undefined)
+        ?.setProvider?.(provider);
+    }
+  };
   if (backend.provider) {
-    const learner = agents.get('LearnNew') ?? agents.get('LearnNewAgent');
-    (learner as unknown as { setProvider?: (p: unknown) => void } | undefined)
-      ?.setProvider?.(backend.provider);
-    const showAndTell = agents.get('ShowAndTell');
-    (showAndTell as unknown as { setProvider?: (p: unknown) => void } | undefined)
-      ?.setProvider?.(backend.provider);
+    updateAgentProviders(backend.provider);
   }
   if (backend.kind === 'none' && backend.remedy) {
     // Actionable, not a stack trace: this is what the operator has to do.
@@ -202,6 +210,7 @@ async function startGatewayInProcess(opts?: {
       + 'You have shell, memory, and skill agents.',
     model: backend.model ?? process.env.OPENRAPPTER_MODEL,
     githubToken: githubToken ?? undefined,
+    allowAmbientCredentials: !desktopProfileAuthority,
     workspaceDir: process.env.OPENRAPPTER_WORKSPACE_DIR,
     // Which rappter this is. Reached the lock, the port and the channels
     // already; without this it never reached the thing that answers. #102
@@ -312,11 +321,18 @@ async function startGatewayInProcess(opts?: {
   let imessageModelProbeStopped = false;
   let imessageModelProbeController: AbortController | undefined;
   let imessageModelProbePromise: Promise<void> | undefined;
-  let updateIMessageToken: ((token: string) => void) | undefined;
+  let updateIMessageToken: ((token: string | null) => void) | undefined;
   if (imessageEnabled) {
     const { CopilotCliProvider } = await import('./providers/copilot-cli.js');
     const imessageModel =
       process.env.OPENRAPPTER_IMESSAGE_MODEL || 'gpt-5.6-sol';
+    const imessageEnv = { ...process.env };
+    if (desktopProfileAuthority) {
+      for (const key of ['COPILOT_GITHUB_TOKEN', 'GH_TOKEN', 'GITHUB_TOKEN']) {
+        delete imessageEnv[key];
+      }
+    }
+    if (githubToken) imessageEnv.COPILOT_GITHUB_TOKEN = githubToken;
     const imessageProvider = new CopilotCliProvider({
       executable: process.env.COPILOT_CLI_PATH,
       copilotHome: path.join(HOME_DIR, 'copilot-imessage-home'),
@@ -326,12 +342,7 @@ async function startGatewayInProcess(opts?: {
         ?? ['']
       ),
       promptTransport: 'attachment',
-      env: githubToken
-        ? {
-            ...process.env,
-            COPILOT_GITHUB_TOKEN: githubToken,
-          }
-        : process.env,
+      env: imessageEnv,
     });
     imessageAssistant = new Assistant(new Map(), {
       name: `${NAME} iMessage`,
@@ -381,7 +392,7 @@ async function startGatewayInProcess(opts?: {
         }
       }
     };
-    updateIMessageToken = (token: string) => {
+    updateIMessageToken = (token: string | null) => {
       imessageProvider.updateToken(token);
       imessageRuntime?.setModelReadiness('pending', 'model_preflight_pending');
       imessageModelProbeController?.abort();
@@ -509,21 +520,20 @@ async function startGatewayInProcess(opts?: {
   const [
     { SurgeonService },
     { buildPatientSnapshot },
-    { CopilotCliDirectProvider },
-    { CopilotProvider },
+    {
+      CopilotProvider,
+      COPILOT_DEFAULT_MODEL: PROFILE_COPILOT_DEFAULT_MODEL,
+    },
   ] = await Promise.all([
     import('./surgeon/service.js'),
     import('./surgeon/patient.js'),
-    import('./providers/copilot-cli-direct.js'),
     import('./providers/copilot.js'),
   ]);
   const surgeonService = new SurgeonService({
     dataDir: HOME_DIR,
-    provider: githubToken
-      ? new CopilotProvider({ githubToken })
-      : new CopilotCliDirectProvider({
-          model: process.env.OPENRAPPTER_SURGEON_MODEL ?? 'auto',
-        }),
+    provider: backend.provider ?? new CopilotProvider({
+      allowAmbientCredentials: !desktopProfileAuthority,
+    }),
     inspectPatient: async () => {
       const status = server.getStatus();
       const channels = channelRegistry.getStatusList();
@@ -621,43 +631,83 @@ async function startGatewayInProcess(opts?: {
   server.setSurgeonService(surgeonService);
 
   // Wire auth profile token updates → live provider refresh (no restart needed)
+  let authTokenUpdateGeneration = 0;
+  let authTokenUpdateController: AbortController | undefined;
   server.setAuthTokenCallback((token) => {
-    assistant.setGithubToken(token);
-    void import('./providers/copilot-token.js')
-      .then(({ resolveCopilotApiToken }) =>
-        resolveCopilotApiToken({ githubToken: token })
-      )
-      .then(() => {
-        surgeonService.setProvider(new CopilotProvider({ githubToken: token }));
-      })
-      .catch(async () => {
-        // A credential we have just observed to be bad is a decision point, not
-        // a warning to print and walk past. Re-select a backend that works.
-        const { selectBackend: reselect } = await import('./providers/backend-select.js');
-        const next = await reselect({ githubToken: token, model: process.env.OPENRAPPTER_MODEL });
-        if (next.provider) {
-          surgeonService.setProvider(next.provider);
-          assistant.setProvider?.(
-            next.provider,
-            next.model ?? (next.kind === 'copilot-cli' ? 'auto' : assistant.getModel()),
-          );
-          log(`${EMOJI} Stored Copilot profile is stale — switched to ${next.kind}`);
-        } else {
-          log(`${EMOJI} Stored Copilot profile is stale and no backend can answer`);
-        }
-        server.setBackendStatus?.({
-          kind: next.kind,
-          reason: next.reason,
-          remedy: next.remedy,
-          // Re-selection has to carry these too. Dropping them here is what put
-          // `"model":"unknown"` on every reply: the startup path set them
-          // correctly, then this fallback replaced the whole record with one
-          // that had no model in it at all.
-          model: next.model ?? process.env.OPENRAPPTER_MODEL,
-          requestedModel: process.env.OPENRAPPTER_MODEL ?? next.model,
-        });
-      });
+    const generation = ++authTokenUpdateGeneration;
+    authTokenUpdateController?.abort();
+    const controller = new AbortController();
+    authTokenUpdateController = controller;
+    const profileModel =
+      process.env.OPENRAPPTER_MODEL
+      ?? (assistant.getModel() === 'auto'
+        ? PROFILE_COPILOT_DEFAULT_MODEL
+        : assistant.getModel());
+    const profileProvider = new CopilotProvider({
+      githubToken: token ?? undefined,
+      allowAmbientCredentials: false,
+    });
+    assistant.setGithubToken(token, false);
+    assistant.setProvider(profileProvider, profileModel);
+    surgeonService.setProvider(profileProvider);
+    updateAgentProviders(profileProvider);
     updateIMessageToken?.(token);
+    if (!token) {
+      server.setBackendStatus?.({
+        kind: 'unauthenticated',
+        reason: 'No active Copilot profile',
+        remedy: {
+          title: 'Sign in to GitHub',
+          detail: 'Open Accounts and authenticate a Copilot-enabled GitHub account.',
+          action: 'auth.login',
+        },
+        model: profileModel,
+        requestedModel: process.env.OPENRAPPTER_MODEL ?? profileModel,
+      });
+      void import('./providers/copilot-token.js').then(
+        ({ clearCachedCopilotToken }) => clearCachedCopilotToken(),
+      ).catch((error) => {
+        log(
+          `${EMOJI} Copilot profile removed; cached token cleanup failed: ${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      });
+      log(`${EMOJI} Copilot profile removed — live credential cleared`);
+      return;
+    }
+    void import('./providers/copilot-token.js')
+      .then(({ clearCachedCopilotToken, resolveCopilotApiToken }) => {
+        clearCachedCopilotToken();
+        return resolveCopilotApiToken({
+          githubToken: token,
+          signal: controller.signal,
+        });
+      })
+      .then(() => {
+        if (generation !== authTokenUpdateGeneration) return;
+        server.setBackendStatus?.({
+          kind: 'copilot-direct',
+          reason: 'Authenticated with the active Copilot profile',
+          model: profileModel,
+          requestedModel: process.env.OPENRAPPTER_MODEL ?? profileModel,
+        });
+      })
+      .catch((error) => {
+        if (generation !== authTokenUpdateGeneration) return;
+        server.setBackendStatus?.({
+          kind: 'unavailable',
+          reason: error instanceof Error ? error.message : String(error),
+          remedy: {
+            title: 'Re-authenticate GitHub',
+            detail: 'The selected account could not obtain a Copilot API token.',
+            action: 'auth.login',
+          },
+          model: profileModel,
+          requestedModel: process.env.OPENRAPPTER_MODEL ?? profileModel,
+        });
+        log(`${EMOJI} Active Copilot profile could not be validated`);
+      });
     log(`${EMOJI} Copilot token updated from profile store`);
   });
 

--- a/typescript/src/infra/owner-watch.test.ts
+++ b/typescript/src/infra/owner-watch.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from 'vitest';
+import { watchOwnerProcess } from './owner-watch.js';
+
+describe('desktop owner watcher', () => {
+  it('runs cleanup once when the owner disappears', async () => {
+    vi.useFakeTimers();
+    const cleanup = vi.fn();
+    const isAlive = vi.fn()
+      .mockReturnValueOnce(true)
+      .mockReturnValue(false);
+    const cancel = watchOwnerProcess(12345, cleanup, {
+      intervalMs: 100,
+      isAlive,
+    });
+
+    await vi.advanceTimersByTimeAsync(300);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+    cancel();
+    vi.useRealTimers();
+  });
+});

--- a/typescript/src/infra/owner-watch.ts
+++ b/typescript/src/infra/owner-watch.ts
@@ -1,0 +1,34 @@
+export function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM';
+  }
+}
+
+export function watchOwnerProcess(
+  ownerPid: number,
+  onOwnerExit: () => void | Promise<void>,
+  options: {
+    intervalMs?: number;
+    isAlive?: (pid: number) => boolean;
+  } = {},
+): () => void {
+  if (!Number.isSafeInteger(ownerPid) || ownerPid <= 0 || ownerPid === process.pid) {
+    return () => {};
+  }
+  const isAlive = options.isAlive ?? processIsAlive;
+  let stopped = false;
+  const timer = setInterval(() => {
+    if (stopped || isAlive(ownerPid)) return;
+    stopped = true;
+    clearInterval(timer);
+    void onOwnerExit();
+  }, options.intervalMs ?? 1_000);
+  timer.unref();
+  return () => {
+    stopped = true;
+    clearInterval(timer);
+  };
+}

--- a/typescript/src/mcp/server.ts
+++ b/typescript/src/mcp/server.ts
@@ -7,6 +7,7 @@
 
 import { createInterface } from 'readline';
 import { BasicAgent } from '../agents/BasicAgent.js';
+import { agentResultIsError } from '../agents/result-status.js';
 import { VERSION } from '../version.js';
 import { recordInvocation } from '../agents/invocation-journal.js';
 
@@ -171,7 +172,8 @@ export class McpServer {
       // never sees these calls and `agent_logs` came back empty even when an
       // agent had demonstrably run. Journal it here — this is the only place
       // that observes the invocation.
-      recordInvocation(toolName, resultStr);
+      const contractError = agentResultIsError(resultStr);
+      recordInvocation(toolName, resultStr, contractError);
       let content: unknown;
       try {
         content = JSON.parse(resultStr);
@@ -183,6 +185,7 @@ export class McpServer {
         id: request.id,
         result: {
           content: [{ type: 'text', text: typeof content === 'string' ? content : JSON.stringify(content, null, 2) }],
+          ...(contractError ? { isError: true } : {}),
         },
       };
     } catch (e) {

--- a/typescript/src/providers/__tests__/backend-select.test.ts
+++ b/typescript/src/providers/__tests__/backend-select.test.ts
@@ -64,6 +64,37 @@ describe('backend selection', () => {
     expect(choice.reason).toMatch(/own sign-in/i);
   });
 
+  it('can forbid a separately authenticated CLI account', async () => {
+    let probed = false;
+    const choice = await selectBackend({
+      env: {},
+      probeSdk: no,
+      probeCli: async () => {
+        probed = true;
+        return true;
+      },
+      allowIndependentCli: false,
+    });
+    expect(choice.kind).toBe('none');
+    expect(probed).toBe(false);
+  });
+
+  it('can forbid ambient SDK credentials', async () => {
+    let probed = false;
+    const choice = await selectBackend({
+      env: { GITHUB_TOKEN: 'ambient-account' },
+      probeSdk: async () => {
+        probed = true;
+        return true;
+      },
+      probeCli: no,
+      allowAmbientCredentials: false,
+      allowIndependentCli: false,
+    });
+    expect(choice.kind).toBe('none');
+    expect(probed).toBe(false);
+  });
+
   it('reports a remedy — not a failure — when nothing can answer', async () => {
     const choice = await selectBackend({
       githubToken: 'gho_unentitled', env: {}, probeSdk: no, probeCli: no,

--- a/typescript/src/providers/__tests__/copilot.test.ts
+++ b/typescript/src/providers/__tests__/copilot.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'fs';
 import os from 'os';
 import path from 'path';
+import { createHash } from 'crypto';
 
 // ── copilot-token.ts tests ───────────────────────────────────────────────────
 
@@ -56,6 +57,7 @@ describe('copilot-token', () => {
         token: 'cached-token;proxy-ep=proxy.test.com',
         expiresAt: Date.now() + 3600 * 1000,
         updatedAt: Date.now(),
+        githubTokenFingerprint: createHash('sha256').update('gh-token').digest('hex'),
       };
       fs.writeFileSync(cachePath, JSON.stringify(cached));
 
@@ -68,6 +70,64 @@ describe('copilot-token', () => {
       expect(result.token).toBe(cached.token);
       expect(result.source).toContain('cache');
       expect(result.baseUrl).toBe('https://api.test.com');
+    });
+
+    it('should not reuse a cached token from another GitHub account', async () => {
+      const { resolveCopilotApiToken } = await import('../copilot-token.js');
+      const cachePath = path.join(tmpDir, 'other-account-token.json');
+      fs.writeFileSync(cachePath, JSON.stringify({
+        token: 'previous-account-token',
+        expiresAt: Date.now() + 3600 * 1000,
+        updatedAt: Date.now(),
+        githubTokenFingerprint: createHash('sha256')
+          .update('previous-github-token')
+          .digest('hex'),
+      }));
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => Promise.resolve({
+          token: 'replacement-account-token',
+          expires_at: Math.floor(Date.now() / 1000) + 3600,
+        }),
+      });
+
+      const result = await resolveCopilotApiToken({
+        githubToken: 'replacement-github-token',
+        cachePath,
+        fetchImpl: mockFetch as unknown as typeof fetch,
+      });
+
+      expect(result.token).toBe('replacement-account-token');
+      expect(mockFetch).toHaveBeenCalledOnce();
+    });
+
+    it('should not cache a token after its account update is cancelled', async () => {
+      const { resolveCopilotApiToken } = await import('../copilot-token.js');
+      const cachePath = path.join(tmpDir, 'cancelled-account-token.json');
+      const controller = new AbortController();
+      let resolveJson: ((value: unknown) => void) | undefined;
+      const mockFetch = vi.fn().mockResolvedValue({
+        ok: true,
+        json: () => new Promise((resolve) => {
+          resolveJson = resolve;
+        }),
+      });
+
+      const pending = resolveCopilotApiToken({
+        githubToken: 'cancelled-github-token',
+        cachePath,
+        fetchImpl: mockFetch as unknown as typeof fetch,
+        signal: controller.signal,
+      });
+      await vi.waitFor(() => expect(resolveJson).toBeDefined());
+      controller.abort();
+      resolveJson?.({
+        token: 'must-not-be-cached',
+        expires_at: Math.floor(Date.now() / 1000) + 3600,
+      });
+
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' });
+      expect(fs.existsSync(cachePath)).toBe(false);
     });
 
     it('should fetch new token when cache is expired', async () => {
@@ -479,6 +539,15 @@ describe('CopilotProvider', () => {
     const provider = new CopilotProvider();
     const available = await provider.isAvailable();
     expect(available).toBe(false);
+  });
+
+  it('should not restore ambient credentials after explicit profile removal', async () => {
+    const { CopilotProvider } = await import('../copilot.js');
+    process.env.GITHUB_TOKEN = 'ambient-account-token';
+
+    const provider = new CopilotProvider({ allowAmbientCredentials: false });
+
+    expect(await provider.isAvailable()).toBe(false);
   });
 
   it('should expose default models', async () => {

--- a/typescript/src/providers/backend-select.ts
+++ b/typescript/src/providers/backend-select.ts
@@ -79,6 +79,10 @@ export interface SelectBackendOptions {
   /** Injected so selection can be tested without network or a CLI on disk. */
   probeSdk?: (token: string) => Promise<boolean>;
   probeCli?: () => Promise<boolean>;
+  /** Disable silent use of a separately authenticated CLI account. */
+  allowIndependentCli?: boolean;
+  /** Disable SDK fallback to GITHUB_TOKEN/GH_TOKEN. */
+  allowAmbientCredentials?: boolean;
 }
 
 /** Does this GitHub token really exchange for a Copilot API token? */
@@ -108,12 +112,26 @@ export async function selectBackend(options: SelectBackendOptions = {}): Promise
   const env = options.env ?? process.env;
   const probeSdk = options.probeSdk ?? defaultProbeSdk;
   const probeCli = options.probeCli ?? defaultProbeCli;
+  const allowIndependentCli = options.allowIndependentCli ?? true;
+  const allowAmbientCredentials = options.allowAmbientCredentials ?? true;
   const model = options.model;
 
   // 1. An explicit choice is honoured without probing. If an operator pins a
   //    backend, silently using a different one would be worse than failing.
   const pinned = env.OPENRAPPTER_AI_BACKEND;
   if (pinned === 'copilot-cli') {
+    if (!allowIndependentCli) {
+      return {
+        kind: 'none',
+        provider: null,
+        reason: 'Desktop profile authority has no active account',
+        remedy: {
+          title: 'Connect a GitHub account',
+          detail: 'Open Accounts and sign in before using Copilot.',
+          action: 'reconnect-github',
+        },
+      };
+    }
     return {
       kind: 'copilot-cli',
       // exposeAgents: without it the CLI runs with an empty tool allow-list
@@ -126,9 +144,24 @@ export async function selectBackend(options: SelectBackendOptions = {}): Promise
     };
   }
   if (pinned === 'copilot-sdk' || pinned === 'copilot') {
+    if (!options.githubToken && !allowAmbientCredentials) {
+      return {
+        kind: 'none',
+        provider: null,
+        reason: 'Desktop profile authority has no active account',
+        remedy: {
+          title: 'Connect a GitHub account',
+          detail: 'Open Accounts and sign in before using Copilot.',
+          action: 'reconnect-github',
+        },
+      };
+    }
     return {
       kind: 'copilot-sdk',
-      provider: new CopilotProvider({ githubToken: options.githubToken }),
+      provider: new CopilotProvider({
+        githubToken: options.githubToken,
+        allowAmbientCredentials,
+      }),
       // The SDK rung sends an explicit model on every request, so unlike the
       // CLI it always knows which one was asked to answer.
       model: model ?? COPILOT_DEFAULT_MODEL,
@@ -139,11 +172,18 @@ export async function selectBackend(options: SelectBackendOptions = {}): Promise
   // 2. The SDK, but only on proof. Holding a token is not the same as the token
   //    working — that assumption is exactly what produced the 401 on every
   //    message while a usable CLI sat unused on the same disk.
-  const token = options.githubToken ?? env.GITHUB_TOKEN ?? env.GH_TOKEN ?? '';
+  const token = options.githubToken ?? (
+    allowAmbientCredentials
+      ? env.GITHUB_TOKEN ?? env.GH_TOKEN ?? ''
+      : ''
+  );
   if (token && (await probeSdk(token))) {
     return {
       kind: 'copilot-sdk',
-      provider: new CopilotProvider({ githubToken: token }),
+      provider: new CopilotProvider({
+        githubToken: token,
+        allowAmbientCredentials,
+      }),
       model: model ?? COPILOT_DEFAULT_MODEL,
       reason: 'GitHub token has Copilot API access',
     };
@@ -151,7 +191,7 @@ export async function selectBackend(options: SelectBackendOptions = {}): Promise
 
   // 3. The local rung. The CLI owns its own credential and refresh, so it keeps
   //    working when the GitHub token does not.
-  if (await probeCli()) {
+  if (allowIndependentCli && await probeCli()) {
     return {
       kind: 'copilot-cli',
       // exposeAgents: without it the CLI runs with an empty tool allow-list

--- a/typescript/src/providers/copilot-auth.ts
+++ b/typescript/src/providers/copilot-auth.ts
@@ -86,6 +86,7 @@ export async function pollForAccessToken(params: {
   expiresAt: number;
   fetchImpl?: typeof fetch;
   onPoll?: () => void;
+  signal?: AbortSignal;
 }): Promise<string> {
   const fetchImpl = params.fetchImpl ?? fetch;
 
@@ -98,6 +99,9 @@ export async function pollForAccessToken(params: {
   let consecutiveNetworkErrors = 0;
 
   while (Date.now() < params.expiresAt) {
+    if (params.signal?.aborted) {
+      throw new DOMException('GitHub device flow cancelled', 'AbortError');
+    }
     params.onPoll?.();
 
     let res: Response;
@@ -109,9 +113,11 @@ export async function pollForAccessToken(params: {
           'Content-Type': 'application/x-www-form-urlencoded',
         },
         body,
+        signal: params.signal,
       });
       consecutiveNetworkErrors = 0;
     } catch (error) {
+      if (params.signal?.aborted) throw error;
       consecutiveNetworkErrors++;
       if (consecutiveNetworkErrors >= 5) throw error;
       await new Promise((r) => setTimeout(r, params.intervalMs));

--- a/typescript/src/providers/copilot-cli.ts
+++ b/typescript/src/providers/copilot-cli.ts
@@ -452,11 +452,11 @@ export class CopilotCliProvider implements LLMProvider {
       options.promptAttachmentPreparer ?? defaultPromptAttachmentPreparer;
   }
 
-  updateToken(token: string): void {
+  updateToken(token: string | null): void {
     for (const key of TOKEN_ENV_KEYS) {
       delete this.sourceEnv[key];
     }
-    const normalized = token.trim();
+    const normalized = token?.trim() ?? '';
     if (normalized) {
       this.sourceEnv.COPILOT_GITHUB_TOKEN = normalized;
     }

--- a/typescript/src/providers/copilot-token.ts
+++ b/typescript/src/providers/copilot-token.ts
@@ -8,6 +8,7 @@
 import fs from 'fs';
 import path from 'path';
 import os from 'os';
+import { createHash } from 'crypto';
 
 // ── Constants ────────────────────────────────────────────────────────────────
 
@@ -25,6 +26,8 @@ export interface CachedCopilotToken {
   expiresAt: number;
   /** milliseconds since epoch */
   updatedAt: number;
+  /** Binds this API token to the GitHub credential that produced it. */
+  githubTokenFingerprint?: string;
 }
 
 export interface ResolvedCopilotToken {
@@ -72,6 +75,10 @@ export function clearCachedCopilotToken(cachePath?: string): void {
 
 function isTokenUsable(cache: CachedCopilotToken, now = Date.now()): boolean {
   return cache.expiresAt - now > TOKEN_SAFETY_MARGIN_MS;
+}
+
+function githubTokenFingerprint(token: string): string {
+  return createHash('sha256').update(token).digest('hex');
 }
 
 // ── Base URL extraction ──────────────────────────────────────────────────────
@@ -166,13 +173,22 @@ export async function resolveCopilotApiToken(params: {
   githubToken: string;
   cachePath?: string;
   fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
 }): Promise<ResolvedCopilotToken> {
   const cachePath = params.cachePath ?? getDefaultCachePath();
   const fetchImpl = params.fetchImpl ?? fetch;
+  const sourceFingerprint = githubTokenFingerprint(params.githubToken);
+  if (params.signal?.aborted) {
+    throw new DOMException('Copilot token exchange cancelled', 'AbortError');
+  }
 
   // 1. Try cache
   const cached = loadCachedToken(cachePath);
-  if (cached && isTokenUsable(cached)) {
+  if (
+    cached
+    && cached.githubTokenFingerprint === sourceFingerprint
+    && isTokenUsable(cached)
+  ) {
     return {
       token: cached.token,
       expiresAt: cached.expiresAt,
@@ -193,6 +209,7 @@ export async function resolveCopilotApiToken(params: {
       'Editor-Plugin-Version': 'copilot/1.0.0',
       'User-Agent': 'GitHubCopilotChat/0.22.2024',
     },
+    signal: params.signal,
   });
 
   if (!res.ok) {
@@ -207,12 +224,16 @@ export async function resolveCopilotApiToken(params: {
   }
 
   const parsed = parseCopilotTokenResponse(await res.json());
+  if (params.signal?.aborted) {
+    throw new DOMException('Copilot token exchange cancelled', 'AbortError');
+  }
 
   // 3. Cache
   const payload: CachedCopilotToken = {
     token: parsed.token,
     expiresAt: parsed.expiresAt,
     updatedAt: Date.now(),
+    githubTokenFingerprint: sourceFingerprint,
   };
   saveCachedToken(cachePath, payload);
 

--- a/typescript/src/providers/copilot.ts
+++ b/typescript/src/providers/copilot.ts
@@ -154,23 +154,33 @@ export class CopilotProvider implements LLMProvider {
 
   private githubToken: string | null = null;
   private resolvedToken: ResolvedCopilotToken | null = null;
+  private allowAmbientCredentials: boolean;
 
-  constructor(options?: { githubToken?: string }) {
+  constructor(options?: {
+    githubToken?: string;
+    allowAmbientCredentials?: boolean;
+  }) {
     this.githubToken = options?.githubToken ?? null;
+    this.allowAmbientCredentials = options?.allowAmbientCredentials ?? true;
   }
 
   /**
    * Update the GitHub token at runtime (e.g. after device-code login).
    * Clears the cached Copilot API token so the next call re-exchanges.
    */
-  setGithubToken(token: string): void {
+  setGithubToken(
+    token: string | null,
+    allowAmbientCredentials = true,
+  ): void {
     this.githubToken = token;
+    this.allowAmbientCredentials = allowAmbientCredentials;
     this.resolvedToken = null;
   }
 
   /** Resolve the GitHub token from constructor, env, or gh CLI */
   private getGithubToken(): string | null {
     if (this.githubToken) return this.githubToken;
+    if (!this.allowAmbientCredentials) return null;
 
     // Check environment variables (same order as openclaw)
     return (

--- a/typescript/src/show-and-tell/analyzer.ts
+++ b/typescript/src/show-and-tell/analyzer.ts
@@ -2,7 +2,10 @@ import { z } from 'zod';
 
 import type { LLMProvider } from '../providers/types.js';
 import { chatWithFlightRecorder } from '../providers/recorded-chat.js';
-import { sanitizeShowAndTellText } from './privacy.js';
+import {
+  privacyReducedUrl,
+  sanitizeShowAndTellText,
+} from './privacy.js';
 import type { ShowAndTellStore } from './store.js';
 import {
   SHOW_AND_TELL_ANALYSIS_SCHEMA,
@@ -32,6 +35,34 @@ const SubmissionSchema = z.object({
   intentConfidence: z.enum(['high', 'medium', 'low']),
   steps: z.array(StepSchema).min(1).max(60),
 });
+
+function normalizedStep(stepInput: unknown): ShowAndTellStep {
+  const parsed = StepSchema.parse(stepInput);
+  return {
+    ...parsed,
+    url: privacyReducedUrl(parsed.url),
+  };
+}
+
+function narrationText(event: ShowAndTellEvent): string {
+  if (event.type === 'session.note') {
+    return sanitizeShowAndTellText(event.data.note, 1200);
+  }
+  if (event.type !== 'narration.transcribed') return '';
+  const direct = sanitizeShowAndTellText(event.data.text, 1200);
+  if (direct) return direct;
+  if (!Array.isArray(event.data.segments)) return '';
+  return sanitizeShowAndTellText(
+    event.data.segments
+      .map((segment) =>
+        segment && typeof segment === 'object'
+          ? (segment as Record<string, unknown>).text
+          : '')
+      .filter((value): value is string => typeof value === 'string')
+      .join(' '),
+    1200,
+  );
+}
 
 function titleFromIntent(intent: string): string {
   return intent
@@ -141,8 +172,11 @@ function deterministicSteps(events: ShowAndTellEvent[]): ShowAndTellStep[] {
           },
         );
       }
-    } else if (event.type === 'session.note') {
-      const note = sanitizeShowAndTellText(data.note, 1200);
+    } else if (
+      event.type === 'session.note' ||
+      event.type === 'narration.transcribed'
+    ) {
+      const note = narrationText(event);
       if (note) {
         const previous = steps.at(-1);
         if (previous) {
@@ -212,8 +246,7 @@ export function buildDeterministicAnalysis(
   previous?: ShowAndTellAnalysis | null,
 ): ShowAndTellAnalysis {
   const note = events
-    .filter((event) => event.type === 'session.note')
-    .map((event) => sanitizeShowAndTellText(event.data.note, 1000))
+    .map((event) => narrationText(event))
     .find(Boolean);
   const intent =
     sanitizeShowAndTellText(session.intentHint, 1200) ||
@@ -315,7 +348,7 @@ export async function analyzeShowAndTellSession(
       intent: submission.intent,
       intentRationale: submission.intentRationale,
       intentConfidence: submission.intentConfidence,
-      steps: submission.steps,
+      steps: submission.steps.map(normalizedStep),
       updatedAt: Date.now(),
     };
     await store.saveAnalysis(analysis);
@@ -342,10 +375,11 @@ export function reviseAnalysis(
     approve?: boolean;
   },
 ): ShowAndTellAnalysis {
-  let steps = current.steps;
+  let steps = current.steps.map(normalizedStep);
   if (typeof input.stepsJson === 'string' && input.stepsJson.trim()) {
     const parsed = JSON.parse(input.stepsJson) as unknown;
-    steps = z.array(StepSchema).min(1).max(60).parse(parsed);
+    steps = z.array(StepSchema).min(1).max(60).parse(parsed)
+      .map(normalizedStep);
   }
   const feedback = sanitizeShowAndTellText(input.feedback, 2000);
   const now = Date.now();

--- a/typescript/src/show-and-tell/artifacts.ts
+++ b/typescript/src/show-and-tell/artifacts.ts
@@ -21,6 +21,7 @@ import {
 } from '../flight-recorder/permissions.js';
 import {
   artifactContainsSensitiveText,
+  privacyReducedUrl,
   sanitizeShowAndTellText,
 } from './privacy.js';
 import type { ShowAndTellStore } from './store.js';
@@ -117,7 +118,9 @@ export function renderShowAndTellSkill(
     lines.push(
       `${index + 1}. **${step.title}** — ${step.detail}` +
         `${step.tool ? ` Prefer \`${step.tool}\`.` : ''}` +
-        `${step.url ? ` Destination: ${step.url}` : ''}`,
+        `${privacyReducedUrl(step.url)
+          ? ` Destination: ${privacyReducedUrl(step.url)}`
+          : ''}`,
     );
   });
   lines.push(
@@ -144,6 +147,7 @@ function skillManifest(
     description: analysis.intent,
     tags: ['show-and-tell', 'recorded-workflow'],
     sourceSessionId: analysis.sessionId,
+    sourceAnalysisRevision: analysis.revision,
     generatedBy: 'OpenRappter Show-and-Tell',
   }, null, 2)}\n`;
 }
@@ -156,22 +160,31 @@ function renderAutomation(analysis: ShowAndTellAnalysis, name: string): string {
     enabled: false,
     trigger: { type: 'manual' },
     sourceSessionId: analysis.sessionId,
+    sourceAnalysisRevision: analysis.revision,
     steps: analysis.steps.map((step, index) => ({
       id: step.id || `s${index + 1}`,
       label: step.title,
       prompt:
         `${step.detail}` +
         `${step.tool ? ` Prefer ${step.tool}.` : ''}` +
-        `${step.url ? ` Use ${step.url}.` : ''}`,
+        `${privacyReducedUrl(step.url)
+          ? ` Use ${privacyReducedUrl(step.url)}.`
+          : ''}`,
     })),
   }, null, 2)}\n`;
 }
 
-function existingSourceSession(directory: string): string | null {
-  const manifest = path.join(directory, 'manifest.json');
-  if (!existsSync(manifest)) return null;
+function existingSourceSession(
+  directory: string,
+  kind: ShowAndTellArtifactKind,
+): string | null {
+  const metadataFile = path.join(
+    directory,
+    kind === 'skill' ? 'manifest.json' : 'automation.json',
+  );
+  if (!existsSync(metadataFile)) return null;
   try {
-    const parsed = JSON.parse(readFileSync(manifest, 'utf8')) as {
+    const parsed = JSON.parse(readFileSync(metadataFile, 'utf8')) as {
       sourceSessionId?: unknown;
     };
     return typeof parsed.sourceSessionId === 'string'
@@ -196,8 +209,7 @@ function destination(
   if (
     existsSync(candidate) &&
     (!candidateIsSafeDirectory ||
-      kind !== 'skill' ||
-      existingSourceSession(candidate) !== sessionId)
+      existingSourceSession(candidate, kind) !== sessionId)
   ) {
     let index = 2;
     while (existsSync(path.join(root, `${baseName}-${index}`))) index += 1;
@@ -319,6 +331,7 @@ export async function testShowAndTellArtifacts(
         const manifest = readFileSync(manifestPath, 'utf8');
         const parsed = JSON.parse(manifest) as {
           sourceSessionId?: unknown;
+          sourceAnalysisRevision?: unknown;
           name?: unknown;
         };
         const manifestOk =
@@ -331,6 +344,15 @@ export async function testShowAndTellArtifacts(
           detail: manifestOk
             ? 'Manifest matches the recorded session and skill.'
             : 'Manifest is missing, changed, or belongs to another session.',
+        });
+        const revisionOk =
+          parsed.sourceAnalysisRevision === analysis?.revision;
+        checks.push({
+          name: 'skill-analysis-revision',
+          ok: revisionOk,
+          detail: revisionOk
+            ? 'Skill matches the current analysis revision.'
+            : 'Skill was built from an older analysis revision.',
         });
         privacySafe = privacySafe && !artifactContainsSensitiveText(manifest);
         digest = createHash('sha256')
@@ -358,13 +380,26 @@ export async function testShowAndTellArtifacts(
     });
     if (artifact.kind === 'automation') {
       try {
-        const parsed = JSON.parse(content) as { schema?: unknown; enabled?: unknown };
+        const parsed = JSON.parse(content) as {
+          schema?: unknown;
+          enabled?: unknown;
+          sourceAnalysisRevision?: unknown;
+        };
         checks.push({
           name: 'automation-shape',
           ok:
             parsed.schema === SHOW_AND_TELL_AUTOMATION_SCHEMA &&
             parsed.enabled === false,
           detail: 'Automation is versioned and disabled by default.',
+        });
+        const revisionOk =
+          parsed.sourceAnalysisRevision === analysis?.revision;
+        checks.push({
+          name: 'automation-analysis-revision',
+          ok: revisionOk,
+          detail: revisionOk
+            ? 'Automation matches the current analysis revision.'
+            : 'Automation was built from an older analysis revision.',
         });
       } catch {
         checks.push({

--- a/typescript/src/show-and-tell/privacy.ts
+++ b/typescript/src/show-and-tell/privacy.ts
@@ -7,7 +7,7 @@ const JWT_TOKEN =
   /(?:^|[^A-Za-z0-9_-])([A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{16,})(?:$|[^A-Za-z0-9_-])/;
 
 const PRIVATE_CONTEXT =
-  /\b(?:1password|bitwarden|keychain|password|passkey|credential|secret|token|private key|security code|sign[ -]?in|log[ -]?in)\b/i;
+  /\b(?:1password|bitwarden|keychain|password|passkey|credential|secret|token|private key|security code|sign[ -]?in|log[ -]?in|incognito|inprivate|private browsing)\b/i;
 
 const NAMED_KEYS = new Set([
   'return', 'enter', 'tab', 'space', 'delete', 'escape', 'esc',

--- a/typescript/src/show-and-tell/show-and-tell.test.ts
+++ b/typescript/src/show-and-tell/show-and-tell.test.ts
@@ -22,6 +22,7 @@ import {
   ShowAndTellStore,
   SHOW_AND_TELL_ANALYSIS_SCHEMA,
   SHOW_AND_TELL_SCHEMA,
+  reviseAnalysis,
   runShowAndTellCollector,
   spawnShowAndTellCollector,
 } from './index.js';
@@ -108,6 +109,23 @@ describe('ShowAndTellStore', () => {
   });
 
   describe('Show-and-Tell collector ownership', () => {
+    it('does not let a second collector replace the attached owner', async () => {
+      const store = new ShowAndTellStore(tempRoot());
+      const session = await store.createSession();
+      expect(
+        await store.attachCollector(session.id, 'typescript', 101, 'first'),
+      ).toBe(true);
+      expect(
+        await store.attachCollector(session.id, 'python', 202, 'second'),
+      ).toBe(false);
+      expect(await store.getSession(session.id)).toMatchObject({
+        collectorRuntime: 'typescript',
+        collectorPid: 101,
+        collectorNonce: 'first',
+      });
+      store.close();
+    });
+
     it('reports an executable launch failure without crashing the host', async () => {
       const priorPath = process.env.PATH;
       process.env.PATH = '';
@@ -385,11 +403,34 @@ describe('ShowAndTellAgent', () => {
     );
     expect(tested.status).toBe('success');
     expect(tested.ok).toBe(true);
+    const secondApprovalToken = await seedConsent(store, 'approve');
+    const revised = JSON.parse(
+      await agent.perform({
+        action: 'review',
+        session_id: sessionId,
+        intent: 'Create a revised weekly project status report',
+        approve: true,
+        consent_token: secondApprovalToken,
+      }),
+    );
+    expect(revised.analysis.revision).toBeGreaterThan(
+      analyzed.analysis.revision,
+    );
+    const stale = JSON.parse(
+      await agent.perform({ action: 'test', session_id: sessionId }),
+    );
+    expect(stale.status).toBe('error');
+    expect(
+      stale.checks.some(
+        (check: { name: string; ok: boolean }) =>
+          check.name.endsWith('-analysis-revision') && check.ok === false,
+      ),
+    ).toBe(true);
     const rebuilt = JSON.parse(
       await agent.perform({
         action: 'build',
         session_id: sessionId,
-        target: 'skill',
+        target: 'all',
       }),
     );
     expect(rebuilt.status).toBe('success');
@@ -677,6 +718,9 @@ describe('show-and-tell privacy and analysis', () => {
     ).toBe('https://example.com/callback/:id');
     expect(artifactContainsSensitiveText(JSON.stringify({ url: jwt }))).toBe(true);
     expect(isPrivateContext('Safari', 'Google Accounts', '/signin/oauth')).toBe(true);
+    expect(isPrivateContext('Google Chrome', 'New Incognito Tab')).toBe(true);
+    expect(isPrivateContext('Microsoft Edge', 'InPrivate browsing')).toBe(true);
+    expect(isPrivateContext('Safari', 'Private Browsing')).toBe(true);
   });
 
   it('never persists text typed through ComputerUse', () => {
@@ -731,14 +775,61 @@ describe('show-and-tell privacy and analysis', () => {
         sessionId: 'narrated-session',
         sequence: 0,
         timestamp: now,
-        type: 'session.note',
-        source: 'local-whisper-narration',
-        data: { note: 'Summarize blockers before listing next steps.' },
+        type: 'narration.transcribed',
+        source: 'local-whisper',
+        data: { text: 'Summarize blockers before listing next steps.' },
       }],
     );
     expect(analysis.steps[0].title).toBe('Follow the narrated instruction');
     expect(analysis.steps[0].detail).toContain('Summarize blockers');
-    expect(analysis.steps[0].evidence).toContain('event:0:session.note');
+    expect(analysis.steps[0].evidence).toContain(
+      'event:0:narration.transcribed',
+    );
+  });
+
+  it('privacy-reduces reviewed step URLs before persistence', () => {
+    const now = Date.now();
+    const revised = reviseAnalysis(
+      {
+        schema: SHOW_AND_TELL_ANALYSIS_SCHEMA,
+        sessionId: 'session-1',
+        revision: 1,
+        title: 'Research',
+        intent: 'Research safely',
+        intentRationale: 'Test',
+        intentConfidence: 'high',
+        steps: [{
+          id: 's1',
+          title: 'Search',
+          detail: 'Search for the report.',
+          kind: 'action',
+          tool: 'Browser or Web',
+          app: 'Safari',
+          url: 'https://example.com/start',
+          evidence: [],
+          confidence: 'high',
+        }],
+        feedbackLog: [],
+        approved: false,
+        approvedAt: null,
+        createdAt: now,
+        updatedAt: now,
+      },
+      {
+        stepsJson: JSON.stringify([{
+          id: 's1',
+          title: 'Search',
+          detail: 'Search for the report.',
+          kind: 'action',
+          tool: 'Browser or Web',
+          app: 'Safari',
+          url: 'https://example.com/search?q=confidential#private',
+          evidence: [],
+          confidence: 'high',
+        }]),
+      },
+    );
+    expect(revised.steps[0].url).toBe('https://example.com/search');
   });
 
   it('builds a useful deterministic baseline without sending frames to a model', () => {

--- a/typescript/src/show-and-tell/store.ts
+++ b/typescript/src/show-and-tell/store.ts
@@ -554,6 +554,9 @@ export class ShowAndTellStore {
         SET collector_runtime = ?, collector_pid = ?, collector_nonce = ?,
             collector_started_at = ?, collector_heartbeat_at = ?, updated_at = ?
         WHERE id = ? AND state = 'recording'
+          AND collector_runtime IS NULL
+          AND collector_pid IS NULL
+          AND collector_nonce IS NULL
       `)
       .run(runtime, pid, nonce, now, now, now, sessionId);
     return result.changes === 1;

--- a/typescript/ui/index.html
+++ b/typescript/ui/index.html
@@ -18,6 +18,7 @@
         --text-primary: #f7f9ff;
         --text-secondary: #94a0ba;
         --accent: #58f5d2;
+        --accent-foreground: #050711;
         --accent-hover: #72b5ff;
         --error: #fb7185;
         --warning: #fbbf24;

--- a/typescript/ui/src/__tests__/chat-component.test.ts
+++ b/typescript/ui/src/__tests__/chat-component.test.ts
@@ -6,8 +6,10 @@ import { gateway } from '../services/gateway.js';
 
 interface TestChatElement extends HTMLElement {
   activeRunId: string | null;
+  sessionKey: string | null;
   sending: boolean;
   error: string | null;
+  inputValue: string;
   messages: Array<{
     id: string;
     role: 'assistant';
@@ -17,6 +19,9 @@ interface TestChatElement extends HTMLElement {
   }>;
   handleChatEvent(payload: unknown): void;
   armRunDeadline(runId: string): void;
+  startNewChat(): Promise<void>;
+  switchSession(sessionId: string): Promise<void>;
+  handleSend(): Promise<void>;
 }
 
 describe('chat component terminal events', () => {
@@ -101,5 +106,126 @@ describe('chat component terminal events', () => {
     expect(chat.sending).toBe(false);
     expect(chat.messages[0].streaming).toBe(false);
     expect(chat.error).toContain('cancelled');
+  });
+
+  it('aborts and fences the active run before starting a new chat', async () => {
+    const abort = vi.spyOn(gateway, 'request').mockResolvedValue({
+      aborted: true,
+    });
+    const chat = document.createElement('openrappter-chat') as TestChatElement;
+    chat.sessionKey = 'session-1';
+    chat.activeRunId = 'run-1';
+    chat.sending = true;
+    chat.messages = [{
+      id: 'run-1',
+      role: 'assistant',
+      content: '',
+      timestamp: 1,
+      streaming: true,
+    }];
+
+    await chat.startNewChat();
+
+    expect(abort).toHaveBeenCalledWith(
+      'chat.abort',
+      { runId: 'run-1' },
+      { timeoutMs: 5_000 },
+    );
+    expect(chat.sessionKey).toBeNull();
+    expect(chat.activeRunId).toBeNull();
+    chat.handleChatEvent({
+      runId: 'run-1',
+      sessionKey: 'session-1',
+      state: 'final',
+      message: { content: [{ type: 'text', text: 'late result' }] },
+    });
+    expect(chat.messages).toEqual([]);
+  });
+
+  it('fences a pending send response when the user switches sessions', async () => {
+    let finishSend!: (value: {
+      runId: string;
+      sessionKey: string;
+      status: string;
+    }) => void;
+    const send = new Promise<{
+      runId: string;
+      sessionKey: string;
+      status: string;
+    }>((resolve) => {
+      finishSend = resolve;
+    });
+
+    const request = vi.spyOn(gateway, 'request').mockImplementation(
+      async (method) => {
+        if (method === 'chat.send') return send;
+        return { aborted: true };
+      },
+    );
+    vi.spyOn(gateway, 'call').mockResolvedValue([]);
+    const chat = document.createElement('openrappter-chat') as TestChatElement;
+    chat.sessionKey = 'session-1';
+    chat.activeRunId = null;
+    chat.sending = false;
+    chat.error = null;
+    chat.inputValue = 'hello';
+    chat.messages = [];
+
+    const sending = chat.handleSend();
+    await Promise.resolve();
+    const switching = chat.switchSession('session-2');
+    finishSend({ runId: 'run-1', sessionKey: 'session-1', status: 'started' });
+    await sending;
+    await switching;
+
+    expect(chat.sessionKey).toBe('session-2');
+    expect(chat.activeRunId).toBeNull();
+    expect(chat.messages).toEqual([]);
+    expect(request).toHaveBeenCalledWith(
+      'chat.abort',
+      { runId: 'run-1' },
+      { timeoutMs: 5_000 },
+    );
+  });
+
+  it('blocks a new send while a session transition is aborting', async () => {
+    let finishAbort!: () => void;
+    const aborting = new Promise<void>((resolve) => {
+      finishAbort = resolve;
+    });
+    const request = vi.spyOn(gateway, 'request').mockImplementation(
+      async (method) => {
+        if (method === 'chat.abort') {
+          await aborting;
+          return { aborted: true };
+        }
+        return { runId: 'unexpected', sessionKey: 'session-1', status: 'started' };
+      },
+    );
+    vi.spyOn(gateway, 'call').mockResolvedValue([]);
+    const chat = document.createElement('openrappter-chat') as TestChatElement;
+    chat.sessionKey = 'session-1';
+    chat.activeRunId = 'run-1';
+    chat.sending = true;
+    chat.error = null;
+    chat.inputValue = '';
+    chat.messages = [{
+      id: 'run-1',
+      role: 'assistant',
+      content: '',
+      timestamp: 1,
+      streaming: true,
+    }];
+
+    const switching = chat.switchSession('session-2');
+    await Promise.resolve();
+    chat.inputValue = 'must not send';
+    await chat.handleSend();
+    expect(
+      request.mock.calls.filter(([method]) => method === 'chat.send'),
+    ).toHaveLength(0);
+    finishAbort();
+    await switching;
+    expect(chat.sessionKey).toBe('session-2');
   });
 });

--- a/typescript/ui/src/__tests__/show-and-tell-component.test.ts
+++ b/typescript/ui/src/__tests__/show-and-tell-component.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import '../components/show-and-tell.js';
+
+interface TestShowAndTellElement extends HTMLElement {
+  session: { id: string; state: string } | null;
+  narrationState: string;
+  startNarration(): Promise<void>;
+  stopNarration(): Promise<void>;
+}
+
+describe('Show-and-Tell narration lifecycle', () => {
+  afterEach(() => {
+    delete window.openrappterDesktop;
+    vi.restoreAllMocks();
+  });
+
+  it('does not acquire the microphone after the recording stops during model setup', async () => {
+    let finishDownload!: (value: Record<string, unknown>) => void;
+    const download = new Promise<Record<string, unknown>>((resolve) => {
+      finishDownload = resolve;
+    });
+    const getUserMedia = vi.fn();
+    Object.defineProperty(navigator, 'mediaDevices', {
+      configurable: true,
+      value: { getUserMedia },
+    });
+    window.openrappterDesktop = {
+      platform: 'darwin',
+      gatewayUrl: 'ws://127.0.0.1:18791',
+      gatewayToken: 'test',
+      showAndTell: vi.fn(),
+      desktopControl: vi.fn(),
+      narration: vi.fn().mockReturnValue(download),
+      onNarrationStatus: vi.fn().mockReturnValue(() => {}),
+      voice: vi.fn(),
+      onVoiceStatus: vi.fn().mockReturnValue(() => {}),
+      getInfo: vi.fn(),
+    };
+
+    const element = document.createElement(
+      'openrappter-show-and-tell',
+    ) as TestShowAndTellElement;
+    element.session = { id: 'session-1', state: 'recording' };
+    element.narrationState = 'missing';
+
+    const starting = element.startNarration();
+    await Promise.resolve();
+    element.session = { id: 'session-1', state: 'stopped' };
+    await element.stopNarration();
+    finishDownload({ model: 'ready', phase: 'idle' });
+
+    await expect(starting).rejects.toThrow(/cancelled|recording/i);
+    expect(getUserMedia).not.toHaveBeenCalled();
+  });
+});

--- a/typescript/ui/src/__tests__/show-and-tell-desktop.test.ts
+++ b/typescript/ui/src/__tests__/show-and-tell-desktop.test.ts
@@ -9,6 +9,10 @@ const component = readFileSync(
 );
 const app = readFileSync(resolve(root, 'components/app.ts'), 'utf8');
 const sidebar = readFileSync(resolve(root, 'components/sidebar.ts'), 'utf8');
+const desktopControl = readFileSync(
+  resolve(root, 'services/desktop-control.ts'),
+  'utf8',
+);
 const preload = readFileSync(
   resolve(root, '../../desktop/src/preload.cts'),
   'utf8',
@@ -20,7 +24,22 @@ describe('Electron Show-and-Tell surface', () => {
     expect(sidebar).toContain("id: 'show-and-tell'");
     expect(component).toContain('@customElement(\'openrappter-show-and-tell\')');
     expect(app).toContain("if (window.openrappterDesktop)");
-    expect(app).toContain("this.currentView = 'chat'");
+    expect(app).toContain("this.navigate('chat')");
+  });
+
+  it('keeps desktop navigation keyboard reachable and scrollable', () => {
+    expect(sidebar).toContain('<button');
+    expect(sidebar).toContain('aria-current=');
+    expect(sidebar).toContain('overflow-y: auto');
+    expect(sidebar).toContain('focus-visible');
+  });
+
+  it('wires chat focus mode into the application shell', () => {
+    expect(app).toContain('@toggle-focus=${this.handleToggleFocus}');
+    expect(app).toContain("main-content ${this.focusMode ? 'focused' : ''}");
+    expect(app).toContain('navigate(view: View): void');
+    expect(desktopControl).toContain('app.navigate(view)');
+    expect(desktopControl).not.toContain('app.currentView = view');
   });
 
   it('uses the narrow desktop bridge instead of Node APIs', () => {
@@ -43,5 +62,11 @@ describe('Electron Show-and-Tell surface', () => {
     ]) {
       expect(component).toContain(`action: '${action}'`);
     }
+  });
+
+  it('binds narration to the recording session instead of the selected row', () => {
+    expect(component).toContain('private narrationSessionId?: string');
+    expect(component).toContain('session_id: sessionId');
+    expect(component).toContain('Stop narration before switching demonstrations.');
   });
 });

--- a/typescript/ui/src/components/app.ts
+++ b/typescript/ui/src/components/app.ts
@@ -2,7 +2,7 @@
  * Main App Component
  */
 
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, state } from 'lit/decorators.js';
 import { gateway } from '../services/gateway.js';
 
@@ -21,6 +21,10 @@ export class OpenRappterApp extends LitElement {
       display: flex;
       flex-direction: column;
       margin-left: 240px;
+    }
+
+    .main-content.focused {
+      margin-left: 0;
     }
 
     .header {
@@ -152,10 +156,13 @@ export class OpenRappterApp extends LitElement {
   @state()
   private status: { uptime: number; connections: number } | null = null;
 
+  @state()
+  private focusMode = false;
+
   connectedCallback() {
     super.connectedCallback();
     if (window.openrappterDesktop) {
-      this.currentView = 'chat';
+      this.navigate('chat');
     }
     this.connectToGateway();
 
@@ -197,7 +204,16 @@ export class OpenRappterApp extends LitElement {
   }
 
   private handleNavigation(e: CustomEvent<{ view: View }>) {
-    this.currentView = e.detail.view;
+    this.navigate(e.detail.view);
+  }
+
+  private handleToggleFocus(e: CustomEvent<{ focused: boolean }>) {
+    this.focusMode = e.detail.focused;
+  }
+
+  navigate(view: View): void {
+    this.currentView = view;
+    if (view !== 'chat') this.focusMode = false;
   }
 
   private renderView() {
@@ -205,7 +221,11 @@ export class OpenRappterApp extends LitElement {
       case 'surgeon':
         return html`<openrappter-surgeon></openrappter-surgeon>`;
       case 'chat':
-        return html`<openrappter-chat></openrappter-chat>`;
+        return html`
+          <openrappter-chat
+            @toggle-focus=${this.handleToggleFocus}
+          ></openrappter-chat>
+        `;
       case 'show-and-tell':
         return html`<openrappter-show-and-tell></openrappter-show-and-tell>`;
       case 'channels':
@@ -274,15 +294,21 @@ export class OpenRappterApp extends LitElement {
     }
 
     return html`
-      <openrappter-sidebar
-        .currentView=${this.currentView}
-        @navigate=${this.handleNavigation}
-      ></openrappter-sidebar>
+      ${this.focusMode
+        ? nothing
+        : html`
+            <openrappter-sidebar
+              .currentView=${this.currentView}
+              @navigate=${this.handleNavigation}
+            ></openrappter-sidebar>
+          `}
 
-      <div class="main-content">
-        <header class="header">
+      <div class="main-content ${this.focusMode ? 'focused' : ''}">
+        ${this.focusMode
+          ? nothing
+          : html`<header class="header">
           <div class="header-title">
-            <button class="back" @click=${() => { this.currentView = 'surgeon'; }}>
+            <button class="back" @click=${() => this.navigate('surgeon')}>
               ← Operating room
             </button>
             <h1>${this.getViewTitle()}</h1>
@@ -292,7 +318,7 @@ export class OpenRappterApp extends LitElement {
             ${this.connected ? 'Connected' : 'Disconnected'}
             ${this.status ? html` • Uptime: ${this.formatUptime(this.status.uptime)}` : ''}
           </div>
-        </header>
+        </header>`}
 
         <div class="view-container">
           ${this.renderView()}

--- a/typescript/ui/src/components/chat.ts
+++ b/typescript/ui/src/components/chat.ts
@@ -125,13 +125,13 @@ export class OpenRappterChat extends LitElement {
 
     .icon-btn.active {
       background: var(--accent);
-      color: white;
+      color: var(--accent-foreground);
     }
 
     .header-btn {
       padding: 0.375rem 0.75rem;
       background: var(--accent);
-      color: white;
+      color: var(--accent-foreground);
       border: none;
       border-radius: 0.375rem;
       font-size: 0.8125rem;
@@ -215,7 +215,7 @@ export class OpenRappterChat extends LitElement {
 
     .group-avatar.user {
       background: var(--accent);
-      color: white;
+      color: var(--accent-foreground);
     }
 
     .group-avatar.assistant {
@@ -245,7 +245,7 @@ export class OpenRappterChat extends LitElement {
 
     .message.user {
       background: var(--accent);
-      color: white;
+      color: var(--accent-foreground);
       white-space: pre-wrap;
       word-break: break-word;
     }
@@ -676,7 +676,7 @@ export class OpenRappterChat extends LitElement {
     button.send-btn {
       padding: 0.75rem 1.25rem;
       background: var(--accent);
-      color: white;
+      color: var(--accent-foreground);
       border: none;
       border-radius: 0.5rem;
       font-size: 0.9375rem;
@@ -806,7 +806,7 @@ export class OpenRappterChat extends LitElement {
       transform: translateX(-50%);
       z-index: 10;
       background: var(--accent);
-      color: white;
+      color: var(--accent-foreground);
       border: none;
       border-radius: 1rem;
       padding: 0.375rem 1rem;
@@ -869,15 +869,23 @@ export class OpenRappterChat extends LitElement {
   @state() private error: string | null = null;
   @state() private sessions: ChatSessionSummary[] = [];
   @state() private sessionsLoading = false;
+  @state() private sessionTransitioning = false;
   @state() private focusMode = false;
   @state() private toolCalls: ToolCall[] = [];
   @state() private toolSidebarOpen = false;
   @state() private toolExpandedIds = new Set<string>();
   @state() private attachments: AttachmentPreview[] = [];
   @state() private draggingOver = false;
-  @state() private messageQueue: Array<{ id: string; text: string; createdAt: number }> = [];
+  @state() private messageQueue: Array<{
+    id: string;
+    text: string;
+    createdAt: number;
+    sessionKey: string | null;
+  }> = [];
   @state() private showNewMessages = false;
   @state() private userAtBottom = true;
+  private sessionLoadGeneration = 0;
+  private sendGeneration = 0;
 
   private toolSidebarWidth = 320;
   private resizing = false;
@@ -1106,17 +1114,28 @@ export class OpenRappterChat extends LitElement {
 
   private async switchSession(sessionId: string) {
     if (sessionId === this.sessionKey) return;
-    this.sessionKey = sessionId;
-    this.toolCalls = [];
-    this.error = null;
-
+    const generation = ++this.sessionLoadGeneration;
+    this.sessionTransitioning = true;
+    this.sendGeneration += 1;
+    this.messageQueue = [];
     try {
+      await this.closeActiveRun();
+      if (generation !== this.sessionLoadGeneration) return;
+      this.sessionKey = sessionId;
+      this.toolCalls = [];
+      this.error = null;
       const loaded = await gateway.call<Array<{
         id: string;
         role: 'user' | 'assistant' | 'system';
         content: string;
         timestamp: string;
       }>>('chat.messages', { sessionId, limit: 100 });
+      if (
+        generation !== this.sessionLoadGeneration ||
+        this.sessionKey !== sessionId
+      ) {
+        return;
+      }
 
       this.messages = loaded.map((m) => ({
         id: m.id,
@@ -1126,28 +1145,46 @@ export class OpenRappterChat extends LitElement {
       }));
       this.scrollToBottom();
     } catch (err) {
+      if (generation !== this.sessionLoadGeneration) return;
       this.error = `Failed to load session: ${(err as Error).message}`;
       this.messages = [];
+    } finally {
+      if (generation === this.sessionLoadGeneration) {
+        this.sessionTransitioning = false;
+        this.sending = false;
+      }
     }
   }
 
-  private startNewChat() {
-    this.sessionKey = null;
-    this.messages = [];
-    this.toolCalls = [];
-    this.activeRunId = null;
-    this.sending = false;
-    this.error = null;
-    this.attachments = [];
+  private async startNewChat() {
+    const generation = ++this.sessionLoadGeneration;
+    this.sessionTransitioning = true;
+    this.sendGeneration += 1;
+    this.messageQueue = [];
+    try {
+      await this.closeActiveRun();
+      if (generation !== this.sessionLoadGeneration) return;
+      this.sessionKey = null;
+      this.messages = [];
+      this.toolCalls = [];
+      this.activeRunId = null;
+      this.error = null;
+      this.attachments = [];
+    } finally {
+      if (generation === this.sessionLoadGeneration) {
+        this.sessionTransitioning = false;
+        this.sending = false;
+      }
+    }
   }
 
-  private handleSessionChange(e: Event) {
+  private async handleSessionChange(e: Event) {
     const select = e.target as HTMLSelectElement;
     const value = select.value;
     if (value === '__new__') {
-      this.startNewChat();
+      await this.startNewChat();
     } else if (value) {
-      this.switchSession(value);
+      await this.switchSession(value);
     }
   }
 
@@ -1181,6 +1218,13 @@ export class OpenRappterChat extends LitElement {
       errorMessage?: string;
     };
     if (!data.runId || this.closedRunIds.has(data.runId)) return;
+    if (
+      this.sessionKey &&
+      data.sessionKey &&
+      data.sessionKey !== this.sessionKey
+    ) {
+      return;
+    }
 
     if (data.state === 'delta' || data.state === 'final') {
       const text = data.message?.content
@@ -1267,12 +1311,33 @@ export class OpenRappterChat extends LitElement {
     } catch { /* best effort */ }
   }
 
+  private async closeActiveRun(): Promise<void> {
+    if (!this.activeRunId) return;
+    const runId = this.activeRunId;
+    this.rememberClosedRun(runId);
+    this.finishStreaming(runId, false);
+    this.speechGeneration += 1;
+    this.activeAudio?.pause();
+    try {
+      await gateway.request('chat.abort', { runId }, {
+        timeoutMs: RUN_ABORT_TIMEOUT_MS,
+      });
+    } catch {
+      // Switching sessions remains available if the stale run already ended.
+    }
+  }
+
   // ── Message Queue ──
 
   private enqueueMessage(text: string) {
     this.messageQueue = [
       ...this.messageQueue,
-      { id: `q_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`, text, createdAt: Date.now() },
+      {
+        id: `q_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        text,
+        createdAt: Date.now(),
+        sessionKey: this.sessionKey,
+      },
     ];
   }
 
@@ -1284,6 +1349,10 @@ export class OpenRappterChat extends LitElement {
     if (this.sending || this.messageQueue.length === 0) return;
     const [next, ...rest] = this.messageQueue;
     this.messageQueue = rest;
+    if (next.sessionKey !== this.sessionKey) {
+      await this.flushQueue();
+      return;
+    }
     this.inputValue = next.text;
     await this.handleSend();
   }
@@ -1322,6 +1391,7 @@ export class OpenRappterChat extends LitElement {
   // ── Sending Messages ──
 
   private async handleSend() {
+    if (this.sessionTransitioning) return;
     const content = this.inputValue.trim();
     // Allow queueing if busy
     if (this.sending && content) {
@@ -1332,6 +1402,8 @@ export class OpenRappterChat extends LitElement {
     if (!content) return;
 
     this.sending = true;
+    const sendGeneration = ++this.sendGeneration;
+    const visibleSessionKey = this.sessionKey;
     this.inputValue = '';
     this.error = null;
 
@@ -1362,6 +1434,12 @@ export class OpenRappterChat extends LitElement {
           filename: a.filename,
         });
       }
+      if (
+        sendGeneration !== this.sendGeneration ||
+        this.sessionKey !== visibleSessionKey
+      ) {
+        return;
+      }
 
       const params: Record<string, unknown> = {
         message: content,
@@ -1376,6 +1454,16 @@ export class OpenRappterChat extends LitElement {
         sessionKey: string;
         status: string;
       }>('chat.send', params);
+      if (
+        sendGeneration !== this.sendGeneration ||
+        this.sessionKey !== visibleSessionKey
+      ) {
+        this.rememberClosedRun(result.runId);
+        void gateway.request('chat.abort', { runId: result.runId }, {
+          timeoutMs: RUN_ABORT_TIMEOUT_MS,
+        }).catch(() => {});
+        return;
+      }
 
       this.sessionKey = result.sessionKey;
       this.activeRunId = result.runId;
@@ -1397,6 +1485,7 @@ export class OpenRappterChat extends LitElement {
       this.messages = [...this.messages, assistantMessage];
       this.scrollToBottom();
     } catch (err) {
+      if (sendGeneration !== this.sendGeneration) return;
       this.error = (err as Error).message;
       this.sending = false;
     }
@@ -1412,7 +1501,7 @@ export class OpenRappterChat extends LitElement {
     this.scrollToBottom();
   }
 
-  private finishStreaming(runId: string) {
+  private finishStreaming(runId: string, flushQueued = true) {
     this.rememberClosedRun(runId);
     const idx = this.messages.findIndex((m) => m.id === runId);
     if (idx >= 0) {
@@ -1426,7 +1515,7 @@ export class OpenRappterChat extends LitElement {
     this.sending = false;
     this.activeRunId = null;
     // Flush queued messages
-    if (this.messageQueue.length > 0) {
+    if (flushQueued && this.messageQueue.length > 0) {
       setTimeout(() => this.flushQueue(), 100);
     }
   }
@@ -1786,7 +1875,11 @@ export class OpenRappterChat extends LitElement {
         ${this.sessionsLoading
           ? html`<span class="loading-sessions">Loading…</span>`
           : html`
-              <select @change=${this.handleSessionChange} .value=${this.sessionKey ?? '__new__'}>
+              <select
+                @change=${this.handleSessionChange}
+                .value=${this.sessionKey ?? '__new__'}
+                ?disabled=${this.sessionTransitioning}
+              >
                 <option value="__new__">✨ New Chat</option>
                 ${this.sessions.map(
                   (s) => html`
@@ -1905,6 +1998,7 @@ export class OpenRappterChat extends LitElement {
                 @dragover=${this.handleDragOver}
                 @dragleave=${this.handleDragLeave}
                 @drop=${this.handleDrop}
+                ?disabled=${this.sessionTransitioning}
                 rows="1"
               ></textarea>
               ${this.sending && this.activeRunId
@@ -1913,7 +2007,7 @@ export class OpenRappterChat extends LitElement {
               <button
                 class="send-btn"
                 @click=${this.handleSend}
-                ?disabled=${!this.inputValue.trim() && !this.sending}
+                ?disabled=${this.sessionTransitioning || (!this.inputValue.trim() && !this.sending)}
               >
                 ${this.sending ? 'Queue' : 'Send'}<span class="btn-kbd">↵</span>
               </button>

--- a/typescript/ui/src/components/show-and-tell.ts
+++ b/typescript/ui/src/components/show-and-tell.ts
@@ -194,7 +194,7 @@ export class OpenRappterShowAndTell extends LitElement {
     button.primary {
       border-color: var(--accent);
       background: var(--accent);
-      color: white;
+      color: var(--accent-foreground);
     }
 
     button.danger {
@@ -331,6 +331,10 @@ export class OpenRappterShowAndTell extends LitElement {
   private narrationStartedAt = 0;
   private narrationTimer?: ReturnType<typeof setTimeout>;
   private narrationStopping = false;
+  private narrationGeneration = 0;
+  private narrationSessionId?: string;
+  private statusGeneration = 0;
+  @state() private sessionLoading = false;
 
   connectedCallback(): void {
     super.connectedCallback();
@@ -351,7 +355,11 @@ export class OpenRappterShowAndTell extends LitElement {
       }).catch(() => {});
     }
     this.poll = setInterval(() => {
-      if (this.session?.state === 'recording' || this.session?.state === 'stopping') {
+      if (
+        !this.sessionLoading &&
+        (this.session?.state === 'recording' ||
+          this.session?.state === 'stopping')
+      ) {
         void this.refreshStatus();
       }
     }, 1_500);
@@ -364,6 +372,7 @@ export class OpenRappterShowAndTell extends LitElement {
     this.mediaRecorder?.stop();
     if (this.narrationTimer) clearTimeout(this.narrationTimer);
     this.mediaStream?.getTracks().forEach((track) => track.stop());
+    this.narrationGeneration += 1;
     super.disconnectedCallback();
   }
 
@@ -380,7 +389,18 @@ export class OpenRappterShowAndTell extends LitElement {
     if (!this.session || this.session.state !== 'recording') {
       throw new Error('Start a Show-and-Tell recording before narration.');
     }
+    const sessionId = this.session.id;
+    const generation = ++this.narrationGeneration;
+    this.narrationSessionId = sessionId;
     await this.ensureNarrationModel();
+    if (
+      generation !== this.narrationGeneration ||
+      this.session?.id !== sessionId ||
+      this.session.state !== 'recording'
+    ) {
+      this.narrationSessionId = undefined;
+      throw new Error('Narration start was cancelled because recording stopped.');
+    }
     const stream = await navigator.mediaDevices.getUserMedia({
       audio: {
         channelCount: 1,
@@ -388,6 +408,15 @@ export class OpenRappterShowAndTell extends LitElement {
         noiseSuppression: true,
       },
     });
+    if (
+      generation !== this.narrationGeneration ||
+      this.session?.id !== sessionId ||
+      this.session.state !== 'recording'
+    ) {
+      stream.getTracks().forEach((track) => track.stop());
+      this.narrationSessionId = undefined;
+      throw new Error('Narration start was cancelled because recording stopped.');
+    }
     const mime = MediaRecorder.isTypeSupported('audio/webm;codecs=opus')
       ? 'audio/webm;codecs=opus'
       : 'audio/webm';
@@ -419,9 +448,17 @@ export class OpenRappterShowAndTell extends LitElement {
   }
 
   private async stopNarration(): Promise<void> {
+    this.narrationGeneration += 1;
     if (this.narrationStopping) return;
     const recorder = this.mediaRecorder;
-    if (!recorder || recorder.state === 'inactive') return;
+    if (!recorder || recorder.state === 'inactive') {
+      this.narrationSessionId = undefined;
+      return;
+    }
+    const sessionId = this.narrationSessionId;
+    if (!sessionId) {
+      throw new Error('Narration is not bound to a recording session.');
+    }
     this.narrationStopping = true;
     if (this.narrationTimer) {
       clearTimeout(this.narrationTimer);
@@ -458,7 +495,7 @@ export class OpenRappterShowAndTell extends LitElement {
       const desktop = desktopBridge()!;
       const transcript = await desktop.narration({
         action: 'transcribe',
-        session_id: this.session?.id,
+        session_id: sessionId,
         language: 'en',
         duration_ms: Date.now() - this.narrationStartedAt,
         audio: audioBytes,
@@ -473,6 +510,7 @@ export class OpenRappterShowAndTell extends LitElement {
       }
     } finally {
       this.narrationStopping = false;
+      this.narrationSessionId = undefined;
     }
   }
 
@@ -509,6 +547,9 @@ export class OpenRappterShowAndTell extends LitElement {
   ): Promise<Record<string, unknown>> {
     const bridge = desktopBridge();
     if (!bridge) throw new Error('Show-and-Tell desktop controls require the Electron app.');
+    if (interactive && this.sessionLoading) {
+      throw new Error('Wait for the selected Show-and-Tell session to finish loading.');
+    }
     if (interactive) {
       this.busy = true;
       this.error = '';
@@ -556,16 +597,27 @@ export class OpenRappterShowAndTell extends LitElement {
     }
   }
 
-  private async refreshStatus(sessionId = this.session?.id): Promise<void> {
+  private async refreshStatus(
+    sessionId = this.session?.id,
+    generation = ++this.statusGeneration,
+  ): Promise<void> {
     if (!desktopBridge()) return;
-    const result = await this.call({
-      action: 'status',
-      ...(sessionId ? { session_id: sessionId } : {}),
-    }, false);
+    let result: Record<string, unknown>;
+    try {
+      result = await this.call({
+        action: 'status',
+        ...(sessionId ? { session_id: sessionId } : {}),
+      }, false);
+    } catch (error) {
+      if (generation === this.statusGeneration) {
+        this.error = (error as Error).message;
+      }
+      return;
+    }
+    if (generation !== this.statusGeneration) return;
     const previousState = this.session?.state;
     this.session = (result.session as SessionSummary | null | undefined) ?? null;
     if (
-      this.narrationRecording &&
       previousState === 'recording' &&
       this.session?.state !== 'recording'
     ) {
@@ -573,23 +625,30 @@ export class OpenRappterShowAndTell extends LitElement {
         this.error = (error as Error).message;
       });
     }
-    const summary = result.analysis as
-      | { approved?: boolean; step_count?: number }
-      | null
-      | undefined;
     const detail = result.analysis_detail as Analysis | null | undefined;
-    if (detail) {
-      this.analysis = detail;
-      this.intent = detail.intent;
-    }
-    if (!summary && this.session && this.session.state !== 'recording') {
-      this.analysis = null;
-    }
+    this.analysis = detail ?? null;
+    this.intent = detail?.intent ?? this.session?.intentHint ?? '';
   }
 
   private async selectSession(id: string): Promise<void> {
+    if (
+      this.narrationRecording ||
+      this.narrationStopping ||
+      this.narrationSessionId
+    ) {
+      this.error = 'Stop narration before switching demonstrations.';
+      return;
+    }
+    const generation = ++this.statusGeneration;
     this.session = this.sessions.find((candidate) => candidate.id === id) ?? null;
-    await this.refreshStatus(id);
+    this.analysis = null;
+    this.intent = '';
+    this.sessionLoading = true;
+    try {
+      await this.refreshStatus(id, generation);
+    } finally {
+      if (generation === this.statusGeneration) this.sessionLoading = false;
+    }
   }
 
   private renderUnavailable() {
@@ -795,7 +854,7 @@ export class OpenRappterShowAndTell extends LitElement {
                         class="danger"
                         ?disabled=${this.busy}
                         @click=${() => void (async () => {
-                          if (this.narrationRecording) await this.stopNarration();
+                          await this.stopNarration();
                           await this.act(
                             { action: 'stop', session_id: this.session?.id },
                             'Recording stopped.',
@@ -960,6 +1019,7 @@ export class OpenRappterShowAndTell extends LitElement {
                 ? this.sessions.map((candidate) => html`
                     <button
                       class="session"
+                      ?disabled=${this.narrationRecording || this.narrationStopping}
                       @click=${() => void this.selectSession(candidate.id)}
                     >
                       <strong>${candidate.title || candidate.intentHint || candidate.id}</strong>

--- a/typescript/ui/src/components/sidebar.ts
+++ b/typescript/ui/src/components/sidebar.ts
@@ -2,7 +2,7 @@
  * Sidebar Navigation Component
  */
 
-import { LitElement, html, css } from 'lit';
+import { LitElement, html, css, nothing } from 'lit';
 import { customElement, property } from 'lit/decorators.js';
 
 type View = 'surgeon' | 'chat' | 'show-and-tell' | 'channels' | 'sessions' | 'cron' | 'config' | 'logs' | 'agents' | 'skills' | 'devices' | 'presence' | 'debug' | 'showcase' | 'zen' | 'accounts';
@@ -48,6 +48,8 @@ export class OpenRappterSidebar extends LitElement {
     nav {
       flex: 1;
       padding: 1rem 0;
+      overflow-y: auto;
+      min-height: 0;
     }
 
     .nav-section {
@@ -74,6 +76,11 @@ export class OpenRappterSidebar extends LitElement {
       transition: background 0.15s ease;
       color: var(--text-secondary);
       text-decoration: none;
+      width: 100%;
+      border: 0;
+      background: transparent;
+      font: inherit;
+      text-align: left;
     }
 
     .nav-item:hover {
@@ -83,7 +90,12 @@ export class OpenRappterSidebar extends LitElement {
 
     .nav-item.active {
       background: var(--accent);
-      color: white;
+      color: var(--accent-foreground);
+    }
+
+    .nav-item:focus-visible {
+      outline: 2px solid var(--accent);
+      outline-offset: 2px;
     }
 
     .nav-icon {
@@ -158,13 +170,15 @@ export class OpenRappterSidebar extends LitElement {
           <div class="nav-section-title">Operating room</div>
           ${this.navItems.slice(0, 1).map(
             (item) => html`
-              <div
+              <button
+                type="button"
                 class="nav-item ${this.currentView === item.id ? 'active' : ''}"
+                aria-current=${this.currentView === item.id ? 'page' : nothing}
                 @click=${() => this.handleClick(item.id)}
               >
                 <span class="nav-icon">${item.icon}</span>
                 <span class="nav-label">${item.label}</span>
-              </div>
+              </button>
             `
           )}
         </div>
@@ -173,13 +187,15 @@ export class OpenRappterSidebar extends LitElement {
           <div class="nav-section-title">Anatomy</div>
           ${this.navItems.slice(1).map(
             (item) => html`
-              <div
+              <button
+                type="button"
                 class="nav-item ${this.currentView === item.id ? 'active' : ''}"
+                aria-current=${this.currentView === item.id ? 'page' : nothing}
                 @click=${() => this.handleClick(item.id)}
               >
                 <span class="nav-icon">${item.icon}</span>
                 <span class="nav-label">${item.label}</span>
-              </div>
+              </button>
             `
           )}
         </div>

--- a/typescript/ui/src/services/desktop-control.ts
+++ b/typescript/ui/src/services/desktop-control.ts
@@ -191,14 +191,12 @@ async function navigate(view: unknown): Promise<Record<string, unknown>> {
   }
   const app = document.querySelector('openrappter-app') as
     | (HTMLElement & {
-        currentView: string;
-        requestUpdate(): void;
+        navigate(view: string): void;
         updateComplete?: Promise<unknown>;
       })
     | null;
   if (!app) throw new Error('OpenRappter app surface is not mounted.');
-  app.currentView = view;
-  app.requestUpdate();
+  app.navigate(view);
   await app.updateComplete;
   return { view };
 }


### PR DESCRIPTION
## Summary

- fixes private-mode capture, collector ownership, narration/session races, stale artifacts, URL privacy, and cross-runtime narration parity
- serializes same-session assistant turns, propagates UI/MCP failures truthfully, and removes stale agents when multi-agent Python files shrink
- upgrades Electron to 41.10.3, recovers crashed renderers, terminates gateways after owner crashes, and closes VibeVoice startup races
- makes Electron the canonical OpenRappter Bar gateway and authentication authority, with token-bound account switching/removal, cancellable device flows, exact endpoint snapshots, and standalone fallback without competing daemons
- improves keyboard navigation, focus mode, contrast, and narrow-window scrolling
- hardens releases with main-branch provenance, immutable action pins/assets, complete dependency audit, packaged app smokes, required Windows Authenticode signing, and deterministic Windows smoke termination

## Validation

- machine buzzsaw gate: all checks passed
- independent GPT-5.6 Sol adversarial review: GO, no significant issues
- TypeScript: 4,720 passed, 5 skipped
- Python: 1,336 passed, 2 skipped
- UI: 123 passed
- Swift Bar: 142 passed
- Electron contracts: 9 passed; full audit: 0 vulnerabilities
- real source and packaged Electron smokes, Whisper, VibeVoice, package smoke, crash-owner cleanup, release preflight, conformance, and staged secret scan passed

## Release prerequisites

- Windows releases now fail closed until `WINDOWS_CERTIFICATE_P12_BASE64` and `WINDOWS_CERTIFICATE_PASSWORD` are configured.
- PyPI trusted publishing remains tracked in #149.
