### PR TITLE
docs: bring the site up to 1.13.0, and fix what the scan found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-
-- **Copilot Surgeon primary interface** — replaces the static dashboard landing
-  page with an adaptive operating room where OpenRappter is the patient and
-  GitHub Copilot shapes each next interaction from live, sanitized patient
-  anatomy. Existing operational pages remain available as secondary anatomy.
-- **Consent-bound procedures** — Copilot proposals are persisted with an
-  immutable SHA-256 digest, require explicit owner approval (plus
-  `OPERATE OPENRAPPTER` for high-risk work), and cannot report recovery without
-  real agent-tool evidence and post-operative verification.
-
 ### Fixed
 
-- **HTTP RPC authentication** — token/password mode no longer trusts every
-  loopback request implicitly; protected JSON-RPC and `/chat` calls now enforce
-  configured credentials consistently with WebSocket authentication.
+- **Browser private network access** — reaching a private or loopback address
+  from the browser agent now requires an explicit operator opt-in
+  (`allowPrivateNetwork`, off by default) rather than being reachable by
+  default.
+- **Full IPv6 link-local range blocked** — the SSRF guard covered only part of
+  `fe80::/10`; the whole range is now rejected.
+- **Allowlisted domains match on DNS-label boundaries** — `evil-example.com`
+  no longer satisfies an allowlist entry of `example.com`.
+- **Chunked downloads are bounded while they stream** — a declared length is
+  not a promise, so the cap is enforced as bytes arrive rather than checked up
+  front.
+- **Cron job ids** — the scheduler sends the job id the gateway actually
+  reads, and cron logs can no longer outlive or precede the job they belong
+  to.
+- **Shell exit codes** — Python returned `status=success` for every completed
+  subprocess even on a nonzero exit, so `false` reported `return_code=1` while
+  the shared classifier recorded success. Python now derives status from the
+  return code; TypeScript already did.
+- **`config` and `doctor` were never registered** — both were implemented and
+  exported, but their words fell through to chat and global help while shipped
+  health guidance told you to run them. Registering them exposed dormant bugs:
+  `get`/`set` no longer echo credential values, validation strictly parses both
+  config files against the real schema, and `doctor` returns nonzero for failed
+  checks in JSON mode too.
+- **`voice-call` skill** prescribed `call start`, `call end` and
+  `call conference`, none of which exist, and required a legacy plugin switch
+  no OpenRappter code reads. It now documents the flow that ships.
+
+### Changed
+
+- The Electron desktop is the authority for OpenRappter Bar authentication,
+  and desktop smoke tests were hardened for concurrent and Windows runs.
 
 ## [1.13.0] - 2026-08-14
 
@@ -147,6 +165,63 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a tool-to-agent causal subtree rather than a disconnected child trace.
 - Standalone records evict sequence caches, and explicit recorder installation
   remains synchronized with environment bootstrap.
+
+## [1.11.0] - 2026-08-10
+
+### Added
+
+- **One device, many rappters** — an *alpha* holds the default port and the
+  device's channels, and any number of *hatched twins* run beside it, each with
+  its own identity, port, and lock. `openrappter hatch <name>`,
+  `openrappter twins`, and `--instance <id>` address them.
+- **Twin-to-twin chat** — a rappter can speak to a peer, not only be spoken to.
+  `POST /twin` carries the `rapp-twin-chat/1.0` envelope, and a peer that
+  speaks `/chat` but not `/twin` is still reachable.
+- **Neighbourhood and roster** — a running rappter can reach a neighbour, tells
+  its neighbours which twin it is, and is judged by the same name the roster
+  calls it.
+- **Copilot Surgeon primary interface** — replaces the static dashboard landing
+  page with an adaptive operating room where OpenRappter is the patient and
+  GitHub Copilot shapes each next interaction from live, sanitized patient
+  anatomy. Existing operational pages remain available as secondary anatomy.
+- **Consent-bound procedures** — Copilot proposals are persisted with an
+  immutable SHA-256 digest, require explicit owner approval (plus
+  `OPERATE OPENRAPPTER` for high-risk work), and cannot report recovery without
+  real agent-tool evidence and post-operative verification.
+- **Release channels** — `openrappter channel` manages stable and experimental
+  rings, with isolated canary, nightly, alpha, and beta promotion.
+
+### Changed
+
+- **The Copilot CLI ships with the commit.** `@github/copilot` is a
+  lockfile-pinned dependency resolved from this package's own `node_modules`
+  rather than found on `PATH`, so its version is no longer decided by whoever
+  last ran `copilot update`. Resolution order — explicit operator override,
+  then the pinned copy, then ambient globals — is covered by tests.
+- **The digest is re-checked before reuse.** The installer stamps the CLI's
+  SHA-256 at build time and verifies it again before reusing an installation,
+  so a binary substituted after install forces a rebuild instead of running.
+- **`--status` names the binary that will actually answer**, instead of
+  judging Copilot solely by `GITHUB_TOKEN` and reporting it unavailable while
+  the gateway answered happily through the CLI backend.
+- Installer digests are computed from the commit's git blob rather than the
+  working tree, so a stale checkout or a local line-ending conversion cannot
+  publish a hash for bytes that were never released.
+
+### Fixed
+
+- **HTTP RPC authentication** — token/password mode no longer trusts every
+  loopback request implicitly; protected JSON-RPC and `/chat` calls now enforce
+  configured credentials consistently with WebSocket authentication.
+- `/twin` requires the same credential `/chat` requires, and `/agents/import`
+  — which executes code — requires it too.
+- A hatched twin shares the device, never a mouth: a channel alias cannot route
+  around the registry, and a twin is told which mouths are not its own.
+- A stale endpoint record is history, not an address; a name that never started
+  is not answered for by someone else; a dead pid is not a serving process.
+- An unknown `POST` path returns 404 rather than `200 "Received: …"`, and an
+  over-cap request body is answered with 413 rather than a connection reset.
+- A `--port` typed after a subcommand reaches that subcommand.
 
 ## [1.10.0] - 2026-07-11
 

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -18,7 +18,7 @@
 <!-- ── Navbar ── -->
 <nav>
   <div class="nav-container">
-    <a href="./" class="logo">openrappter <span class="logo-badge">v1.9.1</span></a>
+    <a href="./" class="logo">openrappter <span class="logo-badge">v1.13.0</span></a>
     <button class="mobile-menu-btn">&#9776;</button>
     <div class="nav-links">
       <a href="./docs.html">Docs</a>
@@ -46,39 +46,55 @@
 <section class="doc-section" id="system-overview" style="max-width:1100px;margin:0 auto;padding:3rem 2rem;">
   <div class="section-label">System Overview</div>
   <h2 class="section-title">Architecture at a glance</h2>
-  <p class="section-subtitle">openrappter is a layered, local-first AI agent framework. Channels funnel messages into a WebSocket gateway, which dispatches them through a registry of agents. Those agents talk to pluggable LLM providers, a hybrid memory system, and a persistent storage layer — all on your own machine.</p>
+  <p class="section-subtitle">openrappter is a layered, local-first AI agent framework. Channels funnel messages into a gateway, which dispatches them through a registry of agents. Those agents talk to pluggable LLM providers, a hybrid memory system, and a persistent storage layer — all on your own machine.</p>
 
