### PR TITLE
fix(storage): cron logs cannot outlive or precede their job

### DIFF
--- a/python/openrappter/storage/adapter.py
+++ b/python/openrappter/storage/adapter.py
@@ -74,7 +74,66 @@ _MIGRATIONS = [
             """,
         ),
     ),
+    (
+        2,
+        (
+            "CREATE TEMP TABLE cron_logs_old_sequence (seq INTEGER NOT NULL)",
+            """
+            INSERT INTO cron_logs_old_sequence (seq)
+            SELECT COALESCE(
+                (SELECT seq FROM sqlite_sequence WHERE name = 'cron_logs'),
+                0
+            )
+            """,
+            """
+            CREATE TABLE cron_logs_with_parent (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                FOREIGN KEY (job_id) REFERENCES cron_jobs(id) ON DELETE CASCADE
+            )
+            """,
+            """
+            INSERT INTO cron_logs_with_parent (seq, job_id, data, created_at)
+            SELECT seq, job_id, data, created_at
+            FROM cron_logs
+            WHERE job_id IN (SELECT id FROM cron_jobs)
+            """,
+            "DROP TABLE cron_logs",
+            "ALTER TABLE cron_logs_with_parent RENAME TO cron_logs",
+            "DELETE FROM sqlite_sequence WHERE name = 'cron_logs'",
+            """
+            INSERT INTO sqlite_sequence (name, seq)
+            SELECT 'cron_logs', seq FROM cron_logs_old_sequence
+            """,
+            "DROP TABLE cron_logs_old_sequence",
+            "CREATE INDEX idx_cron_logs_job_id ON cron_logs(job_id, seq)",
+        ),
+    ),
 ]
+
+
+def _require_cron_log_job_id(log: dict) -> str:
+    job_id = log.get('job_id')
+    if not isinstance(job_id, str) or not job_id.strip():
+        raise ValueError("cron log requires an existing cron job id")
+    return job_id
+
+
+def _execute_with_busy_retry(
+    conn: sqlite3.Connection,
+    statement: str,
+    timeout: float,
+) -> sqlite3.Cursor:
+    deadline = time.monotonic() + max(timeout, 0)
+    while True:
+        try:
+            return conn.execute(statement)
+        except sqlite3.OperationalError as error:
+            if "locked" not in str(error).lower() or time.monotonic() >= deadline:
+                raise
+            time.sleep(min(0.05, max(deadline - time.monotonic(), 0)))
 
 
 class StorageAdapter(abc.ABC):
@@ -166,6 +225,7 @@ class InMemoryStorageAdapter(StorageAdapter):
         self._cron_jobs = {}      # id -> dict
         self._cron_logs = {}      # job_id -> [log_dicts]
         self._config = {}         # key -> value
+        self._lock = threading.RLock()
         self._initialized = False
 
     def initialize(self):
@@ -223,32 +283,43 @@ class InMemoryStorageAdapter(StorageAdapter):
         job = dict(job)
         job.setdefault('created_at', time.time())
         job['updated_at'] = time.time()
-        self._cron_jobs[job['id']] = job
+        with self._lock:
+            self._cron_jobs[job['id']] = job
 
     def get_cron_job(self, job_id: str) -> Optional[dict]:
-        return self._cron_jobs.get(job_id)
+        with self._lock:
+            return self._cron_jobs.get(job_id)
 
     def delete_cron_job(self, job_id: str) -> bool:
-        return self._cron_jobs.pop(job_id, None) is not None
+        with self._lock:
+            deleted = self._cron_jobs.pop(job_id, None) is not None
+            if deleted:
+                self._cron_logs.pop(job_id, None)
+            return deleted
 
     def list_cron_jobs(self) -> list:
-        return list(self._cron_jobs.values())
+        with self._lock:
+            return list(self._cron_jobs.values())
 
     # --- Cron Logs ---
 
     def save_cron_log(self, log: dict) -> None:
         log = dict(log)
         log.setdefault('created_at', time.time())
-        job_id = log.get('job_id', 'unknown')
-        if job_id not in self._cron_logs:
-            self._cron_logs[job_id] = []
-        self._cron_logs[job_id].append(log)
+        job_id = _require_cron_log_job_id(log)
+        with self._lock:
+            if job_id not in self._cron_jobs:
+                raise ValueError(f"cron job does not exist: {job_id}")
+            if job_id not in self._cron_logs:
+                self._cron_logs[job_id] = []
+            self._cron_logs[job_id].append(log)
 
     def get_cron_logs(self, job_id: str, limit: Optional[int] = None) -> list:
-        logs = self._cron_logs.get(job_id, [])
-        if limit is not None:
-            return list(logs[-limit:])
-        return list(logs)
+        with self._lock:
+            logs = self._cron_logs.get(job_id, [])
+            if limit is not None:
+                return list(logs[-limit:])
+            return list(logs)
 
     # --- Config KV ---
 
@@ -303,7 +374,8 @@ class SqliteStorageAdapter(StorageAdapter):
                     pass
 
             conn = sqlite3.connect(self._path, timeout=self._timeout, isolation_level=None)
-            conn.execute("PRAGMA journal_mode=WAL")
+            conn.execute(f"PRAGMA busy_timeout={max(int(self._timeout * 1000), 0)}")
+            _execute_with_busy_retry(conn, "PRAGMA journal_mode=WAL", self._timeout)
             conn.execute("PRAGMA foreign_keys=ON")
             conn.execute("PRAGMA synchronous=NORMAL")
             self._conn = conn
@@ -342,12 +414,16 @@ class SqliteStorageAdapter(StorageAdapter):
             )
             """
         )
