### PR TITLE
fix(storage): async transactions, migration atomicity, parent upserts

### DIFF
--- a/typescript/src/__tests__/integration/storage-regressions.test.ts
+++ b/typescript/src/__tests__/integration/storage-regressions.test.ts
@@ -1,0 +1,319 @@
+/**
+ * SQLite storage correctness regressions.
+ *
+ * Each test here corresponds to a bug that was reproduced against a real
+ * on-disk SQLite database before the fix was written:
+ *
+ *  1. transaction() accepted async callbacks. better-sqlite3 rejects them, but
+ *     the callback body kept running and its writes landed *after* the
+ *     transaction had already been rolled back.
+ *  2. Migration DDL and the migrations version row were written separately, so a
+ *     migration that failed partway left the schema half-applied with no version
+ *     marker — every subsequent startup replayed it and failed forever.
+ *  3. Parent rows were written with INSERT OR REPLACE. In SQLite that is a
+ *     DELETE + INSERT, which fires child foreign key actions (ON DELETE SET NULL
+ *     / ON DELETE CASCADE) and silently destroys associated rows.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { SQLiteAdapter } from '../../storage/sqlite.js';
+import { migrations, type Migration } from '../../storage/migrations.js';
+import type { Session, Device } from '../../storage/types.js';
+
+interface RawDb {
+  prepare(sql: string): { run(...p: unknown[]): unknown; get(...p: unknown[]): unknown; all(...p: unknown[]): unknown[] };
+  exec(sql: string): void;
+}
+
+/** Reach the underlying better-sqlite3 handle to assert on raw rows. */
+function raw(adapter: SQLiteAdapter): RawDb {
+  return (adapter as unknown as { db: RawDb }).db;
+}
+
+const NOW = '2024-01-01T00:00:00.000Z';
+
+function makeSession(id: string, overrides: Partial<Session> = {}): Session {
+  return {
+    id,
+    channelId: 'cli',
+    conversationId: 'conv-1',
+    agentId: 'main',
+    metadata: {},
+    messages: [],
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+function makeDevice(id: string, overrides: Partial<Device> = {}): Device {
+  return {
+    id,
+    name: 'laptop',
+    type: 'cli',
+    lastSeen: NOW,
+    trusted: true,
+    metadata: {},
+    createdAt: NOW,
+    updatedAt: NOW,
+    ...overrides,
+  };
+}
+
+describe('SQLiteAdapter regressions', () => {
+  let dir: string;
+  let adapter: SQLiteAdapter | null;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'openrappter-storage-'));
+    adapter = null;
+  });
+
+  afterEach(async () => {
+    if (adapter) await adapter.close().catch(() => undefined);
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  async function open(file = 'test.db'): Promise<SQLiteAdapter> {
+    const a = new SQLiteAdapter({ type: 'sqlite', path: join(dir, file) });
+    await a.initialize();
+    adapter = a;
+    return a;
+  }
+
+  // ── 1. Async transaction callbacks ────────────────────────────────────
+
+  describe('transaction()', () => {
+    it('rejects an async callback without running any of its body', async () => {
+      const a = await open();
+      let ran = false;
+
+      const asyncFn = async () => {
+        ran = true;
+        await a.setConfig('leaked', 'yes');
+        return 1;
+      };
+
+      await expect(
+        // The type system rejects this too; the cast proves the runtime guard.
+        a.transaction(asyncFn as unknown as () => number)
+      ).rejects.toThrow(/synchronous callback/i);
+
+      expect(ran).toBe(false);
+      await new Promise((r) => setTimeout(r, 20));
+      expect(await a.getConfig('leaked')).toBeNull();
+    });
+
+    it('rejects a promise-returning callback and rolls back its synchronous writes', async () => {
+      const a = await open();
+
+      const promiseFn = () => {
+        void a.setConfig('sync-write', 'written');
+        return Promise.resolve('later');
+      };
+
+      await expect(a.transaction(promiseFn as unknown as () => string)).rejects.toThrow(
+        /synchronous callback/i
+      );
+
+      await new Promise((r) => setTimeout(r, 20));
+      expect(await a.getConfig('sync-write')).toBeNull();
+    });
+
+    it('commits a synchronous callback and returns its value', async () => {
+      const a = await open();
+
+      const result = await a.transaction(() => {
+        void a.setConfig('committed-a', '1');
+        void a.setConfig('committed-b', '2');
+        return 'ok';
+      });
+
+      expect(result).toBe('ok');
+      expect(await a.getConfig('committed-a')).toBe('1');
+      expect(await a.getConfig('committed-b')).toBe('2');
+    });
+
+    it('rolls back every write when a synchronous callback throws', async () => {
+      const a = await open();
+      await a.setConfig('pre-existing', 'kept');
+
+      await expect(
+        a.transaction((): void => {
+          void a.setConfig('rolled-back-a', '1');
+          void a.setConfig('rolled-back-b', '2');
+          throw new Error('boom');
+        })
+      ).rejects.toThrow('boom');
+
+      expect(await a.getConfig('rolled-back-a')).toBeNull();
+      expect(await a.getConfig('rolled-back-b')).toBeNull();
+      expect(await a.getConfig('pre-existing')).toBe('kept');
+    });
+  });
+
+  // ── 2. Migration atomicity ────────────────────────────────────────────
+
+  describe('migrations', () => {
+    /** Adapter whose migration set can be swapped, to induce a mid-migration failure. */
+    class InjectableAdapter extends SQLiteAdapter {
+      constructor(
+        path: string,
+        private readonly set: Migration[]
+      ) {
+        super({ type: 'sqlite', path });
+      }
+      protected override getMigrations(): Migration[] {
+        return this.set;
+      }
+    }
+
+    /** migration 3 (add_session_tokens) with a syntax error after the first ALTER */
+    const brokenThird: Migration = {
+      id: 3,
+      name: 'add_session_tokens',
+      up: `
+        ALTER TABLE sessions ADD COLUMN total_tokens INTEGER DEFAULT 0;
+        ALTER TABLE sessions ADD COLUMN prompt_tokens INTEGER DEFAULT 0 THIS IS NOT SQL;
+      `,
+      down: '',
+    };
+
+    it('rolls back DDL and the version marker together when a migration fails', async () => {
+      const path = join(dir, 'mig.db');
+      const broken = new InjectableAdapter(path, [...migrations.slice(0, 2), brokenThird]);
+
+      await expect(broken.initialize()).rejects.toThrow(
+        /Migration 3 \(add_session_tokens\) failed and was rolled back/
+      );
+
+      // The connection stays usable; inspect what actually landed.
+      const db = raw(broken);
+      const cols = (db.prepare('PRAGMA table_info(sessions)').all() as { name: string }[]).map(
+        (c) => c.name
+      );
+      expect(cols).not.toContain('total_tokens');
+
+      const applied = (db.prepare('SELECT id FROM migrations').all() as { id: number }[]).map(
+        (m) => m.id
+      );
+      expect(applied).toEqual([1, 2]);
+      await broken.close();
+    });
+
+    it('comes up clean on the next startup after a failed migration', async () => {
+      const path = join(dir, 'mig.db');
+      const broken = new InjectableAdapter(path, [...migrations.slice(0, 2), brokenThird]);
+      await expect(broken.initialize()).rejects.toThrow();
+      await broken.close();
+
+      // Restart with the real, correct migration set — must succeed and be complete.
+      const a = new SQLiteAdapter({ type: 'sqlite', path });
+      adapter = a;
+      await expect(a.initialize()).resolves.toBeUndefined();
+
+      const applied = (raw(a).prepare('SELECT id FROM migrations').all() as { id: number }[]).map(
+        (m) => m.id
+      );
+      expect(applied).toEqual(migrations.map((m) => m.id));
+
+      const cols = (raw(a).prepare('PRAGMA table_info(sessions)').all() as { name: string }[]).map(
+        (c) => c.name
+      );
+      expect(cols).toContain('total_tokens');
+      expect(cols).toContain('prompt_tokens');
+      expect(cols).toContain('completion_tokens');
+
+      await a.saveSession(makeSession('after-recovery'));
+      expect(await a.getSession('after-recovery')).not.toBeNull();
+    });
+  });
+
+  // ── 3. Parent upserts must not destroy children ───────────────────────
+
+  describe('parent row upserts', () => {
+    async function seedApproval(a: SQLiteAdapter): Promise<void> {
+      await a.saveSession(makeSession('sess-1'));
+      await a.saveDevice(makeDevice('dev-1'));
+      raw(a)
+        .prepare(
+          `INSERT INTO approval_requests
+             (id, session_id, device_id, tool_name, tool_args, status, created_at)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`
+        )
+        .run('appr-1', 'sess-1', 'dev-1', 'bash', '{}', 'pending', NOW);
+    }
+
+    function approval(a: SQLiteAdapter): { session_id: string | null; device_id: string | null } {
+      return raw(a).prepare('SELECT * FROM approval_requests WHERE id = ?').get('appr-1') as {
+        session_id: string | null;
+        device_id: string | null;
+      };
+    }
+
+    it('keeps the approval association when a session is re-saved', async () => {
+      const a = await open();
+      await seedApproval(a);
+      expect(approval(a).session_id).toBe('sess-1');
+
+      await a.saveSession(makeSession('sess-1', { metadata: { touched: true }, updatedAt: 'later' }));
+
+      expect(approval(a).session_id).toBe('sess-1');
+      expect(approval(a).device_id).toBe('dev-1');
+
+      const reloaded = await a.getSession('sess-1');
+      expect(reloaded?.metadata).toEqual({ touched: true });
+      expect(reloaded?.updatedAt).toBe('later');
+    });
+
+    it('keeps the approval association when a device is re-saved', async () => {
+      const a = await open();
+      await seedApproval(a);
+      expect(approval(a).device_id).toBe('dev-1');
+
+      await a.saveDevice(makeDevice('dev-1', { name: 'renamed', trusted: false }));
+
+      expect(approval(a).device_id).toBe('dev-1');
+      expect(approval(a).session_id).toBe('sess-1');
+
+      const reloaded = await a.getDevice('dev-1');
+      expect(reloaded?.name).toBe('renamed');
+      expect(reloaded?.trusted).toBe(false);
+    });
+
+    it('keeps cron run history when a cron job is re-saved', async () => {
+      const a = await open();
+      await a.saveCronJob({
+        id: 'job-1',
+        name: 'nightly',
+        schedule: '0 0 * * *',
+        agentId: 'main',
+        message: 'run',
+        enabled: true,
+        createdAt: NOW,
+        updatedAt: NOW,
+      });
+      await a.saveCronLog({ id: 'log-1', jobId: 'job-1', startedAt: NOW, status: 'success' });
+      expect(await a.getCronLogs('job-1')).toHaveLength(1);
+
+      await a.saveCronJob({
+        id: 'job-1',
+        name: 'nightly-renamed',
+        schedule: '0 0 * * *',
+        agentId: 'main',
+        message: 'run',
+        enabled: false,
+        createdAt: NOW,
+        updatedAt: 'later',
+      });
+
+      expect(await a.getCronLogs('job-1')).toHaveLength(1);
+      const job = await a.getCronJob('job-1');
+      expect(job?.name).toBe('nightly-renamed');
+      expect(job?.enabled).toBe(false);
+    });
+  });
+});