-  <div class="arch-diagram">                     Channels
-    &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9436;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9436;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9436;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-    &#9474;   CLI   &#9474;  Slack   &#9474;  Discord  &#9474; Telegram &#9474;  ...15+ more
-    &#9492;&#9472;&#9472;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9472;&#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9472;&#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-         &#9474;         &#9474;           &#9474;          &#9474;
-         &#9660;         &#9660;           &#9660;          &#9660;
-    &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-    &#9474;           WebSocket Gateway               &#9474;
-    &#9474;        (JSON-RPC 2.0 / Streaming)         &#9474;
-    &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-                       &#9474;
-                       &#9660;
-    &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-    &#9474;           Agent Registry                  &#9474;
-    &#9474;   &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488; &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;  &#9474;
-    &#9474;   &#9474;Shell &#9474; &#9474;Memory&#9474; &#9474; Web  &#9474; &#9474;Browser&#9474;  &#9474;
-    &#9474;   &#9474;Agent &#9474; &#9474;Agent &#9474; &#9474;Agent &#9474; &#9474; Agent &#9474;  &#9474;
-    &#9474;   &#9492;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9496; &#9492;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9496; &#9492;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9496; &#9492;&#9472;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9496;  &#9474;
-    &#9474;      &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;       &#9474;
-    &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9508;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;
-                       &#9474;
-         &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9532;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-         &#9660;             &#9660;             &#9660;
-    &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;  &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;  &#9484;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9488;
-    &#9474;Providers&#9474;  &#9474;  Memory  &#9474;  &#9474; Storage  &#9474;
-    &#9474; Copilot &#9474;  &#9474; Chunker  &#9474;  &#9474;  SQLite  &#9474;
-    &#9474;Anthropic&#9474;  &#9474;Embeddings&#9474;  &#9474;In-Memory &#9474;
-    &#9474; OpenAI  &#9474;  &#9474;  Search  &#9474;  &#9474;          &#9474;
-    &#9474; Gemini  &#9474;  &#9474;          &#9474;  &#9474;          &#9474;
-    &#9474; Ollama  &#9474;  &#9474;          &#9474;  &#9474;          &#9474;
-    &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;  &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;  &#9492;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9472;&#9496;</div>
+  <p class="section-subtitle">Since v1.10 a single device no longer runs a single rappter. One <strong>alpha</strong> holds the default port and the device's channels; any number of <strong>hatched twins</strong> run beside it, each with its own identity, port, and lock. Twins reach each other over <code>POST /twin</code> using the <code>rapp-twin-chat/1.0</code> envelope. A twin owns a mouth only if the registry says so — sharing a device never means sharing a channel.</p>
+
+  <div class="arch-diagram">                         Channels  (16 in TypeScript)
+    ┌──────────┬──────────┬───────────┬──────────┬──────────────┐
+    │   CLI    │  Slack   │  Discord  │ Telegram │  iMessage …  │
+    └────┬─────┴────┬─────┴─────┬─────┴────┬─────┴──────┬───────┘
+         │          │           │          │            │
+         ▼          ▼           ▼          ▼            ▼
+    ┌──────────────────────────────────────────────────────────┐
+    │                        Gateway                           │
+    │   JSON-RPC 2.0 over WebSocket  +  HTTP                    │
+    │   /health  /livez  /readyz  /status                       │
+    │   /chat    /twin   /agents/import   /vui                  │
+    └───────────────────────────┬──────────────────────────────┘
+                                │
+                                ▼
+    ┌──────────────────────────────────────────────────────────┐
+    │                     Agent Registry                        │
+    │        37 agents (TypeScript) · 26 agents (Python)        │
+    │   ┌───────┐ ┌────────┐ ┌───────┐ ┌────────┐ ┌─────────┐  │
+    │   │ Shell │ │ Memory │ │  Web  │ │Browser │ │  Media  │  │
+    │   └───┬───┘ └───┬────┘ └───┬───┘ └───┬────┘ └────┬────┘  │
+    │       └─────────┴──────────┴─────────┴───────────┘       │
+    └───────────────────────────┬──────────────────────────────┘
+                                │
+        ┌───────────────┬───────┴───────┬───────────────┐
+        ▼               ▼               ▼               ▼
+   ┌─────────┐    ┌──────────┐    ┌──────────┐   ┌────────────┐
+   │Providers│    │  Memory  │    │ Storage  │   │  Security  │
+   │ Copilot │    │ Chunker  │    │  SQLite  │   │ url-guard  │
+   │Anthropic│    │Embeddings│    │In-Memory │   │  redact    │
+   │ OpenAI  │    │  Search  │    │   WAL    │   │secret-keys │
+   │ Gemini  │    │          │    │          │   │            │
+   │ Ollama  │    │          │    │          │   │            │
+   └─────────┘    └──────────┘    └──────────┘   └────────────┘
+
+
+                    One device, many rappters
+    ┌──────────────────────────────────────────────────────────┐
+    │  alpha  (default port, owns the device's channels)       │
+    │     │                                                     │
+    │     ├── twin "ada"    own identity · own port · own lock  │
+    │     └── twin "nicolas"  own identity · own port · own lock│
+    │                                                           │
+    │  peer chat:  POST /twin   envelope rapp-twin-chat/1.0     │
+    │  a twin owns a mouth only if the registry says so         │
+    └──────────────────────────────────────────────────────────┘</div>
 </section>
 
 <!-- ── 2. Agent Contract ── -->
@@ -404,32 +420,105 @@ result_b = agent_b.execute(
                              result propagates up</div>
 </section>
 
-<!-- ── 7. Directory Structure ── -->
+
+<!-- ── 7. Twins ── -->
+<section class="doc-section" id="twins" style="max-width:1100px;margin:0 auto;padding:3rem 2rem;">
+  <div class="section-label">Twins</div>
+  <h2 class="section-title">One device, many rappters</h2>
+  <p class="section-subtitle">Before v1.10 a device ran one rappter. Now an <strong>alpha</strong> holds the default port and the device's channels, and any number of <strong>hatched twins</strong> run beside it. Each twin gets its own identity, its own port, and its own lock — not just a label.</p>
+
+  <pre style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:1.5rem;font-family:'JetBrains Mono',monospace;font-size:0.85rem;line-height:1.8;overflow-x:auto;margin-top:1.5rem;">openrappter hatch ada        <span style="color:#525252;"># hatch a twin on this device</span>
+openrappter twins            <span style="color:#525252;"># which rappters are running</span>
+openrappter --instance ada   <span style="color:#525252;"># address one of them</span></pre>
+
+  <h3 style="margin-top:2.5rem;">What a twin does and does not inherit</h3>
+  <ul style="color:var(--text-secondary);margin:0 0 1.5rem 1.5rem;font-size:0.95rem;line-height:1.9;">
+    <li><strong>Its own identity.</strong> A rappter knows which rappter it is, and a twin is judged by the same name the roster calls it.</li>
+    <li><strong>Its own port and lock.</strong> Status is read for the port being asked about, and a dead pid is not a serving process.</li>
+    <li><strong>Not the device's mouths.</strong> Sharing a device never means sharing a channel. A twin is told which mouths are not its own, and a channel alias cannot route around the registry.</li>
+    <li><strong>Not another rappter's history.</strong> A stale endpoint record is history, not an address.</li>
+  </ul>
+
+  <h3 style="margin-top:2.5rem;">Talking to a peer</h3>
+  <p class="section-subtitle">A rappter can speak to a peer, not only be spoken to. <code>POST /twin</code> carries the <code>rapp-twin-chat/1.0</code> envelope; a peer that speaks <code>/chat</code> but not <code>/twin</code> is still reachable. Both endpoints require the same credential — <code>/twin</code> is not a way around the auth <code>/chat</code> enforces.</p>
+</section>
+
+<!-- ── 8. Local capture ── -->
+<section class="doc-section" id="local-capture" style="max-width:1100px;margin:0 auto;padding:3rem 2rem;">
+  <div class="section-label">Local Capture</div>
+  <h2 class="section-title">Flight Recorder and Show-and-Tell</h2>
+  <p class="section-subtitle">Two subsystems watch what happens on the machine so a rappter can learn from it. Both are local-first and consent-bound, and both are shared by the TypeScript and Python runtimes through a private SQLite WAL database.</p>
+
+  <ul style="color:var(--text-secondary);margin:0 0 1.5rem 1.5rem;font-size:0.95rem;line-height:1.9;">
+    <li><strong>Flight Recorder</strong> (<code>openrappter flight</code>) — a privacy-aware local record of what the agent did, so a failure can be reconstructed after the fact rather than guessed at.</li>
+    <li><strong>Show-and-Tell</strong> (<code>openrappter show-and-tell</code>) — record a real workflow, reconstruct its ordered semantic steps, review them, and emit a portable <code>SKILL.md</code>, a disabled automation, or both.</li>
+    <li><strong>Detached context collectors</strong> — macOS, Windows and Linux adapters capture active app and window context after the CLI exits. Browser URLs lose their query and fragment; screenshots are explicit-only.</li>
+  </ul>
+
+  <p class="section-subtitle" style="margin-top:1.5rem;">The contracts both runtimes are held to live in <code>contracts/</code>: <code>flight-recorder-vector.json</code>, <code>show-and-tell-v1.json</code> and <code>rapp-chat-v1.json</code>.</p>
+</section>
+
+<!-- ── 9. Security ── -->
+<section class="doc-section" id="security" style="max-width:1100px;margin:0 auto;padding:3rem 2rem;">
+  <div class="section-label">Security</div>
+  <h2 class="section-title">The boundaries an agent runs inside</h2>
+  <p class="section-subtitle">An agent that can fetch URLs, run shell commands and drive a browser is a large attack surface. These are the guards, and where they live.</p>
+
+  <ul style="color:var(--text-secondary);margin:0 0 1.5rem 1.5rem;font-size:0.95rem;line-height:1.9;">
+    <li><strong>Outbound URLs</strong> (<code>src/net/url-guard.ts</code>) — every user-supplied URL goes through <code>fetchGuarded</code>, which checks the scheme, resolves the host, rejects private, loopback and link-local addresses, and re-checks <em>every redirect hop</em>. Allowlisted domains match on DNS-label boundaries, so <code>evil-example.com</code> does not pass as <code>example.com</code>.</li>
+    <li><strong>Private network access</strong> — reaching a private address from the browser agent requires an explicit operator opt-in.</li>
+    <li><strong>Logs</strong> (<code>src/security/</code>) — one shared answer to "is this field a secret?", and one recursive redactor used by both config display and the logger. Mirrored in Python and pinned by a cross-runtime test, so the two cannot drift.</li>
+    <li><strong>Gateway</strong> — <code>/chat</code>, <code>/twin</code> and <code>/agents/import</code> all require the configured credential; loopback is not treated as trusted. Request bodies are bounded and an over-cap body is answered with 413, not a reset.</li>
+    <li><strong>Downloads</strong> — chunked downloads are bounded while they stream, not merely checked by a declared length.</li>
+  </ul>
+</section>
+
+<!-- ── 10. Directory Structure ── -->
 <section class="doc-section" id="directory-structure" style="max-width:1100px;margin:0 auto;padding:3rem 2rem;">
   <div class="section-label">Directory Structure</div>
   <h2 class="section-title">Monorepo layout</h2>
-  <p class="section-subtitle">TypeScript and Python share the same repo. The agent contract is identical across both runtimes. Drop a new agent file in the appropriate <code>agents/</code> directory and the registry discovers it automatically.</p>
+  <p class="section-subtitle">TypeScript and Python share the same repo. The agent contract is identical across both runtimes, and <code>parity_vectors/</code> holds golden vectors that both must reproduce. Drop a new agent file in the appropriate <code>agents/</code> directory and the registry discovers it automatically.</p>
 
   <pre style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:2rem;font-family:'JetBrains Mono',monospace;font-size:0.82rem;line-height:1.9;overflow-x:auto;margin-top:2rem;"><span style="color:var(--blue);">openrappter/</span>
-<span style="color:var(--border-light);">&#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">typescript/</span>
-<span style="color:var(--border-light);">&#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">src/</span>
-<span style="color:var(--border-light);">&#9474;   &#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">agents/</span>         <span style="color:#525252;"># All agent implementations</span>
-<span style="color:var(--border-light);">&#9474;   &#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">channels/</span>       <span style="color:#525252;"># 15+ messaging channels</span>
-<span style="color:var(--border-light);">&#9474;   &#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">providers/</span>      <span style="color:#525252;"># LLM provider integrations</span>
-<span style="color:var(--border-light);">&#9474;   &#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">gateway/</span>        <span style="color:#525252;"># WebSocket server</span>
-<span style="color:var(--border-light);">&#9474;   &#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">memory/</span>         <span style="color:#525252;"># Chunking, embeddings, search</span>
-<span style="color:var(--border-light);">&#9474;   &#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">storage/</span>        <span style="color:#525252;"># SQLite + in-memory adapters</span>
-<span style="color:var(--border-light);">&#9474;   &#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">config/</span>         <span style="color:#525252;"># YAML/JSON config + Zod</span>
-<span style="color:var(--border-light);">&#9474;   &#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--text-muted);">clawhub.ts</span>      <span style="color:#525252;"># ClawHub client</span>
-<span style="color:var(--border-light);">&#9474;   &#9474;   &#9492;&#9472;&#9472;</span> <span style="color:var(--blue);">skills/</span>         <span style="color:#525252;"># Skill registry</span>
-<span style="color:var(--border-light);">&#9474;   &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">dist/</span>               <span style="color:#525252;"># Compiled output</span>
-<span style="color:var(--border-light);">&#9474;   &#9492;&#9472;&#9472;</span> <span style="color:var(--text-muted);">package.json</span>
-<span style="color:var(--border-light);">&#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">python/</span>
-<span style="color:var(--border-light);">&#9474;   &#9492;&#9472;&#9472;</span> <span style="color:var(--blue);">openrappter/</span>
-<span style="color:var(--border-light);">&#9474;       &#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">agents/</span>         <span style="color:#525252;"># Python agent mirror</span>
-<span style="color:var(--border-light);">&#9474;       &#9492;&#9472;&#9472;</span> <span style="color:var(--text-muted);">clawhub.py</span>      <span style="color:#525252;"># ClawHub client</span>
-<span style="color:var(--border-light);">&#9500;&#9472;&#9472;</span> <span style="color:var(--blue);">docs/</span>                   <span style="color:#525252;"># GitHub Pages site</span>
-<span style="color:var(--border-light);">&#9492;&#9472;&#9472;</span> <span style="color:var(--text-muted);">CLAUDE.md</span>               <span style="color:#525252;"># Agent architecture guide</span></pre>
+<span style="color:var(--border-light);">├──</span> <span style="color:var(--blue);">typescript/src/</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">agents/</span>               <span style="color:#525252;"># 37 agents + router, broadcast, subagent</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">channels/</span>             <span style="color:#525252;"># 16 messaging channels</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">gateway/</span>              <span style="color:#525252;"># JSON-RPC over WS + HTTP, /chat, /twin</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">twin/</span>                 <span style="color:#525252;"># hatching, soul, vault, peer send</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">identity/</span>             <span style="color:#525252;"># a rappter knows which rappter it is</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">nodes/</span>                <span style="color:#525252;"># roster and neighbourhood</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">providers/</span>            <span style="color:#525252;"># Copilot, Anthropic, OpenAI, Gemini, Ollama</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">memory/</span>               <span style="color:#525252;"># chunking, embeddings, search</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">storage/</span>              <span style="color:#525252;"># SQLite (WAL) + in-memory adapters</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">security/</span>             <span style="color:#525252;"># secret-keys, redact</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">net/</span>                  <span style="color:#525252;"># url-guard, fetchGuarded (SSRF)</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">flight-recorder/</span>      <span style="color:#525252;"># privacy-aware local recorder</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">show-and-tell/</span>        <span style="color:#525252;"># learn a skill from a demonstration</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">surgeon/</span>              <span style="color:#525252;"># Copilot-shaped operating room UI</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">browser/</span>              <span style="color:#525252;"># headless browser control</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">desktop-control/</span>      <span style="color:#525252;"># OS-level automation</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">telephony/</span>            <span style="color:#525252;"># placing and taking calls</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">voice/</span>                <span style="color:#525252;"># TTS and transcription</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">cron/</span>                 <span style="color:#525252;"># scheduled jobs</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">mcp/</span>                  <span style="color:#525252;"># Model Context Protocol</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">media/</span>                <span style="color:#525252;"># guarded download and processing</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">cli/</span>                  <span style="color:#525252;"># config, doctor, twins, hatch, flight …</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">tui/</span>                  <span style="color:#525252;"># terminal UI</span>
+<span style="color:var(--border-light);">│   └──</span> <span style="color:var(--blue);">skills/</span>               <span style="color:#525252;"># skill registry</span>
+<span style="color:var(--border-light);">├──</span> <span style="color:var(--blue);">python/openrappter/</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">agents/</span>               <span style="color:#525252;"># 26 agent modules, same contract</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">gateway/</span>              <span style="color:#525252;"># parity gateway + observability</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">channels/</span>             <span style="color:#525252;"># messaging channels</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">imessage/</span>             <span style="color:#525252;"># macOS iMessage service</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">security/</span>             <span style="color:#525252;"># secret_keys, redact (mirrors TS)</span>
+<span style="color:var(--border-light);">│   └──</span> <span style="color:var(--blue);">memory/ storage/ providers/ config/ mcp/</span>
+<span style="color:var(--border-light);">├──</span> <span style="color:var(--blue);">macos/</span>                <span style="color:#525252;"># OpenRappter Bar, the menu bar app</span>
+<span style="color:var(--border-light);">├──</span> <span style="color:var(--blue);">vui/</span>                  <span style="color:#525252;"># voice UI served at /vui</span>
+<span style="color:var(--border-light);">├──</span> <span style="color:var(--blue);">contracts/</span>            <span style="color:#525252;"># cross-runtime JSON contracts</span>
+<span style="color:var(--border-light);">├──</span> <span style="color:var(--blue);">parity_vectors/</span>       <span style="color:#525252;"># golden vectors both runtimes must match</span>
+<span style="color:var(--border-light);">├──</span> <span style="color:var(--blue);">agents/</span>               <span style="color:#525252;"># drop-in agent files, discovered at runtime</span>
+<span style="color:var(--border-light);">├──</span> <span style="color:var(--blue);">docs/</span>                 <span style="color:#525252;"># this GitHub Pages site</span>
+<span style="color:var(--border-light);">└──</span> <span style="color:var(--blue);">CLAUDE.md</span>             <span style="color:#525252;"># agent architecture guide</span></pre>
 </section>
 
 <!-- ── Footer ── -->

--- a/docs/changelog.html
+++ b/docs/changelog.html
@@ -16,7 +16,7 @@
 
   <nav>
     <div class="nav-container">
-      <a href="./" class="logo">openrappter <span class="logo-badge">v1.9.1</span></a>
+      <a href="./" class="logo">openrappter <span class="logo-badge">v1.13.0</span></a>
       <button class="mobile-menu-btn">&#9776;</button>
       <div class="nav-links">
         <a href="./docs.html">Docs</a>
@@ -42,11 +42,127 @@
   <section class="timeline-section">
     <div class="timeline">
 
-      <!-- v1.9.1 — newest, highlighted -->
+      <!-- v1.13.0 -->
       <div class="timeline-item">
         <div class="timeline-dot" style="background:var(--green);"></div>
         <div class="timeline-card" style="border:1px solid rgba(16,185,129,0.3);">
-          <div class="version-badge" style="background:rgba(16,185,129,0.15);color:var(--green);">v1.9.1</div>
+          <div class="version-badge" style="background:rgba(16,185,129,0.15);color:var(--green);">v1.13.0</div>
+          <div class="version-date">2026-08-14</div>
+
+          <div class="change-group">
+            <div class="change-group-title added">
+              <span class="change-icon">+</span> Added
+            </div>
+            <ul class="change-list added">
+              <li>Show-and-Tell — record a real workflow, reconstruct its ordered semantic steps, and build a portable <code>SKILL.md</code>, a disabled automation, or both</li>
+              <li>Cross-runtime recording store — a private SQLite WAL database gives TypeScript and Python the same session, event, analysis, consent and artifact contract</li>
+              <li>Detached context collectors for macOS, Windows and Linux; browser URLs lose query and fragment, screenshots are explicit-only</li>
+              <li>Electron desktop shell with a sandboxed, context-isolated renderer and a visual Show-and-Tell workspace</li>
+              <li>Chat-driven desktop control through semantic refs while you watch</li>
+              <li>On-device narration (Whisper Small q8) and an opt-in on-device voice preview</li>
+            </ul>
+          </div>
+          <div class="change-group">
+            <div class="change-group-title technical">
+              <span class="change-icon">*</span> Technical
+            </div>
+            <ul class="change-list technical">
+              <li>Typed text is represented only by length, never content; credential- and sign-in-looking windows refuse capture</li>
+              <li>Raw frames never reach Copilot — only a separately approved, privacy-safe textual summary can leave the machine</li>
+              <li>The desktop gateway uses a random per-process bearer token on a dedicated loopback port</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- v1.12.0 -->
+      <div class="timeline-item">
+        <div class="timeline-dot"></div>
+        <div class="timeline-card">
+          <div class="version-badge">v1.12.0</div>
+          <div class="version-date">2026-08-11</div>
+
+          <div class="change-group">
+            <div class="change-group-title added">
+              <span class="change-icon">+</span> Added
+            </div>
+            <ul class="change-list added">
+              <li>Provider-neutral Flight Recorder in both runtimes — a local SQLite WAL ledger of correlated trace, context, provider, tool and agent lifecycle events</li>
+              <li>Privacy-safe defaults — prompts, responses, tool arguments and file contents are omitted unless explicitly enabled, then recursively scrubbed and byte-capped</li>
+              <li>Integrity-checked replay bundles with SHA-256 event hashes and atomic tamper rejection</li>
+              <li><code>flight status</code>, <code>events</code>, <code>export</code>, <code>import</code> and a confirmation-gated <code>clear</code></li>
+            </ul>
+          </div>
+          <div class="change-group">
+            <div class="change-group-title technical">
+              <span class="change-icon">*</span> Technical
+            </div>
+            <ul class="change-list technical">
+              <li>Absolute workspace paths and session identifiers persist as stable SHA-256 scope identifiers, so channel keys cannot leak phone numbers, emails or chat GUIDs</li>
+              <li>Retention prunes whole completed traces and preserves active ones, rather than leaving replay fragments</li>
+              <li>A release-enforced cross-runtime gate blocks artifact publication on behaviour, mutation, privacy, causality and retention checks</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- v1.11.0 -->
+      <div class="timeline-item">
+        <div class="timeline-dot"></div>
+        <div class="timeline-card">
+          <div class="version-badge">v1.11.0</div>
+          <div class="version-date">2026-08-10</div>
+
+          <div class="change-group">
+            <div class="change-group-title added">
+              <span class="change-icon">+</span> Added
+            </div>
+            <ul class="change-list added">
+              <li>One device, many rappters — an <strong>alpha</strong> holds the default port and the device&#39;s channels, and hatched <strong>twins</strong> run beside it with their own identity, port and lock</li>
+              <li>Twin-to-twin chat over <code>POST /twin</code> using the <code>rapp-twin-chat/1.0</code> envelope</li>
+              <li>Neighbourhood and roster — a running rappter can reach a neighbour and is judged by the name the roster calls it</li>
+              <li>Copilot Surgeon as the primary interface, with consent-bound procedures carrying an immutable SHA-256 digest</li>
+              <li>Release channels — <code>openrappter channel</code> manages stable and experimental rings</li>
+            </ul>
+          </div>
+          <div class="change-group">
+            <div class="change-group-title technical">
+              <span class="change-icon">*</span> Technical
+            </div>
+            <ul class="change-list technical">
+              <li>The Copilot CLI ships with the commit — <code>@github/copilot</code> is lockfile-pinned and resolved from this package&#39;s own <code>node_modules</code>, not <code>PATH</code></li>
+              <li>Its SHA-256 is stamped at build time and re-checked before reuse, so a substituted binary forces a rebuild instead of running</li>
+              <li><code>/twin</code> and <code>/agents/import</code> require the same credential <code>/chat</code> requires; loopback is not implicitly trusted</li>
+              <li>A hatched twin shares the device, never a mouth — a channel alias cannot route around the registry</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- v1.10.0 -->
+      <div class="timeline-item">
+        <div class="timeline-dot"></div>
+        <div class="timeline-card">
+          <div class="version-badge">v1.10.0</div>
+          <div class="version-date">2026-07-11</div>
+
+          <div class="change-group">
+            <div class="change-group-title added">
+              <span class="change-icon">+</span> Added
+            </div>
+            <ul class="change-list added">
+              <li>Dual-use binary classification — network-fetch, install, arbitrary-exec and permission binaries are tagged so an approval layer can gate them</li>
+              <li>Brainstem device-code auth — <code>POST /login</code> starts the GitHub device flow and persists the token in the kernel&#39;s format</li>
+            </ul>
+          </div>
+        </div>
+      </div>
+
+      <!-- v1.9.1 -->
+      <div class="timeline-item">
+        <div class="timeline-dot"></div>
+        <div class="timeline-card">
+          <div class="version-badge">v1.9.1</div>
           <div class="version-date">2026-02-20</div>
 
           <div class="change-group">

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -21,7 +21,7 @@
 <!-- ── Navigation ── -->
 <nav>
   <div class="nav-container">
-    <a href="./" class="logo">openrappter <span class="logo-badge">v1.9.1</span></a>
+    <a href="./" class="logo">openrappter <span class="logo-badge">v1.13.0</span></a>
     <button class="mobile-menu-btn">&#9776;</button>
     <div class="nav-links">
       <a href="./docs.html">Docs</a>
@@ -55,9 +55,11 @@
       <li><a href="#providers">LLM Providers</a></li>
       <li><a href="#channels">Messaging Channels</a></li>
       <li><a href="#gateway">WebSocket Gateway</a></li>
+      <li><a href="#twins">Twins &amp; Neighbourhood</a></li>
     </ul>
     <div class="sidebar-title">Systems</div>
     <ul class="sidebar-nav">
+      <li><a href="#local-capture">Flight Recorder &amp; Show-and-Tell</a></li>
       <li><a href="#skills">Skills System</a></li>
       <li><a href="#memory">Memory System</a></li>
       <li><a href="#plugins">Plugin System</a></li>
@@ -67,6 +69,24 @@
     <div class="sidebar-title">Reference</div>
     <ul class="sidebar-nav">
       <li><a href="#api">API Reference</a></li>
+    </ul>
+    <div class="sidebar-title">Guides</div>
+    <ul class="sidebar-nav">
+      <li><a href="https://github.com/kody-w/openrappter/blob/main/docs/flight-recorder.md">Flight Recorder</a></li>
+      <li><a href="https://github.com/kody-w/openrappter/blob/main/docs/show-and-tell.md">Show-and-Tell</a></li>
+      <li><a href="https://github.com/kody-w/openrappter/blob/main/docs/electron-desktop.md">Electron Desktop</a></li>
+      <li><a href="https://github.com/kody-w/openrappter/blob/main/docs/AUTONOMOUS.md">Autonomous Mode</a></li>
+      <li><a href="https://github.com/kody-w/openrappter/blob/main/docs/typescript-imessage.md">iMessage Setup</a></li>
+      <li><a href="https://github.com/kody-w/openrappter/blob/main/docs/imessage-reliability.md">iMessage Reliability</a></li>
+      <li><a href="https://github.com/kody-w/openrappter/blob/main/docs/RAPP.md">RAPP Protocol</a></li>
+    </ul>
+    <div class="sidebar-title">Releases</div>
+    <ul class="sidebar-nav">
+      <li><a href="./changelog.html">Changelog</a></li>
+      <li><a href="./release-notes-1.14.0-evolution.html">v1.14.0 Notes</a></li>
+      <li><a href="./release-notes-1.13.0-evolution.html">v1.13.0 Notes</a></li>
+      <li><a href="./release-notes-1.12.0-evolution.html">v1.12.0 Notes</a></li>
+      <li><a href="./release-notes-1.11.0-evolution.html">v1.11.0 Notes</a></li>
     </ul>
   </aside>
 
@@ -632,6 +652,56 @@ registerChannel(<span class="str">'my-channel'</span>, MyChannel);</pre>
 
       <h3>Rate Limiting</h3>
       <p>The gateway enforces a per-connection rate limit (default: 100 requests/minute). Exceeding the limit results in a JSON-RPC error response with code <code>-32029</code> (rate limit exceeded) and a <code>retry_after</code> field in milliseconds. Configure the limit in <code>config.yaml</code> under <code>gateway.rate_limit</code>.</p>
+    </div>
+
+    <!-- ── Twins ── -->
+    <div id="twins" class="doc-section">
+      <h2>Twins &amp; Neighbourhood</h2>
+      <p>Since v1.11 a device no longer runs a single rappter. One <strong>alpha</strong> holds the default port and the device's channels; any number of <strong>hatched twins</strong> run beside it, each with its own identity, its own port, and its own lock.</p>
+
+      <pre><span class="cm"># hatch a twin on this device</span>
+openrappter hatch ada
+
+<span class="cm"># which rappters are running here</span>
+openrappter twins
+
+<span class="cm"># address a specific one</span>
+openrappter --instance ada --status</pre>
+
+      <h3>What a twin does not inherit</h3>
+      <p>Sharing a device never means sharing a channel. A twin is told which mouths are not its own, and a channel alias cannot route around the registry — so a hatched twin cannot speak out of the alpha's iMessage or Slack connection unless the registry says it owns it.</p>
+
+      <h3>Talking to a peer</h3>
+      <p>A rappter can speak to a peer, not only be spoken to. <code>POST /twin</code> carries the <code>rapp-twin-chat/1.0</code> envelope; a peer that speaks <code>/chat</code> but not <code>/twin</code> is still reachable. Both endpoints require the same credential — <code>/twin</code> is not a way around the authentication <code>/chat</code> enforces.</p>
+
+      <table>
+        <thead><tr><th>Command</th><th>What it does</th></tr></thead>
+        <tbody>
+          <tr><td><code>openrappter hatch &lt;name&gt;</code></td><td>Hatch a twin rappter on this device</td></tr>
+          <tr><td><code>openrappter twins</code></td><td>List the rappters running on this device</td></tr>
+          <tr><td><code>openrappter twin</code></td><td>Your digital twin — local-first, never leaves this machine</td></tr>
+          <tr><td><code>--instance &lt;id&gt;</code></td><td>Name this rappter; omit for the alpha</td></tr>
+        </tbody>
+      </table>
+    </div>
+
+    <!-- ── Local capture ── -->
+    <div id="local-capture" class="doc-section">
+      <h2>Flight Recorder &amp; Show-and-Tell</h2>
+      <p>Two local-first subsystems let a rappter learn from what actually happened on the machine. Both are consent-bound and share a private SQLite WAL database across the TypeScript and Python runtimes.</p>
+
+      <h3>Flight Recorder</h3>
+      <p>A provider-neutral ledger of correlated trace, context, provider, tool and agent lifecycle events. Raw prompts, responses, tool arguments and file contents are omitted unless explicitly enabled — and when enabled, are recursively scrubbed for secrets and bounded by a post-redaction byte cap.</p>
+      <pre>openrappter flight status
+openrappter flight events
+openrappter flight export <span class="cm"># integrity-checked bundle</span>
+openrappter flight clear  <span class="cm"># confirmation-gated</span></pre>
+      <p>Full guide: <a href="https://github.com/kody-w/openrappter/blob/main/docs/flight-recorder.md">flight-recorder.md</a></p>
+
+      <h3>Show-and-Tell</h3>
+      <p>Record a real workflow, reconstruct its intent and ordered semantic steps, review them, then emit a portable <code>SKILL.md</code>, a disabled automation, or both. Automations are disabled by default and replay is a dry run rather than coordinate playback.</p>
+      <pre>openrappter show-and-tell</pre>
+      <p>Full guide: <a href="https://github.com/kody-w/openrappter/blob/main/docs/show-and-tell.md">show-and-tell.md</a></p>
     </div>
 
     <!-- ── 8. Skills System ── -->

--- a/docs/index-old.html
+++ b/docs/index-old.html
@@ -23,7 +23,7 @@
   <!-- Navigation -->
   <nav>
     <div class="nav-container">
-      <a href="./" class="logo">openrappter <span class="logo-badge">v1.9.1</span></a>
+      <a href="./" class="logo">openrappter <span class="logo-badge">v1.13.0</span></a>
       <button class="mobile-menu-btn">&#9776;</button>
       <div class="nav-links">
         <a href="./docs.html">Docs</a>

--- a/docs/nav.js
+++ b/docs/nav.js
@@ -1,4 +1,4 @@
-/* OpenRappter v1.9.1 — Shared Navigation JS */
+/* OpenRappter — Shared Navigation JS */
 
 (function () {
   'use strict';

--- a/docs/release-notes-1.14.0-evolution.html
+++ b/docs/release-notes-1.14.0-evolution.html
@@ -1,0 +1,207 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>OpenRappter 1.14.0 — The doors an agent can open</title>
+  <meta name="description" content="OpenRappter 1.14.0 is a hardening release: every outward door an agent can open is now checked at the moment it opens, not at the moment it is described." />
+  <meta property="og:title" content="OpenRappter 1.14.0 — The doors an agent can open" />
+  <meta property="og:description" content="A hardening release. Private networks need an opt-in, allowlists match on label boundaries, downloads are bounded while they stream, and two stub commands became real." />
+  <meta property="og:type" content="website" />
+  <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="bg-zinc-950 text-zinc-100 antialiased">
+  <nav class="border-b border-zinc-800 bg-zinc-950/95">
+    <div class="mx-auto flex max-w-6xl items-center justify-between px-6 py-4">
+      <a class="logo font-semibold" href="./">OpenRappter</a>
+      <div class="nav-links flex gap-5 text-sm text-zinc-300">
+        <a href="./docs.html">Docs</a>
+        <a href="./architecture.html">Architecture</a>
+        <a href="./tutorial.html">Tutorial</a>
+        <a href="./changelog.html">Changelog</a>
+      </div>
+    </div>
+  </nav>
+
+  <main>
+    <section class="border-b border-zinc-800 bg-gradient-to-b from-emerald-950/40 to-zinc-950">
+      <div class="mx-auto max-w-6xl px-6 py-24">
+        <p class="mb-5 font-mono text-sm text-emerald-400">v1.14.0 · unreleased</p>
+        <h1 class="max-w-4xl text-5xl font-bold tracking-tight md:text-7xl">
+          A rule that is never<br />
+          <span class="text-emerald-400">checked is not a rule.</span>
+        </h1>
+        <p class="mt-8 max-w-3xl text-xl leading-8 text-zinc-300">
+          This is a hardening release. Nothing here adds a capability; everything
+          here closes the distance between what a guard <em>says</em> and the
+          moment it actually runs. Several of these were rules the code already
+          believed it enforced.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto grid max-w-6xl gap-6 px-6 py-16 md:grid-cols-3">
+      <article class="rounded-2xl border border-zinc-800 bg-zinc-900 p-6">
+        <p class="font-mono text-xs uppercase tracking-widest text-emerald-400">Network</p>
+        <h2 class="mt-3 text-2xl font-semibold">Private is not reachable by default</h2>
+        <p class="mt-4 leading-7 text-zinc-400">
+          Reaching a private or loopback address from the browser agent now
+          requires an explicit operator opt-in. <code class="text-zinc-300">allowPrivateNetwork</code>
+          defaults to <code class="text-zinc-300">false</code>, and a blocked route is
+          closed rather than quietly followed.
+        </p>
+      </article>
+      <article class="rounded-2xl border border-zinc-800 bg-zinc-900 p-6">
+        <p class="font-mono text-xs uppercase tracking-widest text-emerald-400">Address space</p>
+        <h2 class="mt-3 text-2xl font-semibold">The whole link-local range</h2>
+        <p class="mt-4 leading-7 text-zinc-400">
+          The SSRF guard covered part of <code class="text-zinc-300">fe80::/10</code>.
+          A range that is partly blocked is a range that is open — the rest of it is
+          now rejected too.
+        </p>
+      </article>
+      <article class="rounded-2xl border border-zinc-800 bg-zinc-900 p-6">
+        <p class="font-mono text-xs uppercase tracking-widest text-emerald-400">Allowlists</p>
+        <h2 class="mt-3 text-2xl font-semibold">Boundaries, not substrings</h2>
+        <p class="mt-4 leading-7 text-zinc-400">
+          Allowlisted domains match on DNS-label boundaries, so
+          <code class="text-zinc-300">evil-example.com</code> no longer satisfies an
+          allowlist entry of <code class="text-zinc-300">example.com</code>.
+        </p>
+      </article>
+    </section>
+
+    <section class="border-y border-zinc-800 bg-zinc-900/50">
+      <div class="mx-auto max-w-6xl px-6 py-16">
+        <h2 class="text-3xl font-bold">A declared length is not a promise</h2>
+        <p class="mt-6 max-w-3xl leading-8 text-zinc-300">
+          A download cap that is checked against the <em>advertised</em> size trusts
+          the thing it is defending against. Chunked downloads are now bounded
+          <strong>while they stream</strong> — the limit is enforced as bytes arrive,
+          so a server that lies about its length runs into the cap anyway.
+        </p>
+        <p class="mt-6 max-w-3xl leading-8 text-zinc-300">
+          The same correction runs through the rest of this release: check the thing
+          itself, at the moment it happens, rather than the description of it.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-6 py-16">
+      <p class="font-mono text-xs uppercase tracking-widest text-emerald-400">Correctness</p>
+      <h2 class="mt-3 text-3xl font-bold">Things that only looked like they worked</h2>
+      <div class="mt-8 grid gap-6 md:grid-cols-2">
+        <article class="rounded-2xl border border-zinc-800 bg-zinc-900 p-6">
+          <h3 class="text-xl font-semibold">Cron sent an id nobody read</h3>
+          <p class="mt-3 leading-7 text-zinc-400">
+            The scheduler now sends the job id the gateway actually reads. Cron logs
+            can also no longer outlive, or precede, the job they belong to.
+          </p>
+        </article>
+        <article class="rounded-2xl border border-zinc-800 bg-zinc-900 p-6">
+          <h3 class="text-xl font-semibold">Two runtimes disagreed about failure</h3>
+          <p class="mt-3 leading-7 text-zinc-400">
+            Python returned <code>status=success</code> for every completed
+            subprocess, even on a nonzero exit — so <code>false</code> reported
+            <code>return_code=1</code> while the shared classifier recorded the
+            invocation as successful. TypeScript already called that an error.
+            Python now derives its status from the return code, and the contract is
+            pinned at both front doors.
+          </p>
+        </article>
+        <article class="rounded-2xl border border-zinc-800 bg-zinc-900 p-6">
+          <h3 class="text-xl font-semibold"><code>config</code> and <code>doctor</code> are real</h3>
+          <p class="mt-3 leading-7 text-zinc-400">
+            Both were fully implemented and exported — and never registered, so their
+            words fell through to chat and global help while shipped health guidance
+            told you to run them. Registering them exposed dormant bugs, so this went
+            further than two function calls: <code>get</code>/<code>set</code> no
+            longer echo credential values, validation strictly parses both config
+            files against the real schema, and Doctor returns nonzero for failed
+            checks in JSON mode too.
+          </p>
+        </article>
+        <article class="rounded-2xl border border-zinc-800 bg-zinc-900 p-6">
+          <h3 class="text-xl font-semibold">The <code>voice-call</code> skill described a CLI that did not ship</h3>
+          <p class="mt-3 leading-7 text-zinc-400">
+            It prescribed <code>call start</code>, <code>call end</code> and
+            <code>call conference</code> — none of which exist. It also required a
+            legacy plugin switch no OpenRappter code reads, so eligibility could hide
+            a working command. It now documents the real flow, and a test rejects any
+            documented subcommand absent from the command tree.
+          </p>
+        </article>
+      </div>
+    </section>
+
+    <section class="border-t border-zinc-800 bg-zinc-900/50">
+      <div class="mx-auto max-w-6xl px-6 py-16">
+        <p class="font-mono text-xs uppercase tracking-widest text-emerald-400">Desktop</p>
+        <h2 class="mt-3 text-3xl font-bold">One authority for authentication</h2>
+        <p class="mt-6 max-w-3xl leading-8 text-zinc-300">
+          The Electron desktop is now the authority for OpenRappter Bar
+          authentication, rather than the two racing to own the same credential.
+          Desktop smoke tests were hardened for concurrent and Windows runs, where
+          completed runs could previously hang instead of exiting.
+        </p>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-6 py-16">
+      <p class="font-mono text-xs uppercase tracking-widest text-emerald-400">Evidence</p>
+      <h2 class="mt-3 text-3xl font-bold">What had to pass before this shipped</h2>
+      <p class="mt-6 max-w-3xl leading-8 text-zinc-300">
+        A release note is a claim. These are the gates that make it checkable —
+        every one of them runs in CI and blocks the release artifact, not a
+        summary written afterwards.
+      </p>
+      <div class="mt-8 grid gap-4 md:grid-cols-2">
+        <div class="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+          <p class="font-mono text-sm text-emerald-400">npm test</p>
+          <p class="mt-2 text-sm leading-6 text-zinc-400">TypeScript suite, including the docs-site tests that check this page.</p>
+        </div>
+        <div class="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+          <p class="font-mono text-sm text-emerald-400">pytest</p>
+          <p class="mt-2 text-sm leading-6 text-zinc-400">Python suite, plus the cross-runtime agreement tests that stop the two drifting.</p>
+        </div>
+        <div class="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+          <p class="font-mono text-sm text-emerald-400">mutation tests</p>
+          <p class="mt-2 text-sm leading-6 text-zinc-400">Each guard in this release was re-broken to prove its test can actually fail. A green suite proves nothing until it has been seen red.</p>
+        </div>
+        <div class="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+          <p class="font-mono text-sm text-emerald-400">lint · builds</p>
+          <p class="mt-2 text-sm leading-6 text-zinc-400">Both runtimes build clean, and packaging builds the Electron desktop artifacts.</p>
+        </div>
+        <div class="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+          <p class="font-mono text-sm text-emerald-400">cold-start CLI smoke</p>
+          <p class="mt-2 text-sm leading-6 text-zinc-400">The CLI is exercised from a clean machine state, so a command that only works on a warm developer box does not pass.</p>
+        </div>
+        <div class="rounded-xl border border-zinc-800 bg-zinc-900 p-5">
+          <p class="font-mono text-sm text-emerald-400">SHA-256</p>
+          <p class="mt-2 text-sm leading-6 text-zinc-400">Installer and Copilot CLI digests are computed from the commit's git blob and re-verified before reuse.</p>
+        </div>
+      </div>
+    </section>
+
+    <section class="mx-auto max-w-6xl px-6 py-16">
+      <h2 class="text-3xl font-bold">Upgrading</h2>
+      <p class="mt-6 max-w-3xl leading-8 text-zinc-300">
+        Nothing here changes a public contract, so no migration is required. One
+        behavioural note: if you relied on the browser agent reaching a private or
+        loopback address, that now needs an explicit opt-in via
+        <code class="text-zinc-300">allowPrivateNetwork</code>. That is the intended
+        breaking edge of this release.
+      </p>
+      <p class="mt-6 max-w-3xl leading-8 text-zinc-400">
+        Full detail in the <a class="text-emerald-400 underline" href="./changelog.html">changelog</a>.
+      </p>
+    </section>
+  </main>
+
+  <footer class="border-t border-zinc-800">
+    <div class="mx-auto max-w-6xl px-6 py-10 text-sm text-zinc-500">
+      OpenRappter · <a class="underline" href="https://github.com/kody-w/openrappter">github.com/kody-w/openrappter</a>
+    </div>
+  </footer>
+</body>
+</html>

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -18,7 +18,7 @@
   <!-- Nav -->
   <nav>
     <div class="nav-container">
-      <a href="./" class="logo">openrappter <span class="logo-badge">v1.9.1</span></a>
+      <a href="./" class="logo">openrappter <span class="logo-badge">v1.13.0</span></a>
       <button class="mobile-menu-btn">&#9776;</button>
       <div class="nav-links">
         <a href="./docs.html">Docs</a>
@@ -154,8 +154,8 @@
         <pre><code><span class="cmd">openrappter --task "list files in current directory"</span></code></pre>
 
         <p><strong>Specify an agent directly</strong> — bypass the router and run a named agent:</p>
-        <pre><code><span class="cmd">openrappter --agent shell "what's in my home directory?"</span>
-<span class="cmd">openrappter --exec ShellAgent "read package.json"</span></code></pre>
+        <pre><code><span class="cmd">openrappter --exec Shell "what's in my home directory?"</span>
+<span class="cmd">openrappter --exec Shell "read package.json"</span></code></pre>
 
         <div class="terminal">
           <div class="terminal-header">
@@ -321,7 +321,7 @@
 <span class="comment"># Should now include GreeterAgent in the list</span>
 
 <span class="comment"># Invoke it directly</span>
-<span class="cmd">openrappter --agent greeter "greet Alice"</span></code></pre>
+<span class="cmd">openrappter --exec GreeterAgent "greet Alice"</span></code></pre>
 
         <div class="terminal">
           <div class="terminal-header">
@@ -333,7 +333,7 @@
           <div class="terminal-body">
             <div class="terminal-line">
               <span class="terminal-prompt">$</span>
-              <span class="terminal-command">openrappter --agent greeter "greet Alice"</span>
+              <span class="terminal-command">openrappter --exec GreeterAgent "greet Alice"</span>
             </div>
             <div class="terminal-output">Executing GreeterAgent...</div>
             <div class="terminal-output">Data sloshing: injecting temporal + memory context</div>


### PR DESCRIPTION
The published site described a product three minor versions old. `architecture.html` — the page flagged as the example — was untouched since 2026-08-01. It listed **nine** TypeScript modules where there are **thirty-four**, and had no idea that twins, the flight recorder, show-and-tell, the desktop shell, or the security guards existed.

Four of the findings were **wrong**, not merely old.

### 1.11.0 was never written down

`CHANGELOG.md` jumped straight from 1.12.0 to 1.10.0. The entire twin and neighbourhood system, the Copilot CLI pinning, Surgeon, and the gateway credential fixes had no released entry anywhere.

Worse: **Surgeon (landed Aug 1) and the HTTP RPC credential fix (Aug 5) were still sitting under `[Unreleased]`** — two releases after they shipped. Anyone reading the changelog would conclude Surgeon wasn't out yet. Both are now recorded under 1.11.0, dated to the release that actually carried them.

### The tutorial taught a flag that does not exist

```
$ openrappter --agent shell "echo hi"
error: unknown option '--agent'
```

The flag is `--exec`. All three invocations in `tutorial.html` were wrong, and the agent name was wrong too — only `Shell` resolves, not `shell` or `ShellAgent`. Each form was checked against the built CLI:

| invocation | result |
|---|---|
| `--exec shell` | `Agent 'shell' not found` |
| `--exec ShellAgent` | `Agent 'ShellAgent' not found` |
| `--exec Shell` | resolves |

### Everything else the scan found

- `changelog.html` stopped at **v1.9.1**, missing four releases.
- Every stale page still badged **v1.9.1** against a 1.13.0 product.
- `docs.html` linked three pages and none of the guides. It now has a **Twins & Neighbourhood** section, a **Flight Recorder & Show-and-Tell** section, and guide links — pointed at GitHub rather than the raw `.md`, since `.nojekyll` makes Pages serve markdown as plain text.

### Counts come from the runtime, not from `ls`

**37** registered agents (`--list-agents`), **26** Python agent modules, **16** exported channels.

My own first draft of this page said 48 agents and 33 channels — because I counted `router.ts`, `graph.ts`, `types.ts` and `registry.ts` as agents and channels. Caught and corrected before commit.

### Release notes for the unreleased work

The twelve commits after the 1.13.0 release commit are almost entirely hardening — private-network opt-in, the full `fe80::/10` range, DNS-label-boundary allowlist matching, downloads bounded while they stream. Written up as a release notes page in the existing house style.

**The version in the filename is a placeholder.** `RELEASING-PINNED.md` makes choosing the version an explicit owner step, so `package.json` is untouched and the file is trivially renameable.

### Evidence

Docs site tests: **160/160 pass**.

I simulated the release by bumping `package.json` to 1.14.0, because `CURRENT_RELEASE_FILE` is derived from it. That surfaced the new page failing **"keeps release evidence tied to executable validation gates"**, so it now documents the gates it must pass (`npm test`, `pytest`, `mutation tests`, `lint`, `builds`, `cold-start CLI smoke`, `SHA-256`) — verified present in `.github/workflows/`. That check now passes.

Five failures in `copilot-cli-local.test.ts` were confirmed **pre-existing on clean main** by stashing these changes and re-running.

---

### Two things for you, not fixed here

**A latent bug in `site.test.ts`.** The test `presents Show-and-Tell as consent-bound reusable learning` asserts against `CURRENT_RELEASE_FILE` — a moving target — but hardcodes 1.13.0's *marketing copy*: `Show it once.`, `Context, not surveillance`, `Native tools over pixel replay`. It will fail on **every** future release regardless of content quality. The sibling evidence test is written correctly, against generalizable requirements. Worth splitting the release-specific assertions out, but that's a judgement call about intent, so I left it.

**`index.html` says "22 agents, ready on day one"** while the registry reports 37. `index.html` is recent work (Aug 15) and "ready on day one" may deliberately exclude agents needing setup, so I did not overwrite it. Worth a confirm.
