### PR TITLE
fix(gateway): the Bar's approval screen called two methods that did not exist

### DIFF
--- a/macos/Sources/OpenRappterBar/Services/RpcClient.swift
+++ b/macos/Sources/OpenRappterBar/Services/RpcClient.swift
@@ -502,14 +502,52 @@ public struct RpcClient: RpcClientProtocol, Sendable {
 
     // MARK: - Execution Approval Methods
 
+    /// The gateway timestamps approvals as ISO-8601 strings (`toISOString()`,
+    /// so always with milliseconds), while `JSONDecoder`'s default date
+    /// strategy expects a `Double`. Decoding `ExecutionApproval` with a stock
+    /// decoder therefore always failed — and the old `try?` turned that into an
+    /// empty array, i.e. an approval screen that silently shows nothing while
+    /// commands sit blocked. Accept both spellings, with and without fractional
+    /// seconds.
+    private static func approvalDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        let withFraction = ISO8601DateFormatter()
+        withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        let basic = ISO8601DateFormatter()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            if let text = try? container.decode(String.self) {
+                if let date = withFraction.date(from: text) ?? basic.date(from: text) {
+                    return date
+                }
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "Unrecognised approval timestamp: \(text)"
+                )
+            }
+            // Numeric timestamps stay readable for any client that sends them.
+            let seconds = try container.decode(Double.self)
+            return Date(timeIntervalSince1970: seconds > 3_000_000_000 ? seconds / 1000 : seconds)
+        }
+        return decoder
+    }
+
     public func listPendingApprovals() async throws -> [ExecutionApproval] {
         let response = try await connection.sendRequest(method: "exec.pending")
-        guard response.ok else { throw RpcClientError.decodingFailed("Failed to list approvals") }
-        let data = try JSONEncoder().encode(response.payload ?? AnyCodable([]))
-        if let approvals = try? JSONDecoder().decode([ExecutionApproval].self, from: data) {
-            return approvals
+        guard response.ok else {
+            throw GatewayConnectionError.serverError(
+                code: response.error?.code ?? -1,
+                message: response.error?.message ?? "Failed to list approvals"
+            )
         }
-        return []
+        let data = try JSONEncoder().encode(response.payload ?? AnyCodable([]))
+        // Throw rather than return []: an approval the user cannot see is an
+        // approval they cannot deny, so a decode failure must be visible.
+        do {
+            return try Self.approvalDecoder().decode([ExecutionApproval].self, from: data)
+        } catch {
+            throw RpcClientError.decodingFailed("Pending approvals: \(error)")
+        }
     }
 
     public func respondToApproval(approvalId: String, approved: Bool) async throws {
@@ -525,12 +563,18 @@ public struct RpcClient: RpcClientProtocol, Sendable {
 
     public func getApprovalHistory() async throws -> [ExecutionApproval] {
         let response = try await connection.sendRequest(method: "exec.history")
-        guard response.ok else { throw RpcClientError.decodingFailed("Failed to get approval history") }
-        let data = try JSONEncoder().encode(response.payload ?? AnyCodable([]))
-        if let approvals = try? JSONDecoder().decode([ExecutionApproval].self, from: data) {
-            return approvals
+        guard response.ok else {
+            throw GatewayConnectionError.serverError(
+                code: response.error?.code ?? -1,
+                message: response.error?.message ?? "Failed to get approval history"
+            )
         }
-        return []
+        let data = try JSONEncoder().encode(response.payload ?? AnyCodable([]))
+        do {
+            return try Self.approvalDecoder().decode([ExecutionApproval].self, from: data)
+        } catch {
+            throw RpcClientError.decodingFailed("Approval history: \(error)")
+        }
     }
 
     // MARK: - Usage Methods

--- a/macos/Tests/OpenRappterBarTests/RpcClientContractTests.swift
+++ b/macos/Tests/OpenRappterBarTests/RpcClientContractTests.swift
@@ -705,4 +705,129 @@ func runRpcClientContractTests() async {
             await conn.disconnect()
         }
     }
+
+    // The Bar's approval screen was dead: `exec.pending` and `exec.respond`
+    // were never registered on the production gateway. Now that they are, these
+    // pin the wire shape the gateway emits to what RpcClient actually decodes —
+    // including the ISO-8601 `timestamp`, which the stock JSONDecoder date
+    // strategy rejects (it wants a Double), and which the old `try?` swallowed
+    // into an empty list: an approval screen that shows nothing, forever.
+    await suite("RpcClient Execution Approval Contract") {
+        await test("pending approvals decode the gateway's real payload") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let approvals = try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkArrayResponse(id: "rpc-2", payload: [[
+                    "id": "token_1786932956639_v2wdh9c9wgs",
+                    "command": "curl https://example.com",
+                    "description": "Approval token issued for: curl https://example.com",
+                    "timestamp": "2026-08-17T02:15:56.639Z",
+                    "status": "pending",
+                    "binary": "curl",
+                    "kind": "token",
+                    "expiresAt": "2026-08-17T02:20:56.639Z",
+                ]])
+            ) {
+                try await rpc.listPendingApprovals()
+            }
+
+            try expectEqual(approvals.count, 1)
+            try expectEqual(approvals.first?.id, "token_1786932956639_v2wdh9c9wgs")
+            try expectEqual(approvals.first?.command, "curl https://example.com")
+            try expectEqual(approvals.first?.status, .pending)
+            try expectNotNil(approvals.first?.timestamp)
+            let sent = try await lastSentJSON(mock)
+            try expectEqual(sent?["method"] as? String, "exec.pending")
+            await conn.disconnect()
+        }
+
+        await test("a timestamp without fractional seconds still decodes") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let approvals = try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkArrayResponse(id: "rpc-2", payload: [[
+                    "id": "exec_1",
+                    "command": "npm install",
+                    "timestamp": "2026-08-17T02:15:56Z",
+                    "status": "pending",
+                ]])
+            ) {
+                try await rpc.listPendingApprovals()
+            }
+
+            try expectEqual(approvals.count, 1)
+            try expectEqual(approvals.first?.command, "npm install")
+            await conn.disconnect()
+        }
+
+        await test("a payload the Bar cannot read is reported, not silently empty") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            var threw = false
+            do {
+                _ = try await withDeferredResponse(
+                    mock: mock,
+                    response: try makeOkArrayResponse(id: "rpc-2", payload: [[
+                        "id": "exec_1",
+                        "timestamp": "2026-08-17T02:15:56.639Z",
+                        "status": "pending",
+                    ]])
+                ) {
+                    try await rpc.listPendingApprovals()
+                }
+            } catch {
+                threw = true
+            }
+
+            try expect(threw, "a malformed approval list must surface an error")
+            await conn.disconnect()
+        }
+
+        await test("responding sends the approvalId and the decision") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkResponse(id: "rpc-2", payload: [
+                    "ok": true,
+                    "approvalId": "token_1",
+                    "approved": false,
+                    "status": "denied",
+                ])
+            ) {
+                try await rpc.respondToApproval(approvalId: "token_1", approved: false)
+            }
+
+            let sent = try await lastSentJSON(mock)
+            try expectEqual(sent?["method"] as? String, "exec.respond")
+            let params = sent?["params"] as? [String: Any]
+            try expectEqual(params?["approvalId"] as? String, "token_1")
+            try expectEqual(params?["approved"] as? Bool, false)
+            await conn.disconnect()
+        }
+
+        // A refused id must not look like a granted approval: the gateway
+        // answers ok:false, and the Bar has to keep the row and say so.
+        await test("a refused approval id surfaces the gateway error") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let frame: [String: Any] = [
+                "type": "res",
+                "id": "rpc-2",
+                "ok": false,
+                "error": ["code": -32603, "message": "Unknown, expired, or already-resolved approval id: token_x"],
+            ]
+            var threw = false
+            do {
+                try await withDeferredResponse(
+                    mock: mock,
+                    response: try JSONSerialization.data(withJSONObject: frame)
+                ) {
+                    try await rpc.respondToApproval(approvalId: "token_x", approved: true)
+                }
+            } catch {
+                threw = true
+            }
+
+            try expect(threw, "a refused approval must throw")
+            await conn.disconnect()
+        }
+    }
 }

