### PR TITLE
fix(security): block the full IPv6 link-local range

### DIFF
--- a/typescript/src/net/url-guard.test.ts
+++ b/typescript/src/net/url-guard.test.ts
@@ -29,7 +29,10 @@ const agents: Array<[string, () => Validator]> = [
 
 const REFUSED = [
   ['IPv6 loopback', 'http://[::1]/'],
-  ['IPv6 link-local', 'http://[fe80::1]/'],
+  ['IPv6 link-local lower boundary', 'http://[fe80::1]/'],
+  ['IPv6 link-local fe90 subnet', 'http://[fe90::1]/'],
+  ['IPv6 link-local fea0 subnet', 'http://[fea0::1]/'],
+  ['IPv6 link-local upper boundary', 'http://[febf::1]/'],
   ['IPv4-mapped loopback', 'http://[::ffff:127.0.0.1]/'],
   ['IPv4 loopback', 'http://127.0.0.1/'],
   ['RFC 1918', 'http://10.0.0.1/'],
@@ -67,7 +70,7 @@ describe('normaliseHost', () => {
 });
 
 describe('isBlockedHost', () => {
-  it.each(['::1', '::', 'fe80::1', 'fc00::1', 'fd12::1', '127.0.0.1', '169.254.169.254', 'localhost'])(
+  it.each(['::1', '::', 'fe80::1', 'fe90::1', 'fea0::1', 'febf::1', 'fc00::1', 'fd12::1', '127.0.0.1', '169.254.169.254', 'localhost'])(
     'blocks %s', (host) => expect(isBlockedHost(host)).toBe(true),
   );
 

--- a/typescript/src/net/url-guard.ts
+++ b/typescript/src/net/url-guard.ts
@@ -23,7 +23,8 @@ const BLOCKED_HOST_PATTERNS = [
   /^::$/,
   /^fc[0-9a-f]{2}:/,
   /^fd[0-9a-f]{2}:/,
-  /^fe80:/,
+  // IPv6 link-local is fe80::/10, spanning fe80 through febf.
+  /^fe[89ab][0-9a-f]:/,
 ];
 
 const ALLOWED_PROTOCOLS = new Set(['http:', 'https:']);


### PR DESCRIPTION
## What was reachable

The shared TypeScript URL guard blocked only addresses beginning `fe80:`. IPv6 link-local is `fe80::/10`, spanning first hextets `fe80` through `febf`.

Observed on current main:

| address | TypeScript | Python |
|---|---|---|
| `fe80::1` | blocked | blocked |
| `fe90::1` | **allowed** | blocked |
| `fea0::1` | **allowed** | blocked |
| `febf::1` | **allowed** | blocked |
| global IPv6 control | allowed | allowed |

The same predicate protects literal URLs and DNS results, so the omission affected both direct IPv6 URLs and public names resolving into most of the link-local range.

## Fix

Match the complete first-hextet range with `^fe[89ab][0-9a-f]:` and run the omitted boundary cases through:

- `WebAgent.validateUrl`
- `ImageAgent.validateUrl`
- the shared `isBlockedHost` predicate

Python already uses `ipaddress.ip_address(...).is_link_local`; no Python code changes.

## Evidence

Before the fix, the new cases fail **9 times**: three addresses through two agent front doors plus the shared predicate.

Mutation-check: restoring the old `/^fe80:/` rule produces the same **9 failures**.

Validation:

- URL guard + guarded fetch: **50 passed**
- `tsc --noEmit`: clean
- full TypeScript suite: **4,709 passed / 21 skipped**, with 5 `copilot-cli-local` failures reproduced unchanged on a detached clean `origin/main`
