### PR TITLE
fix(install): the Windows installer started a gateway that was a chat prompt

### DIFF
--- a/docs/install.ps1
+++ b/docs/install.ps1
@@ -85,6 +85,12 @@ $REPO_URL       = "https://github.com/kody-w/openrappter.git"
 $MIN_NODE       = 20
 $HOME_DIR       = Join-Path $env:USERPROFILE ".openrappter"
 $GATEWAY_PID    = Join-Path $HOME_DIR "gateway.pid"
+# The port the readiness probe knocks on. It must be the port the gateway
+# actually binds, so it follows the CLI's own precedence: OPENRAPPTER_PORT, then
+# the alpha's default. Probing a port the gateway never bound would report a
+# failure for a healthy daemon, which is the same lie as reporting success for a
+# dead one, only inverted.
+$GATEWAY_PORT   = if ($env:OPENRAPPTER_PORT) { [int]$env:OPENRAPPTER_PORT } else { 18790 }
 $CLIENT_ID      = "Iv1.b507a08c87ecfe98"
 $COPILOT_SCOPE  = "read:user"
 $INSTALL_STAGE  = 0
@@ -627,6 +633,103 @@ function Stop-GatewayIfRunning {
     }
 }
 
+function Resolve-GatewayEntry {
+    param([string]$LauncherPath)
+
+    # `Get-Command openrappter` finds a launcher, not the JavaScript entry point,
+    # and dist/index.js is not one level above that launcher under EITHER install
+    # method: `npm install -g` leaves the shim in %APPDATA%\npm with the package
+    # under node_modules\, and the git method writes .openrappter\bin\openrappter.cmd
+    # for a build that lives in .openrappter\typescript\dist. The old
+    # "<launcher>\..\dist\index.js" guess therefore named a file that exists in
+    # neither layout, so node exited immediately with MODULE_NOT_FOUND.
+    $candidates = New-Object System.Collections.Generic.List[string]
+
+    if ($LauncherPath) {
+        $launcherDir = Split-Path $LauncherPath
+        # npm -g on Windows: shim in <prefix>, package under <prefix>\node_modules
+        $candidates.Add([System.IO.Path]::Combine($launcherDir, "node_modules", "openrappter", "dist", "index.js"))
+        # npm -g with a Unix-style prefix: shim in <prefix>\bin, package under <prefix>\lib\node_modules
+        $candidates.Add([System.IO.Path]::Combine($launcherDir, "..", "lib", "node_modules", "openrappter", "dist", "index.js"))
+        # Launcher shipped inside the package itself (bin\ sits next to dist\)
+        $candidates.Add([System.IO.Path]::Combine($launcherDir, "..", "dist", "index.js"))
+    }
+
+    # git method: .openrappter\bin\openrappter.cmd runs .openrappter\typescript\dist\index.js
+    $candidates.Add([System.IO.Path]::Combine($InstallDir, "typescript", "dist", "index.js"))
+
+    try {
+        $npmRoot = (Invoke-Npm root -g | Where-Object { $_ } | Select-Object -Last 1)
+        if ($npmRoot) {
+            $candidates.Add([System.IO.Path]::Combine($npmRoot.ToString().Trim(), "openrappter", "dist", "index.js"))
+        }
+    } catch {
+        # `npm root -g` is one hint among several; its absence is not fatal.
+    }
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    return $null
+}
+
+function Test-GatewayAnswering {
+    param([int]$Port)
+
+    # /readyz is handled before the origin check in gateway/server.ts, so a
+    # loopback probe needs no token and no Origin header.
+    try {
+        $response = Invoke-WebRequest -Uri "http://127.0.0.1:$Port/readyz" `
+            -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+        return [pscustomobject]@{
+            Answering = ($response.StatusCode -eq 200)
+            Detail    = "answered HTTP $($response.StatusCode)"
+        }
+    } catch {
+        # Connection refused while it boots, or 503 while it is still degraded.
+        return [pscustomobject]@{ Answering = $false; Detail = $_.Exception.Message }
+    }
+}
+
+function Wait-GatewayReady {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [int]$Port,
+        [int]$TimeoutSeconds = 60
+    )
+
+    # A PID is not readiness. Start-Process hands back an ID for a process that
+    # has already died, so the only honest evidence that a gateway is serving is
+    # a gateway answering.
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastReason = "no response on port $Port"
+
+    while ((Get-Date) -lt $deadline) {
+        if ($Process.HasExited) {
+            return [pscustomobject]@{
+                Ready  = $false
+                Reason = "the process exited with code $($Process.ExitCode) before answering on port $Port"
+            }
+        }
+
+        $probe = Test-GatewayAnswering -Port $Port
+        if ($probe.Answering) {
+            return [pscustomobject]@{ Ready = $true; Reason = $null }
+        }
+        $lastReason = "port $Port not ready yet ($($probe.Detail))"
+
+        Start-Sleep -Milliseconds 500
+    }
+
+    return [pscustomobject]@{
+        Ready  = $false
+        Reason = "timed out after $TimeoutSeconds seconds -- $lastReason"
+    }
+}
+
 function Start-GatewayBrainstem {
     Write-Info "Starting gateway brainstem daemon..."
     if ($DryRun) {
@@ -636,29 +739,63 @@ function Start-GatewayBrainstem {
 
     $openrappterBin = Get-Command openrappter -ErrorAction SilentlyContinue
     if (-not $openrappterBin) {
-        Write-Warn "openrappter not on PATH -- skipping gateway start. Restart your terminal and run: openrappter gateway"
+        Write-Warn "openrappter not on PATH -- skipping gateway start. Restart your terminal and run: openrappter --daemon"
+        return
+    }
+
+    $entry = Resolve-GatewayEntry -LauncherPath $openrappterBin.Source
+    if (-not $entry) {
+        Write-Warn "Could not locate the gateway entry point (dist\index.js) -- skipping gateway start."
+        Write-Info "Start manually with: openrappter --daemon"
+        return
+    }
+
+    # A gateway already answering on this port would satisfy the readiness probe
+    # below no matter what was launched, so "this PID is serving" is only a
+    # claim worth making when the port was silent first.
+    if ((Test-GatewayAnswering -Port $GATEWAY_PORT).Answering) {
+        Write-Success "Gateway already running on port $GATEWAY_PORT"
         return
     }
 
     try {
-        # Start gateway in background
+        # `openrappter gateway` is not a registered command. Commander read the
+        # word as the [message] positional, sent it to the model as a chat
+        # prompt, printed an answer about network gateways, and exited 0 -- while
+        # this installer recorded its PID and announced a running daemon. The
+        # daemon is `--daemon`, and no port is passed so the CLI keeps its own
+        # port precedence, which $GATEWAY_PORT mirrors.
         $proc = Start-Process -FilePath "node" `
-            -ArgumentList @((Join-Path (Join-Path (Join-Path (Split-Path $openrappterBin.Source) "..") "dist") "index.js"), "gateway") `
+            -ArgumentList @($entry, "--daemon") `
             -WindowStyle Hidden `
             -PassThru `
             -ErrorAction Stop
-
-        # Save PID
-        if (-not (Test-Path $HOME_DIR)) {
-            New-Item -ItemType Directory -Path $HOME_DIR -Force | Out-Null
-        }
-        $proc.Id | Set-Content -Path $GATEWAY_PID
-
-        Write-Success "Gateway brainstem started (PID $($proc.Id), port 18790)"
     } catch {
         Write-Warn "Could not start gateway: $_"
-        Write-Info "Start manually with: openrappter gateway"
+        Write-Info "Start manually with: openrappter --daemon"
+        return
     }
+
+    $readiness = Wait-GatewayReady -Process $proc -Port $GATEWAY_PORT
+    if (-not $readiness.Ready) {
+        Write-Warn "Gateway did not become ready: $($readiness.Reason)"
+        if (-not $proc.HasExited) {
+            # Leave nothing half-started behind to hold the port and confuse the
+            # next run's probe.
+            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        }
+        Write-Info "Start manually with: openrappter --daemon"
+        return
+    }
+
+    # Recorded only now: the file says "a gateway answered on this port", not
+    # "a process was spawned".
+    if (-not (Test-Path $HOME_DIR)) {
+        New-Item -ItemType Directory -Path $HOME_DIR -Force | Out-Null
+    }
+    $proc.Id | Set-Content -Path $GATEWAY_PID
+
+    Write-Success "Gateway brainstem ready (PID $($proc.Id), port $GATEWAY_PORT)"
 }
 
 # ── Doctor ───────────────────────────────────────────────────────────────────
