### PR TITLE
fix(cron): the gateway denied a job it had just created

### DIFF
--- a/typescript/src/__tests__/integration/cron-get-update-contract.test.ts
+++ b/typescript/src/__tests__/integration/cron-get-update-contract.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GatewayServer } from '../../gateway/server.js';
+import { CronService } from '../../cron/service.js';
+import { createCronGatewayAdapter } from '../../cron/gateway-adapter.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * `cron.get` read only the gateway's file fallback, never the live scheduler.
+ * So the gateway would create a job, answer `{ scheduled: true }`, and then
+ * deny that the job existed:
+ *
+ *   cron.create -> {"id":"job_...","scheduled":true}
+ *   live jobs   -> job_...
+ *   cron.get    -> Job not found: job_...
+ *
+ * `cron.update` was not registered at all, though the macOS Bar calls it and
+ * `CronService.updateJob` has always existed.
+ *
+ * Both are the split that made `cron.delete` lie in #166: two stores, and a
+ * handler wired to the one that is not authoritative.
+ *
+ * These go over real HTTP to a real GatewayServer with a real CronService,
+ * wired by the daemon's own adapter. `gateway/methods/cron-methods.ts` is
+ * deliberately never registered, so a test importing it would prove nothing.
+ */
+
+let server: GatewayServer | undefined;
+let cron: CronService | undefined;
+let dataDir: string | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+  cron?.stop();
+  cron = undefined;
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+  dataDir = undefined;
+});
+
+async function startServer(): Promise<number> {
+  const port = await reserveTestPort();
+  dataDir = mkdtempSync(join(tmpdir(), 'cron-get-'));
+
+  const service = new CronService();
+  await service.start({ execute: async () => 'ok' });
+  cron = service;
+
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  await server.start();
+  server.setCronService(createCronGatewayAdapter({ service, persist: () => {} }));
+  return port;
+}
+
+async function rpc(port: number, method: string, params?: Record<string, unknown>) {
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'c1', method, params }),
+  });
+  return (await res.json()) as {
+    result?: Record<string, unknown>;
+    error?: { message: string };
+  };
+}
+
+async function createJob(port: number): Promise<string> {
+  const { result } = await rpc(port, 'cron.create', {
+    name: 'contract', schedule: '* * * * *', agentId: 'Assistant', message: 'hello',
+  });
+  expect(result?.scheduled).toBe(true);
+  return String(result?.id);
+}
+
+describe('cron.get and cron.update reach the scheduler that actually holds the job', () => {
+  it('finds a job the gateway itself just created', async () => {
+    const port = await startServer();
+    const id = await createJob(port);
+
+    const { result, error } = await rpc(port, 'cron.get', { jobId: id });
+
+    expect(error).toBeUndefined();
+    expect(result?.id).toBe(id);
+    expect(result?.message).toBe('hello');
+  });
+
+  it('still refuses an id that exists nowhere', async () => {
+    const port = await startServer();
+
+    const { error } = await rpc(port, 'cron.get', { jobId: 'no-such-job' });
+
+    expect(error?.message).toMatch(/not found/i);
+  });
+
+  it('cron.update is registered, because the Bar calls it', async () => {
+    const port = await startServer();
+    const id = await createJob(port);
+
+    const { result, error } = await rpc(port, 'cron.update', { jobId: id, enabled: false });
+
+    expect(error).toBeUndefined();
+    expect(result?.enabled).toBe(false);
+  });
+
+  it('an update is visible to the next read, not just in its own reply', async () => {
+    const port = await startServer();
+    const id = await createJob(port);
+
+    await rpc(port, 'cron.update', { jobId: id, message: 'changed' });
+    const { result } = await rpc(port, 'cron.get', { jobId: id });
+
+    expect(result?.message).toBe('changed');
+  });
+
+  it('accepts the Bar spelling `command` and stores it as `message`', async () => {
+    const port = await startServer();
+    const id = await createJob(port);
+
+    await rpc(port, 'cron.update', { jobId: id, command: 'from the bar' });
+    const { result } = await rpc(port, 'cron.get', { jobId: id });
+
+    expect(result?.message).toBe('from the bar');
+  });
+
+  it('refuses to update an id that does not exist, rather than reporting success', async () => {
+    const port = await startServer();
+
+    const { error } = await rpc(port, 'cron.update', { jobId: 'ghost', enabled: false });
+
+    expect(error?.message).toMatch(/not found/i);
+  });
+
+  it('describes a job the same way in get and list', async () => {
+    // Two readers of one job that disagree is how the `command`/`message`
+    // split survived as long as it did.
+    const port = await startServer();
+    const id = await createJob(port);
+
+    const got = (await rpc(port, 'cron.get', { jobId: id })).result;
+    const listed = ((await rpc(port, 'cron.list')).result as unknown as { jobs?: unknown[] });
+    const fromList = (Array.isArray(listed) ? listed : listed?.jobs ?? [])
+      .find((j) => (j as { id?: string }).id === id);
+
+    expect(fromList).toBeDefined();
+    expect(Object.keys(got ?? {}).sort()).toEqual(Object.keys(fromList as object).sort());
+  });
+});

