### PR TITLE
fix(cron): the Bar's job had a prompt, the scheduler never saw it

### DIFF
--- a/macos/Sources/OpenRappterBar/Models/CronModels.swift
+++ b/macos/Sources/OpenRappterBar/Models/CronModels.swift
@@ -31,6 +31,42 @@ public struct CronJob: Codable, Identifiable, Sendable {
         self.nextRun = nextRun
         self.lastResult = lastResult
     }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, name, schedule, command, message, enabled, lastRun, nextRun, lastResult
+    }
+
+    /// The gateway calls this field `message`; this app has always called it
+    /// `command`. Decoding both means a listing from a gateway that only speaks
+    /// the canonical name still produces a job with its prompt intact, instead
+    /// of falling through to the lossy manual parse in `RpcClient`.
+    public init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        name = try c.decode(String.self, forKey: .name)
+        schedule = try c.decode(String.self, forKey: .schedule)
+        command = try c.decodeIfPresent(String.self, forKey: .command)
+            ?? c.decodeIfPresent(String.self, forKey: .message)
+            ?? ""
+        enabled = try c.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+        lastRun = try c.decodeIfPresent(Date.self, forKey: .lastRun)
+        nextRun = try c.decodeIfPresent(Date.self, forKey: .nextRun)
+        lastResult = try c.decodeIfPresent(CronResult.self, forKey: .lastResult)
+    }
+
+    /// Writes both spellings for the same reason the decoder reads both.
+    public func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(name, forKey: .name)
+        try c.encode(schedule, forKey: .schedule)
+        try c.encode(command, forKey: .message)
+        try c.encode(command, forKey: .command)
+        try c.encode(enabled, forKey: .enabled)
+        try c.encodeIfPresent(lastRun, forKey: .lastRun)
+        try c.encodeIfPresent(nextRun, forKey: .nextRun)
+        try c.encodeIfPresent(lastResult, forKey: .lastResult)
+    }
 }
 
 public enum CronResult: String, Codable, Sendable {

--- a/macos/Sources/OpenRappterBar/Services/RpcClient.swift
+++ b/macos/Sources/OpenRappterBar/Services/RpcClient.swift
@@ -410,10 +410,14 @@ public struct RpcClient: RpcClientProtocol, Sendable {
     }
 
     public func createCronJob(name: String, schedule: String, command: String) async throws {
+        // `message` is the gateway's field name — the cron store, the scheduler
+        // and the CLI all use it. This client sent `command`, so every job it
+        // created ran on schedule with an empty prompt. The gateway still
+        // accepts `command` for older builds; new builds send the real name.
         let params: [String: AnyCodable] = [
             "name": AnyCodable(name),
             "schedule": AnyCodable(schedule),
-            "command": AnyCodable(command),
+            "message": AnyCodable(command),
         ]
         let response = try await connection.sendRequest(method: "cron.create", params: params)
         guard response.ok else {

--- a/macos/Tests/OpenRappterBarTests/RpcClientContractTests.swift
+++ b/macos/Tests/OpenRappterBarTests/RpcClientContractTests.swift
@@ -630,4 +630,79 @@ func runRpcClientContractTests() async {
             await conn.disconnect()
         }
     }
+
+    await suite("RpcClient Cron Contract") {
+        // The gateway calls a cron job's prompt `message` — CronJobCreate,
+        // the scheduler, and `execute(agentId, message)` all say so. This
+        // client sent `command`, so every job the Bar created was scheduled
+        // successfully and then fired forever with an empty prompt.
+        await test("createCronJob sends cron.create with the gateway's `message` field") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkResponse(id: "rpc-2", payload: ["id": "job_1", "scheduled": true])
+            ) {
+                try await rpc.createCronJob(
+                    name: "morning brief",
+                    schedule: "0 8 * * *",
+                    command: "summarise my inbox"
+                )
+            }
+
+            let sent = try await lastSentJSON(mock)
+            try expectEqual(sent?["method"] as? String, "cron.create")
+            let params = sent?["params"] as? [String: Any]
+            try expectEqual(params?["message"] as? String, "summarise my inbox")
+            try expectEqual(params?["name"] as? String, "morning brief")
+            try expectEqual(params?["schedule"] as? String, "0 8 * * *")
+            await conn.disconnect()
+        }
+
+        // `nextRun` is the tell. `listCronJobs` has a hand-rolled fallback
+        // parser for listings the decoder rejects, and that fallback only
+        // recovers id/name/schedule/command/enabled — every schedule time is
+        // silently dropped. Decoding both spellings properly is what keeps a
+        // job's next run visible.
+        await test("a listing that names the prompt `message` decodes without losing run times") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let jobs = try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkArrayResponse(id: "rpc-2", payload: [[
+                    "id": "job_1",
+                    "name": "morning brief",
+                    "schedule": "0 8 * * *",
+                    "message": "summarise my inbox",
+                    "enabled": true,
+                    "nextRun": "2026-08-17T08:00:00.000Z",
+                ]])
+            ) {
+                try await rpc.listCronJobs()
+            }
+
+            try expectEqual(jobs.count, 1)
+            try expectEqual(jobs.first?.command, "summarise my inbox")
+            try expectNotNil(jobs.first?.nextRun)
+            await conn.disconnect()
+        }
+
+        await test("a listing that names the prompt `command` still decodes") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let jobs = try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkArrayResponse(id: "rpc-2", payload: [[
+                    "id": "job_1",
+                    "name": "morning brief",
+                    "schedule": "0 8 * * *",
+                    "command": "summarise my inbox",
+                    "enabled": true,
+                ]])
+            ) {
+                try await rpc.listCronJobs()
+            }
+
+            try expectEqual(jobs.count, 1)
+            try expectEqual(jobs.first?.command, "summarise my inbox")
+            await conn.disconnect()
+        }
+    }
 }