--- a/typescript/src/storage/migrations.ts
+++ b/typescript/src/storage/migrations.ts
@@ -229,6 +229,9 @@ export function getMigration(id: number): Migration | undefined {
   return migrations.find((m) => m.id === id);
 }
 
-export function getPendingMigrations(appliedIds: number[]): Migration[] {
-  return migrations.filter((m) => !appliedIds.includes(m.id));
+export function getPendingMigrations(
+  appliedIds: number[],
+  all: Migration[] = migrations
+): Migration[] {
+  return all.filter((m) => !appliedIds.includes(m.id));
 }

--- a/typescript/src/storage/sqlite.ts
+++ b/typescript/src/storage/sqlite.ts
@@ -13,8 +13,27 @@ import type {
   CronLogRecord,
   Device,
   StorageConfig,
+  SyncTransactionCallback,
 } from './types.js';
-import { getPendingMigrations } from './migrations.js';
+import { getPendingMigrations, migrations, type Migration } from './migrations.js';
+
+const ASYNC_TRANSACTION_ERROR =
+  'transaction() requires a synchronous callback. better-sqlite3 cannot hold a SQLite ' +
+  'transaction open across an await — the transaction is rolled back the moment the callback ' +
+  'returns a promise, while the promise keeps running and writes outside it. Do async work ' +
+  'before or after the transaction and keep only storage calls inside it.';
+
+function isAsyncFunction(fn: unknown): boolean {
+  return typeof fn === 'function' && fn.constructor?.name === 'AsyncFunction';
+}
+
+function isThenable(value: unknown): value is PromiseLike<unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    typeof (value as PromiseLike<unknown>).then === 'function'
+  );
+}
 
 // Type definitions for better-sqlite3 (dynamically imported)
 interface Database {
@@ -100,16 +119,35 @@ export class SQLiteAdapter implements StorageAdapter {
     const applied = db.prepare('SELECT id FROM migrations').all() as { id: number }[];
     const appliedIds = applied.map((m) => m.id);
 
-    // Apply pending migrations
-    const pending = getPendingMigrations(appliedIds);
+    // Apply pending migrations. The DDL and the version marker must commit or roll
+    // back together: a half-applied migration with no version row is replayed on the
+    // next startup, and non-idempotent statements (ALTER TABLE ADD COLUMN) then fail
+    // forever, bricking the database.
+    const pending = getPendingMigrations(appliedIds, this.getMigrations());
     for (const migration of pending) {
-      db.exec(migration.up);
-      db.prepare('INSERT INTO migrations (id, name, applied_at) VALUES (?, ?, ?)').run(
-        migration.id,
-        migration.name,
-        new Date().toISOString()
-      );
+      const apply = db.transaction(() => {
+        db.exec(migration.up);
+        db.prepare('INSERT INTO migrations (id, name, applied_at) VALUES (?, ?, ?)').run(
+          migration.id,
+          migration.name,
+          new Date().toISOString()
+        );
+      });
+
+      try {
+        apply();
+      } catch (error) {
+        throw new Error(
+          `Migration ${migration.id} (${migration.name}) failed and was rolled back: ` +
+            (error instanceof Error ? error.message : String(error))
+        );
+      }
     }
+  }
+
+  /** The migration set to apply. Overridable so tests can inject failing migrations. */
+  protected getMigrations(): Migration[] {
+    return migrations;
   }
 
   // Sessions
@@ -122,11 +160,27 @@ export class SQLiteAdapter implements StorageAdapter {
 
   async saveSession(session: Session): Promise<void> {
     const db = this.ensureDb();
+    // Real UPSERT, not INSERT OR REPLACE: REPLACE is a DELETE + INSERT, which fires
+    // ON DELETE SET NULL on approval_requests.session_id and silently destroys the
+    // approval's association with this session.
     db.prepare(
-      `INSERT OR REPLACE INTO sessions
+      `INSERT INTO sessions
        (id, channel_id, conversation_id, agent_id, user_id, metadata, messages,
         created_at, updated_at, expires_at, total_tokens, prompt_tokens, completion_tokens)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         channel_id = excluded.channel_id,
+         conversation_id = excluded.conversation_id,
+         agent_id = excluded.agent_id,
+         user_id = excluded.user_id,
+         metadata = excluded.metadata,
+         messages = excluded.messages,
+         created_at = excluded.created_at,
+         updated_at = excluded.updated_at,
+         expires_at = excluded.expires_at,
+         total_tokens = excluded.total_tokens,
+         prompt_tokens = excluded.prompt_tokens,
+         completion_tokens = excluded.completion_tokens`
     ).run(
       session.id,
       session.channelId,
@@ -330,10 +384,23 @@ export class SQLiteAdapter implements StorageAdapter {
 
   async saveCronJob(job: CronJobRecord): Promise<void> {
     const db = this.ensureDb();
+    // Real UPSERT — same class of bug as saveSession/saveDevice. REPLACE here is a
+    // DELETE + INSERT, which fires ON DELETE CASCADE on cron_logs.job_id and wipes
+    // the job's entire run history.
     db.prepare(
-      `INSERT OR REPLACE INTO cron_jobs
+      `INSERT INTO cron_jobs
        (id, name, schedule, agent_id, message, enabled, last_run, next_run, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         name = excluded.name,
+         schedule = excluded.schedule,
+         agent_id = excluded.agent_id,
+         message = excluded.message,
+         enabled = excluded.enabled,
+         last_run = excluded.last_run,
+         next_run = excluded.next_run,
+         created_at = excluded.created_at,
+         updated_at = excluded.updated_at`
     ).run(
       job.id,
       job.name,
@@ -394,10 +461,21 @@ export class SQLiteAdapter implements StorageAdapter {
 
   async saveDevice(device: Device): Promise<void> {
     const db = this.ensureDb();
+    // Real UPSERT — see saveSession. REPLACE here would null out
+    // approval_requests.device_id via ON DELETE SET NULL.
     db.prepare(
-      `INSERT OR REPLACE INTO devices
+      `INSERT INTO devices
        (id, name, type, public_key, last_seen, trusted, metadata, created_at, updated_at)
-       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(id) DO UPDATE SET
+         name = excluded.name,
+         type = excluded.type,
+         public_key = excluded.public_key,
+         last_seen = excluded.last_seen,
+         trusted = excluded.trusted,
+         metadata = excluded.metadata,
+         created_at = excluded.created_at,
+         updated_at = excluded.updated_at`
     ).run(
       device.id,
       device.name,
@@ -452,10 +530,38 @@ export class SQLiteAdapter implements StorageAdapter {
 
   // Transactions
 
-  async transaction<T>(fn: () => Promise<T>): Promise<T> {
+  /**
+   * Run `fn` inside a SQLite transaction and return its value.
+   *
+   * `fn` must be synchronous — see {@link SyncTransactionCallback}. Async callbacks
+   * are rejected both at the type level and at runtime. Storage methods return
+   * promises but perform their SQLite work synchronously before resolving, so they
+   * can be called (un-awaited) from inside the callback and still take part in the
+   * transaction.
+   */
+  async transaction<T>(fn: SyncTransactionCallback<T>): Promise<T> {
     const db = this.ensureDb();
-    const txn = db.transaction(() => fn());
-    return txn() as T;
+    const callback = fn as unknown as () => T;
+
+    // Reject before opening the transaction so no part of the callback body runs.
+    if (isAsyncFunction(callback)) {
+      throw new Error(ASYNC_TRANSACTION_ERROR);
+    }
+
+    let result!: T;
+    db.transaction(() => {
+      const value = callback() as unknown;
+      if (isThenable(value)) {
+        // The callback already started async work we cannot undo; at least keep its
+        // eventual rejection from crashing the process. Throwing here rolls back
+        // everything the callback wrote synchronously.
+        void Promise.resolve(value).catch(() => undefined);
+        throw new Error(ASYNC_TRANSACTION_ERROR);
+      }
+      result = value as T;
+    })();
+
+    return result;
   }
 
   // Row mappers

--- a/typescript/src/storage/types.ts
+++ b/typescript/src/storage/types.ts
@@ -39,8 +39,23 @@ export interface StorageAdapter {
   getAllConfig(): Promise<Record<string, string>>;
 
   // Transactions
-  transaction<T>(fn: () => Promise<T>): Promise<T>;
+  transaction<T>(fn: SyncTransactionCallback<T>): Promise<T>;
 }
+
+/**
+ * A transaction callback must be synchronous.
+ *
+ * SQLite transactions are held open on a single connection and are executed
+ * synchronously by better-sqlite3. A callback that returns a promise cannot be
+ * run inside one: better-sqlite3 aborts (and rolls back) as soon as it sees a
+ * promise, while the promise keeps running and writing *outside* the
+ * transaction it believes it is in.
+ *
+ * This type makes an async callback a compile-time error: when `T` is a
+ * promise, the required parameter type collapses to `never`.
+ */
+export type SyncTransactionCallback<T> = () => T &
+  (T extends PromiseLike<unknown> ? never : unknown);
 
 export interface Session {
   id: string;


### PR DESCRIPTION
# Three SQLite storage bugs: async transactions, migration atomicity, parent upserts

All three were reproduced against a real on-disk SQLite database before any fix was written. Every test added here has been observed failing when its fix is reverted — the mutation tables below record exactly which.

Files changed: `typescript/src/storage/{sqlite,types,migrations}.ts`, plus a new `typescript/src/__tests__/integration/storage-regressions.test.ts` (9 tests).

---

## 1. `perfect-ts-async-transaction` — async callbacks silently escape the transaction

### Reproduction

A temp on-disk DB, one `transaction()` call whose async callback writes, awaits, writes again, then throws:

```ts
await a.transaction(async () => {
  await a.setConfig('before-await', 'v1');
  await new Promise((r) => setTimeout(r, 20));
  await a.setConfig('after-await', 'v2');
  throw new Error('boom — should roll back everything');
});
```

Observed output on `main`:

```
transaction() threw: TypeError: Transaction function cannot return a promise
UNHANDLED REJECTION from detached callback: Error: boom — should roll back everything
before-await value after "rollback": null
after-await  value after "rollback": v2
inTransaction flag now: false
```

Three distinct failures in one call:

- better-sqlite3 refuses the transaction outright (`Transaction function cannot return a promise`), so the "transaction" never really existed.
- `before-await` was rolled back, but **`after-await` = `v2` survived** — a write that outlived a transaction the caller was told had failed. That is the lie.
- The callback's rejection had no owner and became an unhandled rejection. In the first run of this script it terminated the node process.

### The fix

I chose to **reject async callbacks rather than provide an async-capable path**. Justification: better-sqlite3 runs everything synchronously on one connection. An `await` inside an open transaction yields the event loop while `BEGIN` is still in effect, so unrelated work on the same connection gets swallowed into (or corrupted by) that transaction. There is no way to make that safe without a second connection or a serialising queue, both of which change the adapter's concurrency model far beyond this bug. The honest contract is "synchronous only", enforced so it cannot be misused.

Enforcement is in two layers:

- **Type level** — `StorageAdapter.transaction` now takes `SyncTransactionCallback<T> = () => T & (T extends PromiseLike<unknown> ? never : unknown)`. When `T` is a promise the parameter type collapses to `never`. Verified with `tsc`: `await s.transaction(async () => 42)` produces `error TS2322: Type 'Promise<number>' is not assignable to type 'never'`.
- **Runtime** — an `AsyncFunction` is rejected *before* the transaction opens, so none of the callback body runs and nothing leaks. A plain function that returns a thenable is caught inside the transaction: its synchronous writes are rolled back, its rejection is swallowed so it cannot crash the process, and the caller gets a clear error naming the problem.

One honest caveat, documented in the JSDoc: the adapter's own methods (`setConfig`, `saveSession`, …) are `async` by interface but do their SQLite work synchronously before resolving, so inside a sync transaction callback you call them **un-awaited** and they still take part in the transaction. The tests exercise exactly this.

For the thenable-returning (non-`async`) case, the callback's already-scheduled async continuation cannot be un-run — only its synchronous writes are rolled back and its rejection contained. That limitation is inherent and is stated in the error message.

### Mutation table

| # | Mutation applied to the fix | Test that went red |
|---|---|---|
| M1 | `transaction()` reverted to the original body (`db.transaction(() => fn())`) | `rejects an async callback without running any of its body`; `rejects a promise-returning callback and rolls back its synchronous writes` |
| M2 | Removed only the `isAsyncFunction` pre-check, kept the thenable check | `rejects an async callback without running any of its body` |
| M3 | Ran the callback outside `db.transaction` (no atomicity) | `rejects a promise-returning callback and rolls back its synchronous writes`; `rolls back every write when a synchronous callback throws` |
| M4 | Discarded the callback's return value | `commits a synchronous callback and returns its value` |

---

## 2. `perfect-ts-migration-atomicity` — a half-applied migration bricks every restart

### Reproduction

Migrations 1 and 2 applied and recorded normally. Migration 3 (`add_session_tokens`, three `ALTER TABLE ... ADD COLUMN` statements) then fails after the first column lands. Because `db.exec(migration.up)` and the `INSERT INTO migrations` row were separate statements, the version marker was never written.

Observed output on `main`:

```
migration 3 failed partway: SqliteError: near "SYNTAX": syntax error
sessions columns now: id, channel_id, ..., expires_at, total_tokens
recorded migrations: [ 1, 2 ]
RESTART BRICKED: SqliteError: duplicate column name: total_tokens
SECOND RESTART ALSO BRICKED: SqliteError: duplicate column name: total_tokens
```

`total_tokens` exists on disk but migration 3 is not recorded, so every subsequent `initialize()` replays it and dies on the first `ALTER TABLE`. `ALTER TABLE ADD COLUMN` is not idempotent, so this is permanent: the database can never be opened again without manual surgery.

### The fix

Each pending migration's DDL and its `migrations` version row are wrapped in a single `db.transaction(...)`. SQLite is fully transactional for DDL, so a failure now rolls back both — the schema is left exactly as it was and the migration is retried cleanly on the next startup. Failures are rethrown with a message naming the migration and stating it was rolled back.

To make this testable, `runMigrations` now resolves its migration list through a `protected getMigrations()` hook and `getPendingMigrations` takes an optional list argument (defaulting to the real one, so no caller changes). The test subclasses `SQLiteAdapter` to inject a migration 3 that fails partway.

The recovery test is the point: after an induced mid-migration failure it opens the same file with the *real* migration set and asserts the DB comes up clean — all five migrations recorded, all three token columns present, and a session round-trips.

### Mutation table

| # | Mutation applied to the fix | Test that went red |
|---|---|---|
| M5 | Reverted to writing `db.exec(migration.up)` and the version row as two separate statements | `rolls back DDL and the version marker together when a migration fails`; `comes up clean on the next startup after a failed migration` |

---

## 3. `perfect-ts-parent-upsert` — `INSERT OR REPLACE` destroys child associations

### Reproduction

Create a session and a device, link an `approval_request` to both, then re-save each parent.

Observed output on `main`:

```
before re-save:        { id: 'appr-1', session_id: 'sess-1', device_id: 'dev-1', ... }
after re-save session: { id: 'appr-1', session_id: null,     device_id: 'dev-1', ... }
after re-save device:  { id: 'appr-1', session_id: null,     device_id: null,     ... }
```

`INSERT OR REPLACE` is a `DELETE` + `INSERT` in SQLite. The `DELETE` fires `approval_requests`' `ON DELETE SET NULL` foreign keys, so an ordinary "touch the session's `updated_at`" write silently orphans every approval attached to it. No error, no warning.

### Third instance found while proving this

The same pattern in `saveCronJob` is worse, because `cron_logs.job_id` is `ON DELETE CASCADE`:

```
===== ADJACENT: cron_jobs INSERT OR REPLACE cascades to cron_logs =====
logs before re-save: 1
logs after  re-save: 0
```

Renaming a cron job deletes its entire run history. This is the same bug in the same function family in the same file, so I fixed it too rather than leave a proven data-loss path in place — flagging it explicitly since it is beyond the two parent types the task named.

### The fix

`saveSession`, `saveDevice` and `saveCronJob` now use a real UPSERT — `INSERT ... ON CONFLICT(id) DO UPDATE SET <every non-id column> = excluded.<col>`. No `DELETE`, so no child FK action fires. The set of columns written is identical to before, so update semantics are unchanged.

The remaining three `INSERT OR REPLACE` sites were deliberately left alone: `config` and `cron_logs` have no child rows, and `memory_chunks`' delete+insert is exactly what its FTS5 sync triggers are written to handle. Changing those would be an unrelated change.

### Mutation table

| # | Mutation applied to the fix | Test that went red |
|---|---|---|
| M6 | `saveSession` reverted to `INSERT OR REPLACE` | `keeps the approval association when a session is re-saved` |
| M7 | `saveDevice` reverted to `INSERT OR REPLACE` | `keeps the approval association when a device is re-saved` |
| M8 | `saveCronJob` reverted to `INSERT OR REPLACE` | `keeps cron run history when a cron job is re-saved` |

---

## Verification

```
$ ./node_modules/.bin/vitest run --silent
 Test Files  1 failed | 244 passed | 3 skipped (248)
      Tests  5 failed | 4778 passed | 21 skipped (4804)

$ ./node_modules/.bin/tsc --noEmit -p tsconfig.json
(clean)

$ ./node_modules/.bin/eslint src/storage src/__tests__/integration/storage-regressions.test.ts
(clean)
```

The 5 failures are the known pre-existing ones in `src/providers/copilot-cli-local.test.ts` (Copilot CLI binary path resolution in this environment). They are untouched by this change — the diff is confined to `src/storage/`.

After every mutation was reverted, the full regression file returned to 9/9 green.

## Things I did not do

- No async-capable transaction path was added. Callers needing async work must do it outside the transaction. There are currently no production callers of `StorageAdapter.transaction()`, so this signature change breaks nothing in-tree.
- For a **non-async** function that returns a promise, the callback's pending continuation still runs after the rollback; only its synchronous writes are undone and its rejection contained. This is unavoidable without wrapping user code, and is stated in the thrown error.
- The pre-existing weak transaction tests in `src/__tests__/integration/storage.test.ts` (which never call `transaction()`) were left as-is rather than rewritten; the new file covers that ground properly.