--- a/typescript/src/cron/gateway-adapter.ts
+++ b/typescript/src/cron/gateway-adapter.ts
@@ -11,11 +11,12 @@
  * It is a module now so a contract test can drive the real thing.
  */
 import type { CronService } from './service.js';
+import type { CronJob } from './types.js';
 
 /** The subset of CronService this adapter needs, so tests can supply a real one. */
 type SchedulerLike = Pick<
   CronService,
-  'listJobs' | 'executeJob' | 'updateJob' | 'getRunLogs' | 'addJob' | 'removeJob'
+  'listJobs' | 'executeJob' | 'updateJob' | 'getRunLogs' | 'addJob' | 'removeJob' | 'getJob'
 >;
 
 export interface CronGatewayAdapterOptions {
@@ -24,23 +25,40 @@ export interface CronGatewayAdapterOptions {
   persist: () => void;
 }
 
+/** One shape for a job on the wire, so `list` and `get` cannot disagree. */
+function onTheWire(j: CronJob) {
+  return {
+    id: j.id,
+    name: j.name,
+    schedule: j.schedule,
+    enabled: j.enabled,
+    // `message` is the canonical name on the wire. `command` is emitted
+    // alongside it because the macOS Bar reads that spelling; answering only
+    // in `command` was the read half of the same disagreement that made
+    // `cron.create` drop the Bar's prompt on the floor.
+    message: j.message || '',
+    command: j.message || '',
+    agentId: j.agentId || '',
+    lastRun: j.lastRun || null,
+    nextRun: j.nextRun || null,
+  };
+}
+
 export function createCronGatewayAdapter({ service, persist }: CronGatewayAdapterOptions) {
   return {
-    list: () => service.listJobs().map((j) => ({
-      id: j.id,
-      name: j.name,
-      schedule: j.schedule,
-      enabled: j.enabled,
-      // `message` is the canonical name on the wire. `command` is emitted
-      // alongside it because the macOS Bar reads that spelling; answering only
-      // in `command` was the read half of the same disagreement that made
-      // `cron.create` drop the Bar's prompt on the floor.
-      message: j.message || '',
-      command: j.message || '',
-      agentId: j.agentId || '',
-      lastRun: j.lastRun || null,
-      nextRun: j.nextRun || null,
-    })),
+    list: () => service.listJobs().map(onTheWire),
+    // Without this the gateway read only its file fallback, so a job the
+    // scheduler had just created and confirmed was reported as not found.
+    get: (id: string) => {
+      const job = service.getJob(id);
+      return job ? onTheWire(job) : undefined;
+    },
+    update: async (id: string, patch: Record<string, unknown>) => {
+      const updated = await service.updateJob(id, patch);
+      if (!updated) return undefined;
+      persist();
+      return onTheWire(updated);
+    },
     run: async (id: string) => { await service.executeJob(id, 'force'); },
     enable: async (id: string) => { await service.updateJob(id, { enabled: true }); persist(); },
     disable: async (id: string) => { await service.updateJob(id, { enabled: false }); persist(); },

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -2312,10 +2312,48 @@ export class GatewayServer {
       return { enabled: true };
     }, { requiresAuth: true });
     this.registerMethod('cron.get', async (params: { jobId: string }) => {
+      // The live scheduler first: it holds jobs created this process, which the
+      // file fallback does not see until a persist. Reading only the fallback
+      // made the gateway deny a job it had just created and confirmed.
+      const service = this.cronService as unknown as {
+        get?: (id: string) => Record<string, unknown> | undefined;
+      } | undefined;
+      const live = service?.get?.(params.jobId);
+      if (live) return live;
+
       const job = this.cronStore.find((j) => (j as { id: string }).id === params.jobId);
       if (!job) throw new Error(`Job not found: ${params.jobId}`);
       return job;
     });
+    this.registerMethod('cron.update', async (params: Record<string, unknown>) => {
+      const jobId = String(params.jobId ?? '');
+      if (!jobId) throw new Error('cron.update requires a jobId');
+
+      const { jobId: _ignored, ...patch } = params;
+      // The Bar spells the prompt `command`; `message` is canonical everywhere
+      // on this side. Normalised here so no record stores both spellings.
+      if (patch.command !== undefined && patch.message === undefined) {
+        patch.message = patch.command;
+      }
+      delete patch.command;
+
+      const service = this.cronService as unknown as {
+        update?: (id: string, patch: Record<string, unknown>) => Promise<Record<string, unknown> | undefined>;
+      } | undefined;
+      if (service?.update) {
+        const updated = await service.update(jobId, patch);
+        if (!updated) throw new Error(`Cron job not found: ${jobId}`);
+        return updated;
+      }
+
+      const job = this.cronStore.find((j) => (j as { id: string }).id === jobId) as
+        | Record<string, unknown>
+        | undefined;
+      if (!job) throw new Error(`Cron job not found: ${jobId}`);
+      Object.assign(job, patch);
+      this.saveCronStore();
+      return job;
+    }, { requiresAuth: true });
     this.registerMethod('cron.logs', async (params: Record<string, unknown>) => {
       if (this.cronService) {
         const svc = this.cronService as unknown as { getRunLogs?: (jobId?: string) => unknown[] };


### PR DESCRIPTION
Reproduced against a real `GatewayServer` with a real `CronService`, wired by the daemon's own adapter:

```
cron.create -> {"id":"job_1786931338992_1","scheduled":true}
live jobs   -> job_1786931338992_1
cron.get    -> Job not found: job_1786931338992_1
cron.update -> Method not found: cron.update
```

The gateway creates a job, confirms it is scheduled, and then denies it exists.

### Two defects

**`cron.get` read only `this.cronStore`** — the file fallback — and never the live scheduler. `cron.logs`, directly below it, *does* check the service first. So a job created in this process was invisible until something persisted it.

**`cron.update` was never registered**, though the macOS Bar calls it (`RpcClient.swift:433`) and `CronService.updateJob` has always existed. The capability was there; nothing exposed it.

### The third instance of one split

| PR | symptom |
|---|---|
| #166 | `cron.delete` filtered the file store and reported success while the live job kept firing |
| #174 | the Bar's prompt never reached the scheduler; the job fired with `message: ""` |
| **this** | `cron.get` denies a job the scheduler holds; `cron.update` absent |

Every one is the same shape: two stores, and a handler wired to the one that is not authoritative.

### The fix

Both route through the adapter. `list` and `get` now share one `onTheWire` mapping, so two readers of the same job cannot describe it differently — that divergence is exactly how the `command`/`message` split survived as long as it did, and there is a test asserting the two agree.

`cron.update` follows the precedents: accepts the Bar's `command` spelling and normalises it to `message` (#174), and **refuses an unknown id** rather than reporting success (#166).

### Mutations (7 tests)

| mutation | result |
|---|---|
| `cron.get` reads only the file store *(the original bug)* | **4 failed** |
| unregister `cron.update` | **3 failed** |
| `cron.update` succeeds for an unknown id | **1 failed** |
| drop the `command`→`message` normalisation | **1 failed** |
| `get` and `list` describe a job differently | **4 failed** |

### Suite

`4933` passed · `tsc --noEmit` clean. The 5 `copilot-cli-local.test.ts` failures are pre-existing on clean main.

### Not fixed here

A job created without an explicit agent still fails with `Agent not found: main`. Filed as **#179** — which agent `'main'` denotes is a product decision, and it affects the CLI identically, so it is not a cron-RPC fix.
