### PR TITLE
fix(agents): a resolved {status:"error"} envelope fails the composite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   subprocess even on a nonzero exit, so `false` reported `return_code=1` while
   the shared classifier recorded success. Python now derives status from the
   return code; TypeScript already did.
+- **Composite error status** — `AgentGraph` and `BroadcastManager` (both
+  runtimes) only noticed a sub-agent failure when the call *threw*, so an agent
+  that correctly reported `{"status": "error"}` was recorded as a success and
+  the composite reported success overall. Both layers now classify through the
+  shared `agentResultIsError` / `agent_result_is_error` helper, which also
+  accepts an already-parsed envelope. A failed graph node now skips its
+  dependents (or halts the graph under `stopOnError`); a broadcast keeps the
+  full error envelope per branch but no longer counts it as a success, falls
+  through to the next agent in `fallback` mode (forwarding the failed agent's
+  `data_slush`), and never lets an error envelope win a `race`. Cross-runtime
+  agreement is pinned by `contracts/agent-result-status-vectors.json`.
 - **`config` and `doctor` were never registered** — both were implemented and
   exported, but their words fell through to chat and global help while shipped
   health guidance told you to run them. Registering them exposed dormant bugs:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,7 +117,7 @@ No YAML. No config files. No magic parsing. The code IS the contract.
 - `LearnNewAgent` — Meta-agent that generates new single file agents at runtime with hot-loading (both TypeScript and Python)
 
 **Multi-agent patterns** (TypeScript `src/agents/`):
-- `BroadcastManager` (`broadcast.ts`) — Send to multiple agents; modes: `all` (wait all), `race` (first wins), `fallback` (try until success)
+- `BroadcastManager` (`broadcast.ts`) — Send to multiple agents; modes: `all` (wait all), `race` (first success wins), `fallback` (try until success). A branch that *resolves* with a `{status: 'error'}` envelope counts as a failure, not a success — the envelope is kept per-branch in `results` while `allSucceeded`/`anySucceeded` and `firstResponse` ignore it
 - `AgentRouter` (`router.ts`) — Rule-based message routing by sender/channel/group/pattern with priority; session key isolation
 - `SubAgent` (`subagent.ts`) — Nested agent invocation with depth limits and loop detection
 - `AgentChain` (`chain.ts`) — Sequential pipeline with automatic `data_slush` forwarding between steps; supports transforms, timeouts, stopOnError/continue modes
@@ -140,7 +140,7 @@ No YAML. No config files. No magic parsing. The code IS the contract.
 2. `run()` computes topological levels via Kahn's algorithm
 3. Each level's nodes execute concurrently via `Promise.all`
 4. Multi-dependency slush merging: `upstream_slush = { nodeA: { ...slushA }, nodeB: { ...slushB } }`
