### PR TITLE
fix(storage): the Python adapter's lock was a promise it could not keep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Python storage adapter is genuinely thread-safe** — `SqliteStorageAdapter`
+  held an `RLock` (implying multi-threaded use) but opened its connection with
+  sqlite3's default `check_same_thread=True`, so any call from a worker thread
+  — a `ThreadPoolExecutor`, the gateway's executor, a cron worker — raised
+  `sqlite3.ProgrammingError`. The connection is now opened with
+  `check_same_thread=False` and every use of it, including cursor results and
+  `rowcount`, is funnelled through a single lock-holding gate.
 - **Browser private network access** — reaching a private or loopback address
   from the browser agent now requires an explicit operator opt-in
   (`allowPrivateNetwork`, off by default) rather than being reachable by

--- a/python/openrappter/storage/adapter.py
+++ b/python/openrappter/storage/adapter.py
@@ -16,6 +16,7 @@ SQLite-backed adapter is returned.
 """
 
 import abc
+import contextlib
 import json
 import os
 import sqlite3
@@ -23,7 +24,7 @@ import stat
 import threading
 import time
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Iterator, Optional
 
 DEFAULT_DB_PATH = Path.home() / ".openrappter" / "storage.db"
 
@@ -344,6 +345,27 @@ class SqliteStorageAdapter(StorageAdapter):
     JSON-serializable Python values) alongside a handful of indexed columns
     used for filtering. Every mutation runs inside a transaction so writes
     are atomic; failures are never swallowed.
+
+    **Thread safety.** The adapter owns exactly one ``sqlite3.Connection``,
+    opened with ``check_same_thread=False`` so it may be used from any thread
+    (a ``ThreadPoolExecutor``, the gateway's executor, a cron worker, ...).
+    That flag on its own would only trade an exception for a data race, so it
+    is paired with a hard invariant: **the connection — and every cursor
+    derived from it — is only ever touched while ``self._lock`` is held.**
+    ``_connection()`` is the single door through which that happens; no method
+    reaches ``self._conn`` directly, and every result set is materialized
+    (``fetchone``/``fetchall``) before the lock is released, so no lazy cursor
+    can be stepped while another thread is mid-statement.
+
+    One shared, fully serialized connection is deliberate rather than a
+    connection-per-thread pool: ``:memory:`` databases are private to their
+    connection, so per-thread connections would silently give each thread its
+    own empty database — writes would appear to succeed and then vanish, which
+    is far worse than the ``ProgrammingError`` this replaces. It also keeps
+    ``close()`` meaningful from any thread. WAL mode (already enabled) still
+    provides concurrency across *processes*; within the process, correctness
+    is bought at the cost of read parallelism, which is the right trade for a
+    local-first runtime whose storage calls are sub-millisecond.
     """
 
     def __init__(self, path: Optional[Any] = None, timeout: float = 5.0):
@@ -362,6 +384,17 @@ class SqliteStorageAdapter(StorageAdapter):
             if self._initialized:
                 return
 
+            if sqlite3.threadsafety == 0:
+                # SQLITE_THREADSAFE=0: the library keeps unprotected global
+                # state, so no amount of Python-level locking can make a
+                # connection safe to share across threads. Fail loudly rather
+                # than hand back an adapter that silently corrupts data.
+                raise RuntimeError(
+                    "sqlite3 was built without thread safety "
+                    "(sqlite3.threadsafety == 0); SqliteStorageAdapter cannot "
+                    "guarantee its cross-thread contract on this interpreter."
+                )
+
             if self._path != ":memory:":
                 db_path = Path(self._path)
                 db_path.parent.mkdir(parents=True, exist_ok=True)
@@ -373,7 +406,12 @@ class SqliteStorageAdapter(StorageAdapter):
                     # so proceed rather than failing initialization.
                     pass
 
-            conn = sqlite3.connect(self._path, timeout=self._timeout, isolation_level=None)
+            conn = sqlite3.connect(
+                self._path,
+                timeout=self._timeout,
+                isolation_level=None,
+                check_same_thread=False,
+            )
             conn.execute(f"PRAGMA busy_timeout={max(int(self._timeout * 1000), 0)}")
             _execute_with_busy_retry(conn, "PRAGMA journal_mode=WAL", self._timeout)
             conn.execute("PRAGMA foreign_keys=ON")
@@ -404,36 +442,56 @@ class SqliteStorageAdapter(StorageAdapter):
             )
         return self._conn
 
+    @contextlib.contextmanager
+    def _connection(self, *, write: bool = False) -> Iterator[sqlite3.Connection]:
+        """
+        The only sanctioned way to reach the shared connection.
+
+        Holds ``self._lock`` for the whole body, so the openness check, the
+        statement, and the materialization of its results are one atomic unit
+        with respect to other threads (including a concurrent ``close()``).
+        With ``write=True`` the body additionally runs inside the connection's
+        transaction context manager, committing on success and rolling back on
+        error before the lock is released.
+        """
+        with self._lock:
+            conn = self._ensure_open()
+            if write:
+                with conn:
+                    yield conn
+            else:
+                yield conn
+
     def _run_migrations(self) -> None:
-        conn = self._ensure_open()
-        conn.execute(
-            """
-            CREATE TABLE IF NOT EXISTS schema_migrations (
-                version INTEGER PRIMARY KEY,
-                applied_at REAL NOT NULL
-            )
-            """
-        )
-        for version, statements in _MIGRATIONS:
-            conn.execute("BEGIN IMMEDIATE")
-            try:
-                applied = conn.execute(
-                    "SELECT 1 FROM schema_migrations WHERE version = ?",
-                    (version,),
-                ).fetchone()
-                if applied:
-                    conn.commit()
-                    continue
-                for statement in statements:
-                    conn.execute(statement)
-                conn.execute(
-                    "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
-                    (version, time.time()),
+        with self._connection() as conn:
+            conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS schema_migrations (
+                    version INTEGER PRIMARY KEY,
+                    applied_at REAL NOT NULL
                 )
-                conn.commit()
-            except Exception:
-                conn.rollback()
-                raise
+                """
+            )
+            for version, statements in _MIGRATIONS:
+                conn.execute("BEGIN IMMEDIATE")
+                try:
+                    applied = conn.execute(
+                        "SELECT 1 FROM schema_migrations WHERE version = ?",
+                        (version,),
+                    ).fetchone()
+                    if applied:
+                        conn.commit()
+                        continue
+                    for statement in statements:
+                        conn.execute(statement)
+                    conn.execute(
+                        "INSERT INTO schema_migrations (version, applied_at) VALUES (?, ?)",
+                        (version, time.time()),
+                    )
+                    conn.commit()
+                except Exception:
+                    conn.rollback()
+                    raise
 
     # --- Sessions ---
 
@@ -441,8 +499,7 @@ class SqliteStorageAdapter(StorageAdapter):
         session = dict(session)
         session.setdefault('created_at', time.time())
         session['updated_at'] = time.time()
-        conn = self._ensure_open()
-        with self._lock, conn:
+        with self._connection(write=True) as conn:
             conn.execute(
                 """
                 INSERT OR REPLACE INTO sessions (id, channel_id, data, created_at, updated_at)
@@ -458,27 +515,24 @@ class SqliteStorageAdapter(StorageAdapter):
             )
 
     def get_session(self, session_id: str) -> Optional[dict]:
-        conn = self._ensure_open()
-        with self._lock:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT data FROM sessions WHERE id = ?", (session_id,)
             ).fetchone()
         return json.loads(row[0]) if row else None
 
     def delete_session(self, session_id: str) -> bool:
-        conn = self._ensure_open()
-        with self._lock, conn:
+        with self._connection(write=True) as conn:
             cur = conn.execute("DELETE FROM sessions WHERE id = ?", (session_id,))
-        return cur.rowcount > 0
+            return cur.rowcount > 0
 
     def list_sessions(self, filter_opts: Optional[dict] = None) -> list:
-        conn = self._ensure_open()
         sql = "SELECT data FROM sessions"
         params: list = []
         if filter_opts and 'channel_id' in filter_opts:
             sql += " WHERE channel_id = ?"
             params.append(filter_opts['channel_id'])
-        with self._lock:
+        with self._connection() as conn:
             rows = conn.execute(sql, params).fetchall()
         return [json.loads(row[0]) for row in rows]
 
@@ -487,30 +541,26 @@ class SqliteStorageAdapter(StorageAdapter):
     def save_memory_chunk(self, chunk: dict) -> None:
         chunk = dict(chunk)
         chunk.setdefault('created_at', time.time())
-        conn = self._ensure_open()
-        with self._lock, conn:
+        with self._connection(write=True) as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO memory_chunks (id, data, created_at) VALUES (?, ?, ?)",
                 (chunk['id'], json.dumps(chunk), chunk['created_at']),
             )
 
     def get_memory_chunk(self, chunk_id: str) -> Optional[dict]:
-        conn = self._ensure_open()
-        with self._lock:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT data FROM memory_chunks WHERE id = ?", (chunk_id,)
             ).fetchone()
         return json.loads(row[0]) if row else None
 
     def delete_memory_chunk(self, chunk_id: str) -> bool:
-        conn = self._ensure_open()
-        with self._lock, conn:
+        with self._connection(write=True) as conn:
             cur = conn.execute("DELETE FROM memory_chunks WHERE id = ?", (chunk_id,))
-        return cur.rowcount > 0
+            return cur.rowcount > 0
 
     def list_memory_chunks(self) -> list:
-        conn = self._ensure_open()
-        with self._lock:
+        with self._connection() as conn:
             rows = conn.execute("SELECT data FROM memory_chunks").fetchall()
         return [json.loads(row[0]) for row in rows]
 
@@ -520,8 +570,7 @@ class SqliteStorageAdapter(StorageAdapter):
         job = dict(job)
         job.setdefault('created_at', time.time())
         job['updated_at'] = time.time()