-        applied = {row[0] for row in conn.execute("SELECT version FROM schema_migrations")}
         for version, statements in _MIGRATIONS:
-            if version in applied:
-                continue
             conn.execute("BEGIN IMMEDIATE")
             try:
+                applied = conn.execute(
+                    "SELECT 1 FROM schema_migrations WHERE version = ?",
+                    (version,),
+                ).fetchone()
+                if applied:
+                    conn.commit()
+                    continue
                 for statement in statements:
                     conn.execute(statement)
                 conn.execute(
@@ -448,8 +524,12 @@ class SqliteStorageAdapter(StorageAdapter):
         with self._lock, conn:
             conn.execute(
                 """
-                INSERT OR REPLACE INTO cron_jobs (id, data, created_at, updated_at)
+                INSERT INTO cron_jobs (id, data, created_at, updated_at)
                 VALUES (?, ?, ?, ?)
+                ON CONFLICT(id) DO UPDATE SET
+                    data = excluded.data,
+                    created_at = excluded.created_at,
+                    updated_at = excluded.updated_at
                 """,
                 (job['id'], json.dumps(job), job['created_at'], job['updated_at']),
             )
@@ -479,13 +559,18 @@ class SqliteStorageAdapter(StorageAdapter):
     def save_cron_log(self, log: dict) -> None:
         log = dict(log)
         log.setdefault('created_at', time.time())
-        job_id = log.get('job_id', 'unknown')
+        job_id = _require_cron_log_job_id(log)
         conn = self._ensure_open()
         with self._lock, conn:
-            conn.execute(
-                "INSERT INTO cron_logs (job_id, data, created_at) VALUES (?, ?, ?)",
-                (job_id, json.dumps(log), log['created_at']),
-            )
+            try:
+                conn.execute(
+                    "INSERT INTO cron_logs (job_id, data, created_at) VALUES (?, ?, ?)",
+                    (job_id, json.dumps(log), log['created_at']),
+                )
+            except sqlite3.IntegrityError as error:
+                if "FOREIGN KEY" in str(error).upper():
+                    raise ValueError(f"cron job does not exist: {job_id}") from error
+                raise
 
     def get_cron_logs(self, job_id: str, limit: Optional[int] = None) -> list:
         conn = self._ensure_open()

--- a/python/tests/test_storage_sqlite_adapter.py
+++ b/python/tests/test_storage_sqlite_adapter.py
@@ -8,6 +8,7 @@ import json
 import sqlite3
 import stat
 import sys
+import threading
 
 import pytest
 
@@ -173,6 +174,55 @@ def test_memory_adapter_never_touches_disk(tmp_path, monkeypatch):
     assert not (tmp_path / 'unused').exists()
 
 
+def test_memory_cron_log_cannot_race_parent_deletion():
+    adapter = InMemoryStorageAdapter()
+    adapter.initialize()
+    adapter.save_cron_job({'id': 'job-1'})
+
+    parent_checked = threading.Event()
+    release_writer = threading.Event()
+    parent_deleted = threading.Event()
+
+    class PausingJobs(dict):
+        def __contains__(self, key):
+            present = super().__contains__(key)
+            parent_checked.set()
+            release_writer.wait(timeout=2)
+            return present
+
+        def pop(self, key, default=None):
+            result = super().pop(key, default)
+            parent_deleted.set()
+            return result
+
+    adapter._cron_jobs = PausingJobs(adapter._cron_jobs)
+    errors = []
+
+    def write_log():
+        try:
+            adapter.save_cron_log({'job_id': 'job-1', 'status': 'ok'})
+        except Exception as error:
+            errors.append(error)
+
+    writer = threading.Thread(target=write_log)
+    writer.start()
+    assert parent_checked.wait(timeout=2)
+
+    deleter = threading.Thread(target=lambda: adapter.delete_cron_job('job-1'))
+    deleter.start()
+    # Without a shared lock deletion completes here, before the writer appends.
+    parent_deleted.wait(timeout=0.2)
+    release_writer.set()
+
+    writer.join(timeout=2)
+    deleter.join(timeout=2)
+    assert not writer.is_alive()
+    assert not deleter.is_alive()
+    assert errors == []
+    assert adapter.get_cron_job('job-1') is None
+    assert adapter.get_cron_logs('job-1') == []
+
+
 # --- Filtering / CRUD parity with the in-memory adapter ---
 
 @pytest.fixture(params=['memory', 'sqlite'])
@@ -226,6 +276,230 @@ def test_cron_job_and_log_crud_parity(any_adapter):
     assert any_adapter.get_cron_logs('unknown-job') == []
     assert any_adapter.delete_cron_job('j1') is True
     assert any_adapter.list_cron_jobs() == []
+    assert any_adapter.get_cron_logs('j1') == []
+
+
+def test_updating_a_cron_job_preserves_its_logs(any_adapter):
+    any_adapter.save_cron_job({'id': 'j1', 'name': 'before'})
+    any_adapter.save_cron_log({'job_id': 'j1', 'status': 'ok'})
+
+    any_adapter.save_cron_job({'id': 'j1', 'name': 'after'})
+
+    assert any_adapter.get_cron_job('j1')['name'] == 'after'
+    assert [log['status'] for log in any_adapter.get_cron_logs('j1')] == ['ok']
+
+
+@pytest.mark.parametrize(
+    "log",
+    [
+        {'status': 'missing id'},
+        {'job_id': '', 'status': 'empty id'},
+        {'job_id': 'does-not-exist', 'status': 'orphan'},
+    ],
+)
+def test_cron_log_requires_an_existing_parent_job(any_adapter, log):
+    with pytest.raises(ValueError, match="cron job"):
+        any_adapter.save_cron_log(log)
+
+
+def test_sqlite_cron_log_schema_cascades_to_the_parent(tmp_path):
+    db_path = tmp_path / "cron-parent.sqlite3"
+    adapter = create_storage_adapter({'type': 'sqlite', 'path': str(db_path)})
+    adapter.close()
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        foreign_keys = conn.execute("PRAGMA foreign_key_list(cron_logs)").fetchall()
+    finally:
+        conn.close()
+
+    assert any(
+        row[2] == 'cron_jobs'
+        and row[3] == 'job_id'
+        and row[6].upper() == 'CASCADE'
+        for row in foreign_keys
+    )
+
+
+def test_concurrent_sqlite_initializers_apply_each_migration_once(tmp_path):
+    db_path = tmp_path / "concurrent-initialize.sqlite3"
+    barrier = threading.Barrier(2)
+    errors = []
+
+    def initialize():
+        adapter = SqliteStorageAdapter(db_path, timeout=10)
+        try:
+            barrier.wait(timeout=2)
+            adapter.initialize()
+        except Exception as error:
+            errors.append(error)
+        finally:
+            adapter.close()
+
+    threads = [threading.Thread(target=initialize) for _ in range(2)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join(timeout=12)
+
+    assert all(not thread.is_alive() for thread in threads)
+    assert errors == []
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        versions = conn.execute(
+            "SELECT version, COUNT(*) FROM schema_migrations GROUP BY version"
+        ).fetchall()
+    finally:
+        conn.close()
+    assert versions == [(1, 1), (2, 1)]
+
+
+def test_sqlite_v1_upgrade_keeps_parented_logs_and_removes_orphans(tmp_path):
+    db_path = tmp_path / "cron-v1-upgrade.sqlite3"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at REAL NOT NULL
+            );
+            INSERT INTO schema_migrations (version, applied_at) VALUES (1, 0);
+            CREATE TABLE cron_jobs (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            );
+            CREATE TABLE cron_logs (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                created_at REAL NOT NULL
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO cron_jobs VALUES (?, ?, ?, ?)",
+            ('job-1', json.dumps({'id': 'job-1'}), 1, 1),
+        )
+        conn.execute(
+            "INSERT INTO cron_logs (job_id, data, created_at) VALUES (?, ?, ?)",
+            ('job-1', json.dumps({'job_id': 'job-1', 'status': 'ok'}), 1),
+        )
+        conn.execute(
+            "INSERT INTO cron_logs (job_id, data, created_at) VALUES (?, ?, ?)",
+            ('missing', json.dumps({'job_id': 'missing', 'status': 'orphan'}), 1),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    adapter = create_storage_adapter({'type': 'sqlite', 'path': str(db_path)})
+    try:
+        assert [log['status'] for log in adapter.get_cron_logs('job-1')] == ['ok']
+        assert adapter.get_cron_logs('missing') == []
+        adapter.save_cron_log({'job_id': 'job-1', 'status': 'after'})
+    finally:
+        adapter.close()
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        versions = {
+            row[0] for row in conn.execute("SELECT version FROM schema_migrations")
+        }
+        foreign_keys = conn.execute("PRAGMA foreign_key_list(cron_logs)").fetchall()
+        sequences = [
+            row[0] for row in conn.execute("SELECT seq FROM cron_logs ORDER BY seq")
+        ]
+    finally:
+        conn.close()
+
+    assert versions == {1, 2}
+    assert any(row[2] == 'cron_jobs' and row[6].upper() == 'CASCADE' for row in foreign_keys)
+    assert sequences == [1, 3]
+
+
+def test_sqlite_v1_upgrade_preserves_sequence_when_every_old_log_is_orphaned(tmp_path):
+    db_path = tmp_path / "cron-v1-all-orphans.sqlite3"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.executescript(
+            """
+            CREATE TABLE schema_migrations (
+                version INTEGER PRIMARY KEY,
+                applied_at REAL NOT NULL
+            );
+            INSERT INTO schema_migrations (version, applied_at) VALUES (1, 0);
+            CREATE TABLE cron_jobs (
+                id TEXT PRIMARY KEY,
+                data TEXT NOT NULL,
+                created_at REAL NOT NULL,
+                updated_at REAL NOT NULL
+            );
+            CREATE TABLE cron_logs (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                job_id TEXT NOT NULL,
+                data TEXT NOT NULL,
+                created_at REAL NOT NULL
+            );
+            INSERT INTO cron_logs (job_id, data, created_at)
+            VALUES ('missing-1', '{}', 1), ('missing-2', '{}', 1);
+            """
+        )
+        conn.execute(
+            "INSERT INTO cron_jobs VALUES (?, ?, ?, ?)",
+            ('job-1', json.dumps({'id': 'job-1'}), 1, 1),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    adapter = create_storage_adapter({'type': 'sqlite', 'path': str(db_path)})
+    try:
+        assert adapter.get_cron_logs('missing-1') == []
+        adapter.save_cron_log({'job_id': 'job-1', 'status': 'first-valid'})
+    finally:
+        adapter.close()
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        sequences = conn.execute("SELECT seq FROM cron_logs").fetchall()
+    finally:
+        conn.close()
+    assert sequences == [(3,)]
+
+
+def test_sqlite_failed_parent_delete_keeps_the_job_and_logs(tmp_path):
+    db_path = tmp_path / "cron-delete-atomic.sqlite3"
+    adapter = create_storage_adapter({'type': 'sqlite', 'path': str(db_path)})
+    try:
+        adapter.save_cron_job({'id': 'job-1', 'name': 'protected'})
+        adapter.save_cron_log({'job_id': 'job-1', 'status': 'ok'})
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                """
+                CREATE TRIGGER refuse_cron_delete
+                BEFORE DELETE ON cron_jobs
+                BEGIN
+                    SELECT RAISE(ABORT, 'delete refused');
+                END
+                """
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        with pytest.raises(sqlite3.IntegrityError, match="delete refused"):
+            adapter.delete_cron_job('job-1')
+
+        assert adapter.get_cron_job('job-1') is not None
+        assert [log['status'] for log in adapter.get_cron_logs('job-1')] == ['ok']
+    finally:
+        adapter.close()
 
 
 def test_config_kv_crud_parity(any_adapter):


### PR DESCRIPTION
## Divergence

TypeScript's storage schema has:

```sql
FOREIGN KEY (job_id) REFERENCES cron_jobs(id) ON DELETE CASCADE
```

Python had neither the FK nor an application check. It also did:

```python
job_id = log.get('job_id', 'unknown')
```

So missing IDs, empty IDs, and nonexistent jobs all produced persistent orphan history. Deleting a job left its logs behind in both Python adapters.

The strengthened contract fails **9 ways** on main:

- 3 invalid-parent cases × 2 adapters = 6
- parent deletion retains logs × 2 adapters = 2
- SQLite schema has no cascade = 1

## Fix

### Both adapters

- Require a non-empty `job_id`.
- Require the parent job to exist.
- Delete logs when the parent is deleted.
- Expose the same `ValueError` contract for absent parents.

### SQLite migration v2

- Rebuild `cron_logs` with `ON DELETE CASCADE`.
- Copy only rows whose parent still exists.
- Preserve the old AUTOINCREMENT high-water mark, even when every old row is orphaned, so deleted IDs are never reused.
- Recheck each migration version *inside* `BEGIN IMMEDIATE`, so concurrent initializers cannot both decide to run it.

### Write/atomicity corrections found by review

Independent review found that adding the FK without changing existing writes would cause new data loss:

- `INSERT OR REPLACE` on `cron_jobs` deletes/recreates the parent and would cascade-delete all logs on every update. It is now `ON CONFLICT DO UPDATE`.
- Manually deleting logs then the parent was not atomic under the adapter's autocommit connection. SQLite now deletes only the parent and lets the single-statement cascade do its job.
- Parent check + insert had a cross-adapter race. The FK is the authority and its violation is translated to the adapter's `ValueError` contract.
- Concurrent first boot could still fail before migrations while enabling WAL. WAL bootstrap now has a bounded SQLITE_BUSY/LOCKED retry, and the connection busy timeout is explicit.
- In-memory parent check/append/delete now share an `RLock`.

## Evidence

Tests cover:

- missing, empty, and unknown parent IDs in both adapters,
- cascade parity in both adapters,
- updating a job preserves its logs,
- version-1 upgrade preserves valid logs and removes orphans,
- version-1 upgrade with **only** orphan logs preserves sequence high-water,
- next post-upgrade log receives the unreused next sequence,
- failed parent deletion keeps both parent and logs,
- deterministic in-memory save/delete race,
- two simultaneous SQLite initializers apply versions 1 and 2 exactly once,
- **50 repeated concurrent first-boot runs**.

Mutation checks:

| mutation | result |
|---|---|
| bypass in-memory parent existence check | memory unknown-parent case fails |
| bypass SQLite application parent check | SQLite exception-contract case fails |
| remove in-memory cascade | memory deletion case fails |

Validation:

- storage adapter: **44 passed**
- full Python: **1,346 passed / 6 skipped / 51 subtests passed**
- four independent review passes: final pass reports no significant issues
