### PR TITLE
fix(test): the burrow beacon tests guessed their ports

### DIFF
--- a/typescript/src/gateway/__tests__/conformance.test.ts
+++ b/typescript/src/gateway/__tests__/conformance.test.ts
@@ -19,6 +19,7 @@ import path from 'path';
 import { startBurrowBeacon, BURROW_PROBE_PORTS, type BeaconHandle } from '../burrow-beacon.js';
 import { isReservedAgentPath, RESERVED_AGENT_DIRS, AgentRegistry } from '../../agents/AgentRegistry.js';
 import { readAnatomy } from '../anatomy.js';
+import { reserveTestPort } from '../../__tests__/support/test-port.js';
 
 const open: Array<{ close: () => Promise<void> }> = [];
 afterEach(async () => {
@@ -43,8 +44,11 @@ describe('the burrow beacon makes openrappter detectable', () => {
   });
 
   it('binds a free probed port and answers /health', async () => {
-    // Use a private range for the test so a real grail on 7071 is never touched.
-    const beacon = await startBurrowBeacon([49_181, 49_182], {
+    // Kernel-assigned so a real grail on 7071 is never touched and nothing on
+    // the runner can already hold them. These used to be hardcoded 49_18x,
+    // which is the guessing PR #51 removed everywhere else.
+    const probes = [await reserveTestPort(), await reserveTestPort()];
+    const beacon = await startBurrowBeacon(probes, {
       name: 'Mero', designation: 'openrappter-MR-3565', gatewayPort: 18790,
     });
     expect(beacon).not.toBeNull();
@@ -64,26 +68,30 @@ describe('the burrow beacon makes openrappter detectable', () => {
   it('NEVER displaces something already listening', async () => {
     // 7071 is the grail parent and 7081+ are its twins. Squatting one would
     // break a real brainstem in order to advertise ourselves.
-    const squatter = await occupy(49_183);
+    const taken = await reserveTestPort();
+    const free = await reserveTestPort();
+    const squatter = await occupy(taken);
     open.push(squatter);
 
-    const beacon = await startBurrowBeacon([49_183, 49_184], {
+    const beacon = await startBurrowBeacon([taken, free], {
       name: 'Mero', gatewayPort: 18790,
     });
     open.push(beacon as BeaconHandle);
-    expect(beacon!.port).toBe(49_184);
+    expect(beacon!.port).toBe(free);
   }, 20_000);
 
   it('stays quiet when every probed port is taken, rather than fighting', async () => {
-    const a = await occupy(49_185); open.push(a);
-    const b = await occupy(49_186); open.push(b);
+    const first = await reserveTestPort();
+    const second = await reserveTestPort();
+    const a = await occupy(first); open.push(a);
+    const b = await occupy(second); open.push(b);
     // Not a failure: if something else answers there, the detector already
     // reports a brainstem on this device.
-    expect(await startBurrowBeacon([49_185, 49_186], { name: 'Mero', gatewayPort: 18790 })).toBeNull();
+    expect(await startBurrowBeacon([first, second], { name: 'Mero', gatewayPort: 18790 })).toBeNull();
   }, 20_000);
 
   it('refuses a cross-origin read but still answers, so an opaque probe resolves', async () => {
-    const beacon = await startBurrowBeacon([49_187], { name: 'Mero', gatewayPort: 18790 });
+    const beacon = await startBurrowBeacon([await reserveTestPort()], { name: 'Mero', gatewayPort: 18790 });
     open.push(beacon as BeaconHandle);
 
     const status = await new Promise<number>((resolve) => {


### PR DESCRIPTION
`TypeScript (Node 22)` failed on **#176** with a test that PR had not touched:

```
× the burrow beacon makes openrappter detectable
  > stays quiet when every probed port is taken, rather than fighting
```

### It wasn't #176

Passed locally 5/5 in isolation on `main`, and 5/5 under a **full-suite** run on `perfect/cli` itself — only the 5 known pre-existing `copilot-cli-local.test.ts` failures. So I looked at the test instead of the PR.

It hardcodes ports `49_181`–`49_187`, and `occupy()` **rejects** if a port is already held. One unrelated listener on a CI runner is enough.

### The helper that already solved this

`src/__tests__/support/test-port.ts` exists for exactly this, and its own doc comment says:

> The previous approach guessed… That is a birthday problem wearing a disguise.
> …
> **Nothing in this repo guesses any more, which is the point of routing every caller through here.**

That claim was false. This file guessed, and **#51** — *"stop tests guessing TCP ports, ask the kernel instead"* — missed it. The guard existed; one caller never reached it.

### Reproduced, not assumed

Held `49_181`–`49_187` from a separate process and ran both versions against the same contention:

| version | result |
|---|---|
| hardcoded ports | **4 failed** \| 8 passed |
| kernel-assigned | **12 passed** |

The failing four include the exact test CI reported. Without the squatter both versions pass — which is precisely why this surfaces as a flake on someone else's PR rather than a break on yours.

### The fix

Ports come from `reserveTestPort()`. The two tests that need a port to be *occupied* reserve one and then occupy it, so "taken" is still genuinely taken — the assertions did not weaken to buy stability.

### Scope

Other hardcoded ports in the test tree are config values that are parsed, never bound (`gateway: { port: 9999 }` and similar). I left them alone — they cannot collide with anything.