--- a/typescript/src/__tests__/integration/cron-create-contract.test.ts
+++ b/typescript/src/__tests__/integration/cron-create-contract.test.ts
@@ -1,0 +1,200 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GatewayServer } from '../../gateway/server.js';
+import { CronService } from '../../cron/service.js';
+import { createCronGatewayAdapter } from '../../cron/gateway-adapter.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * Binds the macOS Bar's cron payload to the handler that actually runs.
+ *
+ * `RpcClient.createCronJob` sent `{ name, schedule, command }`. Everything on
+ * the gateway side calls that field `message` — `CronJobCreate.message`, the
+ * scheduler, and the executor signature `execute(agentId, message)`. So the
+ * daemon's `setCronService({ add })` read `String(job.message ?? '')`, the job
+ * was created and scheduled, `cron.create` answered `{ scheduled: true }`, and
+ * the job then fired on its cron expression with an empty prompt forever.
+ *
+ * These tests go over real HTTP to a real `GatewayServer` with a real
+ * `CronService` wired exactly as `typescript/src/index.ts` wires it.
+ * `typescript/src/gateway/methods/cron-methods.ts` is deliberately never
+ * registered (see the doc comment on `registerBuiltinMethods`), so a test that
+ * imported it would prove nothing about production — that module has its own
+ * `action` dialect and would have passed throughout the defect's lifetime.
+ */
+
+let server: GatewayServer | undefined;
+let cron: CronService | undefined;
+let dataDir: string | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+  cron?.stop();
+  cron = undefined;
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+  dataDir = undefined;
+});
+
+/** Wires CronService into GatewayServer with the daemon's own adapter. */
+async function startServer(): Promise<{ port: number; service: CronService; fired: string[] }> {
+  const port = await reserveTestPort();
+  dataDir = mkdtempSync(join(tmpdir(), 'cron-contract-'));
+
+  const fired: string[] = [];
+  const service = new CronService();
+  await service.start({
+    execute: async (agentId: string, message: string) => {
+      fired.push(`${agentId}:${message}`);
+      return 'ok';
+    },
+  });
+  cron = service;
+
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  await server.start();
+  server.setCronService(createCronGatewayAdapter({ service, persist: () => {} }));
+
+  return { port, service, fired };
+}
+
+async function rpc(port: number, method: string, params?: Record<string, unknown>) {
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'c1', method, params }),
+  });
+  return (await res.json()) as {
+    result?: Record<string, unknown>;
+    error?: { message: string };
+  };
+}
+
+/** Exactly the params `RpcClient.createCronJob` builds, before this fix. */
+function legacyBarPayload(command: string) {
+  return { name: 'bar job', schedule: '* * * * *', command };
+}
+
+/** Exactly the params `RpcClient.createCronJob` builds now. */
+function barPayload(message: string) {
+  return { name: 'bar job', schedule: '* * * * *', message };
+}
+
+describe('cron.create contract, against the wired gateway', () => {
+  it('a job created by an older Bar carries its prompt into the live scheduler', async () => {
+    const { port, service } = await startServer();
+
+    const { error } = await rpc(port, 'cron.create', legacyBarPayload('summarise my inbox'));
+
+    expect(error).toBeUndefined();
+    const [job] = service.listJobs();
+    expect(job, 'the job must reach the live scheduler at all').toBeDefined();
+    expect(job.message).toBe('summarise my inbox');
+  });
+
+  it('a job created by an older Bar fires with its prompt, not an empty one', async () => {
+    const { port, service, fired } = await startServer();
+
+    await rpc(port, 'cron.create', legacyBarPayload('check google voice'));
+    await service.executeJob(service.listJobs()[0].id, 'force');
+
+    // The whole symptom: it ran, on time, saying nothing.
+    expect(fired).toEqual(['main:check google voice']);
+  });
+
+  it('the current Bar payload names the field `message`', async () => {
+    const { port, service } = await startServer();
+
+    const { error } = await rpc(port, 'cron.create', barPayload('summarise my inbox'));
+
+    expect(error).toBeUndefined();
+    expect(service.listJobs()[0].message).toBe('summarise my inbox');
+  });
+
+  it('`message` wins when a client sends both spellings', async () => {
+    const { port, service } = await startServer();
+
+    await rpc(port, 'cron.create', {
+      name: 'bar job', schedule: '* * * * *', message: 'canonical', command: 'legacy',
+    });
+
+    expect(service.listJobs()[0].message).toBe('canonical');
+  });
+
+  it('stores one spelling, so a persisted job cannot disagree with itself', async () => {
+    const { port } = await startServer();
+
+    const { result } = await rpc(port, 'cron.create', legacyBarPayload('summarise my inbox'));
+
+    expect(result?.message).toBe('summarise my inbox');
+    expect(result, 'the legacy alias must not survive into the record').not.toHaveProperty('command');
+  });
+
+  it('refuses a job with no prompt in any accepted spelling', async () => {
+    const { port, service } = await startServer();
+
+    const { error } = await rpc(port, 'cron.create', { name: 'bar job', schedule: '* * * * *' });
+
+    expect(error?.message).toMatch(/non-empty `message`/);
+    expect(service.listJobs(), 'nothing may be scheduled').toHaveLength(0);
+  });
+
+  it('refuses a blank prompt, which schedules a job that does nothing', async () => {
+    const { port, service } = await startServer();
+
+    const { error } = await rpc(port, 'cron.create', legacyBarPayload('   '));
+
+    expect(error?.message).toMatch(/non-empty `message`/);
+    expect(service.listJobs()).toHaveLength(0);
+  });
+
+  it('cron.add refuses the same way — it is the same handler', async () => {
+    const { port } = await startServer();
+
+    const { error } = await rpc(port, 'cron.add', { name: 'x', schedule: '* * * * *' });
+
+    expect(error?.message).toMatch(/non-empty `message`/);
+  });
+
+  it('refuses before touching the file store, so no half-written job survives', async () => {
+    // No cron service: the file-backed fallback path.
+    const port = await reserveTestPort();
+    dataDir = mkdtempSync(join(tmpdir(), 'cron-contract-'));
+    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+    await server.start();
+
+    const { error } = await rpc(port, 'cron.add', { name: 'x', schedule: '* * * * *' });
+    expect(error?.message).toMatch(/non-empty `message`/);
+
+    const { result } = await rpc(port, 'cron.list');
+    expect(result).toEqual([]);
+  });
+
+  it('the file-only fallback normalises the legacy spelling too', async () => {
+    const port = await reserveTestPort();
+    dataDir = mkdtempSync(join(tmpdir(), 'cron-contract-'));
+    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+    await server.start();
+
+    await rpc(port, 'cron.create', legacyBarPayload('from an old bar'));
+
+    const { result } = await rpc(port, 'cron.list');
+    const jobs = result as unknown as Record<string, unknown>[];
+    expect(jobs[0].message).toBe('from an old bar');
+  });
+});
+
+describe('cron.list answers in the same field name it accepts', () => {
+  it('round-trips `message`, and keeps `command` for the Bar that reads it', async () => {
+    const { port } = await startServer();
+    await rpc(port, 'cron.create', barPayload('summarise my inbox'));
+
+    const { result } = await rpc(port, 'cron.list');
+    const jobs = result as unknown as Record<string, unknown>[];
+
+    expect(jobs[0].message).toBe('summarise my inbox');
+    expect(jobs[0].command).toBe('summarise my inbox');
+  });
+});