-5. Failed nodes: dependents are marked `skipped` (default) or execution stops immediately (`stopOnError: true`)
+5. Failed nodes: dependents are marked `skipped` (default) or execution stops immediately (`stopOnError: true`). A node fails when its agent throws **or** returns a `{status: 'error'}` envelope — both are classified by the shared `agentResultIsError` / `agent_result_is_error` helper
 
 ```typescript
 const graph = new AgentGraph()

--- a/contracts/agent-result-status-vectors.json
+++ b/contracts/agent-result-status-vectors.json
@@ -1,0 +1,28 @@
+{
+  "description": "Cross-runtime agreement vectors for the shared agent-result classifier (agentResultIsError / agent_result_is_error). kind='string' passes the value as the raw string an agent returned; kind='value' passes the already-parsed value.",
+  "vectors": [
+    { "name": "success-envelope-string", "kind": "string", "value": "{\"status\":\"success\",\"result\":1}", "isError": false },
+    { "name": "error-envelope-string", "kind": "string", "value": "{\"status\":\"error\",\"message\":\"exit code 1\"}", "isError": true },
+    { "name": "error-envelope-string-uppercase", "kind": "string", "value": "{\"status\":\"ERROR\"}", "isError": true },
+    { "name": "error-envelope-string-mixedcase", "kind": "string", "value": "{\"status\":\"Error\"}", "isError": true },
+    { "name": "info-envelope-string", "kind": "string", "value": "{\"status\":\"info\",\"message\":\"skipped\"}", "isError": false },
+    { "name": "status-with-trailing-space-not-trimmed", "kind": "string", "value": "{\"status\":\"error \"}", "isError": false },
+    { "name": "non-json-string", "kind": "string", "value": "boom", "isError": false },
+    { "name": "bare-error-word", "kind": "string", "value": "error", "isError": false },
+    { "name": "empty-string", "kind": "string", "value": "", "isError": false },
+    { "name": "json-null-string", "kind": "string", "value": "null", "isError": false },
+    { "name": "json-number-string", "kind": "string", "value": "5", "isError": false },
+    { "name": "json-array-string", "kind": "string", "value": "[{\"status\":\"error\"}]", "isError": false },
+    { "name": "double-encoded-error-envelope", "kind": "string", "value": "\"{\\\"status\\\":\\\"error\\\"}\"", "isError": false },
+    { "name": "error-envelope-object", "kind": "value", "value": { "status": "error", "message": "exit code 1" }, "isError": true },
+    { "name": "error-envelope-object-uppercase", "kind": "value", "value": { "status": "ERROR" }, "isError": true },
+    { "name": "success-envelope-object", "kind": "value", "value": { "status": "success" }, "isError": false },
+    { "name": "object-without-status", "kind": "value", "value": { "message": "no status here" }, "isError": false },
+    { "name": "object-with-null-status", "kind": "value", "value": { "status": null }, "isError": false },
+    { "name": "object-with-nested-error-status", "kind": "value", "value": { "status": "success", "result": { "status": "error" } }, "isError": false },
+    { "name": "array-value", "kind": "value", "value": [{ "status": "error" }], "isError": false },
+    { "name": "null-value", "kind": "value", "value": null, "isError": false },
+    { "name": "number-value", "kind": "value", "value": 5, "isError": false },
+    { "name": "boolean-value", "kind": "value", "value": true, "isError": false }
+  ]
+}

--- a/python/openrappter/agents/broadcast.py
+++ b/python/openrappter/agents/broadcast.py
@@ -14,6 +14,18 @@ Mirrors TypeScript agents/broadcast.ts
 
 import asyncio
 
+from openrappter.result_status import agent_result_is_error
+
+
+def _branch_succeeded(outcome):
+    """A branch succeeded only if it neither raised nor returned a
+    ``{"status": "error"}`` envelope."""
+    return not isinstance(outcome, Exception) and not agent_result_is_error(outcome)
+
+
+def _count_successes(results):
+    return sum(1 for r in results.values() if _branch_succeeded(r))
+
 
 class BroadcastManager:
     """Manages broadcast groups for multi-agent messaging."""
@@ -84,14 +96,14 @@ class BroadcastManager:
                 else:
                     result = await coro
                 results[agent_id] = result
-                if first_response is None:
+                if first_response is None and not agent_result_is_error(result):
                     first_response = {'agentId': agent_id, 'result': result}
             except Exception as e:
                 results[agent_id] = e
 
         await asyncio.gather(*[run_agent(aid) for aid in group['agentIds']], return_exceptions=True)
 
-        successes = sum(1 for r in results.values() if not isinstance(r, Exception))
+        successes = _count_successes(results)
 
         return {
             'groupId': group['id'],
@@ -115,6 +127,9 @@ class BroadcastManager:
                 else:
                     result = await coro
                 results[agent_id] = result
+                if agent_result_is_error(result):
+                    # A returned error envelope loses the race like a raise does.
+                    return {'agentId': agent_id, 'result': result, 'success': False}
                 return {'agentId': agent_id, 'result': result, 'success': True}
             except Exception as e:
                 results[agent_id] = e
@@ -122,12 +137,17 @@ class BroadcastManager:
 
         tasks = [asyncio.create_task(run_agent(aid)) for aid in group['agentIds']]
 
-        # Wait for first successful result
+        # Wait for the first genuinely successful result. A branch that fails
+        # fast must not preempt a slower success, so keep waiting until either
+        # a success arrives or every branch has settled.
+        pending = set(tasks)
         try:
-            done, pending = await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+            while pending and first_response is None:
+                done, pending = await asyncio.wait(pending, return_when=asyncio.FIRST_COMPLETED)
 
-            for task in done:
-                if not task.cancelled() and task.exception() is None:
+                for task in done:
+                    if task.cancelled() or task.exception() is not None:
+                        continue
                     r = task.result()
                     if r.get('success'):
                         first_response = {'agentId': r['agentId'], 'result': r['result']}
@@ -146,7 +166,7 @@ class BroadcastManager:
         # Wait for all tasks to be done
         await asyncio.gather(*tasks, return_exceptions=True)
 
-        successes = sum(1 for r in results.values() if not isinstance(r, Exception))
+        successes = _count_successes(results)
 
         return {
             'groupId': group['id'],
@@ -175,6 +195,12 @@ class BroadcastManager:
                 else:
                     result = await coro
                 results[agent_id] = result
+                if agent_result_is_error(result):
+                    # A returned error envelope is a failure: keep it in the
+                    # result map, forward its data_slush, and try the next agent.
+                    if isinstance(result, dict) and isinstance(result.get('data_slush'), dict):
+                        last_slush = result['data_slush']
+                    continue
                 first_response = {'agentId': agent_id, 'result': result}
                 break  # Success, stop trying
             except Exception as e:
@@ -183,7 +209,7 @@ class BroadcastManager:
                 if hasattr(e, 'result') and isinstance(e.result, dict) and 'data_slush' in e.result:
                     last_slush = e.result['data_slush']
 
-        successes = sum(1 for r in results.values() if not isinstance(r, Exception))
+        successes = _count_successes(results)
 
         return {
             'groupId': group['id'],

--- a/python/openrappter/agents/graph.py
+++ b/python/openrappter/agents/graph.py
@@ -19,6 +19,8 @@ from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
 from typing import Any, Optional
 
+from openrappter.result_status import agent_result_is_error
+
 
 @dataclass
 class GraphNode:
@@ -284,7 +286,8 @@ class AgentGraph:
                 result=result,
                 data_slush=data_slush,
                 duration_ms=duration_ms,
-                status='success',
+                # A returned {"status": "error"} envelope is a failure, exactly like a raise.
+                status='error' if agent_result_is_error(result) else 'success',
             )
 
         except Exception as e:

--- a/python/openrappter/result_status.py
+++ b/python/openrappter/result_status.py
@@ -1,16 +1,35 @@
+"""Shared agent-result classifier.
+
+An agent reports failure in one of two ways:
+  1. by raising, or
+  2. by *returning* a structured envelope ``{"status": "error", ...}``.
+
+Case 2 is just as much a failure as case 1 — the same principle as a nonzero
+shell exit being an error in both runtimes. Every composition layer (chain,
+graph, broadcast, CLI, brainstem) classifies through this function so the two
+runtimes cannot drift apart.
+
+Accepts either the raw JSON string an agent returned from ``execute()`` or an
+already-parsed envelope dict.
+
+Mirrors typescript/src/agents/result-status.ts
+"""
+
 import json
 from typing import Any
 
 
 def agent_result_is_error(result: Any) -> bool:
-    if not isinstance(result, str):
+    envelope = result
+
+    if isinstance(envelope, str):
+        try:
+            envelope = json.loads(envelope)
+        except (TypeError, ValueError):
+            return False
+
+    if not isinstance(envelope, dict):
         return False
-    try:
-        parsed = json.loads(result)
-    except (TypeError, ValueError):
-        return False
-    return (
-        isinstance(parsed, dict)
-        and isinstance(parsed.get("status"), str)
-        and parsed["status"].lower() == "error"
-    )
+
+    status = envelope.get("status")
+    return isinstance(status, str) and status.lower() == "error"

--- a/python/tests/test_composite_error_status.py
+++ b/python/tests/test_composite_error_status.py
@@ -1,0 +1,310 @@
+"""Composite error-status parity tests.
+
+A sub-agent that *returns* a structured ``{"status": "error"}`` envelope has
+failed just as surely as one that raises. These tests pin that contract for the
+composition layers (AgentGraph, BroadcastManager) and pin the shared classifier
+against the cross-runtime vector file in ``contracts/``.
+
+Mirrors typescript/src/__tests__/parity/composite-error-status.test.ts
+"""
+
+import asyncio
+import json
+from pathlib import Path
+
+import pytest
+
+from openrappter.agents.basic_agent import BasicAgent
+from openrappter.agents.broadcast import BroadcastManager
+from openrappter.agents.graph import AgentGraph
+from openrappter.result_status import agent_result_is_error
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _meta(name, description):
+    return {
+        "name": name,
+        "description": description,
+        "parameters": {"type": "object", "properties": {}, "required": []},
+    }
+
+
+class OkAgent(BasicAgent):
+    def __init__(self, name="Ok"):
+        self.name = name
+        self.metadata = _meta(name, "returns a success envelope")
+        super().__init__(name=self.name, metadata=self.metadata)
+
+    def perform(self, **kwargs):
+        return json.dumps({"status": "success", "ok": True, "data_slush": {"from": self.name}})
+
+
+class SoftFailAgent(BasicAgent):
+    """Reports failure the structured way: returns, never raises."""
+
+    def __init__(self, name="SoftFail"):
+        self.name = name
+        self.metadata = _meta(name, "returns a resolved error envelope")
+        super().__init__(name=self.name, metadata=self.metadata)
+
+    def perform(self, **kwargs):
+        return json.dumps({
+            "status": "error",
+            "message": "exit code 1",
+            "data_slush": {"failed_by": self.name},
+        })
+
+
+class RaiseAgent(BasicAgent):
+    def __init__(self, name="Raise"):
+        self.name = name
+        self.metadata = _meta(name, "raises")
+        super().__init__(name=self.name, metadata=self.metadata)
+
+    def perform(self, **kwargs):
+        raise RuntimeError("hard failure")
+
+
+class SlowOkAgent(BasicAgent):
+    def __init__(self, name="SlowOk", delay_s=0.05):
+        self.name = name
+        self.metadata = _meta(name, "succeeds slowly")
+        self._delay_s = delay_s
+        super().__init__(name=self.name, metadata=self.metadata)
+
+    def perform(self, **kwargs):
+        return json.dumps({"status": "success", "slow": True})
+
+
+def as_executor(agents, delays=None):
+    delays = delays or {}
+
+    async def executor(agent_id, message, upstream_slush=None):
+        if agent_id in delays:
+            await asyncio.sleep(delays[agent_id])
+        return json.loads(agents[agent_id].execute(query=message))
+
+    return executor
+
+
+def make_group(group_id, agent_ids, mode):
+    return {"id": group_id, "name": group_id, "agentIds": agent_ids, "mode": mode}
+
+
+# ---------------------------------------------------------------------------
+# Shared classifier vectors
+# ---------------------------------------------------------------------------
+
+VECTOR_PATH = Path(__file__).parents[2] / "contracts" / "agent-result-status-vectors.json"
+VECTORS = json.loads(VECTOR_PATH.read_text())["vectors"]
+
+
+def test_vector_file_is_loaded():
+    assert len(VECTORS) > 20
+
+
+@pytest.mark.parametrize("vector", VECTORS, ids=[v["name"] for v in VECTORS])
+def test_classifier_matches_cross_runtime_vectors(vector):
+    assert agent_result_is_error(vector["value"]) is vector["isError"]
+
+
+# ---------------------------------------------------------------------------
+# AgentGraph
+# ---------------------------------------------------------------------------
+
+class TestGraphErrorEnvelope:
+    def test_node_returning_error_envelope_is_errored(self):
+        graph = AgentGraph()
+        graph.add_node(name="root", agent=SoftFailAgent())
+        result = graph.run()
+
+        assert result.nodes["root"].status == "error"
+        assert result.status == "partial"
+
+    def test_dependents_are_skipped(self):
+        graph = AgentGraph()
+        graph.add_node(name="root", agent=SoftFailAgent())
+        graph.add_node(name="child", agent=OkAgent(), depends_on=["root"])
+        graph.add_node(name="grandchild", agent=OkAgent("Ok2"), depends_on=["child"])
+        result = graph.run()
+
+        assert result.nodes["child"].status == "skipped"
+        assert result.nodes["grandchild"].status == "skipped"
+        assert result.status == "partial"
+
+    def test_stop_on_error_halts_the_graph(self):
+        graph = AgentGraph({"stop_on_error": True})
+        graph.add_node(name="root", agent=SoftFailAgent())
+        graph.add_node(name="child", agent=OkAgent(), depends_on=["root"])
+        result = graph.run()
+
+        assert result.status == "error"
+        assert result.error == "exit code 1"
+        assert result.nodes["child"].status == "skipped"
+
+    def test_error_envelope_is_preserved_on_the_node(self):
+        graph = AgentGraph()
+        graph.add_node(name="root", agent=SoftFailAgent())
+        result = graph.run()
+
+        assert result.nodes["root"].result["status"] == "error"
+        assert result.nodes["root"].result["message"] == "exit code 1"
+
+    def test_raise_and_error_envelope_are_equivalent(self):
+        soft = AgentGraph()
+        soft.add_node(name="a", agent=SoftFailAgent())
+        soft.add_node(name="b", agent=OkAgent(), depends_on=["a"])
+        soft_result = soft.run()
+
+        hard = AgentGraph()
+        hard.add_node(name="a", agent=RaiseAgent())
+        hard.add_node(name="b", agent=OkAgent(), depends_on=["a"])
+        hard_result = hard.run()
+
+        assert soft_result.status == hard_result.status
+        assert soft_result.nodes["a"].status == hard_result.nodes["a"].status
+        assert soft_result.nodes["b"].status == hard_result.nodes["b"].status
+
+    def test_all_success_still_reports_success(self):
+        graph = AgentGraph()
+        graph.add_node(name="root", agent=OkAgent())
+        graph.add_node(name="child", agent=OkAgent("Ok2"), depends_on=["root"])
+        result = graph.run()
+
+        assert result.status == "success"
+        assert result.nodes["child"].status == "success"
+
+    def test_parallel_level_marks_error_envelope_nodes(self):
+        """Exercises the ThreadPoolExecutor branch (>1 runnable node in a level)."""
+        graph = AgentGraph()
+        graph.add_node(name="a", agent=SoftFailAgent("A"))
+        graph.add_node(name="b", agent=OkAgent("B"))
+        graph.add_node(name="c", agent=OkAgent("C"), depends_on=["a"])
+        result = graph.run()
+
+        assert result.nodes["a"].status == "error"
+        assert result.nodes["b"].status == "success"
+        assert result.nodes["c"].status == "skipped"
+        assert result.status == "partial"
+
+
+# ---------------------------------------------------------------------------
+# BroadcastManager
+# ---------------------------------------------------------------------------
+
+class TestBroadcastErrorEnvelope:
+    def test_all_mode_clears_all_succeeded(self):
+        agents = {"ok": OkAgent(), "bad": SoftFailAgent()}
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["ok", "bad"], "all"))
+
+        result = asyncio.run(mgr.broadcast("g", "ping", as_executor(agents)))
+
+        assert result["allSucceeded"] is False
+        assert result["anySucceeded"] is True
+
+    def test_all_mode_keeps_the_full_error_envelope(self):
+        agents = {"ok": OkAgent(), "bad": SoftFailAgent()}
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["ok", "bad"], "all"))
+
+        result = asyncio.run(mgr.broadcast("g", "ping", as_executor(agents)))
+        bad = result["results"]["bad"]
+
+        assert not isinstance(bad, Exception)
+        assert bad["status"] == "error"
+        assert bad["message"] == "exit code 1"
+        assert "ok" in result["results"]
+
+    def test_all_mode_total_failure(self):
+        agents = {"a": SoftFailAgent("A"), "b": SoftFailAgent("B")}
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["a", "b"], "all"))
+
+        result = asyncio.run(mgr.broadcast("g", "ping", as_executor(agents)))
+
+        assert result["anySucceeded"] is False
+        assert result["allSucceeded"] is False
+        assert result["firstResponse"] is None
+
+    def test_all_mode_first_response_skips_errored_branch(self):
+        agents = {"bad": SoftFailAgent(), "ok": OkAgent()}
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["bad", "ok"], "all"))
+
+        result = asyncio.run(mgr.broadcast("g", "ping", as_executor(agents)))
+
+        assert result["firstResponse"]["agentId"] == "ok"
+
+    def test_fallback_falls_through_to_next_agent(self):
+        agents = {"bad": SoftFailAgent(), "ok": OkAgent()}
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["bad", "ok"], "fallback"))
+
+        result = asyncio.run(mgr.broadcast("g", "ping", as_executor(agents)))
+
+        assert list(result["results"].keys()) == ["bad", "ok"]
+        assert result["firstResponse"]["agentId"] == "ok"
+        assert result["anySucceeded"] is True
+
+    def test_fallback_forwards_data_slush_from_soft_failure(self):
+        seen = []
+
+        async def executor(agent_id, message, upstream_slush=None):
+            seen.append(upstream_slush)
+            if agent_id == "bad":
+                return {"status": "error", "message": "nope", "data_slush": {"tried": "bad"}}
+            return {"status": "success"}
+
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["bad", "ok"], "fallback"))
+        asyncio.run(mgr.broadcast("g", "ping", executor))
+
+        assert seen[0] is None
+        assert seen[1] == {"tried": "bad"}
+
+    def test_fallback_total_failure(self):
+        agents = {"a": SoftFailAgent("A"), "b": SoftFailAgent("B")}
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["a", "b"], "fallback"))
+
+        result = asyncio.run(mgr.broadcast("g", "ping", as_executor(agents)))
+
+        assert result["anySucceeded"] is False
+        assert result["firstResponse"] is None
+
+    def test_race_error_envelope_does_not_win(self):
+        agents = {"bad": SoftFailAgent(), "slow": SlowOkAgent()}
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["bad", "slow"], "race"))
+
+        result = asyncio.run(
+            mgr.broadcast("g", "ping", as_executor(agents, delays={"slow": 0.05}))
+        )
+
+        assert result["firstResponse"]["agentId"] == "slow"
+        assert result["anySucceeded"] is True
+        assert result["allSucceeded"] is False
+
+    def test_race_no_winner_when_all_error(self):
+        agents = {"a": SoftFailAgent("A"), "b": SoftFailAgent("B")}
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["a", "b"], "race"))
+
+        result = asyncio.run(mgr.broadcast("g", "ping", as_executor(agents)))
+
+        assert result["firstResponse"] is None
+        assert result["anySucceeded"] is False
+
+    def test_all_success_broadcast_still_succeeds(self):
+        agents = {"a": OkAgent("A"), "b": OkAgent("B")}
+        mgr = BroadcastManager()
+        mgr.create_group(make_group("g", ["a", "b"], "all"))
+
+        result = asyncio.run(mgr.broadcast("g", "ping", as_executor(agents)))
+
+        assert result["allSucceeded"] is True
+        assert result["anySucceeded"] is True

--- a/typescript/src/__tests__/parity/composite-error-status.test.ts
+++ b/typescript/src/__tests__/parity/composite-error-status.test.ts
@@ -1,0 +1,292 @@
+/**
+ * Composite error-status parity tests.
+ *
+ * A sub-agent that *resolves* with a structured `{status: 'error'}` envelope
+ * has failed just as surely as one that throws. These tests pin that contract
+ * for the composition layers (AgentGraph, BroadcastManager) and pin the shared
+ * classifier against the cross-runtime vector file in `contracts/`.
+ *
+ * Mirrors python/tests/test_composite_error_status.py
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { AgentGraph } from '../../agents/graph.js';
+import { BroadcastManager } from '../../agents/broadcast.js';
+import { BasicAgent } from '../../agents/BasicAgent.js';
+import { agentResultIsError } from '../../agents/result-status.js';
+import type { AgentMetadata, AgentResult } from '../../agents/types.js';
+
+// ── Test helpers ──
+
+function meta(name: string, description: string): AgentMetadata {
+  return { name, description, parameters: { type: 'object', properties: {}, required: [] } };
+}
+
+class OkAgent extends BasicAgent {
+  constructor(name = 'Ok') {
+    super(name, meta(name, 'returns a success envelope'));
+  }
+  async perform(): Promise<string> {
+    return JSON.stringify({ status: 'success', ok: true, data_slush: { from: this.name } });
+  }
+}
+
+/** Reports failure the structured way: resolves, never throws. */
+class SoftFailAgent extends BasicAgent {
+  constructor(name = 'SoftFail') {
+    super(name, meta(name, 'returns a resolved error envelope'));
+  }
+  async perform(): Promise<string> {
+    return JSON.stringify({
+      status: 'error',
+      message: 'exit code 1',
+      data_slush: { failed_by: this.name },
+    });
+  }
+}
+
+class ThrowAgent extends BasicAgent {
+  constructor(name = 'Throw') {
+    super(name, meta(name, 'throws'));
+  }
+  async perform(): Promise<string> {
+    throw new Error('hard failure');
+  }
+}
+
+class SlowOkAgent extends BasicAgent {
+  constructor(name = 'SlowOk', private readonly delayMs = 40) {
+    super(name, meta(name, 'succeeds slowly'));
+  }
+  async perform(): Promise<string> {
+    await new Promise(resolve => setTimeout(resolve, this.delayMs));
+    return JSON.stringify({ status: 'success', slow: true });
+  }
+}
+
+const asExecutor = (agents: Record<string, BasicAgent>) =>
+  async (agentId: string, message: string): Promise<AgentResult> =>
+    JSON.parse(await agents[agentId]!.execute({ query: message })) as AgentResult;
+
+// ── Shared classifier vectors ──
+
+interface Vector {
+  name: string;
+  kind: 'string' | 'value';
+  value: unknown;
+  isError: boolean;
+}
+
+const vectors = (
+  JSON.parse(
+    readFileSync(
+      new URL('../../../../contracts/agent-result-status-vectors.json', import.meta.url),
+      'utf8',
+    ),
+  ) as { vectors: Vector[] }
+).vectors;
+
+describe('agentResultIsError — cross-runtime vectors', () => {
+  it('loads the shared contract vectors', () => {
+    expect(vectors.length).toBeGreaterThan(20);
+  });
+
+  for (const vector of vectors) {
+    it(`classifies "${vector.name}" as ${vector.isError ? 'error' : 'not error'}`, () => {
+      expect(agentResultIsError(vector.value)).toBe(vector.isError);
+    });
+  }
+});
+
+// ── AgentGraph ──
+
+describe('AgentGraph — resolved error envelopes are failures', () => {
+  it('marks a node that returned {status:error} as errored', async () => {
+    const graph = new AgentGraph().addNode({ name: 'root', agent: new SoftFailAgent() });
+    const result = await graph.run();
+
+    expect(result.nodes.get('root')!.status).toBe('error');
+    expect(result.status).toBe('partial');
+  });
+
+  it('skips dependents of a node that returned {status:error}', async () => {
+    const graph = new AgentGraph()
+      .addNode({ name: 'root', agent: new SoftFailAgent() })
+      .addNode({ name: 'child', agent: new OkAgent(), dependsOn: ['root'] })
+      .addNode({ name: 'grandchild', agent: new OkAgent('Ok2'), dependsOn: ['child'] });
+    const result = await graph.run();
+
+    expect(result.nodes.get('child')!.status).toBe('skipped');
+    expect(result.nodes.get('grandchild')!.status).toBe('skipped');
+    expect(result.status).toBe('partial');
+  });
+
+  it('stops the graph on a resolved error envelope when stopOnError is set', async () => {
+    const graph = new AgentGraph({ stopOnError: true })
+      .addNode({ name: 'root', agent: new SoftFailAgent() })
+      .addNode({ name: 'child', agent: new OkAgent(), dependsOn: ['root'] });
+    const result = await graph.run();
+
+    expect(result.status).toBe('error');
+    expect(result.error).toBe('exit code 1');
+    expect(result.nodes.get('child')!.status).toBe('skipped');
+  });
+
+  it('preserves the error envelope on the failed node', async () => {
+    const graph = new AgentGraph().addNode({ name: 'root', agent: new SoftFailAgent() });
+    const result = await graph.run();
+
+    expect(result.nodes.get('root')!.result.status).toBe('error');
+    expect(result.nodes.get('root')!.result.message).toBe('exit code 1');
+  });
+
+  it('treats a thrown failure and a resolved error envelope identically', async () => {
+    const soft = await new AgentGraph()
+      .addNode({ name: 'a', agent: new SoftFailAgent() })
+      .addNode({ name: 'b', agent: new OkAgent(), dependsOn: ['a'] })
+      .run();
+    const hard = await new AgentGraph()
+      .addNode({ name: 'a', agent: new ThrowAgent() })
+      .addNode({ name: 'b', agent: new OkAgent(), dependsOn: ['a'] })
+      .run();
+
+    expect(soft.status).toBe(hard.status);
+    expect(soft.nodes.get('a')!.status).toBe(hard.nodes.get('a')!.status);
+    expect(soft.nodes.get('b')!.status).toBe(hard.nodes.get('b')!.status);
+  });
+
+  it('still reports success when every node returns a success envelope', async () => {
+    const graph = new AgentGraph()
+      .addNode({ name: 'root', agent: new OkAgent() })
+      .addNode({ name: 'child', agent: new OkAgent('Ok2'), dependsOn: ['root'] });
+    const result = await graph.run();
+
+    expect(result.status).toBe('success');
+    expect(result.nodes.get('child')!.status).toBe('success');
+  });
+});
+
+// ── BroadcastManager ──
+
+describe('BroadcastManager — resolved error envelopes are failures', () => {
+  it('all mode: an errored branch clears allSucceeded but keeps the other branch', async () => {
+    const agents = { ok: new OkAgent(), bad: new SoftFailAgent() };
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['ok', 'bad'], mode: 'all' });
+
+    const result = await mgr.broadcast('g', 'ping', asExecutor(agents));
+
+    expect(result.allSucceeded).toBe(false);
+    expect(result.anySucceeded).toBe(true);
+  });
+
+  it('all mode: the failing branch keeps its full error envelope (nothing discarded)', async () => {
+    const agents = { ok: new OkAgent(), bad: new SoftFailAgent() };
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['ok', 'bad'], mode: 'all' });
+
+    const result = await mgr.broadcast('g', 'ping', asExecutor(agents));
+    const bad = result.results.get('bad') as AgentResult;
+
+    expect(bad).not.toBeInstanceOf(Error);
+    expect(bad.status).toBe('error');
+    expect(bad.message).toBe('exit code 1');
+    expect(result.results.get('ok')).toBeDefined();
+  });
+
+  it('all mode: reports total failure when every branch returns an error envelope', async () => {
+    const agents = { a: new SoftFailAgent('A'), b: new SoftFailAgent('B') };
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['a', 'b'], mode: 'all' });
+
+    const result = await mgr.broadcast('g', 'ping', asExecutor(agents));
+
+    expect(result.anySucceeded).toBe(false);
+    expect(result.allSucceeded).toBe(false);
+    expect(result.firstResponse).toBeUndefined();
+  });
+
+  it('all mode: firstResponse never points at an errored branch', async () => {
+    const agents = { bad: new SoftFailAgent(), ok: new OkAgent() };
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['bad', 'ok'], mode: 'all' });
+
+    const result = await mgr.broadcast('g', 'ping', asExecutor(agents));
+
+    expect(result.firstResponse?.agentId).toBe('ok');
+  });
+
+  it('fallback mode: an error envelope falls through to the next agent', async () => {
+    const agents = { bad: new SoftFailAgent(), ok: new OkAgent() };
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['bad', 'ok'], mode: 'fallback' });
+
+    const result = await mgr.broadcast('g', 'ping', asExecutor(agents));
+
+    expect(Array.from(result.results.keys())).toEqual(['bad', 'ok']);
+    expect(result.firstResponse?.agentId).toBe('ok');
+    expect(result.anySucceeded).toBe(true);
+  });
+
+  it('fallback mode: forwards data_slush from a soft-failed agent to the next', async () => {
+    const seen: (Record<string, unknown> | undefined)[] = [];
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['bad', 'ok'], mode: 'fallback' });
+
+    await mgr.broadcast('g', 'ping', async (agentId, _message, upstreamSlush) => {
+      seen.push(upstreamSlush);
+      return agentId === 'bad'
+        ? ({ status: 'error', message: 'nope', data_slush: { tried: 'bad' } } as AgentResult)
+        : ({ status: 'success' } as AgentResult);
+    });
+
+    expect(seen[0]).toBeUndefined();
+    expect(seen[1]).toEqual({ tried: 'bad' });
+  });
+
+  it('fallback mode: reports failure when every agent returns an error envelope', async () => {
+    const agents = { a: new SoftFailAgent('A'), b: new SoftFailAgent('B') };
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['a', 'b'], mode: 'fallback' });
+
+    const result = await mgr.broadcast('g', 'ping', asExecutor(agents));
+
+    expect(result.anySucceeded).toBe(false);
+    expect(result.firstResponse).toBeUndefined();
+  });
+
+  it('race mode: an error envelope does not win the race', async () => {
+    const agents = { bad: new SoftFailAgent(), slow: new SlowOkAgent() };
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['bad', 'slow'], mode: 'race' });
+
+    const result = await mgr.broadcast('g', 'ping', asExecutor(agents));
+
+    expect(result.firstResponse?.agentId).toBe('slow');
+    expect(result.anySucceeded).toBe(true);
+    expect(result.allSucceeded).toBe(false);
+  });
+
+  it('race mode: no winner when every branch returns an error envelope', async () => {
+    const agents = { a: new SoftFailAgent('A'), b: new SoftFailAgent('B') };
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['a', 'b'], mode: 'race' });
+
+    const result = await mgr.broadcast('g', 'ping', asExecutor(agents));
+
+    expect(result.firstResponse).toBeUndefined();
+    expect(result.anySucceeded).toBe(false);
+  });
+
+  it('leaves an all-success broadcast reporting success', async () => {
+    const agents = { a: new OkAgent('A'), b: new OkAgent('B') };
+    const mgr = new BroadcastManager();
+    mgr.createGroup({ id: 'g', name: 'g', agentIds: ['a', 'b'], mode: 'all' });
+
+    const result = await mgr.broadcast('g', 'ping', asExecutor(agents));
+
+    expect(result.allSucceeded).toBe(true);
+    expect(result.anySucceeded).toBe(true);
+  });
+});

--- a/typescript/src/agents/broadcast.ts
+++ b/typescript/src/agents/broadcast.ts
@@ -3,6 +3,7 @@
  * Send messages to multiple agents simultaneously
  */
 
+import { agentResultIsError } from './result-status.js';
 import type { AgentResult } from './types.js';
 
 export interface BroadcastGroup {
@@ -15,13 +16,31 @@ export interface BroadcastGroup {
 
 export interface BroadcastResult {
   groupId: string;
+  /**
+   * Per-branch outcome. A branch that *resolved* with a `{status: 'error'}`
+   * envelope keeps that envelope here (nothing is discarded) — it is still
+   * counted as a failure by `allSucceeded` / `anySucceeded`.
+   */
   results: Map<string, AgentResult | Error>;
+  /** First branch that actually succeeded (error envelopes do not qualify). */
   firstResponse?: { agentId: string; result: AgentResult };
   allSucceeded: boolean;
   anySucceeded: boolean;
 }
 
 type AgentExecutor = (agentId: string, message: string, upstreamSlush?: Record<string, unknown>) => Promise<AgentResult>;
+
+/**
+ * A branch succeeded only if it neither threw nor resolved with a
+ * `{status: 'error'}` envelope.
+ */
+function branchSucceeded(outcome: AgentResult | Error): boolean {
+  return !(outcome instanceof Error) && !agentResultIsError(outcome);
+}
+
+function countSuccesses(results: Map<string, AgentResult | Error>): number {
+  return Array.from(results.values()).filter(branchSucceeded).length;
+}
 
 export class BroadcastManager {
   private groups = new Map<string, BroadcastGroup>();
@@ -94,10 +113,10 @@ export class BroadcastManager {
       try {
         const result = await this.executeWithTimeout(executor, agentId, message, group.timeout);
         results.set(agentId, result);
-        if (!firstResponse) {
+        if (!firstResponse && !agentResultIsError(result)) {
           firstResponse = { agentId, result };
         }
-        return { agentId, result, success: true };
+        return { agentId, result, success: !agentResultIsError(result) };
       } catch (error) {
         results.set(agentId, error as Error);
         return { agentId, error, success: false };
@@ -106,9 +125,7 @@ export class BroadcastManager {
 
     await Promise.all(promises);
 
-    const successes = Array.from(results.values()).filter(
-      (r) => !(r instanceof Error)
-    ).length;
+    const successes = countSuccesses(results);
 
     return {
       groupId: group.id,
@@ -134,6 +151,13 @@ export class BroadcastManager {
       try {
         const result = await this.executeWithTimeout(executor, agentId, message, group.timeout);
         results.set(agentId, result);
+        if (agentResultIsError(result)) {
+          return {
+            agentId,
+            error: new Error(`Agent ${agentId} returned an error result`),
+            success: false,
+          };
+        }
         return { agentId, result, success: true };
       } catch (error) {
         results.set(agentId, error as Error);
@@ -141,30 +165,27 @@ export class BroadcastManager {
       }
     });
 
-    // Wait for first successful result
+    // Wait for the first genuinely successful result. `Promise.any` (not `race`)
+    // is required: a branch that fails fast must not preempt a slower success.
     try {
-      const first = await Promise.race(
+      const first = await Promise.any(
         promises.map((p) =>
           p.then((r) => {
-            if (r.success) return r;
-            throw r.error;
+            if (r.success && 'result' in r) return r;
+            throw 'error' in r ? r.error : new Error(`Agent ${r.agentId} failed`);
           })
         )
       );
 
-      if (first.success && 'result' in first) {
-        firstResponse = { agentId: first.agentId, result: first.result as AgentResult };
-      }
+      firstResponse = { agentId: first.agentId, result: first.result as AgentResult };
     } catch {
-      // All failed
+      // Every branch either threw or returned an error envelope
     }
 
     // Wait for all to complete (for result map)
     await Promise.allSettled(promises);
 
-    const successes = Array.from(results.values()).filter(
-      (r) => !(r instanceof Error)
-    ).length;
+    const successes = countSuccesses(results);
 
     return {
       groupId: group.id,
@@ -192,6 +213,15 @@ export class BroadcastManager {
       try {
         const result = await this.executeWithTimeout(executor, agentId, message, group.timeout, lastSlush);
         results.set(agentId, result);
+        if (agentResultIsError(result)) {
+          // A resolved error envelope is a failure: keep it in the result map,
+          // forward its data_slush, and fall through to the next agent in line.
+          const slush = result.data_slush;
+          if (slush && typeof slush === 'object') {
+            lastSlush = slush as Record<string, unknown>;
+          }
+          continue;
+        }
         firstResponse = { agentId, result };
         break; // Success, stop trying
       } catch (error) {
@@ -205,9 +235,7 @@ export class BroadcastManager {
       }
     }
 
-    const successes = Array.from(results.values()).filter(
-      (r) => !(r instanceof Error)
-    ).length;
+    const successes = countSuccesses(results);
 
     return {
       groupId: group.id,

--- a/typescript/src/agents/graph.ts
+++ b/typescript/src/agents/graph.ts
@@ -22,6 +22,7 @@
  */
 
 import { BasicAgent } from './BasicAgent.js';
+import { agentResultIsError } from './result-status.js';
 import type { AgentResult } from './types.js';
 
 export interface GraphNode {
@@ -363,13 +364,14 @@ export class AgentGraph {
         signals: { node_name: name, node_result_status: result.status },
       });
 
+      // A resolved `{status: 'error'}` envelope is a failure, exactly like a throw.
       return {
         name,
         agentName: node.agent.name,
         result,
         dataSlush: effectiveSlush,
         durationMs,
-        status: 'success',
+        status: agentResultIsError(result) ? 'error' : 'success',
       };
     } catch (e) {
       const durationMs = Date.now() - nodeStart;

--- a/typescript/src/agents/result-status.ts
+++ b/typescript/src/agents/result-status.ts
@@ -1,14 +1,35 @@
+/**
+ * Shared agent-result classifier.
+ *
+ * An agent reports failure in one of two ways:
+ *   1. by throwing / rejecting, or
+ *   2. by *resolving* with a structured envelope `{ "status": "error", ... }`.
+ *
+ * Case 2 is just as much a failure as case 1 — the same principle as a nonzero
+ * shell exit being an error in both runtimes. Every composition layer (chain,
+ * graph, broadcast, MCP, chat) classifies through this function so the two
+ * runtimes cannot drift apart.
+ *
+ * Accepts either the raw JSON string an agent returned from `execute()` or an
+ * already-parsed envelope object.
+ *
+ * Mirrors python/openrappter/result_status.py
+ */
 export function agentResultIsError(result: unknown): boolean {
-  if (typeof result !== "string") return false;
-  try {
-    const parsed = JSON.parse(result) as { status?: unknown };
-    return (
-      typeof parsed === "object" &&
-      parsed !== null &&
-      typeof parsed.status === "string" &&
-      parsed.status.toLowerCase() === "error"
-    );
-  } catch {
+  let envelope: unknown = result;
+
+  if (typeof envelope === "string") {
+    try {
+      envelope = JSON.parse(envelope);
+    } catch {
+      return false;
+    }
+  }
+
+  if (typeof envelope !== "object" || envelope === null || Array.isArray(envelope)) {
     return false;
   }
+
+  const status = (envelope as { status?: unknown }).status;
+  return typeof status === "string" && status.toLowerCase() === "error";
 }


### PR DESCRIPTION
## The bug

`AgentGraph` and `BroadcastManager` — in **both** runtimes — only detected a sub-agent failure when the call *threw*. A sub-agent that correctly reported a structured error by **resolving** with `{"status": "error", ...}` was recorded as a success, and the composite reported success overall.

This is the same contract as #154 (a nonzero shell exit is an error in both runtimes): a structured error envelope is a failure in both runtimes too.

## Reproduction (before the fix, real output)

A `SoftFailAgent` returns `{"status": "error", "message": "exit code 1"}` — it never throws. `OkAgent` returns a success envelope.

**TypeScript** (`tsx` against `src/agents/{graph,broadcast}.ts`):

```
=== TS GRAPH ===
graph.status            = success          <-- lie
nodes.root.status       = success          <-- lie
nodes.root.result       = {"status":"error","message":"exit code 1"}
nodes.child.status      = success          <-- ran on a failed parent