@@ -845,7 +982,7 @@ function Main {
     Write-Kv "Check status" "openrappter --status"
     Write-Kv "List agents"  "openrappter --list-agents"
     Write-Kv "Chat"         'openrappter "hello"'
-    Write-Kv "Start gateway" "openrappter gateway"
+    Write-Kv "Start gateway" "openrappter --daemon"
     if ($Method -eq "git") {
         Write-Kv "Install dir" $InstallDir
         Write-Kv "Update"      "cd $InstallDir && git pull && cd typescript && npm run build"

--- a/install.ps1
+++ b/install.ps1
@@ -85,6 +85,12 @@ $REPO_URL       = "https://github.com/kody-w/openrappter.git"
 $MIN_NODE       = 20
 $HOME_DIR       = Join-Path $env:USERPROFILE ".openrappter"
 $GATEWAY_PID    = Join-Path $HOME_DIR "gateway.pid"
+# The port the readiness probe knocks on. It must be the port the gateway
+# actually binds, so it follows the CLI's own precedence: OPENRAPPTER_PORT, then
+# the alpha's default. Probing a port the gateway never bound would report a
+# failure for a healthy daemon, which is the same lie as reporting success for a
+# dead one, only inverted.
+$GATEWAY_PORT   = if ($env:OPENRAPPTER_PORT) { [int]$env:OPENRAPPTER_PORT } else { 18790 }
 $CLIENT_ID      = "Iv1.b507a08c87ecfe98"
 $COPILOT_SCOPE  = "read:user"
 $INSTALL_STAGE  = 0
@@ -627,6 +633,103 @@ function Stop-GatewayIfRunning {
     }
 }
 
+function Resolve-GatewayEntry {
+    param([string]$LauncherPath)
+
+    # `Get-Command openrappter` finds a launcher, not the JavaScript entry point,
+    # and dist/index.js is not one level above that launcher under EITHER install
+    # method: `npm install -g` leaves the shim in %APPDATA%\npm with the package
+    # under node_modules\, and the git method writes .openrappter\bin\openrappter.cmd
+    # for a build that lives in .openrappter\typescript\dist. The old
+    # "<launcher>\..\dist\index.js" guess therefore named a file that exists in
+    # neither layout, so node exited immediately with MODULE_NOT_FOUND.
+    $candidates = New-Object System.Collections.Generic.List[string]
+
+    if ($LauncherPath) {
+        $launcherDir = Split-Path $LauncherPath
+        # npm -g on Windows: shim in <prefix>, package under <prefix>\node_modules
+        $candidates.Add([System.IO.Path]::Combine($launcherDir, "node_modules", "openrappter", "dist", "index.js"))
+        # npm -g with a Unix-style prefix: shim in <prefix>\bin, package under <prefix>\lib\node_modules
+        $candidates.Add([System.IO.Path]::Combine($launcherDir, "..", "lib", "node_modules", "openrappter", "dist", "index.js"))
+        # Launcher shipped inside the package itself (bin\ sits next to dist\)
+        $candidates.Add([System.IO.Path]::Combine($launcherDir, "..", "dist", "index.js"))
+    }
+
+    # git method: .openrappter\bin\openrappter.cmd runs .openrappter\typescript\dist\index.js
+    $candidates.Add([System.IO.Path]::Combine($InstallDir, "typescript", "dist", "index.js"))
+
+    try {
+        $npmRoot = (Invoke-Npm root -g | Where-Object { $_ } | Select-Object -Last 1)
+        if ($npmRoot) {
+            $candidates.Add([System.IO.Path]::Combine($npmRoot.ToString().Trim(), "openrappter", "dist", "index.js"))
+        }
+    } catch {
+        # `npm root -g` is one hint among several; its absence is not fatal.
+    }
+
+    foreach ($candidate in $candidates) {
+        if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+            return (Resolve-Path -LiteralPath $candidate).Path
+        }
+    }
+
+    return $null
+}
+
+function Test-GatewayAnswering {
+    param([int]$Port)
+
+    # /readyz is handled before the origin check in gateway/server.ts, so a
+    # loopback probe needs no token and no Origin header.
+    try {
+        $response = Invoke-WebRequest -Uri "http://127.0.0.1:$Port/readyz" `
+            -UseBasicParsing -TimeoutSec 5 -ErrorAction Stop
+        return [pscustomobject]@{
+            Answering = ($response.StatusCode -eq 200)
+            Detail    = "answered HTTP $($response.StatusCode)"
+        }
+    } catch {
+        # Connection refused while it boots, or 503 while it is still degraded.
+        return [pscustomobject]@{ Answering = $false; Detail = $_.Exception.Message }
+    }
+}
+
+function Wait-GatewayReady {
+    param(
+        [System.Diagnostics.Process]$Process,
+        [int]$Port,
+        [int]$TimeoutSeconds = 60
+    )
+
+    # A PID is not readiness. Start-Process hands back an ID for a process that
+    # has already died, so the only honest evidence that a gateway is serving is
+    # a gateway answering.
+    $deadline = (Get-Date).AddSeconds($TimeoutSeconds)
+    $lastReason = "no response on port $Port"
+
+    while ((Get-Date) -lt $deadline) {
+        if ($Process.HasExited) {
+            return [pscustomobject]@{
+                Ready  = $false
+                Reason = "the process exited with code $($Process.ExitCode) before answering on port $Port"
+            }
+        }
+
+        $probe = Test-GatewayAnswering -Port $Port
+        if ($probe.Answering) {
+            return [pscustomobject]@{ Ready = $true; Reason = $null }
+        }
+        $lastReason = "port $Port not ready yet ($($probe.Detail))"
+
+        Start-Sleep -Milliseconds 500
+    }
+
+    return [pscustomobject]@{
+        Ready  = $false
+        Reason = "timed out after $TimeoutSeconds seconds -- $lastReason"
+    }
+}
+
 function Start-GatewayBrainstem {
     Write-Info "Starting gateway brainstem daemon..."
     if ($DryRun) {
@@ -636,29 +739,63 @@ function Start-GatewayBrainstem {
 
     $openrappterBin = Get-Command openrappter -ErrorAction SilentlyContinue
     if (-not $openrappterBin) {
-        Write-Warn "openrappter not on PATH -- skipping gateway start. Restart your terminal and run: openrappter gateway"
+        Write-Warn "openrappter not on PATH -- skipping gateway start. Restart your terminal and run: openrappter --daemon"
+        return
+    }
+
+    $entry = Resolve-GatewayEntry -LauncherPath $openrappterBin.Source
+    if (-not $entry) {
+        Write-Warn "Could not locate the gateway entry point (dist\index.js) -- skipping gateway start."
+        Write-Info "Start manually with: openrappter --daemon"
+        return
+    }
+
+    # A gateway already answering on this port would satisfy the readiness probe
+    # below no matter what was launched, so "this PID is serving" is only a
+    # claim worth making when the port was silent first.
+    if ((Test-GatewayAnswering -Port $GATEWAY_PORT).Answering) {
+        Write-Success "Gateway already running on port $GATEWAY_PORT"
         return
     }
 
     try {
-        # Start gateway in background
+        # `openrappter gateway` is not a registered command. Commander read the
+        # word as the [message] positional, sent it to the model as a chat
+        # prompt, printed an answer about network gateways, and exited 0 -- while
+        # this installer recorded its PID and announced a running daemon. The
+        # daemon is `--daemon`, and no port is passed so the CLI keeps its own
+        # port precedence, which $GATEWAY_PORT mirrors.
         $proc = Start-Process -FilePath "node" `
-            -ArgumentList @((Join-Path (Join-Path (Join-Path (Split-Path $openrappterBin.Source) "..") "dist") "index.js"), "gateway") `
+            -ArgumentList @($entry, "--daemon") `
             -WindowStyle Hidden `
             -PassThru `
             -ErrorAction Stop
-
-        # Save PID
-        if (-not (Test-Path $HOME_DIR)) {
-            New-Item -ItemType Directory -Path $HOME_DIR -Force | Out-Null
-        }
-        $proc.Id | Set-Content -Path $GATEWAY_PID
-
-        Write-Success "Gateway brainstem started (PID $($proc.Id), port 18790)"
     } catch {
         Write-Warn "Could not start gateway: $_"
-        Write-Info "Start manually with: openrappter gateway"
+        Write-Info "Start manually with: openrappter --daemon"
+        return
     }
+
+    $readiness = Wait-GatewayReady -Process $proc -Port $GATEWAY_PORT
+    if (-not $readiness.Ready) {
+        Write-Warn "Gateway did not become ready: $($readiness.Reason)"
+        if (-not $proc.HasExited) {
+            # Leave nothing half-started behind to hold the port and confuse the
+            # next run's probe.
+            Stop-Process -Id $proc.Id -Force -ErrorAction SilentlyContinue
+        }
+        Write-Info "Start manually with: openrappter --daemon"
+        return
+    }
+
+    # Recorded only now: the file says "a gateway answered on this port", not
+    # "a process was spawned".
+    if (-not (Test-Path $HOME_DIR)) {
+        New-Item -ItemType Directory -Path $HOME_DIR -Force | Out-Null
+    }
+    $proc.Id | Set-Content -Path $GATEWAY_PID
+
+    Write-Success "Gateway brainstem ready (PID $($proc.Id), port $GATEWAY_PORT)"
 }
 
 # ── Doctor ───────────────────────────────────────────────────────────────────
