### PR TITLE
test: pin every client RPC call against the running gateway

### DIFF
--- a/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
+++ b/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, join } from 'path';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * Every RPC method a client calls must exist on the gateway.
+ *
+ * Ten did not. The macOS Bar's approval, usage, logs, node-pairing and skills
+ * screens all called methods the production gateway never registered, and each
+ * one failed only at runtime, in the UI, with `Method not found`. They were
+ * found one at a time — `config.set` in #170, `cron.update` in #180 — because
+ * nothing compared the two sides.
+ *
+ * The trap this file exists to avoid: `typescript/src/gateway/methods/*.ts`
+ * declares many of these names, so grepping the source makes them look present.
+ * Only 5 of those 25 modules are ever invoked (see the doc comment on
+ * `registerBuiltInMethods`). So this asks a *running* server what it registers
+ * rather than reading any source.
+ */
+
+const REPO = resolve(__dirname, '../../..');
+const SWIFT_RPC = join(REPO, '../macos/Sources/OpenRappterBar/Services/RpcClient.swift');
+const UI_SERVICES = join(REPO, 'ui/src/services');
+
+/**
+ * Methods a client calls that the gateway still does not register.
+ *
+ * This list is debt, not permission. It may only shrink. Adding to it means
+ * shipping a client call that cannot work, which is the bug this file guards.
+ */
+const KNOWN_MISSING = new Set<string>([
+  // Dead client wrappers: defined in RpcClient.swift, invoked by nothing.
+  // Tracked in #172 (config.patch) — delete or implement, but they mislead.
+  'agents.execute',
+  'agents.info',
+  'config.patch',
+  'connections.info',
+  'exec.history',
+  'models.list',
+  // Live UI call sites still unimplemented.
+  'agents.files.list',
+  'agents.files.read',
+  'agents.files.write',
+  'cron.runs',
+  'skills.toggle',
+  'zen.sessions',
+  'zen.subscribe',
+  'zen.unsubscribe',
+  // Live macOS Bar screens that cannot work: approvals, usage, logs, node
+  // pairing and skills. Being fixed now; each entry is removed as its method
+  // lands, and the last test in this file fails if one is left here after it
+  // starts existing.
+  'connections.disconnect',
+  'connections.pair',
+  'exec.pending',
+  'exec.respond',
+  'logs.get',
+  'sessions.reset',
+  'skills.install',
+  'skills.list',
+  'usage.history',
+  'usage.stats',
+]);
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+/** Method names registered by a server with every optional service present. */
+async function registeredMethods(): Promise<Set<string>> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  // surgeon.* and rappter.* register only when their service is set, and only
+  // inside start(). A bare server reports them missing and would send someone
+  // chasing methods that are fine.
+  server.setSurgeonService({} as never);
+  server.setRappterManager({} as never);
+  await server.start();
+  return new Set(
+    (server as unknown as { methods: Map<string, unknown> }).methods.keys(),
+  );
+}
+
+function swiftMethods(): string[] {
+  const source = readFileSync(SWIFT_RPC, 'utf-8');
+  return [...source.matchAll(/method:\s*"([a-z][a-zA-Z.]+)"/g)].map((m) => m[1]);
+}
+
+function uiMethods(): string[] {
+  const names: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry !== '__tests__') walk(full);
+        continue;
+      }
+      if (!/\.tsx?$/.test(entry)) continue;
+      const source = readFileSync(full, 'utf-8');
+      for (const m of source.matchAll(/\.call(?:<[^>]*>)?\(\s*'([a-z][a-zA-Z.]+)'/g)) {
+        names.push(m[1]);
+      }
+    }
+  };
+  walk(UI_SERVICES);
+  return names;
+}
+
+describe('every RPC method a client calls exists on the gateway', () => {
+  it('finds call sites in both clients', () => {
+    // Guards the parsers. If a rename makes either match nothing, the
+    // assertions below would pass over an empty list and prove nothing.
+    expect(swiftMethods().length).toBeGreaterThan(20);
+    expect(uiMethods().length).toBeGreaterThan(10);
+  });
+
+  it('the macOS Bar calls nothing the gateway lacks', async () => {
+    const registered = await registeredMethods();
+    const missing = [...new Set(swiftMethods())]
+      .filter((m) => !registered.has(m) && !KNOWN_MISSING.has(m))
+      .sort();
+    expect(missing).toEqual([]);
+  });
+
+  it('the web UI calls nothing the gateway lacks', async () => {
+    const registered = await registeredMethods();
+    const missing = [...new Set(uiMethods())]
+      .filter((m) => !registered.has(m) && !KNOWN_MISSING.has(m))
+      .sort();
+    expect(missing).toEqual([]);
+  });
+
+  it('the known-missing list contains nothing that now exists', async () => {
+    // Makes the debt list self-cleaning: once a method is implemented, this
+    // fails until it is removed from KNOWN_MISSING, so the list cannot rot
+    // into a permanent excuse.
+    const registered = await registeredMethods();
+    const stale = [...KNOWN_MISSING].filter((m) => registered.has(m)).sort();
+    expect(stale).toEqual([]);
+  });
+});


### PR DESCRIPTION
Ten methods the macOS Bar calls do not exist. Live-probed against a started `GatewayServer`:

```
exec.pending             -> Method not found
exec.respond             -> Method not found
usage.stats              -> Method not found
usage.history            -> Method not found
logs.get                 -> Method not found
sessions.reset           -> Method not found
skills.list              -> Method not found
skills.install           -> Method not found
connections.pair         -> Method not found
connections.disconnect   -> Method not found
```

Their callers are real ViewModels — `ApprovalViewModel`, `UsageViewModel`, `LogsViewModel`, `NodesViewModel`. So the **approval, usage, logs, node-pairing and skills screens cannot work at all**. `exec.respond` is the approve/deny path: a user who believes they are gating individual agent actions is using a screen that never functioned.

### Why they kept being found one at a time

`config.set` in #170. `cron.update` in #180. Each surfaced only when somebody exercised the feature, because **nothing compared the two sides**.

### Why grepping the source does not work here

`gateway/methods/*.ts` declares most of these names, so a source search makes them look present. **Only 5 of those 25 modules are ever invoked** — the rest are deliberately unregistered (see the doc comment on `registerBuiltInMethods`).

So this test asks a **running server** what it registers, rather than reading any source.

It also sets the surgeon and rappter services before `start()`. Those register only when their service is present, and a bare server reports them missing — I hit exactly that while building this and nearly went chasing `surgeon.*` methods that are fine.

### `KNOWN_MISSING` is debt, not permission

The final test fails if an entry in the list **starts existing**, so the list cannot rot into a permanent excuse. Entries come out as each method lands. Nothing may be added without shipping a client call that cannot work — which is the bug this guards.

### Mutations

| mutation | result |
|---|---|
| drop an entry from the debt list | **1 failed** |
| keep an entry that now exists | **1 failed** |
| make the Swift parser match nothing | **1 failed** |

The third is why the parser guard exists. A rename in `RpcClient.swift` would otherwise leave both real assertions passing over an empty list, forever.

### Suite

`4942` passed, `0` failed · `tsc --noEmit` clean · stable across three consecutive runs.

### In flight

Four agents are implementing the ten live-missing methods now. Each landing removes its entry from `KNOWN_MISSING`; the self-cleaning test enforces that.