=== TS GRAPH (stopOnError) ===
graph.status            = success
nodes.child.status      = success          <-- stopOnError never fired

=== TS BROADCAST (all) ===
allSucceeded            = true             <-- lie
anySucceeded            = true
results.bad             = {"status":"error","message":"exit code 1"}

=== TS BROADCAST (fallback: bad first) ===
firstResponse.agentId   = bad              <-- "fallback" fell back to the failure
agents attempted        = bad              <-- ok was never tried
anySucceeded            = true

=== TS BROADCAST (race: bad only) ===
firstResponse.agentId   = bad              <-- an error won the race
anySucceeded            = true
```

**Python** (same composite, `openrappter.agents.{graph,broadcast}`):

```
=== PY GRAPH ===
graph.status            = success
nodes[root].status      = success
nodes[root].result      = {"status": "error", "message": "exit code 1"}
nodes[child].status     = success

=== PY GRAPH (stop_on_error) ===
graph.status            = success
nodes[child].status     = success

=== PY BROADCAST (all) ===
allSucceeded            = True
anySucceeded            = True
results[bad]            = {"status": "error", "message": "exit code 1"}

=== PY BROADCAST (fallback: bad first) ===
firstResponse.agentId   = bad
agents attempted        = bad
anySucceeded            = True

