### PR TITLE
fix(media): bound chunked downloads while they stream

### DIFF
--- a/typescript/src/media/processor-stream-limit.test.ts
+++ b/typescript/src/media/processor-stream-limit.test.ts
@@ -1,0 +1,85 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { fetchGuardedMock } = vi.hoisted(() => ({
+  fetchGuardedMock: vi.fn(),
+}));
+
+vi.mock('../net/url-guard.js', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../net/url-guard.js')>();
+  return {
+    ...actual,
+    fetchGuarded: fetchGuardedMock,
+  };
+});
+
+import { MediaProcessor } from './processor.js';
+
+function chunkedResponse(
+  contentType: string,
+  chunks: number[][],
+  onCancel?: () => void,
+): Response {
+  let index = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index === chunks.length) {
+        controller.close();
+        return;
+      }
+      controller.enqueue(Uint8Array.from(chunks[index++]));
+    },
+    cancel() {
+      onCancel?.();
+    },
+  });
+
+  return new Response(body, {
+    status: 200,
+    headers: { 'content-type': contentType },
+  });
+}
+
+function processorWithLimit(maxSize: number): MediaProcessor {
+  const processor = new MediaProcessor();
+  // Keep the fixture tiny while exercising the same policy used in production.
+  Object.defineProperty(processor, 'getMaxSize', { value: () => maxSize });
+  return processor;
+}
+
+beforeEach(() => {
+  fetchGuardedMock.mockReset();
+});
+
+describe('MediaProcessor streamed download limit', () => {
+  it.each(['audio/wav', 'video/mp4'])(
+    'rejects chunked %s once the body crosses its limit',
+    async (contentType) => {
+      let cancelled = false;
+      fetchGuardedMock.mockResolvedValue(
+        chunkedResponse(
+          contentType,
+          [[1, 2, 3, 4], [5, 6, 7, 8], [9, 10, 11, 12]],
+          () => { cancelled = true; },
+        ),
+      );
+
+      await expect(
+        processorWithLimit(5).processUrl('https://example.com/media'),
+      ).rejects.toThrow(/too large/i);
+      expect(cancelled).toBe(true);
+    },
+  );
+
+  it('still accepts a chunked body within the limit', async () => {
+    fetchGuardedMock.mockResolvedValue(
+      chunkedResponse('audio/wav', [[1, 2], [3, 4]]),
+    );
+
+    const result = await processorWithLimit(5).processUrl(
+      'https://example.com/audio',
+    );
+
+    expect(result.type).toBe('audio');
+    expect(result.size).toBe(4);
+  });
+});

--- a/typescript/src/media/processor.ts
+++ b/typescript/src/media/processor.ts
@@ -105,8 +105,41 @@ export class MediaProcessor {
       throw new Error(`Media too large: ${contentLength} bytes (max: ${maxSize})`);
     }
 
-    const buffer = Buffer.from(await response.arrayBuffer());
+    const buffer = await this.readResponseBuffer(response, maxSize);
     return this.processBuffer(buffer, contentType);
+  }
+
+  /**
+   * Read a response without letting a missing or dishonest Content-Length
+   * bypass the media limit.
+   */
+  private async readResponseBuffer(response: Response, maxSize: number): Promise<Buffer> {
+    const reader = response.body?.getReader();
+    if (!reader) return Buffer.alloc(0);
+
+    const chunks: Buffer[] = [];
+    let total = 0;
+
+    try {
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (!value || value.byteLength === 0) continue;
+
+        if (value.byteLength > maxSize - total) {
+          const received = total + value.byteLength;
+          await reader.cancel(`Media too large: ${received} bytes (max: ${maxSize})`);
+          throw new Error(`Media too large: at least ${received} bytes (max: ${maxSize})`);
+        }
+
+        total += value.byteLength;
+        chunks.push(Buffer.from(value));
+      }
+    } finally {
+      reader.releaseLock();
+    }
+
+    return Buffer.concat(chunks, total);
   }
 
   /**


### PR DESCRIPTION
## The bypass

`MediaProcessor.processUrl()` checked `Content-Length`, then did:

```ts
Buffer.from(await response.arrayBuffer())
```

A chunked response has no `Content-Length`. Images and documents happened to reject oversized buffers later, after paying the memory cost; audio and video had no post-buffer size check at all. A hostile URL could therefore make the process buffer an unbounded body.

Measured before the fix with a tiny test cap:

- chunked `audio/wav`: **12 bytes accepted** against a 5-byte limit
- chunked `video/mp4`: **12 bytes accepted** against a 5-byte limit

The production cap for those types is 100 MiB; the original probe accepted 105,906,176 bytes without a `Content-Length`.

## Fix

Read `Response.body` incrementally. Before retaining a chunk, check whether it fits in the remaining budget. If not:

1. cancel the reader,
2. release its lock in `finally`,
3. reject with the observed lower-bound size.

The existing `Content-Length` check remains as an early rejection for honest servers. The stream check is the enforcement point for missing or dishonest lengths.

## Evidence

Front-door tests enter through `processUrl()` with real chunked `ReadableStream`s:

- oversized audio rejects and cancels,
- oversized video rejects and cancels,
- a body within the limit is still accepted with the correct size.

Mutation-check: restore the old `response.arrayBuffer()` call and both overflow tests fail while the within-limit control passes.

Validation:

- media stream + guarded fetch: **8 passed**
- `tsc --noEmit`: clean
- full TypeScript suite: **4,718 passed / 21 skipped**, with only the five previously reproduced clean-main `copilot-cli-local` failures
- independent code review: no streaming, cancellation, lock-release, or false-positive test issues found
