### PR TITLE
fix(cron): cron.delete must stop the job that is actually running

### DIFF
--- a/typescript/src/gateway/__tests__/cron-add-live.test.ts
+++ b/typescript/src/gateway/__tests__/cron-add-live.test.ts
@@ -15,6 +15,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { GatewayServer } from '../server.js';
+import { CronService } from '../../cron/service.js';
 
 type Handler = (params: unknown, connection: unknown) => Promise<unknown>;
 
@@ -162,6 +163,109 @@ describe('cron.create is an alias, not a second implementation', () => {
     expect(res.scheduled).toBe(true);
     expect(sched.jobs).toHaveLength(1);
     expect(sched.jobs[0]).toMatchObject({ name: 'from-menu-bar', agentId: 'GoogleVoice' });
+  });
+});
+
+describe('cron.delete is an alias, not a second implementation', () => {
+  // The menu bar deletes through `cron.delete`. That alias filtered the JSON
+  // file store and returned { removed: true } without ever telling the running
+  // scheduler — the user was told the job was gone and it kept firing.
+  it('removes the job from the live scheduler, not just the file', async () => {
+    const server = await boot();
+    const sched = fakeScheduler();
+    server.setCronService(sched.service as never);
+    const methods = methodsOf(server);
+
+    const created = await methods.get('cron.add')!.handler(
+      { name: 'from-menu-bar', schedule: '* * * * *', agentId: 'GoogleVoice', message: 'check' },
+      {} as never,
+    ) as { id: string };
+    expect(sched.jobs).toHaveLength(1);
+
+    // Exactly the payload RpcClient.deleteCronJob sends.
+    const res = await methods.get('cron.delete')!.handler({ jobId: created.id }, {} as never);
+
+    expect(res).toMatchObject({ removed: true });
+    expect(sched.jobs, 'the scheduler itself must no longer hold it').toHaveLength(0);
+    expect(sched.service.list().map(j => j.id)).not.toContain(created.id);
+  });
+
+  it('refuses an unknown job id instead of reporting a successful delete', async () => {
+    const server = await boot();
+    server.setCronService(fakeScheduler().service as never);
+    await expect(
+      methodsOf(server).get('cron.delete')!.handler({ jobId: 'no-such-job' }, {} as never),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('refuses an empty job id', async () => {
+    const server = await boot();
+    server.setCronService(fakeScheduler().service as never);
+    await expect(
+      methodsOf(server).get('cron.delete')!.handler({ jobId: '' }, {} as never),
+    ).rejects.toThrow(/not found/i);
+  });
+
+  it('is literally the same handler as cron.remove, so it cannot drift again', async () => {
+    const server = await boot();
+    const methods = methodsOf(server);
+    expect(methods.get('cron.delete')!.handler).toBe(methods.get('cron.remove')!.handler);
+  });
+
+  // The symptom the user reports: not "it is still listed" but "it still ran".
+  it('stops the real CronService job from firing again', async () => {
+    const server = await boot();
+    const cron = new CronService();
+    const fired: string[] = [];
+    await cron.start({ execute: async (agentId, message) => { fired.push(`${agentId}:${message}`); return 'ok'; } });
+    // Wired exactly as the daemon wires it (src/index.ts).
+    server.setCronService({
+      list: () => cron.listJobs().map(j => ({ id: j.id, name: j.name, schedule: j.schedule, enabled: j.enabled })),
+      run: async (id: string) => { await cron.executeJob(id, 'force'); },
+      enable: async (id: string) => { await cron.updateJob(id, { enabled: true }); },
+      disable: async (id: string) => { await cron.updateJob(id, { enabled: false }); },
+      add: async (job: Record<string, unknown>) => {
+        const created = await cron.addJob({
+          name: String(job.name ?? 'job'), schedule: String(job.schedule ?? '* * * * *'),
+          agentId: job.agentId ? String(job.agentId) : undefined, message: String(job.message ?? ''),
+          enabled: job.enabled !== false,
+        });
+        return { id: created.id };
+      },
+      remove: async (id: string) => { await cron.removeJob(id); },
+    });
+    const methods = methodsOf(server);
+
+    const created = await methods.get('cron.add')!.handler(
+      { name: 'every minute', schedule: '* * * * *', agentId: 'ReproAgent', message: 'ping' },
+      {} as never,
+    ) as { id: string };
+    // Sanity: before the delete it does fire when its minute comes up. This is
+    // the same call the scheduler's timer makes on a matching minute.
+    expect(await cron.executeJob(created.id, 'force')).toBe('ok');
+    expect(fired).toHaveLength(1);
+
+    await methods.get('cron.delete')!.handler({ jobId: created.id }, {} as never);
+
+    // Now the scheduler tick has nothing left to run.
+    expect(await cron.executeJob(created.id, 'force')).toBeNull();
+    expect(fired, 'a deleted job must not fire again').toHaveLength(1);
+    expect(cron.listJobs()).toHaveLength(0);
+    cron.stop();
+  });
+
+  // Hosts with no live scheduler still delete from the file store.
+  it('still removes a file-only job when no scheduler is wired', async () => {
+    const server = await boot();
+    const methods = methodsOf(server);
+    const created = await methods.get('cron.add')!.handler(
+      { name: 'orphan', schedule: '* * * * *', message: 'x' }, {} as never,
+    ) as { id: string };
+
+    await methods.get('cron.delete')!.handler({ jobId: created.id }, {} as never);
+
+    const listed = await methods.get('cron.list')!.handler({}, {} as never) as Array<{ id: string }>;
+    expect(listed.map(j => j.id)).not.toContain(created.id);
   });
 });
 

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -254,6 +254,35 @@ export class GatewayServer {
   };
 
   /**
+   * The one way a cron job gets removed. The live scheduler comes FIRST: a
+   * delete that only filtered the file store left the running job firing while
+   * telling the caller it was gone. An id nobody knows is refused rather than
+   * answered with `{ removed: true }`.
+   */
+  private removeCronJob = async (params: { jobId: string }): Promise<{ removed: true }> => {
+    const jobId = params?.jobId;
+    let removed = false;
+
+    if (jobId && this.cronService?.remove) {
+      const known = this.cronService.list().some((j) => j.id === jobId);
+      if (known) {
+        await this.cronService.remove(jobId);
+        removed = true;
+      }
+    }
+
+    const previousLength = this.cronStore.length;
+    this.cronStore = this.cronStore.filter((j) => (j as { id: string }).id !== jobId);
+    if (this.cronStore.length !== previousLength) {
+      this.saveCronStore();
+      removed = true;
+    }
+
+    if (!removed) throw new Error(`Cron job not found: ${jobId || '(empty id)'}`);
+    return { removed: true };
+  };
+
+  /**
    * Installs a dropped agent into the running organism.
    *
    * Injected rather than constructed here because only the daemon owns the live
@@ -2151,28 +2180,7 @@ export class GatewayServer {
       return this.cronStore;
     });
     this.registerMethod('cron.add', this.addCronJob, { requiresAuth: true });
-    this.registerMethod('cron.remove', async (params: { jobId: string }) => {
-      const jobId = params.jobId;
-      let removed = false;
-
-      if (jobId && this.cronService?.remove) {
-        const known = this.cronService.list().some((j) => j.id === jobId);
-        if (known) {
-          await this.cronService.remove(jobId);
-          removed = true;
-        }
-      }
-
-      const previousLength = this.cronStore.length;
-      this.cronStore = this.cronStore.filter((j) => (j as { id: string }).id !== jobId);
-      if (this.cronStore.length !== previousLength) {
-        this.saveCronStore();
-        removed = true;
-      }
-
-      if (!removed) throw new Error(`Cron job not found: ${jobId || '(empty id)'}`);
-      return { removed: true };
-    }, { requiresAuth: true });
+    this.registerMethod('cron.remove', this.removeCronJob, { requiresAuth: true });
     this.registerMethod('cron.run', async (params: { jobId: string }) => {
       if (this.cronService) {
         await this.runCronServiceJob(params.jobId);
@@ -2237,11 +2245,10 @@ export class GatewayServer {
     // the original file-only bug after cron.add was fixed, so the menu bar could
     // create a job that silently never ran.
     this.registerMethod('cron.create', this.addCronJob, { requiresAuth: true });
-    this.registerMethod('cron.delete', async (params: { jobId: string }) => {
-      this.cronStore = this.cronStore.filter((j) => (j as { id: string }).id !== params.jobId);
-      this.saveCronStore();
-      return { removed: true };
-    }, { requiresAuth: true });
+    // Same story for delete: this alias filtered the file store and reported
+    // success, so the menu bar could "delete" a job that kept firing — and got
+    // the same cheerful answer for ids that never existed.
+    this.registerMethod('cron.delete', this.removeCronJob, { requiresAuth: true });
     this.registerMethod('cron.trigger', async (params: { jobId: string }) => {
       if (this.cronService) {
         await this.runCronServiceJob(params.jobId);


### PR DESCRIPTION
## The bug

The macOS Bar deletes a scheduled job with `RpcClient.deleteCronJob` → RPC `cron.delete { jobId }`. That alias filtered the file-backed `cronStore`, saved it, and returned `{ removed: true }` — it never touched the live scheduler, and it never checked that the id existed.

## Reproduction (before the fix)

Real `CronService` wired to a real `GatewayServer` exactly as the daemon wires it (`typescript/src/index.ts`), job created via `cron.create` and deleted via `cron.delete { jobId }` — the Bar's own call shapes:

```
Gateway server started on 127.0.0.1:0
cron.create -> {"enabled":true,"name":"repro job","schedule":"* * * * *","agentId":"ReproAgent","message":"ping","id":"job_1786925628840_1","scheduled":true}
live scheduler after create: ["job_1786925628840_1"]
cron.delete -> {"removed":true}
live scheduler after delete: ["job_1786925628840_1"]      <-- SYMPTOM A: still live
cron.delete(no-such-job-id) -> {"removed":true}           <-- SYMPTOM B: ghost delete "succeeds"
waiting 14s for the next minute boundary to see whether the deleted job fires...
>>> JOB FIRED at 2026-08-17T00:14:00.502Z agent=ReproAgent message=ping
fired executions after delete: ["ReproAgent:ping"]        <-- the deleted job ran
```

The same script after the fix, waiting a full minute boundary:

```
cron.create -> {...,"id":"job_1786925761555_1","scheduled":true}
live scheduler after create: ["job_1786925761555_1"]
cron.delete -> {"removed":true}
live scheduler after delete: []
cron.delete(no-such-job-id) REJECTED -> Cron job not found: no-such-job-id
waiting 61s for the next minute boundary to see whether the deleted job fires...
fired executions after delete: []
```

## The fix

There is now one canonical removal path. `cron.remove`'s body moved to a bound `removeCronJob` on `GatewayServer` — live scheduler first, then the file store, and a hard `Cron job not found: <id>` when neither knew the id. `cron.remove` and `cron.delete` both register **that same handler object**, mirroring how `cron.create` already shares `addCronJob`. No second removal implementation exists to drift again; a test asserts the two entries are the identical function reference.

`cron.delete` keeps its name and its `{ jobId }` / `{ removed: true }` success shape, so the Bar's wire contract is unchanged. The one deliberate behaviour change: deleting an id the gateway does not know is now a JSON-RPC error instead of a false success.

## Does the macOS Bar need a change? No.

- `RpcClient.deleteCronJob` already sends `{ jobId }` — the parameter `cron.remove` reads. PR #155 fixed the `{id}` vs `{jobId}` mismatch on the CLI side; the Bar was already correct.
- `CronViewModel.deleteJob` only prunes its local list *after* `try await rpc.deleteCronJob` returns, and sets `self.error` on throw. So the new refusal surfaces as a visible error rather than the job disappearing from the UI while it keeps running. That is the behaviour we want, achieved with zero Swift changes. No Swift was touched, so no Swift build was needed.

## Mutation table

Every mutation was applied to the fixed source, the targeted file re-run, then reverted.

| # | Mutation | Failing tests | Which |
|---|---|---|---|
| A | Restore the old file-only `cron.delete` alias | 5 | delete removes from live scheduler; refuses unknown id; refuses empty id; same handler as `cron.remove`; real `CronService` job stops firing |
| B | Drop the `if (!removed) throw` in `removeCronJob` | 4 | `cron.delete` unknown id; `cron.delete` empty id; plus the two pre-existing `cron.remove` not-found tests |
| C | Keep the alias shared but skip `cronService.remove(...)` (file store only) | 3 | `cron.delete` removes from live scheduler; real `CronService` job stops firing; plus the pre-existing `cron.remove` scheduler test |

Both symptoms are covered independently: **live job survives deletion** (mutations A and C) and **unknown id falsely succeeds** (mutations A and B).

## Validation

- `vitest run src/gateway/__tests__/cron-add-live.test.ts` — 18 passed (5 new).
- `tsc --noEmit -p tsconfig.json` — clean.
- `eslint` on both changed files — clean.
- Full suite: `Tests 5 failed | 4775 passed | 21 skipped (4801)`. The 5 failures are the known pre-existing `src/providers/copilot-cli-local.test.ts` failures present on clean `main` (an ambient `/opt/homebrew/bin/copilot`), unrelated to this change.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 2720e688-7dc9-488f-bf6f-38cfff214088