--- a/typescript/src/cron/gateway-adapter.ts
+++ b/typescript/src/cron/gateway-adapter.ts
@@ -1,0 +1,64 @@
+/**
+ * The adapter the daemon hands to `GatewayServer.setCronService`.
+ *
+ * This lived inline in `src/index.ts`, which is a process entry point and
+ * cannot be imported by a test. That mattered: the mapping in here is one half
+ * of the client/server field contract — it decides that the scheduler is fed
+ * `job.message`, and that a listing reports `message`/`command`. The macOS Bar
+ * sent `command` on create, this side read `message`, and nothing anywhere
+ * could observe the disagreement because no test could reach this code.
+ *
+ * It is a module now so a contract test can drive the real thing.
+ */
+import type { CronService } from './service.js';
+
+/** The subset of CronService this adapter needs, so tests can supply a real one. */
+type SchedulerLike = Pick<
+  CronService,
+  'listJobs' | 'executeJob' | 'updateJob' | 'getRunLogs' | 'addJob' | 'removeJob'
+>;
+
+export interface CronGatewayAdapterOptions {
+  service: SchedulerLike;
+  /** Write the scheduler's jobs back to disk; a job that only runs now vanishes on restart. */
+  persist: () => void;
+}
+
+export function createCronGatewayAdapter({ service, persist }: CronGatewayAdapterOptions) {
+  return {
+    list: () => service.listJobs().map((j) => ({
+      id: j.id,
+      name: j.name,
+      schedule: j.schedule,
+      enabled: j.enabled,
+      // `message` is the canonical name on the wire. `command` is emitted
+      // alongside it because the macOS Bar reads that spelling; answering only
+      // in `command` was the read half of the same disagreement that made
+      // `cron.create` drop the Bar's prompt on the floor.
+      message: j.message || '',
+      command: j.message || '',
+      agentId: j.agentId || '',
+      lastRun: j.lastRun || null,
+      nextRun: j.nextRun || null,
+    })),
+    run: async (id: string) => { await service.executeJob(id, 'force'); },
+    enable: async (id: string) => { await service.updateJob(id, { enabled: true }); persist(); },
+    disable: async (id: string) => { await service.updateJob(id, { enabled: false }); persist(); },
+    getRunLogs: (jobId?: string) => service.getRunLogs(jobId),
+    add: async (job: Record<string, unknown>) => {
+      // `message` only: the gateway normalises the macOS Bar's legacy
+      // `command` spelling before it ever gets here (see `addCronJob` in
+      // gateway/server.ts), so there is exactly one place that knows about it.
+      const created = await service.addJob({
+        name: String(job.name ?? 'job'),
+        schedule: String(job.schedule ?? '*/5 * * * *'),
+        agentId: job.agentId ? String(job.agentId) : undefined,
+        message: String(job.message ?? ''),
+        enabled: job.enabled !== false,
+      });
+      persist();
+      return { id: created.id };
+    },
+    remove: async (id: string) => { await service.removeJob(id); persist(); },
+  };
+}

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -251,9 +251,24 @@ export class GatewayServer {
    * happened rather than reporting a uniform success.
    */
   private addCronJob = async (params: Record<string, unknown>): Promise<Record<string, unknown>> => {
+    // The macOS Bar called the prompt `command`; everything on this side of the
+    // wire calls it `message` — the CronJob type, the scheduler, the executor
+    // signature `execute(agentId, message)`, and the CLI. A job created from
+    // the Bar therefore reached the scheduler with `message: ''` and fired on
+    // schedule forever with nothing to say. `message` is canonical here because
+    // it is what gets persisted and re-read; `command` is accepted so a Bar
+    // binary built before this change keeps working.
+    const { command, ...rest } = params;
+    const message = rest.message ?? command;
+    if (typeof message !== 'string' || message.trim() === '') {
+      throw new Error(
+        'Cron job requires a non-empty `message` (the macOS Bar\'s legacy `command` is also accepted). '
+        + 'A job with no message runs on schedule and does nothing.',
+      );
+    }
     // `enabled` defaults to true when adding, so persisting without the field
     // would round-trip an enabled job back as a disabled one.
-    const job = { enabled: true, ...params };
+    const job = { enabled: true, ...rest, message };
     if (this.cronService?.add) {
       const created = await this.cronService.add(job);
       return { ...job, ...created, scheduled: true };

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -723,6 +723,7 @@ async function startGatewayInProcess(opts?: {
     log(`${EMOJI} Twin "${opts?.instance}" — cron and outbound channels stay with the alpha.`);
   } else try {
     const { CronService } = await import('./cron/service.js');
+    const { createCronGatewayAdapter } = await import('./cron/gateway-adapter.js');
     const cronService = new CronService();
     const cronFile = path.join(HOME_DIR, 'cron.json');
     try {
@@ -777,29 +778,7 @@ async function startGatewayInProcess(opts?: {
       if (event.type === 'job:executed' || event.type === 'job:error') persistCronJobs();
     });
 
-    server.setCronService({
-      list: () => cronService.listJobs().map(j => ({
-        id: j.id, name: j.name, schedule: j.schedule, enabled: j.enabled,
-        command: j.message || '', agentId: j.agentId || '',
-        lastRun: j.lastRun || null, nextRun: j.nextRun || null,
-      })),
-      run: async (id: string) => { await cronService.executeJob(id, 'force'); },
-      enable: async (id: string) => { await cronService.updateJob(id, { enabled: true }); persistCronJobs(); },
-      disable: async (id: string) => { await cronService.updateJob(id, { enabled: false }); persistCronJobs(); },
-      getRunLogs: (jobId?: string) => cronService.getRunLogs(jobId),
-      add: async (job: Record<string, unknown>) => {
-        const created = await cronService.addJob({
-          name: String(job.name ?? 'job'),
-          schedule: String(job.schedule ?? '*/5 * * * *'),
-          agentId: job.agentId ? String(job.agentId) : undefined,
-          message: String(job.message ?? ''),
-          enabled: job.enabled !== false,
-        });
-        persistCronJobs();
-        return { id: created.id };
-      },
-      remove: async (id: string) => { await cronService.removeJob(id); persistCronJobs(); },
-    });
+    server.setCronService(createCronGatewayAdapter({ service: cronService, persist: persistCronJobs }));
     // Send cron job results to Telegram when connected
     const CRON_TELEGRAM_CHAT_ID = process.env.CRON_TELEGRAM_CHAT_ID || '8055092758';
     cronService.onEvent(async (event) => {


### PR DESCRIPTION
The macOS Bar could create a cron job, be told it was scheduled, watch it run on time — and it said nothing, every time.

| client | sends the prompt as |
|---|---|
| macOS Bar — `RpcClient.createCronJob` | **`command`** |
| CLI — `src/cli/cron.ts` | `message` |
| **gateway — `setCronService({ add })`** | **reads `message`** |

## Reproduced before fixing

A real `CronService` wired to a real `GatewayServer` exactly as `typescript/src/index.ts` wires it, driven over real HTTP with the exact params `RpcClient.createCronJob` builds:

```
Bar payload  -> {"name":"bar job","schedule":"* * * * *","command":"summarise my inbox"}
cron.create  -> {"enabled":true,"name":"bar job","schedule":"* * * * *","command":"summarise my inbox","id":"job_1786927513254_1","scheduled":true}
live job     -> {"id":"job_1786927513254_1","name":"bar job","schedule":"* * * * *","agentId":"main","message":"","enabled":true}
stored message = ""   <-- SYMPTOM: empty
cron.list    -> [{"id":"job_...","name":"bar job","schedule":"* * * * *","enabled":true,"command":"","agentId":"main","lastRun":null,"nextRun":"2026-08-17T00:46:00.000Z"}]

CLI payload  -> {"name":"cli job","schedule":"* * * * *","message":"summarise my inbox"}
live job     -> {"id":"job_...","name":"cli job","agentId":"main","message":"summarise my inbox"}

force-running both jobs to show what the executor receives:
>>> JOB FIRED agent=main message=""
>>> JOB FIRED agent=main message="summarise my inbox"
executions: ["main:\"\"","main:\"summarise my inbox\""]
```

Note what *did* work: the job reached the live scheduler, got an id, got a `nextRun`, and reported `scheduled: true`. #166 fixed jobs that never ran. This one ran perfectly and carried nothing. `cron.list` then echoed `command: ""` back, so the Bar's own list showed the job with a blank command — the only visible symptom, and easy to read as a display bug.

The same script after the fix:

```
Bar payload  -> {"name":"bar job","schedule":"* * * * *","command":"summarise my inbox"}
cron.create  -> {"enabled":true,"name":"bar job","schedule":"* * * * *","message":"summarise my inbox","id":"job_1786927830831_1","scheduled":true}
live job     -> {"id":"job_...","name":"bar job","schedule":"* * * * *","agentId":"main","message":"summarise my inbox","enabled":true}
cron.list    -> [{...,"message":"summarise my inbox","command":"summarise my inbox","agentId":"main",...}]

>>> JOB FIRED agent=main message="summarise my inbox"
>>> JOB FIRED agent=main message="summarise my inbox"
```

## Which side is canonical: `message`, the gateway's

- It is what gets **persisted**. `persistCronJobs()` writes `cronService.listJobs()` to `~/.openrappter/cron.json` and `loadJobs()` reads it back as `CronJob.message`. Renaming server-side would orphan every job already on disk.
- It is the type contract end to end: `CronJobCreate.message`, `CronJobPatch.message`, and the executor signature `JobExecutor.execute(agentId, message)`.
- The CLI already speaks it, and that was itself a prior fix — `src/cli/cron.ts` carries the comment *"These key names are the gateway's contract, not this file's choice."*
- The gateway is the contract other clients also speak; the Bar is one client of several.

So the Bar now sends `message`, and the gateway accepts `command` as an alias — a Bar binary built before this change keeps working, exactly as #170 did for `config`/`content`.

Two details beyond the straight rename:

**The alias is normalised away, not stored.** `addCronJob` destructures `command` out and writes only `message`, so no persisted record can carry two spellings that later disagree. There is exactly one place in the codebase that knows the legacy name.

**A job with no prompt is now refused.** Previously `String(job.message ?? '')` turned a missing field into `''` and scheduled it anyway — that coercion is what made this defect silent for its whole life. There is no registered `cron.update`, so an empty job could never be repaired either; it just ran forever saying nothing. Now `cron.add`/`cron.create` reject it. No wired test sent a message-less payload, so nothing legitimate is locked out.

## Why the tests missed it

`src/gateway/methods/cron-methods.ts` is deliberately never registered (see the doc comment on `registerBuiltinMethods`), and it speaks a *third* dialect — `action`. `src/__tests__/parity/dashboard-rpc.test.ts` asserts against it happily:

```ts
await server.call('cron.add', { schedule: '*/5 * * * *', action: 'health-check', enabled: true });
```

Those 41 tests passed throughout. The new test therefore goes over real HTTP to a real `GatewayServer` with a real `CronService`.

That exposed a second gap: the `add`/`list` mapping that actually reads `job.message` lived inline in `src/index.ts`, a process entry point no test can import. It is now `src/cron/gateway-adapter.ts`, and both `index.ts` and the contract test use that one object — so the test binds to production wiring on both halves, not to a copy.

## Field-by-field audit of the Bar's cron payload

The Bar sends only three fields on create. Everything the Bar sends and reads, checked against the gateway:

| field | Bar | gateway | verdict |
|---|---|---|---|
| `name` | `name` | `String(job.name ?? 'job')` | ✅ agrees |
| `schedule` | `schedule` | `String(job.schedule ?? '*/5 * * * *')` | ✅ agrees |
| prompt | **`command`** | **`message`** | ❌ **the bug — fixed** |
| `enabled` | not sent | defaults `true` in both `addCronJob` and `CronService.addJob` | ✅ agrees, and #164's round-trip fix holds |
| `agentId` | not sent | defaults to `'main'` | ⚠️ see below — **not fixed here** |
| `id` | not sent on create; `jobId` on delete/pause/resume/trigger/get | `jobId` everywhere | ✅ agrees (fixed for the CLI in #155, confirmed for the Bar in #166) |
| listing prompt | reads `command`, falls back to `message` | returned `command` only | ⚠️ fixed additively — see below |

**`agentId` — a real second defect, reported not fixed.** The Bar has no agent picker, so `CronService.addJob` applies its default `agentId: 'main'`. The daemon's executor routes only `'Assistant'` and `NAME` (`'openrappter'`) to the main assistant; anything else goes to `agents.get(agentId)`, and agent ids come from `*Agent.ts` filenames — there is no `mainAgent.ts`, so `'main'` resolves to nothing and the run returns `Agent not found: main`. This is **not Bar-specific**: `openrappter cron add` without `-a` produces the identical job, and the CLI's own help says that means *"the main assistant"*. It is a distinct bug about which agent `'main'` denotes — an owner call, not a mechanical rename — so it is reported here rather than fixed. It does mean a Bar-created job needs that follow-up before it is end-to-end useful; this PR is what makes the prompt survive the trip.

**The listing was the read half of the same disagreement.** `cron.list` answered in `command` only, so a client speaking the gateway's own canonical name got no prompt back at all. It now returns `message` **and** `command`; the Bar keeps reading the spelling it always read. Symmetrically, `CronJob` in Swift now decodes either name. That matters more than it looks: `listCronJobs` has a hand-rolled fallback parser for listings the decoder rejects, and that fallback silently drops `lastRun`/`nextRun` — so without it, a canonical listing would render every job with no schedule times. The new Swift test asserts `nextRun` survives, which is what distinguishes the two paths.

**Also noticed, not touched.** `cron.update` is not registered on the gateway at all, yet `RpcClient.updateCronJob` exists (currently unreferenced by any view). And `cron.get` searches `cronStore`, the file-only fallback, never `cronService` — so `getCronJob` cannot find any job on a host with a live scheduler. Both are the same family; neither is this bug.

## Mutation table

Every mutation applied to the fixed source, the targeted suite re-run, then reverted.

| # | Mutation | Failing | Which |
|---|---|---|---|
| A | Restore `const job = { enabled: true, ...params }` — *the original bug* | **8** | prompt reaches scheduler; job fires with its prompt; one spelling stored; all four refusal tests; file-only fallback normalises |
| B | Keep the alias, drop the empty-prompt guard | **4** | refuses missing prompt; refuses blank prompt; `cron.add` refuses identically; refuses before touching the file store |
| C | `command ?? message` — legacy alias wins over canonical | **1** | `message` wins when a client sends both |
| D | `{ ...params, message }` — keep the legacy field in the record | **1** | stores one spelling, so a persisted job cannot disagree with itself |
| E | `cron.list` answers in `command` only | **1** | round-trips `message`, and keeps `command` for the Bar |
| F | Swift: `createCronJob` sends `command` again | **1** | `createCronJob` sends `cron.create` with the gateway's `message` field |
| G | Swift: drop `CronJob`'s two-spelling decoder | **1** | a `message` listing decodes without losing run times |

Both halves are covered independently: **the prompt is lost on the way in** (A, C, F) and **the prompt is lost on the way back** (E, G), plus **an empty job is accepted silently** (A, B).

## Validation

- New `src/__tests__/integration/cron-create-contract.test.ts` — **11 passed**.
- `src/gateway/__tests__/cron-add-live.test.ts`, `src/cli/__tests__/cron-add-contract.test.ts`, `src/__tests__/parity/dashboard-rpc.test.ts`, `src/cron/` — 82 passed, no changes needed.
- Full suite: `Tests 5 failed | 4847 passed | 21 skipped (4873)`. The 5 are the known pre-existing `src/providers/copilot-cli-local.test.ts` failures (an ambient `/opt/homebrew/bin/copilot`), unrelated.
- `tsc --noEmit -p tsconfig.json` — clean. `eslint` on all four changed/added TS files — clean.
- macOS: `swift build` clean, `swift run RunTests` — **145 passed, 0 failed** (142 before; +3 new cron contract tests).
