### PR TITLE
fix(cli): login printed the first 20 characters of both tokens

### DIFF
--- a/typescript/src/cli/__tests__/login-no-token-echo.test.ts
+++ b/typescript/src/cli/__tests__/login-no-token-echo.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Command } from 'commander';
+
+/**
+ * `openrappter login` printed the first 20 characters of the access token, and
+ * of the refresh token when one was issued.
+ *
+ * A prefix is still credential material. It lands in terminal scrollback and in
+ * CI logs, and it narrows a brute force. Nothing about "did the flow work"
+ * requires showing any part of the secret.
+ *
+ * The command is not currently registered, so this was unreachable — which is
+ * exactly why it needed a test. An unreachable leak is a leak waiting for
+ * somebody to register the command.
+ */
+
+vi.mock('../../auth/oauth.js', () => ({
+  initiateOAuthFlow: vi.fn(async () => ({
+    accessToken: ['S3CR3T', 'access', 'aaaaaaaaaaaaaaaaaaaaaaaaaaaa'].join('-'),
+    refreshToken: ['S3CR3T', 'refresh', 'bbbbbbbbbbbbbbbbbbbbbbbbbbbb'].join('-'),
+  })),
+}));
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+async function runLogin(): Promise<string> {
+  const { registerLoginCommand } = await import('../login.js');
+  const lines: string[] = [];
+  vi.spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  });
+  vi.spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+    lines.push(args.map(String).join(' '));
+  });
+
+  const program = new Command();
+  program.exitOverride();
+  registerLoginCommand(program);
+  await program.parseAsync(['node', 'openrappter', 'login', 'github']);
+  return lines.join('\n');
+}
+
+describe('login never prints credential material', () => {
+  it('does not print the access token, or any prefix of it', async () => {
+    const output = await runLogin();
+    expect(output).not.toContain('S3CR3T-access');
+    // A prefix is the actual regression this guards: substring(0, 20) of the
+    // token above still starts with the same marker.
+    expect(output).not.toMatch(/S3CR3T/);
+  });
+
+  it('does not print the refresh token', async () => {
+    const output = await runLogin();
+    expect(output).not.toContain('S3CR3T-refresh');
+  });
+
+  it('still tells the user the flow succeeded', async () => {
+    // Without this, deleting all output would satisfy the tests above.
+    const output = await runLogin();
+    expect(output).toMatch(/successful/i);
+    expect(output).toMatch(/github/i);
+  });
+});

--- a/typescript/src/cli/login.ts
+++ b/typescript/src/cli/login.ts
@@ -30,9 +30,13 @@ export function registerLoginCommand(program: Command): void {
       try {
         const result = await initiateOAuthFlow(provider, { port });
         console.log('\n\x1b[32mAuthentication successful!\x1b[0m');
-        console.log(`\nAccess token: ${result.accessToken.substring(0, 20)}...`);
+        // Deliberately prints nothing derived from the tokens. A prefix is
+        // still credential material: it goes to terminal scrollback and to CI
+        // logs, and it narrows a brute force. The user does not need to see a
+        // token to know the flow worked.
+        console.log(`Signed in to ${provider}.`);
         if (result.refreshToken) {
-          console.log(`Refresh token: ${result.refreshToken.substring(0, 20)}...`);
+          console.log('A refresh token was issued.');
         }
         console.log('\nCredentials have been saved to your config.');
       } catch (err) {


### PR DESCRIPTION
```js
console.log(`\nAccess token: ${result.accessToken.substring(0, 20)}...`);
console.log(`Refresh token: ${result.refreshToken.substring(0, 20)}...`);
```

A prefix is still credential material. It lands in terminal scrollback and in CI logs, and it narrows a brute force. Nothing about *"did the flow work"* requires showing any part of the secret.

Found by the agent that did #176 — which reported the access token. There were **two**.

### Severity, stated honestly

I verified it is unreachable before treating it as low severity:

- `login` does not appear in the built CLI's `--help`
- nothing outside `src/cli/login.ts` imports it

So this is a latent leak in an unregistered command, not a live one.

That is precisely why it needed a **test** rather than a shrug. An unreachable leak is a leak waiting for someone to register the command — and #176 showed this repo has a habit of exactly that: ten modules sat implemented, exported and unregistered until somebody wired them up. The next person to register `login` would have had no signal that it prints tokens.

### The fix

It now says it signed in and names the provider. `result.accessToken` is no longer read at all.

Two details in the test:

- Values are assembled at runtime, so secret scanning cannot rewrite a literal and make the test pass for the wrong reason.
- The assertion is on the *marker*, not the whole token, because the bug was a **prefix** — an assertion on the full token would have passed against the original code.

### Mutations

| mutation | result |
|---|---|
| restore the original echo | **2 of 3 failed** |
| print nothing at all | **1 of 3 failed** |

The second is why the "still tells the user it succeeded" test exists. Deleting all output would otherwise satisfy both leak assertions — a fix that passes by saying nothing.

### Suite

`4926` passed · `tsc --noEmit` clean. The 5 `copilot-cli-local.test.ts` failures are pre-existing on clean main.

### Not fixed here

The module still persists nothing while reporting `"Credentials have been saved to your config."` It stays unregistered. #176 deliberately left it that way rather than half-fixing it, and I agree — making it honest is a separate piece of work.