@@ -845,7 +982,7 @@ function Main {
     Write-Kv "Check status" "openrappter --status"
     Write-Kv "List agents"  "openrappter --list-agents"
     Write-Kv "Chat"         'openrappter "hello"'
-    Write-Kv "Start gateway" "openrappter gateway"
+    Write-Kv "Start gateway" "openrappter --daemon"
     if ($Method -eq "git") {
         Write-Kv "Install dir" $InstallDir
         Write-Kv "Update"      "cd $InstallDir && git pull && cd typescript && npm run build"

--- a/typescript/src/__tests__/unit/install-ps1-gateway.test.ts
+++ b/typescript/src/__tests__/unit/install-ps1-gateway.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFile } from 'child_process';
+import fs from 'fs/promises';
+import path from 'path';
+import { promisify } from 'util';
+import { fileURLToPath } from 'url';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const srcRoot = path.resolve(__dirname, '../..');
+const tsRoot = path.resolve(srcRoot, '..');
+const repoRoot = path.resolve(tsRoot, '..');
+
+const INSTALL_PS1 = path.join(repoRoot, 'install.ps1');
+const DOCS_INSTALL_PS1 = path.join(repoRoot, 'docs', 'install.ps1');
+
+/**
+ * The installer's gateway launch, checked against the CLI that actually ships.
+ *
+ * `install.ps1` started the gateway with `node <entry> gateway`. `gateway` is
+ * not a registered command, so Commander read it as the `[message]` positional
+ * and sent the word to the model as a chat prompt: the process answered a
+ * question about network gateways and exited 0 while the installer recorded its
+ * PID and announced a running daemon.
+ *
+ * Source-text assertions could not have caught that, because the string
+ * `"gateway"` is perfectly well-formed. Only a comparison against the real
+ * registered surface can. So these tests run the CLI, read its help, and reject
+ * any argv token the CLI does not register — the same shape of contract PR #158
+ * used for the voice-call skill.
+ */
+
+interface CommandSurface {
+  commands: Set<string>;
+  options: Set<string>;
+}
+
+/**
+ * The command surface as the CLI itself reports it.
+ *
+ * Run through `tsx` against `src/index.ts` rather than `dist/`, so the contract
+ * is measured against the current source and never against a stale build.
+ */
+async function readCommandSurface(): Promise<CommandSurface> {
+  const tsx = path.join(tsRoot, 'node_modules', '.bin', 'tsx');
+  const { stdout } = await execFileAsync(tsx, [path.join(srcRoot, 'index.ts'), '--help'], {
+    cwd: tsRoot,
+    timeout: 120_000,
+    env: { ...process.env, NO_COLOR: '1' },
+  });
+
+  const commands = new Set<string>();
+  const options = new Set<string>();
+
+  let section: 'commands' | 'options' | null = null;
+  for (const rawLine of stdout.split('\n')) {
+    if (/^Commands:/.test(rawLine)) { section = 'commands'; continue; }
+    if (/^Options:/.test(rawLine)) { section = 'options'; continue; }
+    if (/^[A-Za-z].*:\s*$/.test(rawLine)) { section = null; continue; }
+    if (!section) continue;
+
+    // Only the entry lines are indented by exactly two spaces; continuation
+    // lines of a wrapped description are indented further.
+    const entry = /^ {2}(\S.*)$/.exec(rawLine);
+    if (!entry) continue;
+
+    if (section === 'commands') {
+      const name = /^([a-z][\w-]*)/.exec(entry[1]);
+      if (name) commands.add(name[1]);
+    } else {
+      for (const flag of entry[1].matchAll(/(--[\w-]+|-[A-Za-z])(?=[\s,]|$)/g)) {
+        options.add(flag[1]);
+      }
+    }
+  }
+
+  return { commands, options };
+}
+
+/** The body of a single PowerShell function, up to the next top-level function. */
+function functionBody(script: string, name: string): string {
+  const start = script.indexOf(`function ${name}`);
+  expect(start, `${name} should exist in install.ps1`).toBeGreaterThanOrEqual(0);
+  const next = script.indexOf('\nfunction ', start + 1);
+  return next === -1 ? script.slice(start) : script.slice(start, next);
+}
+
+/**
+ * The literal argv the installer hands the CLI.
+ *
+ * Extracted from the shipped script rather than restated here, so the test
+ * reads whatever the installer will really run. Variable tokens (`$entry`) are
+ * the interpreter path and carry no command surface, so only string literals
+ * are returned.
+ */
+function launchedCliArgs(script: string): string[] {
+  const body = functionBody(script, 'Start-GatewayBrainstem');
+  const marker = body.indexOf('-ArgumentList @(');
+  expect(marker, 'the gateway launch should pass an -ArgumentList').toBeGreaterThanOrEqual(0);
+
+  const open = body.indexOf('(', marker + '-ArgumentList @'.length);
+  let depth = 0;
+  let close = -1;
+  for (let i = open; i < body.length; i++) {
+    if (body[i] === '(') depth++;
+    else if (body[i] === ')') {
+      depth--;
+      if (depth === 0) { close = i; break; }
+    }
+  }
+  expect(close, 'the -ArgumentList should be balanced').toBeGreaterThan(open);
+
+  const inner = body.slice(open + 1, close);
+  return [...inner.matchAll(/"([^"$]*)"|'([^']*)'/g)]
+    .map(match => (match[1] ?? match[2]).trim())
+    .filter(token => token.length > 0);
+}
+
+describe('install.ps1 gateway start', () => {
+  let script: string;
+  let surface: CommandSurface;
+
+  beforeAll(async () => {
+    script = await fs.readFile(INSTALL_PS1, 'utf-8');
+    surface = await readCommandSurface();
+  }, 180_000);
+
+  it('reads a non-empty command surface from the CLI', () => {
+    // Guards the rest of the file: an empty surface would make every argv look
+    // unregistered, and an unparsed one would make every argv look fine.
+    expect(surface.commands.size).toBeGreaterThan(0);
+    expect(surface.options.has('--daemon')).toBe(true);
+    expect(surface.commands.has('doctor')).toBe(true);
+  });
+
+  it('launches the gateway with argv the CLI registers', () => {
+    const unregistered = launchedCliArgs(script).filter(token =>
+      token.startsWith('-') ? !surface.options.has(token) : !surface.commands.has(token),
+    );
+
+    expect(unregistered).toEqual([]);
+  });
+
+  it('launches a mode that actually serves a gateway', () => {
+    // `--daemon` is the only argv that binds the port the installer then
+    // reports. Passing a registered but unrelated command would satisfy the
+    // check above while still starting no gateway.
+    expect(launchedCliArgs(script)).toContain('--daemon');
+  });
+
+  it('never advertises a command the CLI does not register', () => {
+    // The closing summary told users to run `openrappter gateway` — the same
+    // non-command, reaching them as advice instead of as a silent failure.
+    const advertised = [
+      // The "What's next" table: Write-Kv <label> <command>.
+      ...[...script.matchAll(/Write-Kv\s+"[^"]*"\s+(?:"([^"]*)"|'([^']*)')/g)]
+        .map(match => match[1] ?? match[2]),
+      // Prose that hands the user a command to type.
+      ...[...script.matchAll(/(?:run|with):\s*(openrappter [^"']+)/g)].map(match => match[1]),
+    ]
+      .map(line => line.trim())
+      .filter(line => line.startsWith('openrappter '));
+
+    expect(advertised.length).toBeGreaterThan(0);
+
+    for (const line of advertised) {
+      const token = line.split(/\s+/)[1];
+      if (token.startsWith('-')) {
+        expect(
+          surface.options.has(token),
+          `install.ps1 advertises "${line}", but the CLI registers no ${token} option`,
+        ).toBe(true);
+      } else if (/^[a-z][\w-]*$/.test(token)) {
+        expect(
+          surface.commands.has(token),
+          `install.ps1 advertises "${line}", which the CLI does not register`,
+        ).toBe(true);
+      }
+      // Anything else is a quoted argument, e.g. openrappter "hello".
+    }
+  });
+
+  it('probes an endpoint the gateway actually serves', async () => {
+    const body = functionBody(script, 'Test-GatewayAnswering');
+    const probed = /http:\/\/127\.0\.0\.1:\$Port(\/[\w-]+)/.exec(body);
+    expect(probed, 'the readiness probe should name a loopback URL path').not.toBeNull();
+
+    // A typo here would poll a 404 forever and report a healthy gateway as
+    // failed, so the path is checked against the server that has to answer it.
+    const server = await fs.readFile(path.join(srcRoot, 'gateway', 'server.ts'), 'utf-8');
+    expect(server).toContain(`req.url === '${probed![1]}'`);
+  });
+
+  it('does not credit itself with a gateway that was already running', () => {
+    // Any gateway already bound to the port answers the probe regardless of
+    // what was just launched, so the pre-flight check has to run before the
+    // launch for the readiness result to mean anything.
+    const body = functionBody(script, 'Start-GatewayBrainstem');
+    const preflight = body.indexOf('Test-GatewayAnswering');
+    const launch = body.indexOf('Start-Process');
+
+    expect(preflight).toBeGreaterThanOrEqual(0);
+    expect(preflight).toBeLessThan(launch);
+  });
+
+  it('treats process exit as failure rather than waiting out the timeout', () => {
+    const body = functionBody(script, 'Wait-GatewayReady');
+    expect(body).toContain('HasExited');
+    expect(body).toMatch(/TimeoutSeconds/);
+  });
+
+  it('reports success only after readiness, never on a PID alone', () => {
+    const body = functionBody(script, 'Start-GatewayBrainstem');
+
+    const launch = body.indexOf('Start-Process');
+    const readiness = body.indexOf('Wait-GatewayReady');
+    const gate = body.indexOf('if (-not $readiness.Ready)');
+    const recordPid = body.indexOf('Set-Content -Path $GATEWAY_PID');
+    // Only the line that claims a PID is at stake here; the "already running"
+    // branch reports a gateway it probed rather than one it launched.
+    const pidClaim = [...body.matchAll(/Write-Success[^\r\n]*/g)]
+      .find(match => match[0].includes('$proc.Id'));
+
+    expect(launch).toBeGreaterThanOrEqual(0);
+    expect(readiness).toBeGreaterThan(launch);
+    expect(gate).toBeGreaterThan(readiness);
+    expect(pidClaim, 'the launch should report the PID it verified').toBeDefined();
+    // A PID is not readiness. Both the recorded PID and the success line must
+    // sit behind the gate, or the installer is back to announcing a daemon it
+    // never observed.
+    expect(recordPid).toBeGreaterThan(gate);
+    expect(pidClaim!.index).toBeGreaterThan(gate);
+  });
+
+  it('gives up on a gateway that never answers instead of claiming one', () => {
+    const body = functionBody(script, 'Start-GatewayBrainstem');
+    const failure = body.slice(body.indexOf('if (-not $readiness.Ready)'));
+    expect(failure).toContain('Write-Warn');
+    expect(failure).toContain('$($readiness.Reason)');
+    // The failure path has to leave the function without recording a PID.
+    expect(failure.indexOf('return')).toBeLessThan(failure.indexOf('Set-Content'));
+  });
+
+  it('verifies the entry point exists before launching node', () => {
+    const body = functionBody(script, 'Resolve-GatewayEntry');
+    expect(body).toContain('Test-Path');
+
+    const start = functionBody(script, 'Start-GatewayBrainstem');
+    const resolve = start.indexOf('Resolve-GatewayEntry');
+    const guard = start.indexOf('if (-not $entry)');
+    const launch = start.indexOf('Start-Process');
+
+    expect(resolve).toBeGreaterThanOrEqual(0);
+    expect(guard).toBeGreaterThan(resolve);
+    expect(launch).toBeGreaterThan(guard);
+  });
+
+  it('ships the same script it serves from docs/', async () => {
+    // `irm https://kody-w.github.io/openrappter/install.ps1 | iex` fetches the
+    // docs/ copy. Fixing only the repo root would leave every piped install on
+    // the broken script.
+    const served = await fs.readFile(DOCS_INSTALL_PS1, 'utf-8');
+    expect(served).toBe(script);
+  });
+});


### PR DESCRIPTION
## The gateway the installer started was a chat prompt

`install.ps1` started the gateway like this:

```powershell
$proc = Start-Process -FilePath "node" `
    -ArgumentList @((Join-Path (Join-Path (Join-Path (Split-Path $openrappterBin.Source) "..") "dist") "index.js"), "gateway") `
    -WindowStyle Hidden -PassThru -ErrorAction Stop
$proc.Id | Set-Content -Path $GATEWAY_PID
Write-Success "Gateway brainstem started (PID $($proc.Id), port 18790)"
```

`gateway` is not a registered command. Commander reads it as the `[message]`
positional and sends it to the model as a chat prompt. Run against the real CLI:

```console
$ node dist/index.js gateway

🦖 openrappter: Sure! The term **"gateway"** can have several meanings depending on the context.

### 1. **Networking & Computers**
- **Gateway** refers to a device or software that connects two different networks...
$ echo $?
0
```

It burns an API call, answers a question about network gateways, exits 0, and
binds nothing. The installer then recorded that PID and announced a daemon.

### argv vs. the registered command surface

| installer argv | registered? |
|---|---|
| `gateway` | **no** — not a command; falls through to the `[message]` positional |
| `--daemon` | yes — `-d, --daemon` |

The full top-level surface, from `openrappter --help`:

```
Commands: onboard, service, imessage, reset, bar, channel, call, twin, cron,
          config, doctor, twins, hatch, flight, show-and-tell
Options:  -V/--version, -t/--task, -e/--evolve, -d/--daemon, --instance,
          --port, -s/--status, -l/--list-agents, --exec, --web, -h/--help
```

`gateway` appears in neither list. `index.ts` already carries a comment about
the identical bug one line above `program.parse()`:

> ``// `openrappter cron` was not a command at all. Commander read it as a chat
> message, which is why asking for `cron add --help` printed the top-level help
> instead of an error.``

### The entry path was wrong under both install methods

`Get-Command openrappter` finds a launcher, not the JS entry point, and
`<launcher>\..\dist\index.js` exists in neither layout the installer produces:

| method | launcher | old guess | real location |
|---|---|---|---|
| `npm install -g` | `%APPDATA%\npm\openrappter.cmd` | `%APPDATA%\dist\index.js` | `%APPDATA%\npm\node_modules\openrappter\dist\index.js` |
| `--method git` | `%USERPROFILE%\.openrappter\bin\openrappter.cmd` | `%USERPROFILE%\.openrappter\dist\index.js` | `%USERPROFILE%\.openrappter\typescript\dist\index.js` |

So node had nothing to run and exited immediately — which is exactly the case a
PID cannot distinguish from success.

## The fix

- launch `--daemon`, the argv that binds the port
- resolve `dist/index.js` against the layouts npm and the git method actually
  produce, and skip the start with a warning when none exists
- poll `/readyz` until the gateway answers, with process exit treated as
  immediate failure and the wait bounded at 60s
- record the PID and report success **only** behind that gate; on failure, stop
  anything left half-started and print the manual command
- skip the launch when a gateway already answers on the port, since a
  pre-existing one would satisfy the probe no matter what was launched
- stop advertising `openrappter gateway` in the "What's next" table

`docs/install.ps1` is the copy `irm | iex` and `install.bat` fetch, so it
carries the same fix, and a test now pins the two together.

## Contract, not another source-text promise

`"gateway"` is a perfectly well-formed string; no source-text assertion could
have caught it. So the test runs the CLI, reads the surface it registers, and
rejects any argv token the installer passes that the CLI does not know — the
shape PR #158 used for the voice-call skill.

Against the unfixed script:

```text
× launches the gateway with argv the CLI registers
  → expected [ 'gateway' ] to deeply equal []
```

### Mutation table

Every fix reverted independently, applied to both copies of the script:

| mutation | result | caught by |
|---|---|---|
| *(baseline, fixed)* | 11 passed | — |
| `--daemon` → `gateway` (the original bug) | **2 failed / 9 passed** | argv registered; mode serves a gateway |
| `--daemon` → `doctor` (registered, but starts no gateway) | **1 failed / 10 passed** | mode serves a gateway |
| record PID + report success before the gate | **1 failed / 10 passed** | success only after readiness |
| drop the probe, trust the PID | **1 failed / 10 passed** | success only after readiness |
| stop treating process exit as failure | **1 failed / 10 passed** | process exit is failure |
| probe `/ready` instead of `/readyz` | **1 failed / 10 passed** | probes an endpoint the gateway serves |
| failure path records a PID anyway | **1 failed / 10 passed** | gives up instead of claiming |
| drop the `Test-Path` guard before launching node | **1 failed / 10 passed** | entry verified before launch |
| restore `openrappter gateway` in "What's next" | **1 failed / 10 passed** | never advertises an unregistered command |
| check the port only *after* launching | **1 failed / 10 passed** | does not credit a pre-existing gateway |
| fix the repo root, leave `docs/` on the old script | **1 failed / 10 passed** | ships the same script it serves |

No mutation survived.

## What was and was not executed on Windows

**Nothing was executed on Windows.** No Windows machine, and no Windows
PowerShell 5.1, was involved at any point.

`pwsh` was not installed on this macOS host (`which pwsh` → nothing), so I
fetched a portable PowerShell 7.4.6 to verify more than syntax. What that did
and did not establish:

**Executed, and passing:**

- *Parser validation.* `[Parser]::ParseFile()` on both copies: clean, 4199
  tokens each. Not a smoke test of behaviour, but it rules out syntax errors.
- *The readiness logic itself,* under pwsh 7.4.6 on macOS. A harness extracted
  `Resolve-GatewayEntry`, `Test-GatewayAnswering` and `Wait-GatewayReady` from
  `install.ps1` **via the PowerShell AST** — so it ran the shipped code, not a
  copy — and drove them against real processes:

  ```text
  Loaded from install.ps1: Resolve-GatewayEntry, Test-GatewayAnswering, Wait-GatewayReady
    PASS  finds the git-method build under <InstallDir>/typescript/dist
    PASS  returns null rather than a path that does not exist
    PASS  reports a silent port as not answering
          reason: the process exited with code 0 before answering on port 18902
    PASS  rejects a process that exits 0 without ever binding
          reason: timed out after 4 seconds -- port 18902 not ready yet (Connection refused)
    PASS  times out on a process that stays up but binds nothing
          ready after 0.5s
    PASS  reports ready once a real gateway answers, and only then
    PASS  reports the port as silent again once the gateway is gone
  ```

  The third case is the old bug's exact signature — a real `openrappter`
  process that prints, exits 0 and binds nothing. The old code called that a
  running gateway; the new code names the exit code.

- *The `/readyz` contract it depends on,* against a real daemon on macOS:

  ```console
  $ node dist/index.js --daemon --port 18899
  $ curl -i http://127.0.0.1:18899/readyz
  HTTP/1.1 200 OK
  {"ready":true,"status":"ready","timestamp":"..."}
  ```

  `/readyz` is handled before the origin check in `gateway/server.ts`, so the
  loopback probe needs no token and no `Origin` header. A test also pins the
  probed path against that handler, so a typo cannot poll a 404 forever.

**Not executed, and unverified:**

- the whole script end to end, on any platform;
- anything under **Windows PowerShell 5.1** — the harness ran pwsh 7. In
  particular `Invoke-WebRequest -UseBasicParsing` and `[pscustomobject]` behave
  differently enough between the two engines that I will not claim them;
- `Start-Process -WindowStyle Hidden` (a no-op on macOS);
- the **npm-global path candidates** (`%APPDATA%\npm\node_modules\...`) and
  `Invoke-Npm root -g`. Only the git-method candidate was exercised, because
  it is the only layout that exists on this host. The candidates are derived
  from reading `Install-ViaNpm`/`Install-ViaGit`, not from observation.

## Also checked: install.sh and install.bat

**`install.sh` does not have this bug — it never starts a gateway at all.**
`detect_and_restart_gateway()` only *stops* one on upgrade and leaves it to
auto-start on next invocation. There is no `openrappter gateway` anywhere in
it, and no start to report falsely.

It does carry a weaker version of the same shape, which I have **not** changed:

```bash
kill "$pid" 2>/dev/null || true
sleep 1
rm -f "$pid_file"
ui_success "Gateway stopped (will auto-start on next use)"
```

`kill` is sent, one second is slept, and "stopped" is announced without ever
checking that the process died. `Stop-GatewayIfRunning` in `install.ps1` has the
identical shape. Both claim an outcome they did not observe, but neither is the
reported defect, and fixing the stop path is a separate change.

**`install.bat` has no gateway logic.** It is pure delegation — it tries `pwsh`,
falls back to `powershell`, and runs the local `install.ps1` or downloads
`https://kody-w.github.io/openrappter/install.ps1`. That download is the
`docs/` copy, which is why this PR fixes both copies and pins them together.

## Unresolved: `Start-GatewayBrainstem` has no call site

While reproducing this I found that **`Start-GatewayBrainstem` is never
called** — not on `main`, and not after this PR:

```console
$ git show main:install.ps1 | grep -n "Start-GatewayBrainstem"
630:function Start-GatewayBrainstem {
```

One match: the definition. So the defects above are real and exactly as
described in the code, but they are currently **latent** — no user sees the
false success today, because on Windows the installer never attempts a gateway
start at all. The script's own header still advertises "gateway brainstem
startup" as a feature.

I did not wire it up, deliberately. `install.sh` **intentionally** does not
start a gateway either — it defers to auto-start on first invocation — so
enabling this path would make Windows diverge from the POSIX installer, and
that is a product decision rather than a bug fix. It is also the one change I
could not test on the platform it affects. Flagging it for a maintainer: either
call `Start-GatewayBrainstem` (it is now correct if you do) or delete it and
the header claim.

## Validation

- new contract test: **11 passed**
- full TypeScript suite: **4847 passed**, 21 skipped, **5 failed** — all five in
  `src/providers/copilot-cli-local.test.ts`, the known pre-existing failures on
  this host, in a file this PR does not touch. Confirmed stable across two
  consecutive full runs. (One earlier run showed a sixth failure in a second
  file; it did not reproduce in either subsequent full run and I could not
  identify it. This host is shared with other worktrees running builds.)
- `tsc --noEmit`: clean
- `[Parser]::ParseFile()` on `install.ps1` and `docs/install.ps1`: clean
