### PR TITLE
fix(cron): send the job id the gateway actually reads

### DIFF
--- a/typescript/src/__tests__/parity/cron.test.ts
+++ b/typescript/src/__tests__/parity/cron.test.ts
@@ -226,10 +226,10 @@ describe('Cron Service Parity', () => {
     it('should support cron.remove', () => {
       const request = {
         method: 'cron.remove',
-        params: { id: 'job_1' },
+        params: { jobId: 'job_1' },
       };
 
-      expect(request.params.id).toBeDefined();
+      expect(request.params.jobId).toBeDefined();
     });
 
     it('should support cron.list', () => {
@@ -269,10 +269,10 @@ describe('Cron Service Parity', () => {
     it('should support cron.run (immediate execution)', () => {
       const request = {
         method: 'cron.run',
-        params: { id: 'job_1' },
+        params: { jobId: 'job_1' },
       };
 
-      expect(request.params.id).toBeDefined();
+      expect(request.params.jobId).toBeDefined();
     });
   });
 });

--- a/typescript/src/__tests__/parity/gateway.test.ts
+++ b/typescript/src/__tests__/parity/gateway.test.ts
@@ -227,11 +227,11 @@ describe('Gateway Parity', () => {
         const request = {
           method: 'cron.run',
           params: {
-            id: 'job_1',
+            jobId: 'job_1',
           },
         };
 
-        expect(request.params.id).toBeDefined();
+        expect(request.params.jobId).toBeDefined();
       });
     });
 

--- a/typescript/src/cli/__tests__/cron-add-contract.test.ts
+++ b/typescript/src/cli/__tests__/cron-add-contract.test.ts
@@ -81,4 +81,23 @@ describe('cron add sends what the gateway actually reads', () => {
       agentId: 'GoogleVoice',
     });
   });
+
+  describe('cron job actions send the identifier the gateway actually reads', () => {
+    it.each(['remove', 'run'])('sends `jobId` for cron %s', async (action) => {
+      await runCron([action, 'job-7']);
+
+      expect(calls.find(c => c.method === `cron.${action}`)!.params).toEqual({
+        jobId: 'job-7',
+      });
+    });
+
+    it('sends `jobId` and the requested state for cron enable', async () => {
+      await runCron(['enable', 'job-7', '--disable']);
+
+      expect(calls.find(c => c.method === 'cron.enable')!.params).toEqual({
+        jobId: 'job-7',
+        enabled: false,
+      });
+    });
+  });
 });

--- a/typescript/src/cli/cron.ts
+++ b/typescript/src/cli/cron.ts
@@ -55,7 +55,7 @@ export function registerCronCommand(program: Command): void {
     .description('Remove a cron job')
     .action(async (id: string) => {
       await withClient(async (client) => {
-        await client.call('cron.remove', { id });
+        await client.call('cron.remove', { jobId: id });
         console.log(`Removed cron job: ${id}`);
       });
     });
@@ -65,7 +65,7 @@ export function registerCronCommand(program: Command): void {
     .description('Run a cron job immediately')
     .action(async (id: string) => {
       await withClient(async (client) => {
-        const result = await client.call('cron.run', { id });
+        const result = await client.call('cron.run', { jobId: id });
         console.log('Job result:', result);
       });
     });
@@ -76,7 +76,7 @@ export function registerCronCommand(program: Command): void {
     .option('--disable', 'Disable instead of enable')
     .action(async (id: string, options: { disable?: boolean }) => {
       await withClient(async (client) => {
-        await client.call('cron.enable', { id, enabled: !options.disable });
+        await client.call('cron.enable', { jobId: id, enabled: !options.disable });
         console.log(`${options.disable ? 'Disabled' : 'Enabled'} cron job: ${id}`);
       });
     });

--- a/typescript/src/gateway/__tests__/cron-add-live.test.ts
+++ b/typescript/src/gateway/__tests__/cron-add-live.test.ts
@@ -114,6 +114,27 @@ describe('cron.add reaches the running scheduler', () => {
     expect(sched.jobs).toHaveLength(0);
   });
 
+  it('does not report success for a job that does not exist', async () => {
+    const server = await boot();
+    server.setCronService(fakeScheduler().service as never);
+
+    await expect(
+      methodsOf(server).get('cron.remove')!.handler(
+        { jobId: 'no-such-job' },
+        null,
+      ),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('does not report success when the client sends no job id', async () => {
+    const server = await boot();
+    server.setCronService(fakeScheduler().service as never);
+
+    await expect(
+      methodsOf(server).get('cron.remove')!.handler({ jobId: '' }, null),
+    ).rejects.toThrow(/not found/i);
+  });
+
   // Older hosts wire no scheduler. Saving to disk is still useful, but the
   // caller must not be told it was scheduled when it was not.
   it('says so plainly when it could only reach the file', async () => {

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -2152,9 +2152,25 @@ export class GatewayServer {
     });
     this.registerMethod('cron.add', this.addCronJob, { requiresAuth: true });
     this.registerMethod('cron.remove', async (params: { jobId: string }) => {
-      if (this.cronService?.remove) await this.cronService.remove(params.jobId);
-      this.cronStore = this.cronStore.filter((j) => (j as { id: string }).id !== params.jobId);
-      this.saveCronStore();
+      const jobId = params.jobId;
+      let removed = false;
+
+      if (jobId && this.cronService?.remove) {
+        const known = this.cronService.list().some((j) => j.id === jobId);
+        if (known) {
+          await this.cronService.remove(jobId);
+          removed = true;
+        }
+      }
+
+      const previousLength = this.cronStore.length;
+      this.cronStore = this.cronStore.filter((j) => (j as { id: string }).id !== jobId);
+      if (this.cronStore.length !== previousLength) {
+        this.saveCronStore();
+        removed = true;
+      }
+
+      if (!removed) throw new Error(`Cron job not found: ${jobId || '(empty id)'}`);
       return { removed: true };
     }, { requiresAuth: true });
     this.registerMethod('cron.run', async (params: { jobId: string }) => {


### PR DESCRIPTION
## What the CLI said vs what the gateway read

`cron remove`, `cron run`, and `cron enable` sent:

```json
{"id":"job-7"}
```

The gateway handlers all read `params.jobId`.

For `run`/`enable`, this usually surfaced as “not found.” `remove` was worse: it filtered the live/file stores on `undefined`, changed nothing, returned `{removed:true}`, and the CLI printed:

```text
Removed cron job: job-7
```

## Fix

- Send `{jobId}` from all three CLI actions.
- Make `cron.remove` verify the ID exists in either the live scheduler or file store before returning success.
- Preserve a successful removal when a job exists in either or both stores.
- Correct two parity tests that explicitly encoded the broken `{id}` request shape.

## Evidence

New tests fail five ways on main:

- **3** CLI wire failures: remove/run/enable send `id` instead of `jobId`.
- **2** gateway honesty failures: missing and empty IDs resolve `{removed:true}` instead of rejecting.

Independent mutations after the fix:

| mutation | result |
|---|---|
| restore `{id}` in the CLI | **3 failed / 5 passed** |
| remove the server’s not-found refusal | **2 failed / 10 passed** |

Validation:

- cron wire + live gateway + parity: **85 passed**
- `tsc --noEmit`: clean
- full TypeScript suite: **4,715 passed / 21 skipped**, with only the 5 `copilot-cli-local` failures reproduced previously on detached clean `origin/main`
