### PR TITLE
fix(pkg): ship the 52 skills the runtime loads

### DIFF
--- a/typescript/package.json
+++ b/typescript/package.json
@@ -1,7 +1,7 @@
 {
   "name": "openrappter",
   "version": "1.13.0",
-  "description": "🦖 Local-first AI agent powered by GitHub Copilot SDK — no API keys required",
+  "description": "\ud83e\udd96 Local-first AI agent powered by GitHub Copilot SDK \u2014 no API keys required",
   "type": "module",
   "main": "dist/index.js",
   "bin": {
@@ -57,6 +57,7 @@
     "!dist/**/__mocks__/",
     "bin/",
     "ui/dist/",
+    "skills/",
     "npm-shrinkwrap.json"
   ],
   "dependencies": {

--- a/typescript/src/skills/__tests__/bundled-packaging.test.ts
+++ b/typescript/src/skills/__tests__/bundled-packaging.test.ts
@@ -69,8 +69,14 @@ describe('bundled skills are actually published', () => {
   });
 
   it('ships the assets the loader reads, not only the loader', () => {
-    const packed = packedFiles();
-    expect(packed).toContain('dist/skills/bundled.js');
-    expect(packed.some((path) => path.startsWith('skills/'))).toBe(true);
+    const pkg = JSON.parse(readFileSync(join(PKG_DIR, 'package.json'), 'utf-8')) as {
+      files: string[];
+    };
+    // The loader lives in dist/, which the prepack build produces and
+    // packedFiles() deliberately skips. Assert dist/ is *declared* for
+    // publication rather than that it happens to be built right now, or this
+    // passes or fails depending on whether anyone has run a build.
+    expect(pkg.files).toContain('dist/');
+    expect(packedFiles().some((path) => path.startsWith('skills/'))).toBe(true);
   });
 });

--- a/typescript/src/skills/__tests__/bundled-packaging.test.ts
+++ b/typescript/src/skills/__tests__/bundled-packaging.test.ts
@@ -1,0 +1,76 @@
+import { describe, it, expect } from 'vitest';
+import { spawnSync } from 'child_process';
+import { readFileSync, readdirSync, existsSync } from 'fs';
+import { resolve, join } from 'path';
+
+/**
+ * The runtime loads bundled skills from `<package>/skills/`, but `files` in
+ * package.json never listed that directory, so the published tarball carried
+ * the loader and none of the 52 skills it reads.
+ *
+ * `loadBundledSkills` swallows a missing directory and returns an empty list,
+ * so an install with zero skills is indistinguishable from one that genuinely
+ * has none. Nothing failed; there were simply no skills.
+ *
+ * These assert against what npm would really put in the tarball. The working
+ * tree is not what users get, so checking the working tree proves nothing.
+ */
+
+const PKG_DIR = resolve(__dirname, '../../..');
+const SKILLS_DIR = join(PKG_DIR, 'skills');
+
+function onDiskSkillCount(): number {
+  return readdirSync(SKILLS_DIR, { withFileTypes: true }).filter(
+    (entry) => entry.isDirectory() && existsSync(join(SKILLS_DIR, entry.name, 'SKILL.md')),
+  ).length;
+}
+
+let cache: string[] | undefined;
+
+/** File paths npm would publish. The listing goes to stderr as `npm notice`. */
+function packedFiles(): string[] {
+  if (cache) return cache;
+  // --ignore-scripts skips the prepack build; file selection is unaffected and
+  // the check drops from minutes to about a second.
+  const result = spawnSync('npm', ['pack', '--dry-run', '--ignore-scripts'], {
+    cwd: PKG_DIR,
+    encoding: 'utf-8',
+  });
+  if (result.error) throw result.error;
+  cache = (result.stderr || '')
+    .split('\n')
+    .filter((line) => line.startsWith('npm notice'))
+    .map((line) => line.replace(/^npm notice\s*/, '').trim())
+    // entries look like "1.2kB skills/weather/SKILL.md"
+    .map((line) => line.replace(/^[\d.]+\s*[kMG]?B\s+/, ''))
+    .filter((line) => line && !line.includes(' '));
+  return cache;
+}
+
+describe('bundled skills are actually published', () => {
+  it('package.json declares the skills directory', () => {
+    const pkg = JSON.parse(readFileSync(join(PKG_DIR, 'package.json'), 'utf-8')) as {
+      files: string[];
+    };
+    expect(pkg.files).toContain('skills/');
+  });
+
+  it('there are bundled skills on disk to publish', () => {
+    expect(onDiskSkillCount()).toBeGreaterThan(0);
+  });
+
+  it('every bundled SKILL.md on disk is in the tarball', () => {
+    const packed = packedFiles().filter(
+      (path) => path.startsWith('skills/') && path.endsWith('SKILL.md'),
+    );
+    // Exact, not "greater than zero": shipping a subset is the same silent
+    // failure in a smaller form.
+    expect(packed.length).toBe(onDiskSkillCount());
+  });
+
+  it('ships the assets the loader reads, not only the loader', () => {
+    const packed = packedFiles();
+    expect(packed).toContain('dist/skills/bundled.js');
+    expect(packed.some((path) => path.startsWith('skills/'))).toBe(true);
+  });
+});


### PR DESCRIPTION
`files` in `package.json` never listed `skills/`, so every published tarball carried the loader and none of the skills it reads.

```
on disk:  52
packed:   0
```

### Why nobody noticed

```
$ loadBundledSkills('/tmp/definitely-not-here')
0 skills, no error thrown
```

`loadBundledSkills` catches a missing directory and returns an empty list. An install that shipped nothing is therefore **indistinguishable from one that legitimately has no skills**. Nothing failed, nothing warned — there were simply never any skills, and `dist/skills/bundled.js` shipped faithfully to read a directory that wasn't there.

### The fix

`skills/` added to `files` — 212 kB, markdown only.

Plus a packaging test that asserts against **what npm would actually publish**, not against the working tree. The working tree was never the thing that was broken, so a test that reads it would have passed throughout.

Two details worth flagging:

- The SKILL.md count is asserted **exactly**, not "greater than zero". Shipping a subset is the same silent failure in a smaller form.
- `npm pack --dry-run --ignore-scripts` keeps the check at ~1.6s. Skipping the `prepack` build does not affect file selection, and without it the test triggers a full rebuild.

### Mutations

| mutation | result |
|---|---|
| remove `skills/` from `files` *(the original bug)* | **3 of 4 failed** |
| ship only `skills/1password/**` *(partial ship)* | **2 of 4 failed** |

### Suite

`4773` passed · `tsc --noEmit` clean.

The 5 failures in `copilot-cli-local.test.ts` are **pre-existing on clean main** — confirmed by stashing these changes and re-running, not assumed.

### Deliberately not changed

The loader's silent swallow. A user with no skills directory is a legitimate case, and making it throw would break them to catch a packaging error that this test now catches directly. Worth a separate discussion if you'd rather it warned.
