### PR TITLE
fix(storage): make async transactions actually atomic

### DIFF
--- a/typescript/src/__tests__/integration/storage.test.ts
+++ b/typescript/src/__tests__/integration/storage.test.ts
@@ -176,22 +176,228 @@ describe('Storage Integration', () => {
   // ── Transactions ──────────────────────────────────────────────────────
 
   describe('Transactions', () => {
-    it('should commit synchronous transaction on success', async () => {
-      // better-sqlite3 transactions are synchronous — cannot use async/await inside
-      await storage.setConfig('tx-key', 'tx-value');
+    it('commits writes on both sides of an await', async () => {
+      let callbackDone!: () => void;
+      const done = new Promise<void>((resolve) => { callbackDone = resolve; });
 
-      const value = await storage.getConfig('tx-key');
-      expect(value).toBe('tx-value');
+      const outcome = storage.transaction(async () => {
+        await storage.setConfig('tx-before', 'before');
+        await Promise.resolve();
+        await storage.setConfig('tx-after', 'after');
+        callbackDone();
+        return 'committed';
+      }).then(
+        (value) => ({ value, error: null }),
+        (error: Error) => ({ value: null, error }),
+      );
+
+      await done;
+      expect(await outcome).toEqual({ value: 'committed', error: null });
+      expect(await storage.getConfig('tx-before')).toBe('before');
+      expect(await storage.getConfig('tx-after')).toBe('after');
     });
 
-    it('should support multiple sequential operations', async () => {
-      await storage.setConfig('tx-a', 'val-a');
-      await storage.setConfig('tx-b', 'val-b');
+    it('does not let unrelated work join a transaction while it awaits', async () => {
+      let entered!: () => void;
+      const transactionEntered = new Promise<void>((resolve) => { entered = resolve; });
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
 
-      const a = await storage.getConfig('tx-a');
-      const b = await storage.getConfig('tx-b');
-      expect(a).toBe('val-a');
-      expect(b).toBe('val-b');
+      const transaction = storage.transaction(async () => {
+        await storage.setConfig('tx-inside-before', 'before');
+        entered();
+        await gate;
+        await storage.setConfig('tx-inside-after', 'after');
+      });
+      // The broken adapter rejects immediately; attach before awaiting the gate.
+      const observed = transaction.then(
+        () => null,
+        (error: Error) => error,
+      );
+
+      await transactionEntered;
+      let outsideError: Error | null = null;
+      try {
+        await storage.setConfig('tx-outside', 'outside');
+      } catch (error) {
+        outsideError = error as Error;
+      }
+      release();
+
+      expect(outsideError?.message).toMatch(/transaction/i);
+      expect(await observed).toBeNull();
+      expect(await storage.getConfig('tx-outside')).toBeNull();
+      expect(await storage.getConfig('tx-inside-after')).toBe('after');
+    });
+
+    it('rolls back writes on both sides of an await when the callback fails', async () => {
+      await expect(
+        storage.transaction(async () => {
+          await storage.setConfig('tx-rollback-before', 'before');
+          await Promise.resolve();
+          await storage.setConfig('tx-rollback-after', 'after');
+          throw new Error('rollback requested');
+        }),
+      ).rejects.toThrow('rollback requested');
+
+      expect(await storage.getConfig('tx-rollback-before')).toBeNull();
+      expect(await storage.getConfig('tx-rollback-after')).toBeNull();
+    });
+
+    it('blocks an unawaited child task after the transaction completes', async () => {
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
+      let childFinished!: (error: Error | null) => void;
+      const childResult = new Promise<Error | null>((resolve) => {
+        childFinished = resolve;
+      });
+
+      await storage.transaction(async () => {
+        void (async () => {
+          await gate;
+          try {
+            await storage.setConfig('tx-late-child', 'must-not-persist');
+            childFinished(null);
+          } catch (error) {
+            childFinished(error as Error);
+          }
+        })();
+      });
+
+      release();
+      expect((await childResult)?.message).toMatch(/transaction completed/i);
+      expect(await storage.getConfig('tx-late-child')).toBeNull();
+    });
+
+    it('cannot replace or close the connection from inside a transaction', async () => {
+      await expect(
+        storage.transaction(async () => {
+          await storage.setConfig('tx-lifecycle-before', 'before');
+          await storage.initialize();
+          await storage.setConfig('tx-lifecycle-after', 'after');
+        }),
+      ).rejects.toThrow(/initialize.*transaction/i);
+
+      expect(await storage.getConfig('tx-lifecycle-before')).toBeNull();
+      expect(await storage.getConfig('tx-lifecycle-after')).toBeNull();
+
+      await expect(
+        storage.transaction(async () => {
+          await storage.close();
+        }),
+      ).rejects.toThrow(/close.*transaction/i);
+
+      await storage.setConfig('still-open', 'yes');
+      expect(await storage.getConfig('still-open')).toBe('yes');
+    });
+
+    it('rejects unrelated initialization without corrupting an active transaction', async () => {
+      let entered!: () => void;
+      const transactionEntered = new Promise<void>((resolve) => { entered = resolve; });
+      let release!: () => void;
+      const gate = new Promise<void>((resolve) => { release = resolve; });
+
+      const transaction = storage.transaction(async () => {
+        await storage.setConfig('tx-owner', 'inside');
+        entered();
+        await gate;
+      });
+
+      await transactionEntered;
+      await expect(storage.initialize()).rejects.toThrow(/transaction/i);
+      release();
+      await transaction;
+
+      expect(await storage.getConfig('tx-owner')).toBe('inside');
+      await storage.setConfig('after-owner', 'works');
+      expect(await storage.getConfig('after-owner')).toBe('works');
+    });
+
+    it('serializes concurrent initialize and close operations', async () => {
+      const adapter = createStorageAdapter({ type: 'memory', inMemory: true });
+
+      const initializing = adapter.initialize();
+      const closing = adapter.close();
+      await Promise.all([initializing, closing]);
+
+      await expect(adapter.getConfig('after-close')).rejects.toThrow(
+        /not initialized/i,
+      );
+    });
+
+    it('does not let a transaction overtake an earlier close', async () => {
+      const closing = storage.close();
+      const transaction = storage.transaction(async () => {
+        await storage.setConfig('after-queued-close', 'must-not-run');
+      });
+
+      await closing;
+      await expect(transaction).rejects.toThrow(/not initialized/i);
+
+      await storage.initialize();
+      expect(await storage.getConfig('after-queued-close')).toBeNull();
+    });
+
+    it('can retry cleanly after initialization fails', async () => {
+      const adapter = createStorageAdapter({ type: 'memory', inMemory: true });
+      const internal = adapter as unknown as {
+        runMigrations(db: unknown): Promise<void>;
+      };
+      const runMigrations = internal.runMigrations.bind(adapter);
+      let fail = true;
+      internal.runMigrations = async (db: unknown) => {
+        if (fail) {
+          fail = false;
+          throw new Error('injected migration failure');
+        }
+        await runMigrations(db);
+      };
+
+      await expect(adapter.initialize()).rejects.toThrow(
+        'injected migration failure',
+      );
+      await adapter.initialize();
+      await adapter.setConfig('after-retry', 'works');
+      expect(await adapter.getConfig('after-retry')).toBe('works');
+      await adapter.close();
+    });
+
+    it('invalidates the connection when rollback itself fails', async () => {
+      const internal = storage as unknown as {
+        db: {
+          exec(sql: string): void;
+          close(): void;
+          [key: PropertyKey]: unknown;
+        } | null;
+      };
+      const raw = internal.db!;
+      internal.db = new Proxy(raw, {
+        get(target, property) {
+          if (property === 'exec') {
+            return (sql: string) => {
+              if (sql === 'ROLLBACK') throw new Error('injected rollback failure');
+              return target.exec(sql);
+            };
+          }
+          const value = Reflect.get(target, property);
+          return typeof value === 'function' ? value.bind(target) : value;
+        },
+      });
+
+      await expect(
+        storage.transaction(async () => {
+          await storage.setConfig('tx-poisoned', 'must-not-survive');
+          throw new Error('transaction failed');
+        }),
+      ).rejects.toThrow(/rollback could not restore/i);
+
+      await expect(storage.getConfig('tx-poisoned')).rejects.toThrow(
+        /not initialized/i,
+      );
+
+      await storage.initialize();
+      await storage.setConfig('after-rollback-retry', 'works');
+      expect(await storage.getConfig('after-rollback-retry')).toBe('works');
     });
   });
 });

--- a/typescript/src/storage/sqlite.ts
+++ b/typescript/src/storage/sqlite.ts
@@ -3,6 +3,7 @@
  * Uses better-sqlite3 for synchronous operations wrapped in async interface
  */
 
+import { AsyncLocalStorage } from 'node:async_hooks';
 import type {
   StorageAdapter,
   Session,
@@ -39,53 +40,103 @@ interface RunResult {
 
 type BetterSqlite3 = (filename: string, options?: { readonly?: boolean }) => Database;
 
+interface TransactionContext {
+  active: boolean;
+}
+
 export class SQLiteAdapter implements StorageAdapter {
   private db: Database | null = null;
   private config: StorageConfig;
   private betterSqlite3: BetterSqlite3 | null = null;
+  private activeTransaction: TransactionContext | null = null;
+  private transactionContext = new AsyncLocalStorage<TransactionContext>();
+  private lifecycleTail: Promise<void> = Promise.resolve();
 
   constructor(config: StorageConfig) {
     this.config = config;
   }
 
   async initialize(): Promise<void> {
-    // Dynamic import of better-sqlite3
-    try {
-      const module = await import('better-sqlite3');
-      this.betterSqlite3 = module.default as BetterSqlite3;
-    } catch {
-      throw new Error(
-        'better-sqlite3 is required for SQLite storage. Install it with: npm install better-sqlite3'
-      );
-    }
+    this.assertLifecycleAllowed('initialize');
+    await this.enqueueLifecycle(async () => {
+      this.assertLifecycleAllowed('initialize');
+      if (this.db) return;
 
-    const dbPath = this.config.inMemory ? ':memory:' : (this.config.path ?? 'openrappter.db');
-    this.db = this.betterSqlite3(dbPath);
+      let factory: BetterSqlite3;
+      try {
+        const module = await import('better-sqlite3');
+        factory = module.default as BetterSqlite3;
+      } catch {
+        throw new Error(
+          'better-sqlite3 is required for SQLite storage. Install it with: npm install better-sqlite3'
+        );
+      }
 
-    // Enable foreign keys and WAL mode for better performance
-    this.db.pragma('foreign_keys = ON');
-    this.db.pragma('journal_mode = WAL');
+      const dbPath = this.config.inMemory ? ':memory:' : (this.config.path ?? 'openrappter.db');
+      const db = factory(dbPath);
+      try {
+        // Enable foreign keys and WAL mode for better performance
+        db.pragma('foreign_keys = ON');
+        db.pragma('journal_mode = WAL');
+        await this.runMigrations(db);
+      } catch (error) {
+        try {
+          db.close();
+        } catch { /* preserve the initialization error */ }
+        throw error;
+      }
 
-    // Run migrations
-    await this.runMigrations();
+      this.betterSqlite3 = factory;
+      this.db = db;
+    });
   }
 
   async close(): Promise<void> {
-    if (this.db) {
-      this.db.close();
-      this.db = null;
-    }
+    this.assertLifecycleAllowed('close');
+    await this.enqueueLifecycle(async () => {
+      this.assertLifecycleAllowed('close');
+      if (this.db) {
+        this.db.close();
+        this.db = null;
+      }
+    });
   }
 
   private ensureDb(): Database {
+    this.assertTransactionAccess();
     if (!this.db) {
       throw new Error('Database not initialized. Call initialize() first.');
     }
     return this.db;
   }
 
-  private async runMigrations(): Promise<void> {
-    const db = this.ensureDb();
+  private assertTransactionAccess(): void {
+    const current = this.transactionContext.getStore();
+    if (current && !current.active) {
+      throw new Error('Storage operation continued after its transaction completed');
+    }
+    if (this.activeTransaction && current !== this.activeTransaction) {
+      throw new Error('Storage operation attempted outside the active transaction');
+    }
+  }
+
+  private assertLifecycleAllowed(operation: 'initialize' | 'close'): void {
+    this.assertTransactionAccess();
+    if (this.activeTransaction) {
+      throw new Error(`Cannot ${operation} storage during an active transaction`);
+    }
+  }
+
+  private enqueueLifecycle<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.lifecycleTail.then(operation, operation);
+    this.lifecycleTail = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
+  }
+
+  private async runMigrations(db: Database): Promise<void> {
 
     // Create migrations table if not exists
     db.exec(`
@@ -453,9 +504,48 @@ export class SQLiteAdapter implements StorageAdapter {
   // Transactions
 
   async transaction<T>(fn: () => Promise<T>): Promise<T> {
-    const db = this.ensureDb();
-    const txn = db.transaction(() => fn());
-    return txn() as T;
+    this.assertTransactionAccess();
+    if (this.activeTransaction) {
+      throw new Error('Nested storage transactions are not supported');
+    }
+
+    return this.enqueueLifecycle(async () => {
+      const db = this.ensureDb();
+      if (this.activeTransaction) {
+        throw new Error('Nested storage transactions are not supported');
+      }
+
+      const context: TransactionContext = { active: true };
+      this.activeTransaction = context;
+      let began = false;
+      try {
+        db.exec('BEGIN IMMEDIATE');
+        began = true;
+        const result = await this.transactionContext.run(context, fn);
+        db.exec('COMMIT');
+        began = false;
+        return result;
+      } catch (error) {
+        if (began) {
+          try {
+            db.exec('ROLLBACK');
+          } catch (rollbackError) {
+            try {
+              db.close();
+            } catch { /* the connection is unusable either way */ }
+            if (this.db === db) this.db = null;
+            throw new AggregateError(
+              [error, rollbackError],
+              'Storage transaction failed and rollback could not restore the connection',
+            );
+          }
+        }
+        throw error;
+      } finally {
+        context.active = false;
+        this.activeTransaction = null;
+      }
+    });
   }
 
   // Row mappers


### PR DESCRIPTION
## The false transaction

`StorageAdapter.transaction()` explicitly accepts an async callback, but SQLiteAdapter did:

```ts
const txn = db.transaction(() => fn());
return txn();
```

`better-sqlite3` transactions must be synchronous. It rejects the returned Promise and rolls back immediately—but the async callback keeps running.

Reproduced on main:

```text
Transaction function cannot return a promise
```

while a write after `await` remained in the database. The caller was told rollback; state committed afterward.

## Fix

Implement the declared async contract with:

1. `BEGIN IMMEDIATE`
2. run/await the callback under an `AsyncLocalStorage` owner context
3. `COMMIT` on success
4. `ROLLBACK` on failure

Every adapter operation passes through ownership checks:

- the owner callback may read/write across awaits,
- unrelated work is rejected rather than silently joining,
- child tasks spawned inside the callback are rejected after transaction completion,
- nested transactions are rejected,
- initialize/close are rejected from an active transaction.

If rollback itself fails, the connection is closed and invalidated before ownership clears; later calls require reinitialization instead of joining a poisoned SQLite transaction.

## Lifecycle serialization

Independent review found initialize/close could race and transactions could overtake earlier lifecycle calls. Initialize, close, and transaction admission now share one ordered lifecycle queue.

- concurrent initialize then close ends closed,
- a transaction invoked after close cannot overtake it,
- concurrent initialize calls do not replace connections,
- connection fields publish only after pragmas/migrations succeed,
- failed setup closes its local handle and can retry,
- unrelated initialize during an active transaction is rejected without corrupting the owner.

## Evidence

Tests prove:

- writes before/after `await` commit together,
- writes before/after `await` roll back together,
- unrelated writes cannot enter while callback awaits,
- unawaited child tasks cannot write after commit,
- initialize/close cannot run inside a transaction,
- unrelated initialize cannot corrupt an active owner,
- initialize/close preserve invocation order,
- transaction cannot overtake queued close,
- failed initialization retries cleanly,
- forced rollback failure invalidates and can reinitialize.

Before the fix, the two first contracts both fail: async commit reports `Transaction function cannot return a promise`, and unrelated writes are accepted.

Validation:

- transaction/storage integration: **25 passed**
- all non-baseline TypeScript: **4,766 passed / 21 skipped**
- `tsc --noEmit`: clean
- three independent concurrency review passes

## Explicitly not claimed

A separate audit finding shows migration SQL + version markers are not yet atomic. That is queued as the next bounded fix; this PR does **not** claim partial DDL rollback.