=== PY BROADCAST (race: bad only) ===
firstResponse.agentId   = bad
anySucceeded            = True
```

The two runtimes were **identically wrong** — neither was already correct. The most damaging case is `fallback`: the mode whose entire purpose is "try until one succeeds" stopped at the first agent that reported failure and never tried the healthy one.

## After the fix (same script, real output)

```
                          TypeScript              Python
graph.status              partial                 partial
nodes root/child          error / skipped         error / skipped
graph stopOnError         error, child skipped    error, child skipped
broadcast all             allSucceeded=false      allSucceeded=False
                          anySucceeded=true       anySucceeded=True
                          envelope preserved      envelope preserved
broadcast fallback        firstResponse=ok        firstResponse=ok
                          attempted bad,ok        attempted bad,ok
broadcast race (bad only) firstResponse=undefined firstResponse=None
                          anySucceeded=false      anySucceeded=False
```

## The fix

**One classifier, no duplicated logic.** `typescript/src/agents/result-status.ts` and `python/openrappter/result_status.py` already existed and already agreed; they only accepted the *raw JSON string* an agent returned. Graph and broadcast hold *parsed* envelopes, which is exactly why they could not use the classifier and grew a throw-only notion of failure instead. The classifier now accepts either a raw string or an already-parsed envelope. String behaviour is byte-for-byte unchanged, so the six existing call sites (BasicAgent, Assistant, chat, MCP server/stdio, CLI, brainstem) are unaffected.

Their agreement is pinned by a shared vector file, `contracts/agent-result-status-vectors.json` (23 vectors), read by both suites — the same mechanism `contracts/flight-recorder-vector.json` already uses. It covers case-insensitivity (`ERROR`, `Error`), non-JSON strings, `null`/number/array/double-encoded inputs, objects with a missing or non-string `status`, and a nested `status: "error"` under a successful envelope (not an error).

**Graph** (`graph.ts`, `graph.py`): a node's status is now `agentResultIsError(result) ? 'error' : 'success'`. Everything downstream — dependent skipping, `stopOnError`, the `partial`/`error` rollup — already keyed off that status, so it just starts telling the truth. The error envelope and the node's `data_slush` are kept on the node result.

**Broadcast** (`broadcast.ts`, `broadcast.py`): success counting goes through a single `branchSucceeded` / `_branch_succeeded` helper (`not an Error` **and** not an error envelope). `fallback` falls through to the next agent and forwards the failed agent's `data_slush` as `upstream_slush` — previously only thrown failures did this. `race` no longer lets an error envelope win.

**One coupled fix in `race`.** Once error envelopes lose, `race` had to actually wait for the first *success*: TS used `Promise.race` over the mapped promises, which settles on the first *rejection* too, and Python's `asyncio.wait(FIRST_COMPLETED)` inspected only the first completed batch. Both would have reported "no winner" while `anySucceeded` said `true`. TS now uses `Promise.any`; Python loops on `FIRST_COMPLETED` until a success or exhaustion. Mutations M9/M10 pin this.

## Design decision: broadcast semantics for "one branch errored"

Considered three options:

1. **Abort the whole broadcast on the first error** — destroys the other branches' work and turns `all` into `stopOnError`. Rejected.
2. **Convert the envelope into a thrown `Error` in the `results` map** — uniform, but discards the structured payload (`message`, `data_slush`, any diagnostic fields) that the sub-agent went to the trouble of producing. Rejected: it destroys exactly the information the fix is about.
3. **Chosen: per-branch reporting, aggregate honesty.** The failing branch keeps its full error envelope in `results` (callers can still distinguish a thrown failure — `instanceof Error` / `isinstance(Exception)` — from a structured one). The aggregate stops lying: `allSucceeded` is false, `anySucceeded` counts only genuine successes, and `firstResponse` never points at an errored branch.

This preserves the most information: nothing is discarded, the caller sees *which* branch failed and *why*, and the summary flags are trustworthy. It also keeps each mode's stated contract intact — `all` still waits for everyone, `race` still returns a first *success*, `fallback` still tries until something actually succeeds. The public `BroadcastResult` shape is unchanged; only the values are now correct.

Consequence worth naming: in `fallback` mode `allSucceeded` remains near-meaningless (agents after the first success are never attempted). That is pre-existing and untouched.

## Mutation table

Every new test was reverted-and-checked. Baseline green, then each piece of the fix individually reverted; all 12 mutants go red.

| # | Runtime | Mutation | Result |
|---|---------|----------|--------|
| — | TS | baseline, fix in place | **PASS** — 40 passed (40) |
| — | PY | baseline, fix in place | **PASS** — 41 passed |
| M1 | TS | graph: node status hardcoded back to `'success'` | **RED** — 4 failed / 36 passed |
| M2 | PY | graph: node status hardcoded back to `'success'` | **RED** — 5 failed / 36 passed |
| M3 | TS | broadcast: success count ignores error envelopes | **RED** — 5 failed / 35 passed |
| M4 | PY | broadcast: success count ignores error envelopes | **RED** — 5 failed / 36 passed |
| M5 | TS | fallback: error envelope no longer falls through | **RED** — 3 failed / 37 passed |
| M6 | PY | fallback: error envelope no longer falls through | **RED** — 3 failed / 38 passed |
| M7 | TS | race: error envelope allowed to win | **RED** — 2 failed / 38 passed |
| M8 | PY | race: error envelope allowed to win | **RED** — 2 failed / 39 passed |
| M9 | TS | race: `Promise.any` → `Promise.race` (fast failure preempts) | **RED** — 1 failed / 39 passed |
| M10 | PY | race: only inspect the first completed batch | **RED** — 1 failed / 40 passed |
| M11 | TS | classifier: reject already-parsed objects (pre-fix) | **RED** — 14 failed / 26 passed |
| M12 | PY | classifier: reject already-parsed dicts (pre-fix) | **RED** — 15 failed / 26 passed |

## Verification

- **TypeScript full suite**: `Test Files 1 failed | 244 passed | 3 skipped (248)`, `Tests 5 failed | 4809 passed | 21 skipped (4835)`. The 5 failures are all in `src/providers/copilot-cli-local.test.ts` — the known pre-existing environment failures on this checkout, verified unrelated (they are about resolving a local `copilot` binary) and untouched by this change.
- **`tsc --noEmit -p tsconfig.json`**: clean.
- **ESLint** on all changed/added TS files: clean.
- **Python full suite**: `1386 passed, 7 skipped, 51 subtests passed`. No failures.
- New tests: 40 TS (`typescript/src/__tests__/parity/composite-error-status.test.ts`), 41 Python (`python/tests/test_composite_error_status.py`), mirroring each other case for case, including a Python-only case that exercises the `ThreadPoolExecutor` branch of the graph (>1 runnable node per level).

## Honest caveats / not fixed here

- **`AgentChain` has a partial version of the same bug**, and is out of scope for this change. Its final rollup *does* inspect `result.status === 'error'`, so a chain ends `partial` — but `stopOnError` only fires in the `catch`, so a step that returns an error envelope does **not** halt the chain and downstream steps still run. `PipelineAgent` and `SubAgent` were not audited. Worth a follow-up on the same contract.
- `allSucceeded` in `fallback` mode is still structurally odd (see above); unchanged, pre-existing.
- The `race` mode runtimes still differ in one pre-existing way this PR does not touch: Python cancels losing tasks, TypeScript cannot and lets them settle. So a Python `race` `results` map may omit cancelled branches. Not related to error status; left alone.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
