### PR TITLE
fix(cli): make config and doctor real, safe commands

### DIFF
--- a/typescript/src/__tests__/parity/cli-commands.test.ts
+++ b/typescript/src/__tests__/parity/cli-commands.test.ts
@@ -262,7 +262,7 @@ describe('CLI Commands', () => {
 
       for (const file of commandFiles) {
         const content = readFileSync(join(CLI_DIR, file), 'utf-8');
-        expect(content).toMatch(/function register\w+Command\(program:\s*Command\)/);
+        expect(content).toMatch(/function register\w+Command\(\s*program:\s*Command/);
       }
     });
   });

--- a/typescript/src/__tests__/parity/cli-registration.test.ts
+++ b/typescript/src/__tests__/parity/cli-registration.test.ts
@@ -1,8 +1,16 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { execFileSync } from 'child_process';
-import { mkdtempSync } from 'fs';
+import { execFileSync, spawnSync } from 'child_process';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import { createRequire } from 'module';
 
 /**
  * What the CLI actually exposes, asked of the CLI.
@@ -14,6 +22,19 @@ import { join } from 'path';
  */
 
 const ENTRY = join(__dirname, '../../index.ts');
+const TSX_CLI = createRequire(import.meta.url).resolve('tsx/cli');
+
+function tsxArgs(...args: string[]): string[] {
+  return [TSX_CLI, ENTRY, ...args];
+}
+
+function isolatedHomeEnv(home: string): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    HOME: home,
+    USERPROFILE: home,
+  };
+}
 
 /** Commands the CLI is known to expose. Each is asserted individually. */
 const REGISTERED = [
@@ -26,6 +47,8 @@ const REGISTERED = [
   'call',
   'twin',
   'cron',
+  'config',
+  'doctor',
 ];
 
 let commands: string[];
@@ -43,9 +66,9 @@ beforeAll(() => {
   // A throwaway HOME so nothing here can read or write the real config.
   const home = mkdtempSync(join(tmpdir(), 'openrappter-cli-'));
   const help = execFileSync(
-    'npx',
-    ['tsx', ENTRY, '--help'],
-    { encoding: 'utf-8', env: { ...process.env, HOME: home }, timeout: 120_000 },
+    process.execPath,
+    tsxArgs('--help'),
+    { encoding: 'utf-8', env: isolatedHomeEnv(home), timeout: 120_000 },
   );
   commands = parseCommands(help);
 }, 180_000);
@@ -60,4 +83,243 @@ describe('CLI command registration, observed from outside', () => {
     // this file would pass vacuously against an empty list.
     expect(commands.length).toBeGreaterThanOrEqual(REGISTERED.length);
   });
+
+  it('config validate reads the JSON5 source the runtime reads', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openrappter-config-command-'));
+    try {
+      const configDir = join(home, '.openrappter');
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(
+        join(configDir, 'config.json5'),
+        '{ gateway: { port: 70000, }, }',
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        tsxArgs('config', 'validate'),
+        {
+          encoding: 'utf-8',
+          env: isolatedHomeEnv(home),
+          timeout: 120_000,
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('gateway.port');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  it('config validate rejects malformed JSON5 instead of calling it empty and valid', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openrappter-config-malformed-'));
+    try {
+      const configDir = join(home, '.openrappter');
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(join(configDir, 'config.json5'), '{ gateway: {');
+
+      const result = spawnSync(
+        process.execPath,
+        tsxArgs('config', 'validate'),
+        {
+          encoding: 'utf-8',
+          env: isolatedHomeEnv(home),
+          timeout: 120_000,
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('Cannot parse');
+      expect(result.stdout).toContain('config.json5');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  it('config set writes only the JSON override, not the resolved JSON5 merge', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openrappter-config-set-'));
+    try {
+      const configDir = join(home, '.openrappter');
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(
+        join(configDir, 'config.json5'),
+        '{ gateway: { bind: "all" }, channels: { sms: { enabled: true } } }',
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        tsxArgs('config', 'set', 'gateway.port', '19000'),
+        {
+          encoding: 'utf-8',
+          env: isolatedHomeEnv(home),
+          timeout: 120_000,
+        },
+      );
+
+      expect(result.status).toBe(0);
+      const written = JSON.parse(
+        readFileSync(join(configDir, 'config.json'), 'utf8'),
+      ) as Record<string, unknown>;
+      expect(written).toEqual({ gateway: { port: 19000 } });
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  it('config get and set never echo a credential value', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openrappter-config-secrets-'));
+    const secret = ['never', 'print', 'this', 'value'].join('-');
+    try {
+      const configDir = join(home, '.openrappter');
+      mkdirSync(configDir, { recursive: true });
+
+      const set = spawnSync(
+        process.execPath,
+        tsxArgs('config', 'set', 'channels.telegram.token', secret),
+        {
+          encoding: 'utf-8',
+          env: isolatedHomeEnv(home),
+          timeout: 120_000,
+        },
+      );
+      expect(set.status).toBe(0);
+      expect(set.stdout).not.toContain(secret);
+      expect(set.stdout).toContain('REDACTED');
+
+      const get = spawnSync(
+        process.execPath,
+        tsxArgs('config', 'get', 'channels.telegram.token'),
+        {
+          encoding: 'utf-8',
+          env: isolatedHomeEnv(home),
+          timeout: 120_000,
+        },
+      );
+      expect(get.status).toBe(0);
+      expect(get.stdout).not.toContain(secret);
+      expect(get.stdout).toContain('REDACTED');
+
+      const persisted = JSON.parse(
+        readFileSync(join(configDir, 'config.json'), 'utf8'),
+      ) as { channels: { telegram: { token: string } } };
+      expect(persisted.channels.telegram.token).toBe(secret);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  it('config reset clears JSON5 settings instead of leaving them active', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openrappter-config-reset-'));
+    try {
+      const configDir = join(home, '.openrappter');
+      mkdirSync(configDir, { recursive: true });
+      const json5Path = join(configDir, 'config.json5');
+      writeFileSync(json5Path, '{ channels: { sms: { enabled: true } } }');
+
+      const result = spawnSync(
+        process.execPath,
+        tsxArgs('config', 'reset', '--yes'),
+        {
+          encoding: 'utf-8',
+          env: isolatedHomeEnv(home),
+          timeout: 120_000,
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(existsSync(json5Path)).toBe(false);
+      expect(existsSync(join(configDir, 'config.json'))).toBe(true);
+
+      const validate = spawnSync(
+        process.execPath,
+        tsxArgs('config', 'validate'),
+        {
+          encoding: 'utf-8',
+          env: isolatedHomeEnv(home),
+          timeout: 120_000,
+        },
+      );
+      expect(validate.status).toBe(0);
+      expect(validate.stdout).toContain('Configuration is valid');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  it('config validate rejects reset-era keys the runtime does not consume', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openrappter-config-legacy-'));
+    try {
+      const configDir = join(home, '.openrappter');
+      mkdirSync(configDir, { recursive: true });
+      writeFileSync(
+        join(configDir, 'config.json'),
+        JSON.stringify({
+          agent: { maxTokens: 'bad' },
+          gateway: { host: '0.0.0.0' },
+          memory: { chunkSize: -1 },
+        }),
+      );
+
+      const result = spawnSync(
+        process.execPath,
+        tsxArgs('config', 'validate'),
+        {
+          encoding: 'utf-8',
+          env: isolatedHomeEnv(home),
+          timeout: 120_000,
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stdout).toContain('agents.defaults');
+      expect(result.stdout).toContain('gateway.bind');
+      expect(result.stdout).toContain('memory.chunkTokens');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  it('config edit reports a missing editor instead of crashing', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openrappter-config-editor-'));
+    try {
+      const result = spawnSync(
+        process.execPath,
+        tsxArgs('config', 'edit'),
+        {
+          encoding: 'utf-8',
+          env: {
+            ...isolatedHomeEnv(home),
+            EDITOR: 'openrappter-editor-that-does-not-exist',
+          },
+          timeout: 120_000,
+        },
+      );
+
+      expect(result.status).toBe(1);
+      expect(result.stderr).toContain('Could not open config editor');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 180_000);
+
+  it('doctor --help reaches the doctor command and advertises JSON output', () => {
+    const home = mkdtempSync(join(tmpdir(), 'openrappter-doctor-command-'));
+    try {
+      const result = spawnSync(
+        process.execPath,
+        tsxArgs('doctor', '--help'),
+        {
+          encoding: 'utf-8',
+          env: isolatedHomeEnv(home),
+          timeout: 120_000,
+        },
+      );
+
+      expect(result.status).toBe(0);
+      expect(result.stdout).toMatch(/Usage: .*doctor/);
+      expect(result.stdout).toContain('--json');
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+    }
+  }, 180_000);
 });

--- a/typescript/src/cli/__tests__/commands.test.ts
+++ b/typescript/src/cli/__tests__/commands.test.ts
@@ -25,7 +25,7 @@ describe('DoctorCommand', () => {
 
   it('should accept Command parameter', () => {
     const content = readFileSync(join(CLI_DIR, 'doctor.ts'), 'utf-8');
-    expect(content).toMatch(/function registerDoctorCommand\(program:\s*Command\)/);
+    expect(content).toMatch(/function registerDoctorCommand\(\s*program:\s*Command/);
   });
 
   it('should import Command from commander', () => {

--- a/typescript/src/cli/__tests__/doctor-command.test.ts
+++ b/typescript/src/cli/__tests__/doctor-command.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { Command } from 'commander';
+
+import {
+  checkNodeVersion,
+  registerDoctorCommand,
+  type CheckResult,
+} from '../doctor.js';
+
+let previousExitCode: typeof process.exitCode;
+
+async function runJsonDoctor(results: CheckResult[]): Promise<void> {
+  const program = new Command();
+  program.exitOverride();
+  registerDoctorCommand(program, async () => results);
+  await program.parseAsync(['node', 'openrappter', 'doctor', '--json']);
+}
+
+beforeEach(() => {
+  previousExitCode = process.exitCode;
+  process.exitCode = undefined;
+  vi.spyOn(console, 'log').mockImplementation(() => {});
+});
+
+afterEach(() => {
+  process.exitCode = previousExitCode;
+  vi.restoreAllMocks();
+});
+
+describe('doctor --json process contract', () => {
+  it('returns a failing exit status when a check fails', async () => {
+    await runJsonDoctor([
+      { name: 'Node.js', status: 'pass', message: 'ok' },
+      { name: 'Disk', status: 'fail', message: 'full' },
+    ]);
+
+    expect(process.exitCode).toBe(1);
+  });
+
+  it('does not fail the process for warnings alone', async () => {
+    await runJsonDoctor([
+      { name: 'Node.js', status: 'pass', message: 'ok' },
+      { name: 'FFmpeg', status: 'warn', message: 'not installed' },
+    ]);
+
+    expect(process.exitCode).toBeUndefined();
+  });
+});
+
+describe('doctor Node.js support floor', () => {
+  it.each(['v18.20.0', 'v20.8.9'])('fails unsupported %s', (version) => {
+    expect(checkNodeVersion(version).status).toBe('fail');
+  });
+
+  it.each(['v20.9.0', 'v20.10.0', 'v21.0.0', 'v22.0.0'])(
+    'passes supported %s',
+    (version) => {
+      expect(checkNodeVersion(version).status).toBe('pass');
+    },
+  );
+});

--- a/typescript/src/cli/config.ts
+++ b/typescript/src/cli/config.ts
@@ -13,29 +13,107 @@
 
 import type { Command } from 'commander';
 import { promises as fs } from 'fs';
-import { join } from 'path';
-import { homedir } from 'os';
 import { spawn } from 'child_process';
+import JSON5 from 'json5';
+import {
+  CONFIG_FILE,
+  CONFIG_FILE_JSON5,
+  HOME_DIR as CONFIG_DIR,
+  loadConfig,
+  mergeConfigObjects,
+  saveConfig,
+} from '../env.js';
+import { validateConfig as validateConfigSchema } from '../config/schema.js';
 export { redactSecrets } from '../security/redact.js';
 import { redactSecrets } from '../security/redact.js';
-
-const CONFIG_DIR = join(homedir(), '.openrappter');
-const CONFIG_FILE = join(CONFIG_DIR, 'config.json');
+import { isSecretKey } from '../security/secret-keys.js';
 
 /** Fields whose values should be redacted in display output */
 
-async function loadConfig(): Promise<Record<string, unknown>> {
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+async function readOptionalConfig(
+  filePath: string,
+  parse: (source: string) => unknown,
+): Promise<Record<string, unknown>> {
+  let source: string;
   try {
-    const data = await fs.readFile(CONFIG_FILE, 'utf-8');
-    return JSON.parse(data);
+    source = await fs.readFile(filePath, 'utf-8');
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'ENOENT') return {};
+    throw error;
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = parse(source);
+  } catch (error) {
+    throw new Error(`Cannot parse ${filePath}: ${(error as Error).message}`);
+  }
+  if (!isPlainObject(parsed)) {
+    throw new Error(`Invalid config in ${filePath}: top level must be an object`);
+  }
+  return parsed;
+}
+
+/** Strict counterpart to the tolerant runtime loader, for `config validate`. */
+async function loadConfigForValidation(): Promise<Record<string, unknown>> {
+  const json5 = await readOptionalConfig(CONFIG_FILE_JSON5, JSON5.parse);
+  const json = await readOptionalConfig(CONFIG_FILE, JSON.parse);
+  return mergeConfigObjects(json5, json);
+}
+
+/** Mutations touch only the higher-priority JSON override, never the merge. */
+async function loadConfigForMutation(): Promise<Record<string, unknown>> {
+  return readOptionalConfig(CONFIG_FILE, JSON.parse);
+}
+
+function formatValidationErrors(error: string): string[] {
+  try {
+    const issues = JSON.parse(error) as unknown;
+    if (!Array.isArray(issues)) return [error];
+    return issues.map((issue) => {
+      if (!isPlainObject(issue)) return String(issue);
+      const path = Array.isArray(issue.path)
+        ? issue.path.map(String).join('.')
+        : '';
+      const message = typeof issue.message === 'string'
+        ? issue.message
+        : 'Invalid value';
+      return path ? `${path}: ${message}` : message;
+    });
   } catch {
-    return {};
+    return [error];
   }
 }
 
-async function saveConfig(config: Record<string, unknown>): Promise<void> {
-  await fs.mkdir(CONFIG_DIR, { recursive: true });
-  await fs.writeFile(CONFIG_FILE, JSON.stringify(config, null, 2));
+function unsupportedConfigErrors(config: Record<string, unknown>): string[] {
+  const errors: string[] = [];
+  if ('agent' in config) {
+    errors.push('agent is not supported; use agents.defaults');
+  }
+  if (
+    isPlainObject(config.gateway)
+    && 'host' in config.gateway
+  ) {
+    errors.push('gateway.host is not supported; use gateway.bind');
+  }
+  if (
+    isPlainObject(config.memory)
+    && 'chunkSize' in config.memory
+  ) {
+    errors.push('memory.chunkSize is not supported; use memory.chunkTokens');
+  }
+  return errors;
+}
+
+function redactValueAtPath(path: string, value: unknown): unknown {
+  const secretSegment = path.split('.').find(isSecretKey);
+  if (!secretSegment) return redactSecrets(value);
+  const wrapped = redactSecrets({ [secretSegment]: value }) as Record<string, unknown>;
+  return wrapped[secretSegment];
 }
 
 export function getNestedValue(obj: Record<string, unknown>, path: string): unknown {
@@ -55,46 +133,20 @@ export function setNestedValue(obj: Record<string, unknown>, path: string, value
 const DEFAULT_CONFIG: Record<string, unknown> = {
   gateway: {
     port: 18790,
-    host: '127.0.0.1',
+    bind: 'loopback',
   },
-  agent: {
-    model: 'claude-3-haiku-20240307',
-    maxTokens: 4096,
+  agents: {
+    defaults: {
+      model: 'claude-3-haiku-20240307',
+    },
   },
   memory: {
-    chunkSize: 512,
-    chunkOverlap: 50,
+    provider: 'openai',
+    chunkTokens: 512,
+    chunkOverlap: 64,
   },
   channels: {},
 };
-
-/**
- * Validate a config object against known schema rules.
- * Returns an array of validation error messages (empty = valid).
- */
-function validateConfig(cfg: Record<string, unknown>): string[] {
-  const errors: string[] = [];
-
-  const gateway = cfg.gateway as any;
-  if (gateway?.port !== undefined) {
-    const port = Number(gateway.port);
-    if (isNaN(port) || port < 1 || port > 65535) {
-      errors.push('gateway.port must be a valid port number (1-65535)');
-    }
-  }
-
-  const agent = cfg.agent as any;
-  if (agent?.maxTokens !== undefined && typeof agent.maxTokens !== 'number') {
-    errors.push('agent.maxTokens must be a number');
-  }
-
-  const memory = cfg.memory as any;
-  if (memory?.chunkSize !== undefined && (typeof memory.chunkSize !== 'number' || memory.chunkSize < 1)) {
-    errors.push('memory.chunkSize must be a positive number');
-  }
-
-  return errors;
-}
 
 export function registerConfigCommand(program: Command): void {
   const config = program.command('config').description('Manage configuration');
@@ -115,7 +167,7 @@ export function registerConfigCommand(program: Command): void {
       const cfg = await loadConfig();
       if (key) {
         const value = getNestedValue(cfg, key);
-        console.log(JSON.stringify(value, null, 2));
+        console.log(JSON.stringify(redactValueAtPath(key, value), null, 2));
       } else {
         const safe = redactSecrets(cfg);
         console.log(JSON.stringify(safe, null, 2));
@@ -126,14 +178,14 @@ export function registerConfigCommand(program: Command): void {
     .command('set <key> <value>')
     .description('Set configuration value (supports dot-notation paths)')
     .action(async (key: string, value: string) => {
-      const cfg = await loadConfig();
+      const cfg = await loadConfigForMutation();
       let parsed: unknown = value;
       try {
         parsed = JSON.parse(value);
       } catch {}
       setNestedValue(cfg, key, parsed);
       await saveConfig(cfg);
-      console.log(`Set ${key} = ${JSON.stringify(parsed)}`);
+      console.log(`Set ${key} = ${JSON.stringify(redactValueAtPath(key, parsed))}`);
     });
 
   config
@@ -146,6 +198,7 @@ export function registerConfigCommand(program: Command): void {
         console.log('Run with --yes to confirm.');
         return;
       }
+      await fs.rm(CONFIG_FILE_JSON5, { force: true });
       await saveConfig(DEFAULT_CONFIG);
       console.log('Configuration reset to defaults.');
     });
@@ -154,16 +207,29 @@ export function registerConfigCommand(program: Command): void {
     .command('validate')
     .description('Validate configuration against schema')
     .action(async () => {
-      const cfg = await loadConfig();
-      const errors = validateConfig(cfg);
-      if (errors.length === 0) {
-        console.log('Configuration is valid.');
-      } else {
-        console.log('Configuration validation failed:');
-        for (const err of errors) {
-          console.log(`  - ${err}`);
+      try {
+        const cfg = await loadConfigForValidation();
+        const unsupported = unsupportedConfigErrors(cfg);
+        if (unsupported.length > 0) {
+          console.log('Configuration validation failed:');
+          for (const error of unsupported) console.log(`  - ${error}`);
+          process.exitCode = 1;
+          return;
         }
-        process.exit(1);
+        const result = validateConfigSchema(cfg);
+        if (!result.success) {
+          console.log('Configuration validation failed:');
+          for (const error of formatValidationErrors(result.error ?? 'Invalid config')) {
+            console.log(`  - ${error}`);
+          }
+          process.exitCode = 1;
+          return;
+        }
+        console.log('Configuration is valid.');
+      } catch (error) {
+        console.log('Configuration validation failed:');
+        console.log(`  - ${(error as Error).message}`);
+        process.exitCode = 1;
       }
     });
 
@@ -171,7 +237,9 @@ export function registerConfigCommand(program: Command): void {
     .command('edit')
     .description('Open configuration file in $EDITOR')
     .action(async () => {
-      const editor = process.env.EDITOR || 'vim';
+      const editor = process.env.EDITOR
+        || process.env.VISUAL
+        || (process.platform === 'win32' ? 'notepad.exe' : 'vim');
       await fs.mkdir(CONFIG_DIR, { recursive: true });
       // Ensure file exists
       try {
@@ -179,7 +247,18 @@ export function registerConfigCommand(program: Command): void {
       } catch {
         await saveConfig({});
       }
-      const child = spawn(editor, [CONFIG_FILE], { stdio: 'inherit' });
-      await new Promise((resolve) => child.on('close', resolve));
+      try {
+        const child = spawn(editor, [CONFIG_FILE], { stdio: 'inherit' });
+        await new Promise<void>((resolve, reject) => {
+          child.once('error', reject);
+          child.once('close', (code) => {
+            if (code === 0) resolve();
+            else reject(new Error(`${editor} exited with status ${code ?? 'unknown'}`));
+          });
+        });
+      } catch (error) {
+        console.error(`Could not open config editor: ${(error as Error).message}`);
+        process.exitCode = 1;
+      }
     });
 }

--- a/typescript/src/cli/doctor.ts
+++ b/typescript/src/cli/doctor.ts
@@ -3,7 +3,7 @@
  * System diagnostics and health checks for openrappter.
  *
  * Checks:
- *   - Node.js version (>= 18)
+ *   - Node.js version (>= 20.9.0)
  *   - npm/pnpm availability
  *   - Git installation
  *   - Python availability (for Python agents)
@@ -19,8 +19,8 @@
  */
 
 import type { Command } from 'commander';
-import { execSync } from 'child_process';
-import { existsSync, statSync } from 'fs';
+import { execFileSync, execSync } from 'child_process';
+import { existsSync, statfsSync, statSync } from 'fs';
 import { homedir, tmpdir } from 'os';
 import { join } from 'path';
 import { createConnection } from 'net';
@@ -54,17 +54,31 @@ function colorStatus(status: CheckStatus): string {
 // Individual checks
 // ---------------------------------------------------------------------------
 
-function checkNode(): CheckResult {
-  const version = process.version;
-  const major = parseInt(version.slice(1).split('.')[0], 10);
-  if (major >= 18) {
-    return { name: 'Node.js Version', status: 'pass', message: `${version} (>= 18 required)` };
+export function checkNodeVersion(version = process.version): CheckResult {
+  const match = /^v?(\d+)\.(\d+)\.(\d+)/.exec(version);
+  const current = match?.slice(1).map(Number);
+  const minimum = [20, 9, 0];
+  let supported = current !== undefined;
+  if (current) {
+    for (let index = 0; index < minimum.length; index++) {
+      if (current[index] === minimum[index]) continue;
+      supported = current[index] > minimum[index];
+      break;
+    }
+  }
+
+  if (supported) {
+    return {
+      name: 'Node.js Version',
+      status: 'pass',
+      message: `${version} (>= 20.9.0 required)`,
+    };
   }
   return {
     name: 'Node.js Version',
     status: 'fail',
     message: `${version} is too old`,
-    detail: 'Requires Node.js >= 18',
+    detail: 'Requires Node.js >= 20.9.0',
   };
 }
 
@@ -106,7 +120,20 @@ function checkPython(): CheckResult {
 }
 
 function checkFfmpeg(): CheckResult {
-  return checkTool('ffmpeg', 'ffmpeg -version 2>&1 | head -1', 'FFmpeg');
+  try {
+    const out = execFileSync('ffmpeg', ['-version'], {
+      timeout: 5000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    }).toString().trim().split(/\r?\n/, 1)[0];
+    return { name: 'FFmpeg', status: 'pass', message: out || 'available' };
+  } catch {
+    return {
+      name: 'FFmpeg',
+      status: 'warn',
+      message: 'ffmpeg not found',
+      detail: 'Install ffmpeg to enable related features',
+    };
+  }
 }
 
 function checkCopilot(): CheckResult {
@@ -202,22 +229,8 @@ function checkMemorySystem(): CheckResult {
 
 function checkDiskSpace(): CheckResult {
   try {
-    const tmp = tmpdir();
-    // On most systems we can estimate from the fs stats
-    // Use df command as a portable way to get disk space
-    const out = execSync(`df -k "${tmp}" 2>/dev/null | tail -1`, {
-      timeout: 3000,
-      stdio: ['ignore', 'pipe', 'ignore'],
-    }).toString().trim();
-
-    const parts = out.split(/\s+/);
-    // df output: Filesystem 1K-blocks Used Available Use% Mountpoint
-    const availableKB = parseInt(parts[3], 10);
-    if (isNaN(availableKB)) {
-      return { name: 'Disk Space', status: 'warn', message: 'Could not determine disk space' };
-    }
-
-    const availableGB = availableKB / (1024 * 1024);
+    const stats = statfsSync(tmpdir());
+    const availableGB = (stats.bavail * stats.bsize) / (1024 ** 3);
     if (availableGB < 0.5) {
       return {
         name: 'Disk Space',
@@ -280,7 +293,7 @@ async function checkGatewayPort(port = 18790): Promise<CheckResult> {
 
 export async function runDoctorChecks(): Promise<CheckResult[]> {
   const checks: CheckResult[] = [
-    checkNode(),
+    checkNodeVersion(),
     checkNpm(),
     checkGit(),
     checkPython(),
@@ -299,7 +312,10 @@ export async function runDoctorChecks(): Promise<CheckResult[]> {
 // Command registration
 // ---------------------------------------------------------------------------
 
-export function registerDoctorCommand(program: Command): void {
+export function registerDoctorCommand(
+  program: Command,
+  runChecks: () => Promise<CheckResult[]> = runDoctorChecks,
+): void {
   program
     .command('doctor')
     .description('Run system diagnostics and health checks')
@@ -309,10 +325,12 @@ export function registerDoctorCommand(program: Command): void {
         console.log('\nRunning OpenRappter diagnostics...\n');
       }
 
-      const results = await runDoctorChecks();
+      const results = await runChecks();
+      const failed = results.some((result) => result.status === 'fail');
 
       if (options.json) {
         console.log(JSON.stringify(results, null, 2));
+        if (failed) process.exitCode = 1;
         return;
       }
 
@@ -340,8 +358,6 @@ export function registerDoctorCommand(program: Command): void {
       console.log(`Results: ${green(String(passCount))} passed, ${yellow(String(warnCount))} warnings, ${red(String(failCount))} failed`);
       console.log('');
 
-      if (failCount > 0) {
-        process.exit(1);
-      }
+      if (failed) process.exitCode = 1;
     });
 }

--- a/typescript/src/config/schema.ts
+++ b/typescript/src/config/schema.ts
@@ -61,7 +61,7 @@ export const channelConfigSchema = z.object({
 });
 
 export const gatewayConfigSchema = z.object({
-  port: z.number().default(18790),
+  port: z.number().int().min(1).max(65535).default(18790),
   bind: z.enum(['loopback', 'all']).default('loopback'),
   auth: z.object({
     mode: z.enum(['none', 'password']).default('none'),

--- a/typescript/src/env.ts
+++ b/typescript/src/env.ts
@@ -90,7 +90,7 @@ function isPlainObject(value: unknown): value is Record<string, unknown> {
 }
 
 /** Recursive merge where `override` wins on conflict. */
-function mergeConfigObjects(
+export function mergeConfigObjects(
   base: Record<string, unknown>,
   override: Record<string, unknown>,
 ): Record<string, unknown> {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -17,6 +17,8 @@ import { VERSION } from './version.js';
 import { registerTelephonyCommands } from './telephony/cli.js';
 import { registerTwinCommands } from './twin/index.js';
 import { registerCronCommand } from './cli/cron.js';
+import { registerConfigCommand } from './cli/config.js';
+import { registerDoctorCommand } from './cli/doctor.js';
 import { registerRappterCommand } from './cli/rappters.js';
 import { registerFlightRecorderCommand } from './cli/flight-recorder.js';
 import { registerShowAndTellCommand } from './cli/show-and-tell.js';
@@ -2584,6 +2586,8 @@ registerTwinCommands(program);
 // message, which is why asking for `cron add --help` printed the top-level help
 // instead of an error.
 registerCronCommand(program);
+registerConfigCommand(program);
+registerDoctorCommand(program);
 // Seeing and creating the rappters on this device. #107
 registerRappterCommand(program);
 registerFlightRecorderCommand(program);


### PR DESCRIPTION
## The visible bug

`registerConfigCommand` and `registerDoctorCommand` existed and were exported, but `src/index.ts` never called either. Shipped guidance tells users to run:

```bash
openrappter doctor
openrappter config validate
```

Both fell through to top-level help/chat behavior instead of their implementations.

A real `--help` test fails exactly twice on main: `config` and `doctor` are absent.

## Why this is larger than two registration calls

Independent review of the first registration patch found the dormant commands were not safe to expose as written.

### Config

- **One read contract:** show/get/validate use the runtime's `config.json5` + higher-priority `config.json` merge. Validation reuses the exact recursive merge helper.
- **Safe mutation:** `config set` reads and writes only the JSON override; it does not copy every JSON5 value into the higher-priority file and permanently shadow future edits.
- **Real reset:** `config reset --yes` removes JSON5 and writes canonical schema keys (`gateway.bind`, `agents.defaults`, `memory.chunkTokens`). It no longer leaves JSON5 settings active or create aliases the runtime ignores.
- **Honest validation:** each contributing file is parsed strictly; malformed JSON5 is a failure, not `{}`. The resolved object goes through the real Zod schema. Reset-era aliases (`agent`, `gateway.host`, `memory.chunkSize`) fail with migration guidance.
- **No secret echo:** targeted `config get` and `config set` output is redacted by the same key classifier as config display, while the real value is still persisted.
- **Portable editing:** Windows defaults to `notepad.exe`; missing editors and nonzero exits produce a controlled CLI error instead of an unhandled child-process exception.

### Doctor

- Enforces the package's real Node floor: **>=20.9.0**, not >=18.
- Uses `execFileSync('ffmpeg', ['-version'])` instead of Unix `head`.
- Uses Node `statfsSync` instead of Unix `df | tail`.
- `doctor --json` sets a failing exit status when any check fails; installers can no longer print “Doctor check passed” for a JSON report containing failures.

## Behavioral evidence

Tests execute the real CLI with `process.execPath` + the resolved `tsx` entry (portable across Windows/macOS/Linux), isolated with both `HOME` and `USERPROFILE`.

They prove:

- config/doctor appear in real top-level help,
- invalid JSON5 values reach validation,
- malformed JSON5 fails,
- set does not copy merged JSON5,
- get/set never echo credentials but persist the value,
- reset clears JSON5 and the result validates,
- stale aliases are rejected with replacements,
- missing editors fail cleanly,
- doctor help reaches the command and advertises JSON,
- JSON Doctor failures propagate through the process status,
- Node 20.8 fails while 20.9/21/22 pass.

Mutation checks:

| mutation | result |
|---|---|
| remove config + doctor registrations | **2 failed** |
| validate through tolerant/JSON-only loader | **1 failed** |
| config set writes the resolved merge | **1 failed** |
| reset leaves JSON5 in place | **1 failed** |
| Doctor JSON ignores failed checks | **1 failed** |
| get/set echo raw credentials | **1 failed** |

## Validation

- focused CLI/config/doctor contracts: **120+ passed**
- all non-baseline TypeScript tests: **4,735 passed / 21 skipped**
- `tsc --noEmit`: clean
- five local `copilot-cli-local` tests are excluded only because the pinned optional binary is absent; the same five were reproduced on detached clean main
- four independent review passes found the issues above and re-reviewed the corrected diff