--- a/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
+++ b/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
@@ -37,7 +37,6 @@ const KNOWN_MISSING = new Set<string>([
   'agents.info',
   'config.patch',
   'connections.info',
-  'exec.history',
   'models.list',
   // Live UI call sites still unimplemented.
   'agents.files.list',
@@ -48,14 +47,14 @@ const KNOWN_MISSING = new Set<string>([
   'zen.sessions',
   'zen.subscribe',
   'zen.unsubscribe',
-  // Live macOS Bar screens that cannot work: approvals, usage, logs, node
-  // pairing and skills. Being fixed now; each entry is removed as its method
-  // lands, and the last test in this file fails if one is left here after it
-  // starts existing.
+  // Live macOS Bar screens that cannot work: usage, logs, node pairing and
+  // skills. Being fixed now; each entry is removed as its method lands, and the
+  // last test in this file fails if one is left here after it starts existing.
+  // Approvals left this list in the exec.pending/exec.respond fix: they are
+  // served by the ExecSafety engine ShellAgent actually blocks on, not by the
+  // unwired gateway/methods/exec-methods.ts module.
   'connections.disconnect',
   'connections.pair',
-  'exec.pending',
-  'exec.respond',
   'logs.get',
   'sessions.reset',
   'skills.install',

--- a/typescript/src/__tests__/integration/exec-approval-contract.test.ts
+++ b/typescript/src/__tests__/integration/exec-approval-contract.test.ts
@@ -1,0 +1,306 @@
+import { describe, it, expect, afterEach, beforeEach } from 'vitest';
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { WebSocket } from 'ws';
+import { GatewayServer } from '../../gateway/server.js';
+import { ShellAgent } from '../../agents/ShellAgent.js';
+import { getSharedExecSafety, resetSharedExecSafety } from '../../security/exec-safety.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * Binds the macOS Bar's approval screen to handlers that actually run.
+ *
+ * `ApprovalViewModel.swift` calls `exec.pending` on appear and `exec.respond`
+ * on approve/deny. Neither was registered on the production gateway, so the
+ * screen that gates every agent command answered:
+ *
+ *   exec.pending -> Method not found: exec.pending
+ *   exec.respond -> Method not found: exec.respond
+ *
+ * `gateway/methods/exec-methods.ts` is not the missing wiring: it declares
+ * different names (`exec.approval.request`, `exec.approvals.get`, …) against an
+ * injected `approvalManager` no caller supplies. Registering it would have
+ * yielded an always-empty list and an "approve" that resolved nothing while
+ * reporting success. So these tests never import a method module. They start a
+ * real GatewayServer, let a real ShellAgent block a real command, and drive the
+ * exact frames `RpcClient.swift` builds — over the WebSocket protocol the Bar
+ * speaks and over HTTP JSON-RPC.
+ */
+
+let server: GatewayServer | undefined;
+let sandbox: string | undefined;
+
+const sandboxRoot = join(process.cwd(), '.exec-approval-tests');
+
+beforeEach(() => {
+  // A fresh process-wide approval engine, so each test starts with an empty
+  // queue and proves the *default* wiring — nothing is injected anywhere.
+  resetSharedExecSafety();
+  mkdirSync(sandboxRoot, { recursive: true });
+  sandbox = mkdtempSync(join(sandboxRoot, 'run-'));
+});
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+  if (sandbox) rmSync(sandbox, { recursive: true, force: true });
+  sandbox = undefined;
+  rmSync(sandboxRoot, { recursive: true, force: true });
+  resetSharedExecSafety();
+});
+
+async function startServer(): Promise<number> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir: sandbox });
+  await server.start();
+  return port;
+}
+
+function connect(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const socket = new WebSocket(`ws://127.0.0.1:${port}`);
+    socket.once('open', () => resolve(socket));
+    socket.once('error', reject);
+  });
+}
+
+/** Opens a socket and completes the protocol handshake the Bar performs. */
+async function connectAndHandshake(port: number): Promise<WebSocket> {
+  const socket = await connect(port);
+  await request(socket, 'rpc-1', 'connect', {
+    minProtocol: 3,
+    maxProtocol: 3,
+    client: { id: 'bar-test', version: '1.0.0', platform: 'macos', mode: 'test' },
+  });
+  return socket;
+}
+
+/** One `{type:'req'}` frame, exactly as GatewayConnection.swift sends it. */
+function request(
+  socket: WebSocket,
+  id: string,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{ ok?: boolean; payload?: unknown; error?: { code?: number; message?: string } }> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error(`RPC timeout: ${method}`)), 5_000);
+    const onMessage = (raw: Buffer | string) => {
+      const frame = JSON.parse(raw.toString()) as Record<string, unknown>;
+      if (frame.id !== id) return;
+      clearTimeout(timeout);
+      socket.off('message', onMessage);
+      resolve(frame);
+    };
+    socket.on('message', onMessage);
+    socket.send(JSON.stringify({ type: 'req', id, method, params }));
+  });
+}
+
+async function rpc(port: number, method: string, params?: Record<string, unknown>) {
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'e1', method, params }),
+  });
+  return (await res.json()) as { result?: unknown; error?: { message: string } };
+}
+
+interface BlockedResult {
+  status: string;
+  blocked?: boolean;
+  approval_required?: boolean;
+  approval_id?: string;
+  message?: string;
+}
+
+/** Runs a command that safety policy blocks, returning its approval token id. */
+async function blockCommand(agent: ShellAgent, command: string): Promise<BlockedResult> {
+  return JSON.parse(await agent.perform({ action: 'bash', command })) as BlockedResult;
+}
+
+describe('exec approval RPC contract, against the wired gateway', () => {
+  it('registers the two methods the Bar calls', async () => {
+    const port = await startServer();
+    const { result } = await rpc(port, 'methods');
+
+    expect(result as string[]).toContain('exec.pending');
+    expect(result as string[]).toContain('exec.respond');
+  });
+
+  it('exec.pending lists what a real ShellAgent is actually blocked on', async () => {
+    const port = await startServer();
+    const agent = new ShellAgent();
+    const blocked = await blockCommand(agent, 'curl https://example.com');
+    expect(blocked.approval_required).toBe(true);
+
+    const socket = await connectAndHandshake(port);
+    const frame = await request(socket, 'rpc-2', 'exec.pending');
+    socket.close();
+
+    expect(frame.ok).toBe(true);
+    // RpcClient.swift decodes the payload *directly* as [ExecutionApproval],
+    // so it has to be a top-level array, not { approvals: [...] }.
+    const payload = frame.payload as Array<Record<string, unknown>>;
+    expect(Array.isArray(payload)).toBe(true);
+    expect(payload).toHaveLength(1);
+
+    const [approval] = payload;
+    expect(approval.id).toBe(blocked.approval_id);
+    // Field names ExecutionApproval declares: id, command, description,
+    // requestedBy, sessionKey, timestamp, status.
+    expect(approval.command).toBe('curl https://example.com');
+    expect(typeof approval.description).toBe('string');
+    expect(approval.status).toBe('pending');
+    expect(typeof approval.timestamp).toBe('string');
+    expect(new Date(approval.timestamp as string).toISOString()).toBe(approval.timestamp);
+  });
+
+  it('approve lets the exact command through, once', async () => {
+    const port = await startServer();
+    const agent = new ShellAgent();
+    const marker = join(sandbox!, 'approved.txt');
+
+    const blocked = await blockCommand(agent, `touch ${marker}`);
+    expect(existsSync(marker)).toBe(false);
+
+    const socket = await connectAndHandshake(port);
+    // The exact params RpcClient.respondToApproval builds.
+    const frame = await request(socket, 'rpc-2', 'exec.respond', {
+      approvalId: blocked.approval_id,
+      approved: true,
+    });
+    expect(frame.ok).toBe(true);
+
+    const retry = JSON.parse(
+      await agent.perform({ action: 'bash', command: `touch ${marker}`, approval_id: blocked.approval_id }),
+    ) as BlockedResult;
+    expect(retry.status).toBe('success');
+    expect(existsSync(marker)).toBe(true);
+
+    // Single use: the same token cannot authorise a second run.
+    rmSync(marker, { force: true });
+    const replay = JSON.parse(
+      await agent.perform({ action: 'bash', command: `touch ${marker}`, approval_id: blocked.approval_id }),
+    ) as BlockedResult;
+    expect(replay.status).toBe('error');
+    expect(replay.message).toContain('already used');
+    expect(existsSync(marker)).toBe(false);
+
+    // Resolved approvals leave the pending list.
+    const after = await request(socket, 'rpc-3', 'exec.pending');
+    socket.close();
+    expect(after.payload).toEqual([]);
+  });
+
+  it('deny actually denies: the command never runs', async () => {
+    const port = await startServer();
+    const agent = new ShellAgent();
+    const marker = join(sandbox!, 'denied.txt');
+
+    const blocked = await blockCommand(agent, `touch ${marker}`);
+
+    const socket = await connectAndHandshake(port);
+    const frame = await request(socket, 'rpc-2', 'exec.respond', {
+      approvalId: blocked.approval_id,
+      approved: false,
+    });
+    expect(frame.ok).toBe(true);
+
+    const retry = JSON.parse(
+      await agent.perform({ action: 'bash', command: `touch ${marker}`, approval_id: blocked.approval_id }),
+    ) as BlockedResult;
+    socket.close();
+
+    expect(retry.status).toBe('error');
+    expect(retry.message).toContain('rejected');
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it('refuses an unknown approval id instead of reporting success', async () => {
+    const port = await startServer();
+    const socket = await connectAndHandshake(port);
+
+    const frame = await request(socket, 'rpc-2', 'exec.respond', {
+      approvalId: 'token_does_not_exist',
+      approved: true,
+    });
+    socket.close();
+
+    expect(frame.ok).toBe(false);
+    expect(frame.error?.message).toContain('token_does_not_exist');
+  });
+
+  it('refuses an approval id that was already resolved', async () => {
+    const port = await startServer();
+    const agent = new ShellAgent();
+    const blocked = await blockCommand(agent, 'curl https://example.com');
+
+    const first = await rpc(port, 'exec.respond', { approvalId: blocked.approval_id, approved: false });
+    expect(first.error).toBeUndefined();
+
+    // Flipping a decided approval to "approved" must not succeed.
+    const second = await rpc(port, 'exec.respond', { approvalId: blocked.approval_id, approved: true });
+    expect(second.result).toBeUndefined();
+    expect(second.error?.message).toContain(blocked.approval_id!);
+
+    const retry = JSON.parse(
+      await agent.perform({
+        action: 'bash',
+        command: 'curl https://example.com',
+        approval_id: blocked.approval_id,
+      }),
+    ) as BlockedResult;
+    expect(retry.status).toBe('error');
+  });
+
+  it('refuses an expired approval and stops listing it as pending', async () => {
+    const port = await startServer();
+    // The production engine the gateway serves — no injection.
+    const token = getSharedExecSafety().issueApprovalToken('curl https://example.com', 1);
+    await new Promise((resolve) => setTimeout(resolve, 15));
+
+    const pending = await rpc(port, 'exec.pending');
+    expect(pending.result).toEqual([]);
+
+    const respond = await rpc(port, 'exec.respond', { approvalId: token.id, approved: true });
+    expect(respond.result).toBeUndefined();
+    expect(respond.error?.message).toContain(token.id);
+  });
+
+  it('refuses a response that carries no decision rather than assuming one', async () => {
+    const port = await startServer();
+    const agent = new ShellAgent();
+    const blocked = await blockCommand(agent, 'curl https://example.com');
+
+    const missing = await rpc(port, 'exec.respond', { approvalId: blocked.approval_id });
+    expect(missing.result).toBeUndefined();
+    expect(missing.error?.message).toContain('approved');
+
+    const noId = await rpc(port, 'exec.respond', { approved: true });
+    expect(noId.result).toBeUndefined();
+    expect(noId.error?.message).toContain('approvalId');
+
+    // Still pending: a malformed response decided nothing.
+    const pending = (await rpc(port, 'exec.pending')).result as unknown[];
+    expect(pending).toHaveLength(1);
+  });
+
+  it('exec.history reports the real audit trail in the Bar vocabulary', async () => {
+    const port = await startServer();
+    const agent = new ShellAgent();
+    const blocked = await blockCommand(agent, 'curl https://example.com');
+    await rpc(port, 'exec.respond', { approvalId: blocked.approval_id, approved: false });
+
+    const history = (await rpc(port, 'exec.history')).result as Array<Record<string, unknown>>;
+    const entry = history.find((e) => e.id === blocked.approval_id);
+
+    expect(entry).toBeDefined();
+    expect(entry?.command).toBe('curl https://example.com');
+    // ApprovalStatus in ApprovalModels.swift has no 'rejected' case.
+    expect(entry?.status).toBe('denied');
+    expect(entry?.auditStatus).toBe('rejected');
+    for (const e of history) {
+      expect(['pending', 'approved', 'denied', 'expired']).toContain(e.status);
+    }
+  });
+});

--- a/typescript/src/agents/ShellAgent.ts
+++ b/typescript/src/agents/ShellAgent.ts
@@ -14,7 +14,7 @@ import path from 'path';
 import os from 'os';
 import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
-import { ExecSafety } from '../security/exec-safety.js';
+import { ExecSafety, getSharedExecSafety } from '../security/exec-safety.js';
 
 
 export const __manifest__ = {
@@ -80,7 +80,9 @@ export class ShellAgent extends BasicAgent {
       },
     };
     super('Shell', metadata);
-    this.execSafety = execSafety ?? new ExecSafety();
+    // Defaults to the process-wide engine so the approvals this agent blocks on
+    // are the ones the gateway serves to the reviewer (see getSharedExecSafety).
+    this.execSafety = execSafety ?? getSharedExecSafety();
   }
 
   /** Access to the underlying safety engine, e.g. for reviewing/resolving approval tokens. */

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -30,6 +30,8 @@ import { registerRappterMethods } from './methods/rappter-methods.js';
 import { registerAuthMethods } from './methods/auth-methods.js';
 import { registerBackupMethods } from './methods/backup-methods.js';
 import { registerSurgeonMethods } from './methods/surgeon-methods.js';
+import { getSharedExecSafety } from '../security/exec-safety.js';
+import type { ExecSafety } from '../security/exec-safety.js';
 import { readAnatomy } from './anatomy.js';
 import { renderAnatomyPage } from './anatomy-page.js';
 import type { RappterManager } from './rappter-manager.js';
@@ -54,6 +56,22 @@ const RATE_LIMIT_WINDOW_MS = 60000;
 const RATE_LIMIT_MAX_REQUESTS = 100;
 const PROTOCOL_VERSION = 3;
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
+
+/**
+ * ExecSafety's audit vocabulary → the macOS Bar's `ApprovalStatus` enum, which
+ * only knows pending/approved/denied/expired. An unmapped value would fail the
+ * Swift decode for the whole array, so every audit status is covered here and
+ * the raw one is echoed alongside as `auditStatus`.
+ */
+const EXEC_AUDIT_STATUS_TO_BAR: Record<string, 'pending' | 'approved' | 'denied' | 'expired'> = {
+  allowed: 'approved',
+  approved: 'approved',
+  used: 'approved',
+  blocked: 'denied',
+  rejected: 'denied',
+  pending: 'pending',
+  expired: 'expired',
+};
 
 /** Parse a response that may contain a |||VOICE||| delimiter into formatted + voice parts */
 function parseVoiceDelimiter(content: string): { text: string; voiceText: string } {
@@ -227,6 +245,14 @@ export class GatewayServer {
   private agentList?: () => { id: string; type: string; description?: string; capabilities?: string[]; tools?: { name: string; description?: string }[]; channels?: { type: string; connected: boolean }[] }[];
   private cronStore: Record<string, unknown>[] = [];
   private surgeonService?: SurgeonService;
+  /**
+   * The approval queue `exec.pending`/`exec.respond` serve.
+   *
+   * Defaults to the process-wide engine, which is the same object ShellAgent
+   * blocks on — see `getSharedExecSafety`. Anything else would give the Bar a
+   * screen that lists nothing and approves nothing while reporting success.
+   */
+  private execSafety?: ExecSafety;
 
   constructor(config?: Partial<GatewayConfig>) {
     this.config = {
@@ -527,6 +553,15 @@ export class GatewayServer {
 
   setSurgeonService(service: SurgeonService): void {
     this.surgeonService = service;
+  }
+
+  /** Override the approval engine served by `exec.*` (tests, embedders). */
+  setExecSafety(execSafety: ExecSafety): void {
+    this.execSafety = execSafety;
+  }
+
+  getExecSafety(): ExecSafety {
+    return (this.execSafety ??= getSharedExecSafety());
   }
 
   setReadinessProvider(
@@ -2418,9 +2453,96 @@ export class GatewayServer {
     this.registerMethod('config.set', writeConfig, { requiresAuth: true });
     this.registerMethod('config.apply', writeConfig, { requiresAuth: true });
 
+    // ── Execution approvals ────────────────────────────────────────────────
+    //
+    // The macOS Bar's Permissions screen (ApprovalViewModel.swift) calls
+    // `exec.pending` on appear and `exec.respond` on approve/deny. Neither was
+    // registered, so every button on the screen that gates agent commands
+    // returned "Method not found: exec.pending". `gateway/methods/exec-methods.ts`
+    // is not the fix: it declares different names (`exec.approval.request`,
+    // `exec.approvals.get`, …) against an injected `approvalManager` that no
+    // caller ever supplies, so registering it would have produced a screen that
+    // renders an empty list and reports success — strictly worse than an error.
+    //
+    // These handlers serve the engine that actually blocks commands: the
+    // ExecSafety instance ShellAgent issues approval tokens from.
+    this.registerMethod('exec.pending', async () =>
+      this.getExecSafety().listPendingApprovals().map((approval) => ({
+        // Field names the Bar decodes into ExecutionApproval.
+        id: approval.id,
+        command: approval.cmd,
+        description: approval.reason,
+        timestamp: approval.createdAt,
+        status: 'pending',
+        // Extra context; unknown keys are ignored by the Swift decoder.
+        binary: approval.binary,
+        kind: approval.kind,
+        expiresAt: approval.expiresAt,
+      })),
+    );
+
+    this.registerMethod(
+      'exec.respond',
+      async (params: {
+        approvalId?: string;
+        id?: string;
+        requestId?: string;
+        approved?: boolean;
+        decision?: string;
+      }) => {
+        const approvalId = params?.approvalId ?? params?.id ?? params?.requestId;
+        if (typeof approvalId !== 'string' || approvalId.trim() === '') {
+          throw new Error('exec.respond requires an `approvalId`');
+        }
+
+        // Never infer the decision. A missing/garbled field defaulting to
+        // "approved" is an unaudited execution, and defaulting to "denied"
+        // silently kills a command the user approved.
+        let approved: boolean;
+        if (typeof params.approved === 'boolean') {
+          approved = params.approved;
+        } else if (params.decision === 'approve' || params.decision === 'approved') {
+          approved = true;
+        } else if (
+          params.decision === 'deny' ||
+          params.decision === 'denied' ||
+          params.decision === 'reject' ||
+          params.decision === 'rejected'
+        ) {
+          approved = false;
+        } else {
+          throw new Error('exec.respond requires a boolean `approved` (or a `decision`)');
+        }
+
+        // Refuse rather than report success: an unknown, expired, or
+        // already-resolved id means this approval cannot be granted, and the
+        // reviewer has to see that instead of a row quietly disappearing.
+        if (!this.getExecSafety().respondToApproval(approvalId, approved)) {
+          throw new Error(
+            `Unknown, expired, or already-resolved approval id: ${approvalId}`,
+          );
+        }
+
+        return { ok: true, approvalId, approved, status: approved ? 'approved' : 'denied' };
+      },
+    );
+
+    // The Bar's approval history view reads the same shape. Backed by the real
+    // audit log, mapped onto the Bar's vocabulary (it has no 'rejected'/'used').
+    this.registerMethod('exec.history', async () =>
+      this.getExecSafety().getAuditLog().map((entry) => ({
+        id: entry.id,
+        command: entry.cmd,
+        description: entry.reason,
+        timestamp: entry.timestamp,
+        status: EXEC_AUDIT_STATUS_TO_BAR[entry.status] ?? 'pending',
+        binary: entry.binary,
+        auditStatus: entry.status,
+      })),
+    );
+
     // Showcase methods
     registerShowcaseMethods(this);
-
     if (this.surgeonService) {
       registerSurgeonMethods(this, this.surgeonService);
     }

--- a/typescript/src/security/exec-safety.ts
+++ b/typescript/src/security/exec-safety.ts
@@ -66,6 +66,22 @@ export interface ApprovalConsumeResult {
   reason?: string;
 }
 
+/**
+ * One pending approval, normalized across both queues (blocking promise and
+ * single-use token) so a reviewer UI can render them uniformly.
+ */
+export interface PendingApprovalView {
+  id: string;
+  cmd: string;
+  binary: string;
+  reason: string;
+  createdAt: string;
+  /** Which mechanism issued it: an awaited promise, or a single-use token. */
+  kind: 'blocking' | 'token';
+  /** Only tokens carry a hard expiry. */
+  expiresAt?: string;
+}
+
 // Broad compatibility allowlist. Risky members are also classified as
 // dual-use below, so callers can preserve the historical `safe` result while
 // still requiring explicit approval before execution.
@@ -443,6 +459,59 @@ export class ExecSafety {
   }
 
   /**
+   * Every approval this process is actually waiting on, from both queues.
+   *
+   * Two mechanisms issue real approvals against the same engine — the blocking
+   * `requestApproval` promise and the non-blocking single-use token — and a
+   * reviewer (the macOS Bar) has to see both or it will silently miss half of
+   * what it is supposed to gate. Expired tokens are excluded: an approval that
+   * can no longer be consumed is not pending, and offering it as a button
+   * would be a lie.
+   */
+  listPendingApprovals(): PendingApprovalView[] {
+    const now = Date.now();
+    const blocking: PendingApprovalView[] = Array.from(this.pendingApprovals.values()).map(
+      (p) => ({
+        id: p.id,
+        cmd: p.cmd,
+        binary: p.binary,
+        reason: p.reason,
+        createdAt: p.createdAt,
+        kind: 'blocking' as const,
+      })
+    );
+    const tokens: PendingApprovalView[] = Array.from(this.approvalTokens.values())
+      .filter((t) => t.status === 'pending' && t.expiresAt > now)
+      .map((t) => ({
+        id: t.id,
+        cmd: t.cmd,
+        binary: this.parseBinary(t.cmd),
+        reason:
+          this.auditLog.find((e) => e.id === t.id)?.reason ??
+          `Approval required for: ${t.cmd}`,
+        createdAt: t.createdAt,
+        kind: 'token' as const,
+        expiresAt: new Date(t.expiresAt).toISOString(),
+      }));
+    return [...blocking, ...tokens].sort((a, b) => a.createdAt.localeCompare(b.createdAt));
+  }
+
+  /**
+   * Resolve an approval by id, whichever queue issued it.
+   *
+   * Returns false — never true — for an id this engine does not have pending:
+   * unknown, already resolved, already used, or expired. Callers must surface
+   * that refusal rather than reporting success, since "approved" is a security
+   * decision and a false positive here is an unaudited execution.
+   */
+  respondToApproval(approvalId: string, approved: boolean): boolean {
+    if (this.pendingApprovals.has(approvalId)) {
+      return approved ? this.approve(approvalId) : this.reject(approvalId);
+    }
+    return this.resolveApprovalToken(approvalId, approved);
+  }
+
+  /**
    * Look up an approval token by id (any status).
    */
   getApprovalToken(tokenId: string): ApprovalToken | undefined {
@@ -500,4 +569,31 @@ export class ExecSafety {
 
 export function createExecSafety(safeBins?: Iterable<string>, options?: ExecSafetyOptions): ExecSafety {
   return new ExecSafety(safeBins, options);
+}
+
+/**
+ * The one approval queue in this process.
+ *
+ * An approval is only meaningful if the thing that blocked the command and the
+ * thing the human answers on are the same object. ShellAgent constructs its
+ * safety engine with no arguments (AgentRegistry does `new AgentClass()`), and
+ * the gateway serves `exec.pending`/`exec.respond` — with two separate
+ * instances the Bar would show an empty list forever and "approve" would
+ * resolve nothing, which is worse than an error because it looks like it
+ * worked. Both therefore default to this instance.
+ *
+ * Callers that genuinely want an isolated engine (tests, sandboxes) still pass
+ * their own to `new ShellAgent(...)` / `GatewayServer#setExecSafety`; those are
+ * deliberately invisible to the gateway.
+ */
+let sharedExecSafety: ExecSafety | undefined;
+
+export function getSharedExecSafety(): ExecSafety {
+  if (!sharedExecSafety) sharedExecSafety = new ExecSafety();
+  return sharedExecSafety;
+}
+
+/** Drops the shared engine so a test starts from an empty approval queue. */
+export function resetSharedExecSafety(): void {
+  sharedExecSafety = undefined;
 }


### PR DESCRIPTION
## The defect

The macOS Bar's Permissions screen — the UI that gates what an agent is allowed to run — was dead. `ApprovalViewModel.swift` calls two RPC methods the production gateway never registered:

```
ApprovalViewModel.swift:43  rpc.listPendingApprovals()  -> exec.pending
ApprovalViewModel.swift:54  rpc.respondToApproval(...)  -> exec.respond   (approve)
ApprovalViewModel.swift:66  rpc.respondToApproval(...)  -> exec.respond   (deny)
```

**Reproduced first**, against a started `GatewayServer` on clean `main`:

```
exec.* registered in production: []
exec.pending  -> {"code":-32601,"message":"Method not found: exec.pending"}
exec.respond  -> {"code":-32601,"message":"Method not found: exec.respond"}
exec.history  -> {"code":-32601,"message":"Method not found: exec.history"}
```

A user who believed they were approving individual actions was using a screen that had never functioned.

## Where the real approval state lives

`typescript/src/security/exec-safety.ts`. `ShellAgent.executeBash` runs every command through `ExecSafety.checkCommand`; anything injection-shaped or dual-use (`curl`, `npm`, `chmod`, …) is refused, and the agent issues a **single-use approval token** bound to that exact normalized command. The command only runs if a later call presents an `approval_id` that `consumeApprovalToken` accepts. The same engine also holds the older blocking `requestApproval` queue. Nothing outside the process could resolve either. That is what these handlers now serve.

An approval only means anything if the object that blocked the command is the object the human answers on, so `ShellAgent` and `GatewayServer` now both default to one process-wide engine (`getSharedExecSafety()`); `AgentRegistry` constructs agents with `new AgentClass()`, so the loaded ShellAgent gets it. Explicitly injected engines (tests, embedders) stay isolated, and `GatewayServer#setExecSafety` exists for deliberate wiring.

## Why I did not reuse `exec-methods.ts`

It is not the missing wiring, in two independent ways:

1. **It does not define these names.** It declares `exec.approval.request`, `exec.approval.resolve`, `exec.approvals.get`, `exec.approvals.set` — none of which the Bar calls.
2. **It is backed by nothing.** Every handler reads `deps?.approvalManager`, and no caller in the repo supplies one. With no manager, `exec.approvals.get` returns `{ requests: [] }` — success, empty list, forever.

Registering it would have given the Bar a screen that lists nothing and an approve button that resolves nothing while reporting success: the #170 (`config-methods.ts` demo store) and #176 (stubs reporting success) failure mode, and strictly worse than an error. `ApprovalManager` in `security/approvals.ts` is a second, also-unwired store — `checkApproval` has no production caller; the engine that actually blocks commands is `ExecSafety`.

## What was registered

| method | shape |
| --- | --- |
| `exec.pending` | Both real queues, as a **top-level array** (RpcClient decodes `payload` directly into `[ExecutionApproval]`), in the field names `ExecutionApproval` declares: `id`, `command`, `description`, `timestamp`, `status`. Expired tokens are excluded — an approval that can no longer be consumed is not pending, and offering it as a button would be a lie. |
| `exec.respond` | Accepts `{ approvalId, approved }` exactly as `RpcClient.respondToApproval` sends it (plus `id`/`requestId`/`decision` aliases). Refuses unknown, expired and already-resolved ids with an error rather than reporting success (#166 precedent), and **never infers a missing decision** — defaulting to `true` is an unaudited execution, defaulting to `false` silently kills an approved command. |
| `exec.history` | The real `ExecSafety` audit log, mapped onto the Bar's `ApprovalStatus` enum, which has no `rejected`/`used` case; the raw value rides along as `auditStatus`. |

## The Swift side could not read the answer either

`ExecutionApproval.timestamp` is a non-optional `Date`; the gateway sends ISO-8601; the stock `JSONDecoder` date strategy wants a `Double`. The decode failed and `try?` turned that into `return []` — an approval screen that silently shows nothing while commands sit blocked. Observed as three red Swift tests before the fix. `RpcClient` now decodes with an ISO-8601 strategy (with and without fractional seconds, numeric still accepted) and **throws** where an empty array used to hide the failure.

## Verification

End-to-end, through a real `ShellAgent` and a real gateway over HTTP:

```
agent blocked: true token_1786932956639_v2wdh9c9wgs
exec.pending  -> [{"id":"token_…","command":"curl https://example.com","description":"Approval token issued for: curl https://example.com","timestamp":"2026-08-17T02:15:56.639Z","status":"pending","binary":"curl","kind":"token","expiresAt":"2026-08-17T02:20:56.639Z"}]
unknown id    -> {"code":-32603,"message":"Unknown, expired, or already-resolved approval id: nope"}
deny          -> {"ok":true,"approved":false,"status":"denied"}
retry after deny: error | Command blocked: … Approval rejected: Approval token was rejected
replay        -> Command blocked: … Approval token was already used (replay attempt)
```

The contract test (`src/__tests__/integration/exec-approval-contract.test.ts`) never imports a method module. It starts a real `GatewayServer`, lets a real `ShellAgent` block a real command, and drives the exact frames the Bar sends over both the WebSocket protocol (`{type:'req'}` after the `connect` handshake) and HTTP JSON-RPC. The approve/deny tests assert on an **observable side effect**: the blocked command is `touch <marker>`, and the marker file must exist after an approve and must not exist after a deny.

## Mutation table

Each fix reverted in isolation; suite re-run; then restored.

| Mutation | Result |
| --- | --- |
| Unregister `exec.pending`/`exec.respond` (the original bug) | **9 TS failed** |
| Gateway serves its own `ExecSafety` instead of the shared one | **8 TS failed** |
| `ShellAgent` keeps its own `ExecSafety` | **6 TS failed** |
| Drop the refusal of unknown/expired/already-resolved ids | **3 TS failed** |
| A deny resolves as an approve (`respondToApproval(id, true)`) | **3 TS failed** |
| List expired tokens as pending | **1 TS failed** |
| Wrap the pending list as `{ approvals: [...] }` | **4 TS failed** |
| Default a missing `approved` to `true` | **1 TS failed** |
| `exec.history` keeps ExecSafety's own status vocabulary | **1 TS failed** |
| Revert the Swift ISO-8601 decoder to `try? JSONDecoder()` | **3 Swift failed** |

## Validation

- TypeScript: **4947 passed, 21 skipped, 0 failed** (256 files)
- `tsc --noEmit -p tsconfig.json`: clean
- `eslint` on changed files: clean — the single `_ignored` warning in `server.ts` is present on clean `main` (verified by stashing)
- macOS: `swift build` clean, `swift run RunTests` **150 passed, 0 failed**

## Not verified / out of scope

- **No live push.** `AppViewModel.handleEvent` listens for an `approval` event that the gateway still never broadcasts, so the list refreshes on `ApprovalDetailView.onAppear` (which is the path the screen actually uses) rather than the instant a command is blocked. Wiring an emitter into `ExecSafety` is a separate change.
- **Approvals are in-memory and per-process.** A restarted daemon loses pending tokens; they expire in 5 minutes anyway. Unchanged by this PR.
- **`exec.history` has no UI caller** — `RpcClient.getApprovalHistory` exists but no view model calls it. Registered so it is not a third dead method, and covered by a test, but it has not been exercised by a human through the app.
- I could not run the Bar against a live daemon end-to-end by hand; the Swift coverage is `RpcClient` + the mocked transport, pinned to the exact bytes the wired gateway emits.


---

## Rebased onto #181, and the `KNOWN_MISSING` entries removed

Rebased onto `origin/main` to pick up `client-rpc-coverage.test.ts` (#181). It failed on this branch exactly as designed — three methods now exist that the debt list still claimed were missing:

```
× the known-missing list contains nothing that now exists
  → expected [ "exec.history", "exec.pending", "exec.respond" ] to deeply equal []
```

**Removed exactly the three methods this PR registers, and nothing else:**

| entry | why it could be removed |
| --- | --- |
| `exec.pending` | Registered against the real `ExecSafety` queues (blocking approvals + single-use tokens) |
| `exec.respond` | Registered against the same engine; refuses unknown/expired/already-resolved ids |
| `exec.history` | Registered against the real `ExecSafety` audit log |

**Everything else stays.** `agents.execute`, `agents.info`, `config.patch`, `connections.info`, `models.list`, `agents.files.list/read/write`, `cron.runs`, `skills.toggle`, `zen.sessions/subscribe/unsubscribe`, `connections.disconnect`, `connections.pair`, `logs.get`, `sessions.reset`, `skills.install`, `skills.list`, `usage.history`, `usage.stats` — I did not touch any of them. There is no honest backing state wired for them here, and inventing one would be the exact failure this PR argues against. Their entries are what keeps those screens' brokenness visible.

Two extra mutations on this change:

| Mutation | Result |
| --- | --- |
| Leave the three entries in `KNOWN_MISSING` | **1 failed** (`the known-missing list contains nothing that now exists`) |
| Also remove `usage.stats`, which is still unregistered | **1 failed** (`the macOS Bar calls nothing the gateway lacks` → `[ "usage.stats" ]`) |

Re-validated after the rebase: TS **4951 passed / 21 skipped / 0 failed** (257 files), `client-rpc-coverage.test.ts` 4 passed, `exec-approval-contract.test.ts` 9 passed, `tsc --noEmit` clean, `swift build` clean, `RunTests` **150 passed**.
