### PR TITLE
fix(shell): nonzero commands are errors in both runtimes

### DIFF
--- a/python/openrappter/agents/shell_agent.py
+++ b/python/openrappter/agents/shell_agent.py
@@ -211,7 +211,7 @@ class ShellAgent(BasicAgent):
             
             output = result.stdout or result.stderr
             return json.dumps({
-                "status": "success",
+                "status": "success" if result.returncode == 0 else "error",
                 "command": command,
                 "output": output[:2000] if output else "(no output)",
                 "return_code": result.returncode

--- a/python/tests/test_shell_agent.py
+++ b/python/tests/test_shell_agent.py
@@ -6,6 +6,7 @@ import pytest
 from pathlib import Path
 
 from openrappter.agents.shell_agent import ShellAgent
+from openrappter.result_status import agent_result_is_error
 
 
 @pytest.fixture
@@ -34,8 +35,11 @@ class TestBashAction:
         assert result["return_code"] == 0
 
     def test_failed_command(self, agent):
-        result = json.loads(agent.perform(action="bash", command="false"))
+        result_json = agent.perform(action="bash", command="false")
+        result = json.loads(result_json)
+        assert result["status"] == "error"
         assert result["return_code"] != 0
+        assert agent_result_is_error(result_json) is True
 
     def test_no_command_error(self, agent):
         result = json.loads(agent.perform(action="bash", command=""))

--- a/typescript/src/agents/ShellAgent.test.ts
+++ b/typescript/src/agents/ShellAgent.test.ts
@@ -10,6 +10,7 @@
 
 import { describe, it, expect } from 'vitest';
 import { ShellAgent } from './ShellAgent.js';
+import { agentResultIsError } from './result-status.js';
 
 describe('ShellAgent — safety wiring', () => {
   describe('safe commands', () => {
@@ -25,6 +26,15 @@ describe('ShellAgent — safety wiring', () => {
       const result = JSON.parse(await agent.execute({ query: 'run echo hello-from-query' }));
       expect(result.status).toBe('success');
       expect(result.output).toContain('hello-from-query');
+    });
+
+    it('reports a nonzero exit as an agent-contract error', async () => {
+      const agent = new ShellAgent();
+      const resultJson = await agent.execute({ action: 'bash', command: 'false' });
+      const result = JSON.parse(resultJson);
+
+      expect(result.status).toBe('error');
+      expect(agentResultIsError(resultJson)).toBe(true);
     });
   });
 


### PR DESCRIPTION
## The divergence

A completed subprocess was always called successful in Python, regardless of its return code:

```json
{"status":"success","command":"false","output":"(no output)","return_code":1}
```

TypeScript reports the same command as `status:"error"`.

This is more than an envelope mismatch. Both runtimes' invocation/flight-recording paths call their shared result classifier, and both classifiers recognize errors only from `status:"error"`. Python therefore recorded a demonstrably failed shell command as a successful agent invocation.

## Fix

Derive Python's status from `result.returncode` while preserving its useful `command`, `output`, and `return_code` fields.

The contract is pinned at both runtime front doors:

- Python executes `false`, requires `status:"error"`, a nonzero `return_code`, and `agent_result_is_error(...) == True`.
- TypeScript executes `false`, requires `status:"error"` and `agentResultIsError(...) == true`.

## Evidence

Before the fix, the strengthened Python test fails exactly once:

```text
assert 'success' == 'error'
1 failed, 30 passed
```

Mutation-check: restore unconditional `"status": "success"` and the same contract test fails.

Validation:

- Python: **1,332 passed / 6 skipped / 51 subtests passed**
- TypeScript ShellAgent: **15 passed**
- `tsc --noEmit`: clean