-        conn = self._ensure_open()
-        with self._lock, conn:
+        with self._connection(write=True) as conn:
             conn.execute(
                 """
                 INSERT INTO cron_jobs (id, data, created_at, updated_at)
@@ -535,22 +584,19 @@ class SqliteStorageAdapter(StorageAdapter):
             )
 
     def get_cron_job(self, job_id: str) -> Optional[dict]:
-        conn = self._ensure_open()
-        with self._lock:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT data FROM cron_jobs WHERE id = ?", (job_id,)
             ).fetchone()
         return json.loads(row[0]) if row else None
 
     def delete_cron_job(self, job_id: str) -> bool:
-        conn = self._ensure_open()
-        with self._lock, conn:
+        with self._connection(write=True) as conn:
             cur = conn.execute("DELETE FROM cron_jobs WHERE id = ?", (job_id,))
-        return cur.rowcount > 0
+            return cur.rowcount > 0
 
     def list_cron_jobs(self) -> list:
-        conn = self._ensure_open()
-        with self._lock:
+        with self._connection() as conn:
             rows = conn.execute("SELECT data FROM cron_jobs").fetchall()
         return [json.loads(row[0]) for row in rows]
 
@@ -560,8 +606,7 @@ class SqliteStorageAdapter(StorageAdapter):
         log = dict(log)
         log.setdefault('created_at', time.time())
         job_id = _require_cron_log_job_id(log)
-        conn = self._ensure_open()
-        with self._lock, conn:
+        with self._connection(write=True) as conn:
             try:
                 conn.execute(
                     "INSERT INTO cron_logs (job_id, data, created_at) VALUES (?, ?, ?)",
@@ -573,8 +618,7 @@ class SqliteStorageAdapter(StorageAdapter):
                 raise
 
     def get_cron_logs(self, job_id: str, limit: Optional[int] = None) -> list:
-        conn = self._ensure_open()
-        with self._lock:
+        with self._connection() as conn:
             rows = conn.execute(
                 "SELECT data FROM cron_logs WHERE job_id = ? ORDER BY seq ASC",
                 (job_id,),
@@ -587,32 +631,28 @@ class SqliteStorageAdapter(StorageAdapter):
     # --- Config KV ---
 
     def set_config(self, key: str, value: Any) -> None:
-        conn = self._ensure_open()
-        with self._lock, conn:
+        with self._connection(write=True) as conn:
             conn.execute(
                 "INSERT OR REPLACE INTO config_kv (key, value) VALUES (?, ?)",
                 (key, json.dumps(value)),
             )
 
     def get_config(self, key: str) -> Any:
-        conn = self._ensure_open()
-        with self._lock:
+        with self._connection() as conn:
             row = conn.execute(
                 "SELECT value FROM config_kv WHERE key = ?", (key,)
             ).fetchone()
         return json.loads(row[0]) if row else None
 
     def get_all_config(self) -> dict:
-        conn = self._ensure_open()
-        with self._lock:
+        with self._connection() as conn:
             rows = conn.execute("SELECT key, value FROM config_kv").fetchall()
         return {key: json.loads(value) for key, value in rows}
 
     def delete_config(self, key: str) -> bool:
-        conn = self._ensure_open()
-        with self._lock, conn:
+        with self._connection(write=True) as conn:
             cur = conn.execute("DELETE FROM config_kv WHERE key = ?", (key,))
-        return cur.rowcount > 0
+            return cur.rowcount > 0
 
 
 def create_storage_adapter(config: Optional[dict] = None) -> StorageAdapter:

--- a/python/tests/test_storage_thread_safety.py
+++ b/python/tests/test_storage_thread_safety.py
@@ -1,0 +1,439 @@
+"""
+Threaded persistence contract for :mod:`openrappter.storage`.
+
+A ``StorageAdapter`` is guarded by an ``RLock``, which is a promise: the
+adapter may be driven from more than one thread. These tests hold every
+implementation to that promise.
+
+Determinism note: nothing here sleeps or races on wall-clock timing.
+Contention is *constructed* with ``threading.Barrier`` — every worker is
+released at the same instant and, before any worker is allowed to call into
+the adapter, all of them have already registered as "in flight". A
+concurrency probe records the peak number of simultaneous in-flight adapter
+calls, and the tests assert that peak equals the full worker count. A
+concurrency test that never actually overlaps would fail that assertion.
+"""
+
+import json
+import sqlite3
+import threading
+from concurrent.futures import ThreadPoolExecutor
+
+import pytest
+
+from openrappter.storage.adapter import (
+    InMemoryStorageAdapter,
+    SqliteStorageAdapter,
+)
+
+# Barrier waits are bounded so a genuine deadlock or a crashed worker surfaces
+# as a test failure instead of hanging the suite forever.
+BARRIER_TIMEOUT = 30.0
+
+WRITERS = 8
+READERS = 2
+ROUNDS = 25
+
+
+@pytest.fixture(params=['sqlite-file', 'sqlite-memory', 'in-memory'])
+def adapter(request, tmp_path):
+    """Every storage implementation must satisfy the same threaded contract."""
+    if request.param == 'sqlite-file':
+        instance = SqliteStorageAdapter(str(tmp_path / 'threaded.db'))
+    elif request.param == 'sqlite-memory':
+        instance = SqliteStorageAdapter(':memory:')
+    else:
+        instance = InMemoryStorageAdapter()
+    instance.initialize()
+    try:
+        yield instance
+    finally:
+        instance.close()
+
+
+class ConcurrencyProbe:
+    """
+    Proves that workers genuinely overlap inside adapter calls.
+
+    ``round_gate`` releases all workers at once. ``entry_gate`` is crossed
+    *after* a worker has marked itself in flight but *before* it calls the
+    adapter, so once any worker is executing, all of them are provably inside
+    the probed region. Both gates live outside the adapter's own lock, so they
+    cannot deadlock against it.
+    """
+
+    def __init__(self, parties: int):
+        self.parties = parties
+        self.round_gate = threading.Barrier(parties)
+        self.entry_gate = threading.Barrier(parties)
+        self._mutex = threading.Lock()
+        self._in_flight = 0
+        self.peak_in_flight = 0
+        self.errors: list[BaseException] = []
+
+    def __enter__(self):
+        with self._mutex:
+            self._in_flight += 1
+            self.peak_in_flight = max(self.peak_in_flight, self._in_flight)
+        self.entry_gate.wait(timeout=BARRIER_TIMEOUT)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        with self._mutex:
+            self._in_flight -= 1
+        return False
+
+    def abort(self, error: BaseException) -> None:
+        with self._mutex:
+            self.errors.append(error)
+        self.round_gate.abort()
+        self.entry_gate.abort()
+
+
+def _run_contended(adapter, writers=WRITERS, readers=READERS, rounds=ROUNDS):
+    """
+    Drive ``adapter`` from ``writers`` writer threads and ``readers`` reader
+    threads, all contending in lockstep rounds. Returns the probe plus the
+    reader observations.
+    """
+    probe = ConcurrencyProbe(writers + readers)
+    submitted: set[str] = set()
+    submitted_mutex = threading.Lock()
+    observed_counts: list[list[int]] = [[] for _ in range(readers)]
+    observed_ids: set[str] = set()
+    observed_mutex = threading.Lock()
+
+    def writer(worker: int):
+        for round_index in range(rounds):
+            probe.round_gate.wait(timeout=BARRIER_TIMEOUT)
+            session_id = f"w{worker}-r{round_index}"
+            with submitted_mutex:
+                submitted.add(session_id)
+            with probe:
+                adapter.save_session({
+                    'id': session_id,
+                    'channel_id': f"chan-{worker % 3}",
+                    'worker': worker,
+                    'round': round_index,
+                    'payload': 'x' * 64,
+                })
+
+    def reader(index: int):
+        for _ in range(rounds):
+            probe.round_gate.wait(timeout=BARRIER_TIMEOUT)
+            with probe:
+                rows = adapter.list_sessions()
+            observed_counts[index].append(len(rows))
+            ids = set()
+            for row in rows:
+                # A torn or half-written record would show up here.
+                assert isinstance(row['id'], str)
+                assert row['payload'] == 'x' * 64
+                assert row['worker'] == int(row['id'].split('-')[0][1:])
+                ids.add(row['id'])
+            with observed_mutex:
+                observed_ids.update(ids)
+
+    def guarded(fn, arg):
+        try:
+            fn(arg)
+        except BaseException as error:  # noqa: BLE001 - re-raised by the caller
+            probe.abort(error)
+            raise
+
+    with ThreadPoolExecutor(max_workers=writers + readers) as pool:
+        futures = [pool.submit(guarded, writer, i) for i in range(writers)]
+        futures += [pool.submit(guarded, reader, i) for i in range(readers)]
+        failures = [f.exception() for f in futures]
+
+    real_failures = [f for f in failures if f is not None]
+    if real_failures:
+        # Surface the original storage error, not the barrier abort fallout.
+        primary = next(
+            (f for f in real_failures if not isinstance(f, threading.BrokenBarrierError)),
+            real_failures[0],
+        )
+        raise AssertionError(
+            f"{len(real_failures)}/{len(futures)} threads failed; first real error: "
+            f"{type(primary).__name__}: {primary}"
+        ) from primary
+
+    return probe, submitted, observed_counts, observed_ids
+
+
+def test_concurrent_writes_and_reads_do_not_raise_or_lose_data(adapter):
+    """The core contract: no exceptions, no lost writes, consistent final state."""
+    probe, submitted, observed_counts, observed_ids = _run_contended(adapter)
+
+    # Contention actually happened — every worker was inside an adapter call
+    # simultaneously, by construction of the entry gate.
+    assert probe.peak_in_flight == WRITERS + READERS
+
+    # No lost writes: every submitted id landed, exactly once, and nothing else did.
+    stored = adapter.list_sessions()
+    stored_ids = [session['id'] for session in stored]
+    assert len(stored_ids) == len(set(stored_ids)), "duplicate rows written"
+    assert set(stored_ids) == submitted
+    assert len(stored_ids) == WRITERS * ROUNDS
+
+    # Consistent final state: every record round-trips intact.
+    for session in stored:
+        worker, round_index = session['id'][1:].split('-r')
+        assert session['worker'] == int(worker)
+        assert session['round'] == int(round_index)
+        assert session['payload'] == 'x' * 64
+        assert session['channel_id'] == f"chan-{int(worker) % 3}"
+        assert session['created_at'] <= session['updated_at']
+
+    # Readers only ever saw records that had genuinely been submitted, and the
+    # visible row count never went backwards (a lost or rolled-back write would
+    # show up as a decrease).
+    assert observed_ids <= submitted
+    for counts in observed_counts:
+        assert counts == sorted(counts), f"row count regressed mid-run: {counts}"
+        assert counts[-1] <= WRITERS * ROUNDS
+
+
+def test_concurrent_config_writes_are_all_durable(adapter):
+    """Config KV is a distinct code path; hold it to the same contract."""
+    probe = ConcurrencyProbe(WRITERS)
+
+    def writer(worker: int):
+        try:
+            for round_index in range(ROUNDS):
+                probe.round_gate.wait(timeout=BARRIER_TIMEOUT)
+                with probe:
+                    adapter.set_config(f"k{worker}-{round_index}", {'w': worker, 'r': round_index})
+        except BaseException as error:  # noqa: BLE001
+            probe.abort(error)
+            raise
+
+    with ThreadPoolExecutor(max_workers=WRITERS) as pool:
+        futures = [pool.submit(writer, i) for i in range(WRITERS)]
+        errors = [f.exception() for f in futures if f.exception() is not None]
+    assert not errors, f"config writers failed: {errors[0]!r}"
+
+    assert probe.peak_in_flight == WRITERS
+    config = adapter.get_all_config()
+    assert len(config) == WRITERS * ROUNDS
+    for worker in range(WRITERS):
+        for round_index in range(ROUNDS):
+            assert config[f"k{worker}-{round_index}"] == {'w': worker, 'r': round_index}
+
+
+def test_adapter_is_usable_from_a_thread_that_did_not_create_it(adapter):
+    """
+    The narrowest form of the bug: hand the adapter to one other thread and
+    use it there. No concurrency required — this fails outright when the
+    connection is pinned to its creating thread.
+    """
+    adapter.save_session({'id': 'from-main', 'channel_id': 'cli'})
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        pool.submit(adapter.save_session, {'id': 'from-worker', 'channel_id': 'cli'}).result()
+        seen = pool.submit(adapter.list_sessions).result()
+        deleted = pool.submit(adapter.delete_session, 'from-main').result()
+
+    assert deleted is True
+    assert {s['id'] for s in seen} == {'from-main', 'from-worker'}
+    assert {s['id'] for s in adapter.list_sessions()} == {'from-worker'}
+
+
+def test_cron_job_and_log_writes_are_thread_safe(adapter):
+    """Cron logs carry a foreign key to their job; concurrency must not break it."""
+    for worker in range(WRITERS):
+        adapter.save_cron_job({'id': f"job-{worker}", 'schedule': '* * * * *'})
+
+    probe = ConcurrencyProbe(WRITERS)
+
+    def writer(worker: int):
+        try:
+            for round_index in range(ROUNDS):
+                probe.round_gate.wait(timeout=BARRIER_TIMEOUT)
+                with probe:
+                    adapter.save_cron_log({
+                        'job_id': f"job-{worker}",
+                        'status': 'ok',
+                        'round': round_index,
+                    })
+        except BaseException as error:  # noqa: BLE001
+            probe.abort(error)
+            raise
+
+    with ThreadPoolExecutor(max_workers=WRITERS) as pool:
+        futures = [pool.submit(writer, i) for i in range(WRITERS)]
+        errors = [f.exception() for f in futures if f.exception() is not None]
+    assert not errors, f"cron log writers failed: {errors[0]!r}"
+
+    assert probe.peak_in_flight == WRITERS
+    for worker in range(WRITERS):
+        logs = adapter.get_cron_logs(f"job-{worker}")
+        assert len(logs) == ROUNDS
+        assert sorted(log['round'] for log in logs) == list(range(ROUNDS))
+        # Per-job ordering is preserved despite interleaving from other jobs.
+        assert [log['round'] for log in logs] == list(range(ROUNDS))
+
+
+def test_sqlite_adapter_refuses_to_initialize_without_a_threadsafe_sqlite(tmp_path, monkeypatch):
+    """
+    ``check_same_thread=False`` is only sound because the underlying library is
+    at least multi-thread capable. If it is not, fail loudly rather than hand
+    back an adapter that would corrupt data silently.
+    """
+    monkeypatch.setattr(sqlite3, 'threadsafety', 0)
+    instance = SqliteStorageAdapter(str(tmp_path / 'unsafe.db'))
+    with pytest.raises(RuntimeError, match='thread safety'):
+        instance.initialize()
+
+
+def test_sqlite_connection_is_never_touched_outside_the_lock(tmp_path):
+    """
+    Structural guard for the invariant the fix rests on: with
+    ``check_same_thread=False``, the lock is the *only* thing serializing
+    access, so any use of the connection while the lock is unheld is a latent
+    data race. This wraps the live connection and asserts the lock is held for
+    every single call, across every public method.
+    """
+    instance = SqliteStorageAdapter(str(tmp_path / 'guarded.db'))
+    instance.initialize()
+    violations: list[str] = []
+    lock = instance._lock
+    real_conn = instance._conn
+
+    class LockAssertingConnection:
+        def __getattr__(self, name):
+            attr = getattr(real_conn, name)
+            if not callable(attr):
+                return attr
+
+            def checked(*args, **kwargs):
+                # RLock._is_owned() is true only for the holding thread.
+                if not lock._is_owned():
+                    violations.append(name)
+                result = attr(*args, **kwargs)
+                if isinstance(result, sqlite3.Cursor):
+                    return LockAssertingCursor(result)
+                return result
+
+            return checked
+
+        def __enter__(self):
+            if not lock._is_owned():
+                violations.append('__enter__')
+            return real_conn.__enter__()
+
+        def __exit__(self, *args):
+            if not lock._is_owned():
+                violations.append('__exit__')
+            return real_conn.__exit__(*args)
+
+    class LockAssertingCursor:
+        def __init__(self, cursor):
+            self._cursor = cursor
+
+        def __getattr__(self, name):
+            attr = getattr(self._cursor, name)
+            if not callable(attr):
+                if not lock._is_owned():
+                    violations.append(f"cursor.{name}")
+                return attr
+
+            def checked(*args, **kwargs):
+                if not lock._is_owned():
+                    violations.append(f"cursor.{name}")
+                return attr(*args, **kwargs)
+
+            return checked
+
+        def __iter__(self):
+            if not lock._is_owned():
+                violations.append('cursor.__iter__')
+            return iter(self._cursor)
+
+    instance._conn = LockAssertingConnection()
+    try:
+        instance.save_session({'id': 's1', 'channel_id': 'cli'})
+        instance.get_session('s1')
+        instance.list_sessions({'channel_id': 'cli'})
+        instance.delete_session('s1')
+        instance.save_memory_chunk({'id': 'c1', 'text': 'hello'})
+        instance.get_memory_chunk('c1')
+        instance.list_memory_chunks()
+        instance.delete_memory_chunk('c1')
+        instance.save_cron_job({'id': 'j1'})
+        instance.get_cron_job('j1')
+        instance.list_cron_jobs()
+        instance.save_cron_log({'job_id': 'j1', 'status': 'ok'})
+        instance.get_cron_logs('j1')
+        instance.delete_cron_job('j1')
+        instance.set_config('k', {'v': 1})
+        instance.get_config('k')
+        instance.get_all_config()
+        instance.delete_config('k')
+    finally:
+        instance._conn = real_conn
+        instance.close()
+
+    assert violations == [], f"connection used without holding the lock: {violations}"
+
+
+def test_sqlite_connection_allows_cross_thread_use(tmp_path):
+    """Pin the concrete fix: the connection is opened with check_same_thread=False."""
+    instance = SqliteStorageAdapter(str(tmp_path / 'flag.db'))
+    instance.initialize()
+    try:
+        result: list = []
+
+        def probe():
+            # Bypass the adapter entirely: this is the raw sqlite3 behaviour
+            # that produced the original ProgrammingError.
+            row = instance._conn.execute('SELECT 1').fetchone()
+            result.append(row[0])
+
+        thread = threading.Thread(target=probe)
+        thread.start()
+        thread.join(timeout=BARRIER_TIMEOUT)
+        assert result == [1]
+    finally:
+        instance.close()
+
+
+def test_stored_json_survives_concurrent_writes_unmangled(tmp_path):
+    """
+    Interleaved statements on a shared connection would show up as mangled or
+    truncated JSON blobs long before they showed up as a missing row.
+    """
+    instance = SqliteStorageAdapter(str(tmp_path / 'json.db'))
+    instance.initialize()
+    probe = ConcurrencyProbe(WRITERS)
+
+    def writer(worker: int):
+        try:
+            for round_index in range(ROUNDS):
+                probe.round_gate.wait(timeout=BARRIER_TIMEOUT)
+                with probe:
+                    instance.save_session({
+                        'id': f"w{worker}-r{round_index}",
+                        'nested': {'worker': worker, 'items': list(range(round_index + 1))},
+                    })
+        except BaseException as error:  # noqa: BLE001
+            probe.abort(error)
+            raise
+
+    try:
+        with ThreadPoolExecutor(max_workers=WRITERS) as pool:
+            futures = [pool.submit(writer, i) for i in range(WRITERS)]
+            errors = [f.exception() for f in futures if f.exception() is not None]
+        assert not errors, f"writers failed: {errors[0]!r}"
+
+        rows = instance._conn.execute('SELECT data FROM sessions').fetchall()
+        assert len(rows) == WRITERS * ROUNDS
+        for (blob,) in rows:
+            record = json.loads(blob)  # raises if the blob was mangled
+            worker, round_index = record['id'][1:].split('-r')
+            assert record['nested'] == {
+                'worker': int(worker),
+                'items': list(range(int(round_index) + 1)),
+            }
+    finally:
+        instance.close()


### PR DESCRIPTION
## The bug

`SqliteStorageAdapter` holds a `threading.RLock`. That lock is a statement of intent: this adapter expects to be driven from more than one thread. It then opened its connection with sqlite3's default `check_same_thread=True`, so the promise was never kept. The guard existed, which is exactly why nobody noticed — the omission is invisible until concurrency actually happens.

## Reproduction (before the fix)

Driving the adapter from a `ThreadPoolExecutor`, exactly as the gateway's executor or a cron worker would:

```python
adapter = SqliteStorageAdapter(str(tmp / "storage.db"))
adapter.initialize()                       # connection is born on the MAIN thread
adapter.save_session({"id": "main"})       # fine

with ThreadPoolExecutor(max_workers=4) as pool:
    [pool.submit(adapter.save_session, {"id": f"worker-{i}"}) for i in range(8)]
```

```
python: 3.13.12   sqlite3.threadsafety: 3   sqlite_version: 3.53.4

main-thread write ok?
  yes: True

worker-thread writes via ThreadPoolExecutor:
  8/8 worker writes FAILED. First traceback:

Traceback (most recent call last):
  File ".../openrappter/storage/adapter.py", line 446, in save_session
    conn.execute(
    ~~~~~~~~~~~~^
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in
that same thread. The object was created in thread id 8489000576 and this is
thread id 6145650688.

During handling of the above exception, another exception occurred:
  File ".../openrappter/storage/adapter.py", line 445, in save_session
    with self._lock, conn:
                     ^^^^
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in
that same thread. ...

worker-thread read:
  File ".../openrappter/storage/adapter.py", line 482, in list_sessions
    rows = conn.execute(sql, params).fetchall()
sqlite3.ProgrammingError: SQLite objects created in a thread can only be used in
that same thread. ...

sessions persisted: ['main']
```

Every write and every read from a non-creating thread fails. Note the second traceback frame: it blows up on `with self._lock, conn:` — the connection can't even be *entered* as a context manager from another thread. The lock was there; it just guarded nothing that mattered.

## The fix, and why this option

`check_same_thread=False`, paired with the invariant that flag requires.

On its own, `check_same_thread=False` only trades a loud exception for a silent data race — the strictly worse outcome. So the lock is promoted from decoration to the sole serialization point:

- A single `_connection()` context manager is now the only door to `self._conn`. It takes `self._lock`, resolves the connection, and (for writes) runs the body inside the connection's transaction context, committing or rolling back **before** the lock is released.
- All fourteen CRUD methods and `_run_migrations()` go through it. No method reaches `self._conn` directly any more.
- `_ensure_open()` is now called *inside* the lock, closing a race where a thread could grab the connection and then have another thread `close()` it out from under the statement.
- `delete_session` / `delete_memory_chunk` / `delete_cron_job` / `delete_config` read `cur.rowcount` inside the lock instead of after it, so no cursor object is touched outside the critical section.
- Every result set is already materialized (`fetchone`/`fetchall`) before the lock drops, so no lazy cursor can be stepped while another thread is mid-statement. That is now enforced by a test rather than by inspection.

### Why not per-thread connections

This was the tempting option — it buys real read parallelism under WAL — and it is the one that would have caused corruption rather than an exception:

- **`:memory:` databases are private to their connection.** `create_storage_adapter({'in_memory': True})` and a chunk of the existing test suite use `:memory:`. Per-thread connections would hand each thread its own empty database. Writes would appear to succeed and then be invisible everywhere else. Silent data loss beats a `ProgrammingError` in exactly the wrong direction.
- **`close()` stops being meaningful.** A thread cannot close another thread's connection, so shutdown would leak file descriptors and leave WAL readers pinning old snapshots.
- **Lifecycle and migrations get subtle.** Every new thread would need to discover whether migrations had already run, and thread-local connections outlive the threads that are gone.

### Why not a dedicated writer thread / queue

It serializes writes just as the lock does, but adds a thread, a queue, an error-marshalling path and a shutdown protocol — and it would still need the same read-path locking. More moving parts for the same guarantee.

### What the trade costs

Intra-process read parallelism. WAL (already enabled) still gives concurrency *across processes*; inside the process, storage calls are sub-millisecond JSON-blob reads and writes in a local-first runtime, so serializing them is the right trade for a guarantee that is easy to state and easy to test.

### One extra guard

`initialize()` now refuses to start when `sqlite3.threadsafety == 0` (a `SQLITE_THREADSAFE=0` build), because in that configuration no amount of Python-level locking can make the cross-thread contract true. Failing loudly at open time beats corrupting a database later. On this machine it is `3` (SERIALIZED).

## Proving the threads genuinely contend

A concurrency test that never actually overlaps is decoration. This one constructs contention instead of hoping for it, with no sleeps anywhere:

- `round_gate` — a `threading.Barrier(writers + readers)` releases every worker at the same instant, once per round.
- `entry_gate` — a second barrier crossed **after** a worker marks itself in-flight but **before** it calls the adapter. Once any worker is executing a storage call, all of them are provably inside the probed region.
- A probe records peak simultaneous in-flight calls; the tests assert `peak_in_flight == writers + readers` (10) exactly.

Both gates sit outside the adapter's own lock, so they cannot deadlock against it; barrier waits are bounded (30s) so a crashed worker fails the test instead of hanging the suite.

**How I proved the gate is load-bearing:** I deleted the `entry_gate.wait()` and re-ran (mutation M8). The measured peak dropped to **1**:

```
>       assert probe.peak_in_flight == WRITERS + READERS
E       assert 1 == (8 + 2)
```

That is the important result. A barrier-only test — release all threads at once and hope — produces *zero* overlap here, because each storage call completes before the next thread is scheduled. Without the entry gate this suite would have passed while never exercising concurrency at all.

## Mutation table

Every row was produced by mutating the source, running the suite, and restoring. `RED` is the desired outcome for every mutation.

| # | Mutation | Test target | Result |
|---|----------|-------------|--------|
| M0 | none (fix in place) | whole file | **GREEN** — 16 passed |
| M1 | full revert of the fix (`adapter.py` from `main`) | whole file | **RED** — 12 failed, 4 passed |
| M2 | `check_same_thread=True`, lock coverage kept | whole file | **RED** — 10 failed, 6 passed |
| M3 | lock released before the connection is used | whole file | **RED** — 8 failed, 8 passed |
| M4 | **silent lost write** — sessions whose id ends in `7` are dropped, no exception | `test_concurrent_writes_and_reads_do_not_raise_or_lose_data` | **RED** — 2 failed, 1 passed |
| M5 | **silent lost write** — every 5th config key dropped | `test_concurrent_config_writes_are_all_durable` | **RED** — 2 failed, 1 passed |
| M6 | **silent lost write** — every 4th cron log dropped | `test_cron_job_and_log_writes_are_thread_safe` | **RED** — 2 failed, 1 passed |
| M7 | `threadsafety == 0` guard removed | `test_sqlite_adapter_refuses_to_initialize_without_a_threadsafe_sqlite` | **RED** — 1 failed |
| M8 | *(test-of-test)* probe entry gate removed | whole file | **RED** — 3 failed, 13 passed |

M4–M6 are the ones that matter for the brief: they inject **lost writes with no exception**, and the tests still go red. The suite is not merely an exception detector. In each of those rows the "1 passed" is the `in-memory` adapter parameterization, which the sqlite-only mutation legitimately does not touch.

M1 fails with the original `sqlite3.ProgrammingError`, surfaced through the test's own aggregation:

```
E  AssertionError: 10/10 threads failed; first real error: ProgrammingError:
   SQLite objects created in a thread can only be used in that same thread.
```

## The contract test

`python/tests/test_storage_thread_safety.py` — 16 tests, parameterized across **all three** storage configurations (`sqlite` file-backed, `sqlite :memory:`, and `InMemoryStorageAdapter`), because this is a contract on `StorageAdapter`, not on one implementation.

- 8 writers + 2 readers, 25 lockstep rounds, asserting: no exceptions; every submitted id present exactly once and nothing extra (`200` rows); every record round-trips intact; readers only ever saw ids that had genuinely been submitted; and the visible row count **never decreases** (a lost or rolled-back write shows up as a regression).
- Readers validate each row's payload and cross-check its embedded worker id against its key, so a torn or interleaved record is caught, not just a missing one.
- Config KV and cron jobs/logs get their own contended tests — distinct code paths, same contract. Cron logs additionally assert per-job ordering survives interleaving from seven other jobs.
- `test_adapter_is_usable_from_a_thread_that_did_not_create_it` — the narrowest form of the bug, no concurrency needed.
- `test_sqlite_connection_is_never_touched_outside_the_lock` — a structural guard. It wraps the live connection and every cursor it produces, and fails if any of the eighteen public operations touches either while the lock is unheld. This is what keeps the fix from rotting: with `check_same_thread=False`, a future method that reads `self._conn` directly is a latent data race, and this test turns that into a build failure.

### TypeScript parity

I checked for an equivalent contract on the TS side. There isn't one and there shouldn't be: `typescript/src/storage/sqlite.ts` uses `better-sqlite3` on Node's single-threaded event loop, so there is no cross-thread connection to protect. `typescript/src/__tests__/integration/storage.test.ts` covers the same CRUD surface plus a `Transactions` block, with no concurrency contract to mirror. The two suites remain consistent in what they each need to assert; no TS change is warranted.

## Verification

- Reproduction captured **before** any change (real traceback, above), and re-run after: all 8 worker writes and the worker read now succeed.
- Baseline on clean `main` before touching anything: **1345 passed, 7 skipped, 51 subtests** — no pre-existing failures, so nothing here is inherited.
- After the fix: **1361 passed, 7 skipped, 51 subtests** (1345 + the 16 new tests). No regressions.
- New tests re-run 4× to check for flakiness: 16 passed every time, including with pytest's random ordering plugin both on and off.

## Residual risk — being honest

- **Read throughput.** Reads no longer run in parallel within a process. Deliberate (see above), but if a future workload does large scans while writes are in flight, this becomes the bottleneck and the answer would be a read-only connection pool over WAL — not something to speculate on now.
- **Re-entrancy.** `_connection(write=True)` nested inside another would commit the outer transaction early at the inner block's exit. No such nesting exists today (verified: no adapter method calls another public adapter method), and the lock is an `RLock` so it would deadlock-free but commit early. It is a shape to avoid, not a live bug.
- **`close()` racing an in-flight call.** Now correctly serialized: a thread blocked on the lock while another closes will get the clear `RuntimeError("...not initialized. Call initialize() first.")` rather than a `ProgrammingError` or worse. That is the right failure, but it is a behaviour change for anyone closing the adapter concurrently with live work.
- **Contention proof is per-round, not per-statement.** The entry gate proves all 10 threads are simultaneously inside adapter *calls*. The adapter then serializes them internally, which is the point — I am proving they contend for the lock, not that SQLite executes them concurrently.
- **Free-threaded builds.** Everything here was verified on CPython 3.13 with the GIL. The `InMemoryStorageAdapter` parameterization leans on dict-operation atomicity for its session/config paths (it only takes its own lock on the cron paths); that holds on GIL builds and on `3.13t` dicts, but a no-GIL build is not something I exercised. Out of scope for this bug, worth knowing.

---

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
Copilot-Session: 2720e688-7dc9-488f-bf6f-38cfff214088
