### PR TITLE
fix(gateway): three config clients, three dialects, none matching the server

### DIFF
--- a/macos/Sources/OpenRappterBar/Services/RpcClient.swift
+++ b/macos/Sources/OpenRappterBar/Services/RpcClient.swift
@@ -245,7 +245,15 @@ public struct RpcClient: RpcClientProtocol, Sendable {
             return yaml
         }
         if let dict = response.payload?.value as? [String: Any] {
-            // Convert dict to YAML-like string representation
+            // The gateway answers with a snapshot, not a bare string. Read the
+            // config out of it; serialising the whole envelope showed the user
+            // `{"content": "..."}` instead of their YAML.
+            if let raw = dict["raw"] as? String {
+                return raw
+            }
+            if let content = dict["content"] as? String {
+                return content
+            }
             let data = try JSONSerialization.data(withJSONObject: dict, options: .prettyPrinted)
             return String(data: data, encoding: .utf8) ?? "{}"
         }
@@ -253,7 +261,9 @@ public struct RpcClient: RpcClientProtocol, Sendable {
     }
 
     public func setConfig(yaml: String) async throws {
-        let params: [String: AnyCodable] = ["config": AnyCodable(yaml)]
+        // `raw` is the canonical field name; the gateway still accepts the
+        // older `config` and `content` spellings.
+        let params: [String: AnyCodable] = ["raw": AnyCodable(yaml)]
         let response = try await connection.sendRequest(method: "config.set", params: params)
         guard response.ok else {
             let msg = response.error?.message ?? "Unknown error"

--- a/typescript/src/__tests__/integration/config-contract.test.ts
+++ b/typescript/src/__tests__/integration/config-contract.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * Binds the config clients to the handler that actually runs.
+ *
+ * Three clients each spoke a different dialect and none of them matched this
+ * server. `typescript/src/gateway/methods/config-methods.ts` does speak the
+ * dashboard's dialect, and the dashboard's own unit tests assert against it —
+ * but that module is deliberately never registered (see the doc comment on
+ * `registerBuiltinMethods`), so those tests passed while every real save
+ * failed.
+ *
+ *   dashboard  ui/src/services/config.ts   sends { raw, baseHash }
+ *   macOS Bar  RpcClient.swift             sends { config }
+ *   this server                            read  { content }
+ *
+ * These tests therefore go over real HTTP to a real GatewayServer. A test that
+ * imported the method module would reproduce the original bug exactly.
+ */
+
+let server: GatewayServer | undefined;
+let dataDir: string | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+  dataDir = undefined;
+});
+
+async function startServer(): Promise<{ port: number; configPath: string }> {
+  const port = await reserveTestPort();
+  dataDir = mkdtempSync(join(tmpdir(), 'cfg-contract-'));
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  await server.start();
+  return { port, configPath: join(dataDir, 'config.yaml') };
+}
+
+async function rpc(port: number, method: string, params?: Record<string, unknown>) {
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'c1', method, params }),
+  });
+  return (await res.json()) as { result?: Record<string, unknown>; error?: { message: string } };
+}
+
+describe('config RPC contract, against the wired gateway', () => {
+  it('config.get returns the fields the dashboard reads', async () => {
+    const { port, configPath } = await startServer();
+    writeFileSync(configPath, 'gateway:\n  port: 18790\n', 'utf-8');
+
+    const { result } = await rpc(port, 'config.get');
+
+    // ui/src/services/config.ts reads snap.raw, snap.hash, snap.format.
+    expect(result?.raw).toBe('gateway:\n  port: 18790\n');
+    expect(typeof result?.hash).toBe('string');
+    expect(result?.hash).not.toBe('');
+    expect(result?.format).toBe('yaml');
+  });
+
+  it('config.set accepts the dashboard payload and writes it', async () => {
+    const { port, configPath } = await startServer();
+    writeFileSync(configPath, 'old: true\n', 'utf-8');
+    const { result: snap } = await rpc(port, 'config.get');
+
+    const { result, error } = await rpc(port, 'config.set', {
+      raw: 'new: true\n',
+      baseHash: snap?.hash,
+    });
+
+    expect(error).toBeUndefined();
+    expect(result?.saved).toBe(true);
+    expect(readFileSync(configPath, 'utf-8')).toBe('new: true\n');
+  });
+
+  it('config.apply is registered, because the dashboard calls it', async () => {
+    const { port, configPath } = await startServer();
+    writeFileSync(configPath, 'old: true\n', 'utf-8');
+    const { result: snap } = await rpc(port, 'config.get');
+
+    const { error } = await rpc(port, 'config.apply', {
+      raw: 'applied: true\n',
+      baseHash: snap?.hash,
+    });
+
+    expect(error).toBeUndefined();
+    expect(readFileSync(configPath, 'utf-8')).toBe('applied: true\n');
+  });
+
+  it('accepts the macOS Bar payload, which names the field `config`', async () => {
+    const { port, configPath } = await startServer();
+
+    const { error } = await rpc(port, 'config.set', { config: 'from: bar\n' });
+
+    expect(error).toBeUndefined();
+    expect(readFileSync(configPath, 'utf-8')).toBe('from: bar\n');
+  });
+
+  it('still accepts the legacy `content` field', async () => {
+    const { port, configPath } = await startServer();
+
+    const { error } = await rpc(port, 'config.set', { content: 'from: legacy\n' });
+
+    expect(error).toBeUndefined();
+    expect(readFileSync(configPath, 'utf-8')).toBe('from: legacy\n');
+  });
+
+  it('refuses a payload with no config in any accepted field', async () => {
+    const { port, configPath } = await startServer();
+    writeFileSync(configPath, 'untouched: true\n', 'utf-8');
+
+    const { error } = await rpc(port, 'config.set', { nonsense: 1 });
+
+    expect(error?.message).toMatch(/requires a string/i);
+    // The point of failing loudly: the previous handler wrote `undefined` and
+    // threw a type error from deep inside fs.
+    expect(readFileSync(configPath, 'utf-8')).toBe('untouched: true\n');
+  });
+
+  it('refuses to overwrite an edit the client never saw', async () => {
+    const { port, configPath } = await startServer();
+    writeFileSync(configPath, 'v: 1\n', 'utf-8');
+    const { result: snap } = await rpc(port, 'config.get');
+
+    // Someone else saves in between.
+    writeFileSync(configPath, 'v: 2 from someone else\n', 'utf-8');
+
+    const { error } = await rpc(port, 'config.set', {
+      raw: 'v: 3 stale client\n',
+      baseHash: snap?.hash,
+    });
+
+    expect(error?.message).toMatch(/changed since it was loaded/i);
+    expect(readFileSync(configPath, 'utf-8')).toBe('v: 2 from someone else\n');
+  });
+
+  it('allows a save with no baseHash, so older clients are not locked out', async () => {
+    const { port, configPath } = await startServer();
+    writeFileSync(configPath, 'v: 1\n', 'utf-8');
+
+    const { error } = await rpc(port, 'config.set', { raw: 'v: 2\n' });
+
+    expect(error).toBeUndefined();
+    expect(readFileSync(configPath, 'utf-8')).toBe('v: 2\n');
+  });
+});

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -116,6 +116,17 @@ function safeCompare(a: string, b: string): boolean {
 
 type StreamCallback = (response: StreamingResponse) => void;
 
+/**
+ * The dashboard sends `raw`, the macOS Bar sends `config`, and this server
+ * historically read `content`. All three are accepted so an older client keeps
+ * working; `raw` is canonical.
+ */
+interface ConfigWriteParams {
+  raw?: string;
+  content?: string;
+  config?: string;
+  baseHash?: string;
+}
 export interface GatewayReadiness {
   ready: boolean;
   status: 'ready' | 'degraded';
@@ -319,6 +330,14 @@ export class GatewayServer {
 
   private saveConfig(content: string) {
     fs.writeFileSync(this.configPath, content, 'utf-8');
+  }
+
+  /**
+   * Identifies the config bytes a client last read, so a save can refuse to
+   * overwrite an edit it never saw.
+   */
+  private configHash(raw: string): string {
+    return createHash('sha256').update(raw, 'utf-8').digest('hex').slice(0, 16);
   }
 
   private get cronStorePath(): string {
@@ -2296,13 +2315,43 @@ export class GatewayServer {
     });
 
     // Config methods
+    //
+    // Three clients each spoke a different dialect here and none matched the
+    // server: the dashboard sends `raw`/`baseHash`, the macOS Bar sends
+    // `config`, and this handler read `content`. Every one of them therefore
+    // wrote `undefined` and threw ERR_INVALID_ARG_TYPE. `config.apply` was
+    // never registered at all.
+    //
+    // The canonical shape is the dashboard's (`raw` + a hash for optimistic
+    // concurrency). The older field names are accepted as aliases so a Bar
+    // built before this change keeps working, and `content` is echoed back on
+    // read for the same reason.
     this.registerMethod('config.get', async () => {
-      return { content: this.loadConfig() };
+      const raw = this.loadConfig();
+      return { raw, hash: this.configHash(raw), format: 'yaml', content: raw };
     });
-    this.registerMethod('config.set', async (params: { content: string }) => {
-      this.saveConfig(params.content);
-      return { saved: true };
-    }, { requiresAuth: true });
+
+    const writeConfig = async (params: ConfigWriteParams) => {
+      const raw = params.raw ?? params.content ?? params.config;
+      if (typeof raw !== 'string') {
+        throw new Error('config.set requires a string `raw` (or legacy `content`/`config`)');
+      }
+      // A baseHash that no longer matches means someone else wrote after this
+      // client read. Overwriting would silently discard their edit.
+      if (params.baseHash) {
+        const currentHash = this.configHash(this.loadConfig());
+        if (params.baseHash !== currentHash) {
+          throw new Error(
+            'Config changed since it was loaded; reload before saving to avoid discarding the other edit',
+          );
+        }
+      }
+      this.saveConfig(raw);
+      return { saved: true, applied: true, hash: this.configHash(raw) };
+    };
+
+    this.registerMethod('config.set', writeConfig, { requiresAuth: true });
+    this.registerMethod('config.apply', writeConfig, { requiresAuth: true });
 
     // Showcase methods
     registerShowcaseMethods(this);


### PR DESCRIPTION
Every config save from every client failed.

| client | sends |
|---|---|
| dashboard — `ui/src/services/config.ts` | `{ raw, baseHash }` |
| macOS Bar — `RpcClient.swift` | `{ config }` |
| **gateway — `server.ts`** | **read `{ content }`** |

Three dialects, none matching. `params.content` was `undefined`, so `fs.writeFileSync` threw. `config.apply` — which the dashboard calls — was **never registered at all**. And `config.get` returned `{content}` while the dashboard reads `snap.raw`, so the editor loaded empty too.

### Reproduced before fixing

```
config.apply registered in production: 0

writeFileSync(path, undefined) -> THROWS: ERR_INVALID_ARG_TYPE
file after: "original: kept\n"
```

Worth stating plainly: the config file **survives**. It throws before writing. This is a hard failure, not data loss.

### Why the tests missed it

`gateway/methods/config-methods.ts` *does* speak the dashboard's dialect, and the dashboard's unit tests assert against it:

```ts
expect(client.call).toHaveBeenCalledWith('config.set', { raw: 'new', baseHash: 'old' });
```

That module is **deliberately never registered**. The doc comment on `registerBuiltinMethods` warns about precisely this:

> `registerAllMethods` is intentionally **not** invoked here: doing so would silently duplicate or override the real, wired handlers below with divergent implementations (the exact failure mode this method's doc-comment exists to prevent).

The warning was right. The tests were simply pointed at the handler that does not run — so they passed while every real save failed.

### The fix

`raw` is canonical. `content` and `config` are accepted as aliases so a Bar built before this change keeps working, and `content` is echoed back on read for the same reason.

`baseHash` is now **honoured rather than ignored**. A save whose base no longer matches is refused instead of silently discarding whoever wrote in between — that is the entire point of the field, and it was being dropped. A save with *no* `baseHash` is still allowed, so older clients are not locked out.

The new test goes over **real HTTP to a real `GatewayServer`**. A test that imported the method module would have reproduced the original bug exactly.

### The Swift client too

`getConfig` read the payload as a bare string, and on failure serialised the whole envelope — showing the user `{"content": "..."}` instead of their YAML. It now reads the config out of the snapshot.

### Mutations (8 tests)

| mutation | result |
|---|---|
| read only `params.content` *(the original bug)* | **5 failed** |
| unregister `config.apply` | **1 failed** |
| ignore `baseHash` *(lost update)* | **1 failed** |
| `config.get` returns only `{content}` | **2 failed** |

### Verification

TypeScript `4777` passed · `tsc --noEmit` clean.
macOS `swift build` clean · `RunTests` **142 passed, 0 failed**.

The 5 failures in `copilot-cli-local.test.ts` are **pre-existing on clean main**, confirmed by stashing and re-running.

### Not addressed here

`config.patch` and `config.schema` exist only in the unregistered module, and the Bar calls `config.patch`. That is the same class of bug, but fixing it means deciding what patch semantics should be against real config — an owner call rather than a mechanical fix.
