### PR TITLE
docs: AUTONOMOUS.md told agents to call a method that does not exist

### DIFF
--- a/docs/AUTONOMOUS.md
+++ b/docs/AUTONOMOUS.md
@@ -113,7 +113,7 @@ curl -sS -X POST http://127.0.0.1:18790 \
 ```
 
 Useful methods: `agents.list`, `chat.send`, `chat.session`, `chat.list`,
-`chat.messages`, `chat.delete`, `config.get`, `config.schema`.
+`chat.messages`, `chat.delete`, `config.get`, `config.set`.
 
 To enumerate everything this build actually registers rather than trusting this
 list, ask for a method that cannot exist and read the registry from the source:

--- a/typescript/src/__tests__/docs/autonomous-rpc.test.ts
+++ b/typescript/src/__tests__/docs/autonomous-rpc.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * `docs/AUTONOMOUS.md` hands an autonomous agent a list of RPC methods to
+ * call. It listed `config.schema`, which only exists in
+ * `gateway/methods/config-methods.ts` — a module deliberately never registered
+ * — so an agent following the documentation got method-not-found.
+ *
+ * The list is now checked against a real started GatewayServer. Methods are
+ * registered in `start()` rather than the constructor, so a test that only
+ * constructs one reports every method missing and proves nothing.
+ */
+
+const DOC = resolve(__dirname, '../../../../docs/AUTONOMOUS.md');
+
+/** The backticked method names from the "Useful methods:" sentence. */
+function documentedMethods(): string[] {
+  const text = readFileSync(DOC, 'utf-8');
+  const start = text.indexOf('Useful methods:');
+  if (start === -1) throw new Error('AUTONOMOUS.md no longer lists useful methods');
+  const sentence = text.slice(start, text.indexOf('.\n', start));
+  return [...sentence.matchAll(/`([a-z]+\.[a-zA-Z]+)`/g)].map((match) => match[1]);
+}
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+async function registeredMethods(): Promise<Set<string>> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  await server.start();
+  const registry = (server as unknown as {
+    methods: Map<string, unknown>;
+  }).methods;
+  return new Set(registry.keys());
+}
+
+describe('the RPC methods AUTONOMOUS.md tells an agent to call', () => {
+  it('finds a non-empty list in the document', () => {
+    // Guards the parser: if the sentence is reworded and this silently matches
+    // nothing, the test below would pass over an empty list.
+    expect(documentedMethods().length).toBeGreaterThan(4);
+  });
+
+  it('are all registered by a running gateway', async () => {
+    const registered = await registeredMethods();
+    const missing = documentedMethods().filter((method) => !registered.has(method));
+    expect(missing).toEqual([]);
+  });
+});


### PR DESCRIPTION
`docs/AUTONOMOUS.md` hands an autonomous agent a list of RPC methods to call. One of them does not exist.

Probed against a **real started** `GatewayServer`:

```
total registered: 53
OK       agents.list      OK       chat.messages
OK       chat.send        OK       chat.delete
OK       chat.session     OK       config.get
OK       chat.list        MISSING  config.schema
```

`config.schema` exists only in `gateway/methods/config-methods.ts` — the module that is [deliberately never registered](https://github.com/kody-w/openrappter/pull/170) — and the schema it returns there is a hardcoded literal, not the real one. An agent following this document got method-not-found.

### Why the doc was corrected rather than the method registered

Registering it properly is not a small change:

- TypeScript's real schema is Zod (`src/config/schema.ts`)
- `zod-to-json-schema` is **not** a dependency
- Python's `get_config_json_schema()` is hand-written

So the options are a new production dependency, or a second hand-written schema that drifts from the first — which is precisely the defect class this repo keeps paying for (#76, #86, #169 were all one behaviour with two implementations). Neither is mine to decide unilaterally, so the doc now points at `config.set`, which is registered and useful, and the schema question is filed separately.

### The list is now checked rather than trusted

A test parses the method names out of the document and asserts each against a real started gateway. Same shape as #158, which built the Commander tree and rejected every documented subcommand absent from it.

### A trap worth recording

My first probe reported **all 8 missing** — including `config.get`, which I had just fixed in #170. Methods register in `start()`, not the constructor. The instrument was wrong, not the server; had I trusted it, I would have "fixed" seven methods that were never broken. The test starts the server for exactly this reason, and says so in a comment.

### Mutations

| mutation | result |
|---|---|
| restore `config.schema` in the doc *(the original bug)* | **1 of 2 failed** |
| strip the backticks so the parser matches nothing | **1 of 2 failed** |

The second is why the "list is non-empty" guard exists. Without it, a reworded sentence would parse to zero methods and the real assertion would pass vacuously forever — a test that cannot fail.

### Suite

`4838` passed · `tsc --noEmit` clean. The 5 `copilot-cli-local.test.ts` failures are pre-existing on clean main.
