### PR TITLE
fix(skill): teach voice-call the CLI that actually ships

### DIFF
--- a/typescript/skills/voice-call/SKILL.md
+++ b/typescript/skills/voice-call/SKILL.md
@@ -1,38 +1,71 @@
 ---
 name: voice-call
-description: Start and manage voice calls via the openrappter voice-call plugin.
-metadata: {"openclaw":{"emoji":"📞","requires":{"config":["plugins.entries.voice-call.enabled"]}}}
+description: Place goal-directed phone calls with explicit constraints and human approval.
+metadata: {"openclaw":{"emoji":"📞"}}
 ---
 
 # Voice Call
 
-Make and receive voice calls through the openrappter voice plugin.
+Place calls on the owner's behalf without letting the agent negotiate past the
+limits it was given.
 
 ## Requirements
 
-Enable the voice-call plugin in openrappter config:
+No plugin switch is required. Rehearsals use the built-in simulation provider
+and need no account, API key, or phone call.
 
-```yaml
-plugins:
-  entries:
-    voice-call:
-      enabled: true
-```
+For live calls, OpenRappter resolves an available provider from Retell, Twilio,
+Google Voice, or the on-device handoff. Provider credentials are documented in
+`src/telephony/README.md`.
 
-## Start a Call
+## Rehearse First
 
 ```bash
-openrappter call start --to "+1234567890"
+openrappter call place "+1234567890" \
+  --objective "Book a table for two at 7pm" \
+  --constraint "not before 6pm" \
+  --constraint "no later than 8pm" \
+  --rehearse "Seven is unavailable. I can offer 7:45."
 ```
 
-## End a Call
+`--rehearse` exercises the complete negotiation and approval path without
+dialing anyone. Use it before a live call.
+
+## Place a Live Call
 
 ```bash
-openrappter call end
+openrappter call place "+1234567890" \
+  --objective "Book a table for two at 7pm" \
+  --constraint "not before 6pm" \
+  --constraint "no later than 8pm"
 ```
 
-## Conference Call
+If the other party proposes something inside the hard limits but different
+from the requested outcome, the agent stops and creates an approval instead of
+accepting on its own.
+
+## Resolve an Approval
 
 ```bash
-openrappter call conference --participants "+1234567890,+0987654321"
+openrappter call pending
+openrappter call approve "<approval-id>"
+# or:
+openrappter call deny "<approval-id>"
 ```
+
+To ask by phone instead:
+
+```bash
+openrappter call callback "<approval-id>" --to "+1234567890"
+```
+
+## Diagnostics
+
+```bash
+openrappter call brief
+openrappter call google-voice
+openrappter call hotline --pin 4821 --from "+15559998888"
+```
+
+There is no conference-call command. A placed call ends through its provider
+when the synchronous call flow completes.

--- a/typescript/src/__tests__/parity/builtin-skills.test.ts
+++ b/typescript/src/__tests__/parity/builtin-skills.test.ts
@@ -566,7 +566,7 @@ describe('Built-in Skills', () => {
     });
 
     it('should identify skills requiring config paths', () => {
-      const configSkills = ['slack', 'bluebubbles', 'voice-call'];
+      const configSkills = ['slack', 'bluebubbles'];
 
       for (const name of configSkills) {
         const content = readFileSync(join(SKILLS_DIR, name, 'SKILL.md'), 'utf8');

--- a/typescript/src/telephony/voice-call-skill-contract.test.ts
+++ b/typescript/src/telephony/voice-call-skill-contract.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { registerTelephonyCommands } from './cli.js';
+
+const SKILL_PATH = join(
+  dirname(fileURLToPath(import.meta.url)),
+  '..',
+  '..',
+  'skills',
+  'voice-call',
+  'SKILL.md',
+);
+
+function documentedCallCommands(): string[] {
+  const skill = readFileSync(SKILL_PATH, 'utf8');
+  return [...skill.matchAll(/\bopenrappter call ([a-z][a-z-]*)\b/g)]
+    .map((match) => match[1]);
+}
+
+function registeredCallCommands(): string[] {
+  const program = new Command();
+  registerTelephonyCommands(program);
+  const call = program.commands.find((command) => command.name() === 'call');
+  if (!call) throw new Error('call command was not registered');
+  return call.commands.map((command) => command.name());
+}
+
+describe('bundled voice-call skill', () => {
+  it('documents only subcommands the shipped CLI actually registers', () => {
+    const registered = registeredCallCommands();
+    const documented = documentedCallCommands();
+
+    expect(documented.length).toBeGreaterThan(0);
+    expect(documented.filter((command) => !registered.includes(command))).toEqual([]);
+  });
+
+  it('does not require a legacy plugin switch the CLI never reads', () => {
+    const skill = readFileSync(SKILL_PATH, 'utf8');
+    expect(skill).not.toContain('plugins.entries.voice-call.enabled');
+  });
+});


### PR DESCRIPTION
## The shipped skill described another product

`skills/voice-call/SKILL.md` instructed agents to run:

```bash
openrappter call start --to ...
openrappter call end
openrappter call conference --participants ...
```

None of those subcommands exists. All three exit with `unknown command`.

It also declared a requirement on `plugins.entries.voice-call.enabled`. No OpenRappter code reads that legacy OpenClaw plugin switch; telephony is registered unconditionally. Eligibility could therefore hide a working command behind configuration that cannot enable it.

## Fix

The skill now follows the telephony subsystem that actually ships:

- lead with `call place ... --rehearse` (no account, provider, cost, or real call),
- document a live constraint-first `call place`,
- document `pending`, `approve`, `deny`, and `callback`,
- document `brief`, `google-voice`, and `hotline` diagnostics,
- say plainly that conference calls are unsupported and placed calls end through their provider.

The fake plugin requirement is removed.

## Contract, not another source-text promise

A new test builds the real Commander tree with `registerTelephonyCommands`, extracts every `openrappter call <subcommand>` from the bundled skill, and rejects any command absent from the tree.

Before the rewrite:

```text
expected [ 'start', 'end', 'conference' ] to deeply equal []
2 failed
```

Independent mutations after the fix:

| mutation | result |
|---|---|
| change one documented `place` back to `start` | **1 failed / 1 passed** |
| restore `plugins.entries.voice-call.enabled` | **1 failed / 1 passed** |

Validation:

- voice-call contract + bundled skills: **56 passed**
- `tsc --noEmit`: clean
- live `openrappter call --help` lists every documented command
