### PR TITLE
fix(gateway): the Bar's Logs pane and session reset called methods nobody registered

### DIFF
--- a/docs/AUTONOMOUS.md
+++ b/docs/AUTONOMOUS.md
@@ -113,7 +113,8 @@ curl -sS -X POST http://127.0.0.1:18790 \
 ```
 
 Useful methods: `agents.list`, `chat.send`, `chat.session`, `chat.list`,
-`chat.messages`, `chat.delete`, `config.get`, `config.set`.
+`chat.messages`, `chat.delete`, `sessions.reset`, `logs.get`, `config.get`,
+`config.set`.
 
 To enumerate everything this build actually registers rather than trusting this
 list, ask for a method that cannot exist and read the registry from the source:

--- a/typescript/.gitignore
+++ b/typescript/.gitignore
@@ -7,3 +7,6 @@ src/**/*.js
 # instead of a TypeScript original and a hand-copied twin that drifts.
 !src/voice/local-speech.js
 .env
+
+# Temp data dirs for tests that start a real gateway (see gateway/__tests__).
+.vitest-tmp/

--- a/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
+++ b/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
@@ -47,16 +47,16 @@ const KNOWN_MISSING = new Set<string>([
   'zen.sessions',
   'zen.subscribe',
   'zen.unsubscribe',
-  // Live macOS Bar screens that cannot work: usage, logs, node pairing and
-  // skills. Being fixed now; each entry is removed as its method lands, and the
-  // last test in this file fails if one is left here after it starts existing.
+  // Live macOS Bar screens that cannot work: usage, node pairing and skills.
+  // Being fixed now; each entry is removed as its method lands, and the last
+  // test in this file fails if one is left here after it starts existing.
   // Approvals left this list in the exec.pending/exec.respond fix: they are
   // served by the ExecSafety engine ShellAgent actually blocks on, not by the
-  // unwired gateway/methods/exec-methods.ts module.
+  // unwired gateway/methods/exec-methods.ts module. Logs and session reset
+  // left in #183, wired to the daemon's launchd log files and the live
+  // sessionStore.
   'connections.disconnect',
   'connections.pair',
-  'logs.get',
-  'sessions.reset',
   'skills.install',
   'skills.list',
   'usage.history',

--- a/typescript/src/gateway/__tests__/bar-logs-and-session-reset.test.ts
+++ b/typescript/src/gateway/__tests__/bar-logs-and-session-reset.test.ts
@@ -1,0 +1,491 @@
+/**
+ * Two live Bar features answered "Method not found".
+ *
+ *   LogsViewModel.swift:45   rpc.getLogs(limit:)   -> logs.get
+ *   SessionsViewModel.swift  rpc.resetSession(...) -> sessions.reset
+ *
+ * Probed against a started GatewayServer before the fix:
+ *
+ *   logs.get       -> {"code":-32601,"message":"Method not found: logs.get"}
+ *   sessions.reset -> {"code":-32601,"message":"Method not found: sessions.reset"}
+ *
+ * `methods/logs-methods.ts` and `methods/session-methods.ts` declare those
+ * names, and registering them would not have fixed anything — the same probe
+ * with both register functions called by hand:
+ *
+ *   logs.get                    -> still -32601 (the module registers `logs.tail`)
+ *   logs.tail                   -> {"entries":[]} from a buffer whose only
+ *                                  writer, `pushLog`, has no callers in the repo
+ *   sessions.reset {sessionKey} -> "Session not found: undefined" (it reads
+ *                                  `sessionId`, the Bar sends `sessionKey`)
+ *   sessions.reset {sessionId}  -> "Session not found: s1" for a session the
+ *                                  live gateway had just created and listed
+ *
+ * So both names are wired here, in `registerBuiltInMethods`, against the state
+ * that actually exists: the daemon's launchd log files under the data dir, and
+ * the real `sessionStore`.
+ *
+ * Everything below goes over real HTTP to a real started server. Importing the
+ * method modules and calling their handlers is what let these two ship broken
+ * in the first place: those tests pass whether or not production registers
+ * anything.
+ */
+
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest';
+import fs from 'node:fs';
+import { WebSocket } from 'ws';
+import path from 'node:path';
+import { GatewayServer } from '../server.js';
+import { MAX_MESSAGE_LENGTH } from '../log-store.js';
+import { reserveTestPort } from '../../__tests__/support/test-port.js';
+import type { AgentRequest, AgentResponse, ChatSession } from '../types.js';
+
+/**
+ * Temp state lives under the repo, never in the real `~/.openrappter`: these
+ * tests write log files and sessions, and the gateway defaults its data dir to
+ * the user's home.
+ */
+const TMP_ROOT = path.join(process.cwd(), '.vitest-tmp');
+
+let server: GatewayServer;
+let dataDir: string;
+let base: string;
+
+/** Resolved per test so a slow agent can be held open and released on demand. */
+let agentReply: (request: AgentRequest) => Promise<AgentResponse>;
+
+beforeAll(async () => {
+  fs.mkdirSync(TMP_ROOT, { recursive: true });
+  dataDir = fs.mkdtempSync(path.join(TMP_ROOT, 'bar-logs-'));
+  const port = await reserveTestPort();
+  base = `http://127.0.0.1:${port}`;
+  server = new GatewayServer({
+    port,
+    bind: 'loopback',
+    auth: { mode: 'none' },
+    heartbeatInterval: 60_000,
+    dataDir,
+  });
+  server.setAgentHandler((request) => agentReply(request));
+  await server.start();
+});
+
+afterAll(async () => {
+  await server.stop().catch(() => {});
+  fs.rmSync(dataDir, { recursive: true, force: true });
+});
+
+beforeEach(() => {
+  agentReply = async (request) => ({ content: 'ok', finishReason: 'stop', sessionId: request.sessionId ?? '' });
+  fs.rmSync(path.join(dataDir, 'daemon.log'), { force: true });
+  fs.rmSync(path.join(dataDir, 'logs'), { recursive: true, force: true });
+});
+
+interface RpcOutcome {
+  status: number;
+  raw: string;
+  result?: unknown;
+  error?: { code: number; message: string };
+}
+
+async function rpc(method: string, params?: Record<string, unknown>): Promise<RpcOutcome> {
+  const response = await fetch(`${base}/rpc`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: `t-${method}-${Math.random()}`, method, params: params ?? {} }),
+  });
+  const raw = await response.text();
+  const parsed = JSON.parse(raw) as { result?: unknown; error?: { code: number; message: string } };
+  return { status: response.status, raw, result: parsed.result, error: parsed.error };
+}
+
+/** A secret is built at runtime so a scanner cannot rewrite it into a literal that trivially passes. */
+function freshSecret(label: string): string {
+  const alphabet = 'abcdefghijklmnopqrstuvwxyz0123456789';
+  const body = Array.from({ length: 24 }, () => alphabet[Math.floor(Math.random() * alphabet.length)]).join('');
+  return `${String.fromCharCode(103, 104, 112, 95)}${label}${body}`;
+}
+
+function writeDaemonLog(lines: string[]): void {
+  fs.writeFileSync(path.join(dataDir, 'daemon.log'), `${lines.join('\n')}\n`, 'utf-8');
+}
+
+/** The shape `RpcClient.getLogs` decodes: a bare array of dictionaries. */
+type LogPayload = Array<Record<string, unknown>>;
+
+function sessionsOnDisk(): ChatSession[] {
+  const file = path.join(dataDir, 'sessions.json');
+  if (!fs.existsSync(file)) return [];
+  return JSON.parse(fs.readFileSync(file, 'utf-8')) as ChatSession[];
+}
+
+describe('the harness itself', () => {
+  it('never points the gateway at the real ~/.openrappter', () => {
+    expect(dataDir.startsWith(TMP_ROOT)).toBe(true);
+  });
+});
+
+describe('logs.get — the method the Bar calls', () => {
+  it('is registered on a started gateway', async () => {
+    const listed = await rpc('methods');
+    expect(listed.result as string[]).toContain('logs.get');
+
+    const answered = await rpc('logs.get', { limit: 10 });
+    expect(answered.error).toBeUndefined();
+  });
+
+  it('returns the daemon log the launchd job actually writes', async () => {
+    writeDaemonLog([
+      '[2026-08-16T10:00:00.000Z] [INFO] Gateway server started on 127.0.0.1:1234',
+      '[2026-08-16T10:00:05.000Z] [WARN] channel telegram disconnected',
+    ]);
+
+    const entries = (await rpc('logs.get', { limit: 100 })).result as LogPayload;
+    expect(Array.isArray(entries)).toBe(true);
+    expect(entries.map((e) => e.message)).toEqual([
+      'Gateway server started on 127.0.0.1:1234',
+      'channel telegram disconnected',
+    ]);
+    expect(entries.map((e) => e.level)).toEqual(['info', 'warn']);
+    expect(entries.every((e) => typeof e.timestamp === 'number')).toBe(true);
+    expect(entries.every((e) => e.source === 'daemon.log')).toBe(true);
+  });
+
+  it('reads the GUI LaunchAgent stdout/stderr files too', async () => {
+    fs.mkdirSync(path.join(dataDir, 'logs'), { recursive: true });
+    fs.writeFileSync(path.join(dataDir, 'logs', 'gateway.stdout.log'), 'user gateway listening\n');
+    fs.writeFileSync(path.join(dataDir, 'logs', 'gateway.stderr.log'), 'Error: EADDRINUSE 127.0.0.1:18384\n');
+
+    const entries = (await rpc('logs.get', { limit: 100 })).result as LogPayload;
+    const bySource = new Map(entries.map((e) => [e.source, e]));
+    expect(bySource.get('logs/gateway.stdout.log')?.message).toBe('user gateway listening');
+    // A stack trace's leading `Error:` survives — it is the message, not a level.
+    expect(bySource.get('logs/gateway.stderr.log')?.message).toBe('Error: EADDRINUSE 127.0.0.1:18384');
+    // Anything the daemon wrote to stderr is an error even when the line says nothing.
+    expect(bySource.get('logs/gateway.stderr.log')?.level).toBe('error');
+  });
+
+  it('honours the limit the Swift client sends — a smaller limit returns fewer entries', async () => {
+    writeDaemonLog(
+      Array.from({ length: 40 }, (_, i) =>
+        `[2026-08-16T10:00:${String(i).padStart(2, '0')}.000Z] [INFO] line ${i}`)
+    );
+
+    const all = (await rpc('logs.get', { limit: 100 })).result as LogPayload;
+    const few = (await rpc('logs.get', { limit: 5 })).result as LogPayload;
+
+    expect(all).toHaveLength(40);
+    expect(few).toHaveLength(5);
+    expect(few.length).toBeLessThan(all.length);
+    // The newest lines, not the oldest — a log pane that shows the first five
+    // lines of a rotating file is showing nothing anyone needs.
+    expect(few.map((e) => e.message)).toEqual([
+      'line 35', 'line 36', 'line 37', 'line 38', 'line 39',
+    ]);
+  });
+
+  it('caps an absurd limit instead of reading the whole file', async () => {
+    writeDaemonLog(Array.from({ length: 30 }, (_, i) => `line ${i}`));
+    const entries = (await rpc('logs.get', { limit: 10_000_000 })).result as LogPayload;
+    expect(entries).toHaveLength(30);
+  });
+
+  it('is empty, not broken, when no daemon log exists yet', async () => {
+    const entries = (await rpc('logs.get', { limit: 100 })).result as LogPayload;
+    expect(entries).toEqual([]);
+  });
+
+  it('never returns raw file bytes — every line arrives as a structured entry', async () => {
+    const long = 'x'.repeat(MAX_MESSAGE_LENGTH + 500);
+    writeDaemonLog([long]);
+
+    const entries = (await rpc('logs.get', { limit: 10 })).result as LogPayload;
+    expect(entries).toHaveLength(1);
+    const message = entries[0].message as string;
+    expect(typeof message).toBe('string');
+    expect(message.length).toBeLessThan(long.length);
+    expect(message.endsWith('[truncated]')).toBe(true);
+  });
+});
+
+describe('logs.get — redaction', () => {
+  it('does not hand a secret-looking JSON field to an RPC caller', async () => {
+    const secret = freshSecret('json');
+    writeDaemonLog([
+      JSON.stringify({
+        timestamp: '2026-08-16T10:00:00.000Z',
+        level: 'info',
+        message: 'copilot provider ready',
+        apiKey: secret,
+      }),
+    ]);
+
+    const answered = await rpc('logs.get', { limit: 100 });
+    expect(answered.raw).not.toContain(secret);
+    expect((answered.result as LogPayload)[0].message).toBe('copilot provider ready');
+  });
+
+  it('does not hand a secret pasted into a plain log line to an RPC caller', async () => {
+    const secret = freshSecret('plain');
+    writeDaemonLog([
+      `[2026-08-16T10:00:00.000Z] [ERROR] auth failed apiKey=${secret} status=401`,
+      `[2026-08-16T10:00:01.000Z] [INFO] Authorization: Bearer ${secret}`,
+    ]);
+
+    const answered = await rpc('logs.get', { limit: 100 });
+    expect(answered.raw).not.toContain(secret);
+    expect(answered.raw).toContain('REDACTED');
+    // The surrounding line is still useful — redaction is not deletion.
+    expect((answered.result as LogPayload)[0].message).toContain('status=401');
+  });
+
+  it('leaves non-secret fields readable', async () => {
+    writeDaemonLog(['[2026-08-16T10:00:00.000Z] [INFO] keyCount=3 monkey=curious']);
+    const entries = (await rpc('logs.get', { limit: 10 })).result as LogPayload;
+    expect(entries[0].message).toBe('keyCount=3 monkey=curious');
+  });
+
+  it('does not leak a structured record that carries no message of its own', async () => {
+    const secret = freshSecret('nomessage');
+    writeDaemonLog([
+      JSON.stringify({ timestamp: '2026-08-16T10:00:00.000Z', level: 'info', apiKey: secret }),
+    ]);
+
+    const answered = await rpc('logs.get', { limit: 10 });
+    expect(answered.raw).not.toContain(secret);
+    expect((answered.result as LogPayload)[0].message).toContain('REDACTED');
+  });
+
+  it('does not leak a secret under a field name only the key pass recognises', async () => {
+    // `2fa_token` starts with a digit, so the text scan finds no key/value pair
+    // to judge; `redactSecrets` walking the parsed record is what catches it.
+    const secret = freshSecret('twofactor');
+    writeDaemonLog([
+      JSON.stringify({ timestamp: '2026-08-16T10:00:00.000Z', level: 'info', '2fa_token': secret }),
+    ]);
+
+    const answered = await rpc('logs.get', { limit: 10 });
+    expect(answered.raw).not.toContain(secret);
+    expect((answered.result as LogPayload)[0].message).toContain('REDACTED');
+  });
+
+  it('does not leak a secret field dumped alongside a component/event record', async () => {
+    const secret = freshSecret('fields');
+    writeDaemonLog([
+      JSON.stringify({
+        timestamp: '2026-08-16T10:00:00.000Z',
+        level: 'warn',
+        component: 'gateway',
+        event: 'auth.refresh',
+        sessionToken: secret,
+        durationMs: 12,
+      }),
+    ]);
+
+    const answered = await rpc('logs.get', { limit: 10 });
+    expect(answered.raw).not.toContain(secret);
+    const message = (answered.result as LogPayload)[0].message as string;
+    expect(message).toContain('gateway auth.refresh');
+    expect(message).toContain('durationMs=12');
+  });
+});
+
+describe('sessions.reset — the method the Bar calls', () => {
+  async function sendMessage(sessionKey: string, message: string): Promise<void> {
+    const accepted = await rpc('chat.send', { sessionKey, message });
+    expect(accepted.error).toBeUndefined();
+  }
+
+  async function messagesOf(sessionKey: string): Promise<unknown[]> {
+    const answered = await rpc('chat.messages', { sessionKey });
+    return (answered.result ?? []) as unknown[];
+  }
+
+  it('is registered on a started gateway', async () => {
+    const listed = await rpc('methods');
+    expect(listed.result as string[]).toContain('sessions.reset');
+  });
+
+  it('accepts the sessionKey field name the Swift client sends', async () => {
+    await rpc('chat.session', { sessionKey: 'reset-field-name' });
+    const answered = await rpc('sessions.reset', { sessionKey: 'reset-field-name' });
+    expect(answered.error).toBeUndefined();
+    expect(answered.result).toMatchObject({ reset: true, sessionId: 'reset-field-name' });
+  });
+
+  it('actually empties the session — read back afterwards, the messages are gone', async () => {
+    const sessionKey = 'reset-really';
+    await sendMessage(sessionKey, 'first');
+    await sendMessage(sessionKey, 'second');
+    expect((await messagesOf(sessionKey)).length).toBeGreaterThan(0);
+
+    const answered = await rpc('sessions.reset', { sessionKey });
+    expect(answered.result).toMatchObject({ reset: true });
+
+    // The reply is not the evidence. Ask the gateway again.
+    expect(await messagesOf(sessionKey)).toEqual([]);
+    const listed = (await rpc('chat.list')).result as Array<{ id: string; messageCount: number }>;
+    const entry = listed.find((s) => s.id === sessionKey);
+    expect(entry, 'reset clears the session, it does not delete it').toBeDefined();
+    expect(entry!.messageCount).toBe(0);
+  });
+
+  it('persists the reset, so a gateway restart does not resurrect the messages', async () => {
+    const sessionKey = 'reset-persisted';
+    await sendMessage(sessionKey, 'remember this');
+    expect(sessionsOnDisk().find((s) => s.id === sessionKey)!.messages.length).toBeGreaterThan(0);
+
+    await rpc('sessions.reset', { sessionKey });
+
+    const persisted = sessionsOnDisk().find((s) => s.id === sessionKey);
+    expect(persisted, 'the session survives on disk').toBeDefined();
+    expect(persisted!.messages).toEqual([]);
+  });
+
+  it('cancels the run in flight, so the answer cannot repopulate the session', async () => {
+    const sessionKey = 'reset-midflight';
+    let release!: () => void;
+    const gate = new Promise<void>((resolve) => { release = resolve; });
+    let markStarted!: () => void;
+    const handlerStarted = new Promise<void>((resolve) => { markStarted = resolve; });
+    const handlerFinished = new Promise<void>((resolveFinished) => {
+      agentReply = async (request) => {
+        markStarted();
+        await gate;
+        resolveFinished();
+        return { content: 'late answer', finishReason: 'stop', sessionId: request.sessionId ?? '' };
+      };
+    });
+
+    await sendMessage(sessionKey, 'ask something slow');
+    await handlerStarted;
+    await rpc('sessions.reset', { sessionKey });
+
+    release();
+    await handlerFinished;
+    // Give the completion path every chance to write the reply back.
+    await new Promise((resolve) => setTimeout(resolve, 50));
+
+    expect(await messagesOf(sessionKey)).toEqual([]);
+  });
+
+  it('refuses an unknown session instead of reporting a success it did not perform', async () => {
+    const answered = await rpc('sessions.reset', { sessionKey: 'never-existed' });
+    expect(answered.result).toBeUndefined();
+    expect(answered.error?.message).toContain('Session not found');
+  });
+
+  it('refuses a request with no session at all', async () => {
+    const answered = await rpc('sessions.reset', {});
+    expect(answered.result).toBeUndefined();
+    expect(answered.error?.message).toContain('sessionKey required');
+  });
+});
+
+describe('the Bar transport — WebSocket frames, exactly as RpcClient sends them', () => {
+  /** Connect handshake, then one request, then close. Returns the `res` frame. */
+  async function wsCall(method: string, params: Record<string, unknown>): Promise<{
+    ok: boolean;
+    payload?: unknown;
+    error?: { code: number; message: string };
+  }> {
+    const socket = new WebSocket(base.replace('http://', 'ws://'));
+    try {
+      const frames: Array<Record<string, unknown>> = [];
+      const waitFor = (id: string) => new Promise<Record<string, unknown>>((resolve, reject) => {
+        const timer = setTimeout(() => reject(new Error(`timed out waiting for ${id}`)), 4000);
+        const onMessage = (data: unknown) => {
+          const frame = JSON.parse(String(data)) as Record<string, unknown>;
+          frames.push(frame);
+          if (frame.type === 'res' && frame.id === id) {
+            clearTimeout(timer);
+            socket.off('message', onMessage);
+            resolve(frame);
+          }
+        };
+        socket.on('message', onMessage);
+      });
+
+      await new Promise<void>((resolve, reject) => {
+        socket.once('open', () => resolve());
+        socket.once('error', reject);
+      });
+
+      const hello = waitFor('c1');
+      socket.send(JSON.stringify({
+        type: 'req',
+        id: 'c1',
+        method: 'connect',
+        params: { client: { id: 'bar-test', version: '1.0.0', platform: 'macos', mode: 'bar' } },
+      }));
+      const helloFrame = await hello;
+      expect(helloFrame.ok, 'handshake').toBe(true);
+
+      const answered = waitFor('r1');
+      socket.send(JSON.stringify({ type: 'req', id: 'r1', method, params }));
+      return await answered as { ok: boolean; payload?: unknown; error?: { code: number; message: string } };
+    } finally {
+      socket.close();
+    }
+  }
+
+  it('returns logs.get as a bare array payload, which is what getLogs decodes', async () => {
+    writeDaemonLog(['[2026-08-16T10:00:00.000Z] [INFO] over the websocket']);
+    const frame = await wsCall('logs.get', { limit: 100 });
+    expect(frame.ok).toBe(true);
+    expect(Array.isArray(frame.payload)).toBe(true);
+    const entries = frame.payload as LogPayload;
+    expect(entries[0].message).toBe('over the websocket');
+    // getLogs reads exactly these keys off each dictionary.
+    expect(typeof entries[0].timestamp).toBe('number');
+    expect(typeof entries[0].level).toBe('string');
+    expect(typeof entries[0].source).toBe('string');
+  });
+
+  it('answers sessions.reset with ok:true, which is all resetSession checks', async () => {
+    await rpc('chat.session', { sessionKey: 'ws-reset' });
+    const frame = await wsCall('sessions.reset', { sessionKey: 'ws-reset' });
+    expect(frame.error).toBeUndefined();
+    expect(frame.ok).toBe(true);
+  });
+});
+
+describe('both methods are fail-closed when the gateway has credentials', () => {
+  it('rejects an unauthenticated HTTP caller', async () => {
+    const port = await reserveTestPort();
+    const secured = new GatewayServer({
+      port,
+      bind: 'loopback',
+      auth: { mode: 'token', tokens: [freshSecret('gateway')] },
+      heartbeatInterval: 60_000,
+      dataDir,
+    });
+    await secured.start();
+    try {
+      for (const method of ['logs.get', 'sessions.reset']) {
+        const response = await fetch(`http://127.0.0.1:${port}/rpc`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', id: '1', method, params: {} }),
+        });
+        expect(response.status, method).toBe(401);
+      }
+    } finally {
+      await secured.stop().catch(() => {});
+    }
+  });
+
+  /**
+   * The Bar talks WebSocket, and on that path `requiresAuth` is the check that
+   * runs per method (`dispatchMethod`) rather than per transport. It is not
+   * observable from outside — the handshake gate rejects everything first — so
+   * this asserts the registration itself, on the live server's method table.
+   */
+  it('registers both methods as requiring authentication', () => {
+    const methods = (server as unknown as {
+      methods: Map<string, { requiresAuth: boolean }>;
+    }).methods;
+    expect(methods.get('logs.get')?.requiresAuth).toBe(true);
+    expect(methods.get('sessions.reset')?.requiresAuth).toBe(true);
+  });
+});

--- a/typescript/src/gateway/log-store.ts
+++ b/typescript/src/gateway/log-store.ts
@@ -1,0 +1,286 @@
+/**
+ * What "the logs" are for a running gateway.
+ *
+ * There were three candidates and only one of them is real in production:
+ *
+ *  - `methods/logs-methods.ts` keeps an in-memory `logBuffer` fed by `pushLog`.
+ *    `pushLog` has no callers anywhere in the repo, so that buffer is empty on
+ *    every machine, forever. It also registers `logs.tail`, not the `logs.get`
+ *    the Bar calls.
+ *  - `logging/logger.ts` has a rotating `FileTransport`/`JsonTransport`, but
+ *    nothing in the shipped runtime ever installs one — the global `logger` is
+ *    console-only, and only two modules use it at all.
+ *  - The daemon runs under launchd with its stdout and stderr redirected to
+ *    files. That is where `logGatewayLifecycle`, every `console.log` in the
+ *    runtime, and every crash actually land, and it survives restarts. That is
+ *    the log an operator means when they open the Bar's Logs pane.
+ *
+ * So this module reads the daemon's launchd log files out of the gateway's own
+ * data directory. Both installers are covered, because both exist in the wild:
+ *
+ *    ~/.openrappter/daemon.log                  (`--daemon` plist, index.ts)
+ *    ~/.openrappter/logs/gateway.stdout.log     (GUI LaunchAgent,
+ *    ~/.openrappter/logs/gateway.stderr.log      imessage-launchd.ts)
+ *    ~/.openrappter/logs/daemon.stdout.log      (delegated system daemon,
+ *    ~/.openrappter/logs/daemon.stderr.log       index.ts)
+ *
+ * Two properties this file exists to guarantee:
+ *
+ *  1. It never reads a whole log file. These rotate at 5–10 MB; only the tail
+ *     is read, and only up to the requested limit is returned.
+ *  2. It never emits raw log bytes. Every line is parsed into a structured
+ *     entry and passed through the shared redactor (`security/redact.ts`)
+ *     first — key-wise for JSON records, text-wise for plain lines. A log file
+ *     is the one place a stray credential is most likely to already be
+ *     sitting, and RPC hands it to whoever is connected.
+ */
+
+import fs from 'fs';
+import path from 'path';
+import { redactSecrets, redactSecretsInText } from '../security/redact.js';
+
+export type GatewayLogLevel = 'debug' | 'info' | 'warn' | 'error' | 'fatal';
+
+export interface GatewayLogEntry {
+  /** Epoch milliseconds. The Bar divides by 1000 to build a `Date`. */
+  timestamp: number;
+  level: GatewayLogLevel;
+  message: string;
+  /** Log file the line came from, relative to the data dir. */
+  source: string;
+  /**
+   * Whether `timestamp` was read off the line itself or inferred from the
+   * file's last-write time. Plain launchd output frequently carries no
+   * timestamp, and claiming those lines happened "now" would be a lie the
+   * caller cannot detect.
+   */
+  timestampFrom: 'line' | 'file';
+}
+
+/** Log files written by the launchd jobs this repo installs, newest-writer last. */
+export const GATEWAY_LOG_FILES = [
+  'daemon.log',
+  path.join('logs', 'daemon.stdout.log'),
+  path.join('logs', 'daemon.stderr.log'),
+  path.join('logs', 'gateway.stdout.log'),
+  path.join('logs', 'gateway.stderr.log'),
+] as const;
+
+/** Never read more than this per file, however large it has grown. */
+export const LOG_TAIL_BYTES = 256 * 1024;
+
+/** A single line is a message, not a payload. Anything longer is truncated. */
+export const MAX_MESSAGE_LENGTH = 2000;
+
+export const DEFAULT_LOG_LIMIT = 100;
+export const MAX_LOG_LIMIT = 1000;
+
+const LEVELS: GatewayLogLevel[] = ['debug', 'info', 'warn', 'error', 'fatal'];
+
+export interface ReadGatewayLogsOptions {
+  dataDir: string;
+  limit?: number;
+  /** Only entries at or after this epoch-ms timestamp. */
+  since?: number;
+  level?: string;
+}
+
+/**
+ * Clamp a caller-supplied limit. A missing or nonsensical limit falls back to
+ * the default rather than "everything" — the Bar sends 100, and an unbounded
+ * read is how a log endpoint becomes a memory incident.
+ */
+export function resolveLogLimit(limit: unknown): number {
+  const parsed = typeof limit === 'number' ? limit : Number(limit);
+  if (!Number.isFinite(parsed)) return DEFAULT_LOG_LIMIT;
+  const floored = Math.floor(parsed);
+  if (floored <= 0) return 0;
+  return Math.min(floored, MAX_LOG_LIMIT);
+}
+
+/** Read the last `LOG_TAIL_BYTES` of a file without loading the rest of it. */
+function readTail(filePath: string): { text: string; truncated: boolean; mtimeMs: number } | null {
+  let handle: number | null = null;
+  try {
+    const stat = fs.statSync(filePath);
+    if (!stat.isFile()) return null;
+    const start = Math.max(0, stat.size - LOG_TAIL_BYTES);
+    const length = stat.size - start;
+    if (length <= 0) return { text: '', truncated: false, mtimeMs: Math.round(stat.mtimeMs) };
+    const buffer = Buffer.alloc(length);
+    handle = fs.openSync(filePath, 'r');
+    const read = fs.readSync(handle, buffer, 0, length, start);
+    return {
+      text: buffer.subarray(0, read).toString('utf-8'),
+      truncated: start > 0,
+      // Rounded: a fractional epoch is not a time anyone can read back.
+      mtimeMs: Math.round(stat.mtimeMs),
+    };
+  } catch {
+    // A log file that cannot be read is not an error the caller can act on;
+    // the other files still have something to say.
+    return null;
+  } finally {
+    if (handle !== null) {
+      try { fs.closeSync(handle); } catch { /* already gone */ }
+    }
+  }
+}
+
+function normalizeLevel(value: unknown): GatewayLogLevel | undefined {
+  if (typeof value !== 'string') return undefined;
+  const lowered = value.trim().toLowerCase();
+  if ((LEVELS as string[]).includes(lowered)) return lowered as GatewayLogLevel;
+  if (lowered === 'warning') return 'warn';
+  if (lowered === 'err') return 'error';
+  return undefined;
+}
+
+function parseTimestamp(value: unknown): number | undefined {
+  if (typeof value === 'number' && Number.isFinite(value)) {
+    // Seconds vs milliseconds: anything below this is not a plausible ms epoch.
+    return value < 1e11 ? value * 1000 : value;
+  }
+  if (typeof value === 'string') {
+    const parsed = Date.parse(value);
+    if (!Number.isNaN(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+/** `[2026-08-16T12:00:00.000Z] [INFO] [component] message` and looser variants. */
+const LEADING_TIMESTAMP = /^\[?(\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:Z|[+-]\d{2}:?\d{2})?)\]?\s*/;
+/**
+ * A bare `Error:` at the start of a stack trace is a message, not a level
+ * marker — requiring whitespace after the word keeps `Error: ENOENT …` intact
+ * while still recognising `[INFO] …` and `WARN …`.
+ */
+const LEADING_LEVEL = /^(?:\[(debug|info|warn|warning|error|fatal|err)\]|(debug|info|warn|warning|error|fatal|err)(?=\s))\s*/i;
+
+function truncate(message: string): string {
+  if (message.length <= MAX_MESSAGE_LENGTH) return message;
+  return `${message.slice(0, MAX_MESSAGE_LENGTH)}… [truncated]`;
+}
+
+/**
+ * Turn one raw line into a redacted entry, or null if there is nothing in it.
+ *
+ * JSON lines (what `observability.ts` emits under `OPENRAPPTER_LOG_FORMAT=json`
+ * and what `JsonTransport` writes) go through `redactSecrets` so a secret-named
+ * field is blanked by key. Every message string then also goes through
+ * `redactSecretsInText`, because a credential pasted into a message body has no
+ * key left for the object walk to judge.
+ */
+export function parseLogLine(
+  line: string,
+  context: { source: string; fileMtimeMs: number; defaultLevel: GatewayLogLevel }
+): GatewayLogEntry | null {
+  const trimmed = line.trim();
+  if (!trimmed) return null;
+
+  let timestamp: number | undefined;
+  let level: GatewayLogLevel | undefined;
+  let message = trimmed;
+
+  if (trimmed.startsWith('{')) {
+    try {
+      const parsed: unknown = JSON.parse(trimmed);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        const safe = redactSecrets(parsed) as Record<string, unknown>;
+        timestamp = parseTimestamp(safe.timestamp ?? safe.time ?? safe.ts);
+        level = normalizeLevel(safe.level);
+        const body = typeof safe.message === 'string' ? safe.message.trim() : '';
+        const component = typeof safe.component === 'string' ? safe.component : undefined;
+        const event = typeof safe.event === 'string' ? safe.event : undefined;
+        // `logGatewayRequest` emits an empty message and carries its meaning in
+        // component/event, so an empty body is not an empty record.
+        message = body || [component, event].filter(Boolean).join(' ') || JSON.stringify(safe);
+        if (!body && component && event) {
+          const detail = { ...safe };
+          delete detail.timestamp;
+          delete detail.level;
+          delete detail.component;
+          delete detail.event;
+          delete detail.message;
+          const rest = Object.entries(detail).map(([k, v]) => `${k}=${String(v)}`).join(' ');
+          if (rest) message = `${message} ${rest}`;
+        }
+      }
+    } catch {
+      // Not JSON after all — fall through and treat it as text.
+    }
+  }
+
+  if (timestamp === undefined && level === undefined && message === trimmed) {
+    const timestampMatch = LEADING_TIMESTAMP.exec(message);
+    if (timestampMatch) {
+      timestamp = parseTimestamp(timestampMatch[1]);
+      message = message.slice(timestampMatch[0].length);
+    }
+    const levelMatch = LEADING_LEVEL.exec(message);
+    if (levelMatch) {
+      level = normalizeLevel(levelMatch[1] ?? levelMatch[2]);
+      message = message.slice(levelMatch[0].length);
+    }
+  }
+
+  message = truncate(redactSecretsInText(message).trim());
+  if (!message) return null;
+
+  return {
+    timestamp: timestamp ?? context.fileMtimeMs,
+    timestampFrom: timestamp === undefined ? 'file' : 'line',
+    level: level ?? context.defaultLevel,
+    message,
+    source: context.source,
+  };
+}
+
+/**
+ * Read the gateway's real log files, newest entry last, at most `limit`
+ * entries. Missing files are not an error: a gateway started by hand has no
+ * launchd log, and an empty list is the honest answer for it.
+ */
+export function readGatewayLogs(options: ReadGatewayLogsOptions): GatewayLogEntry[] {
+  const limit = resolveLogLimit(options.limit ?? DEFAULT_LOG_LIMIT);
+  if (limit === 0) return [];
+
+  const wantedLevel = normalizeLevel(options.level);
+  const entries: GatewayLogEntry[] = [];
+
+  for (const relative of GATEWAY_LOG_FILES) {
+    const filePath = path.join(options.dataDir, relative);
+    const tail = readTail(filePath);
+    if (!tail || !tail.text) continue;
+
+    const lines = tail.text.split('\n');
+    // The first line of a tail read is very likely half a line.
+    if (tail.truncated) lines.shift();
+
+    const defaultLevel: GatewayLogLevel = relative.endsWith('stderr.log') ? 'error' : 'info';
+    for (const line of lines) {
+      const entry = parseLogLine(line, {
+        source: relative,
+        fileMtimeMs: tail.mtimeMs,
+        defaultLevel,
+      });
+      if (entry) entries.push(entry);
+    }
+  }
+
+  let selected = entries;
+  if (wantedLevel) selected = selected.filter((entry) => entry.level === wantedLevel);
+  if (typeof options.since === 'number' && Number.isFinite(options.since)) {
+    const since = options.since;
+    selected = selected.filter((entry) => entry.timestamp >= since);
+  }
+
+  // Stable sort keeps each file's append order intact where timestamps tie,
+  // which is the only ordering plain launchd output actually carries.
+  selected = selected
+    .map((entry, index) => ({ entry, index }))
+    .sort((a, b) => (a.entry.timestamp - b.entry.timestamp) || (a.index - b.index))
+    .map(({ entry }) => entry);
+
+  return selected.slice(-limit);
+}

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -33,6 +33,7 @@ import { registerSurgeonMethods } from './methods/surgeon-methods.js';
 import { getSharedExecSafety } from '../security/exec-safety.js';
 import type { ExecSafety } from '../security/exec-safety.js';
 import { readAnatomy } from './anatomy.js';
+import { readGatewayLogs } from './log-store.js';
 import { renderAnatomyPage } from './anatomy-page.js';
 import type { RappterManager } from './rappter-manager.js';
 import type { SurgeonService } from '../surgeon/service.js';
@@ -2213,6 +2214,62 @@ export class GatewayServer {
       const result = { deleted: !!sessionId && this.sessionStore.delete(sessionId) };
       this.saveSessions();
       return result;
+    }, { requiresAuth: true });
+
+    /**
+     * sessions.reset — empty a session without discarding it.
+     *
+     * Wired against `sessionStore`, the same map `chat.*` reads, because the
+     * reply is not the evidence: `methods/session-methods.ts` declares this
+     * same name against a `Map` it allocates itself, so it answered "Session
+     * not found" for sessions the live gateway demonstrably held, and would
+     * have cleared nothing had it found one.
+     *
+     * Aborting the in-flight run is part of the reset, not politeness. A run
+     * that survives it pushes its assistant reply into the session on
+     * completion (see `executeAgentWithEvents`), so a reset issued mid-answer
+     * would report success and then be silently undone a few seconds later.
+     */
+    this.registerMethod('sessions.reset', async (params: { sessionId?: string; sessionKey?: string }) => {
+      const sessionId = resolveSessionId(params);
+      if (!sessionId) throw new Error('sessionKey required');
+      const session = this.sessionStore.get(sessionId);
+      if (!session) throw new Error('Session not found');
+
+      const runId = this.activeRunBySession.get(sessionId);
+      const run = runId ? this.activeRunsById.get(runId) : undefined;
+      if (run) this.abortActiveRun(run);
+
+      const clearedMessages = session.messages.length;
+      session.messages = [];
+      session.updatedAt = new Date().toISOString();
+      this.saveSessions();
+
+      return {
+        reset: true,
+        sessionId,
+        sessionKey: sessionId,
+        clearedMessages,
+        messageCount: 0,
+      };
+    }, { requiresAuth: true });
+
+    /**
+     * logs.get — the daemon's own log, redacted.
+     *
+     * Reads the launchd stdout/stderr files under this server's data dir; see
+     * `log-store.ts` for why those files and not the unfed in-memory buffer in
+     * `methods/logs-methods.ts` (which also answers to `logs.tail`, a name
+     * nothing calls). Returns a bare array because that is what the Bar's
+     * `RpcClient.getLogs` decodes.
+     */
+    this.registerMethod('logs.get', async (params: { limit?: number; since?: number; level?: string }) => {
+      return readGatewayLogs({
+        dataDir: this.dataDir,
+        limit: params?.limit,
+        since: params?.since,
+        level: params?.level,
+      });
     }, { requiresAuth: true });
 
     // Channel methods

--- a/typescript/src/security/redact.test.ts
+++ b/typescript/src/security/redact.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { redactSecrets, TOO_DEEP } from './redact.js';
+import { redactSecrets, redactSecretsInText, TOO_DEEP } from './redact.js';
 
 const secret = (tag: string): string => ['S3CR3T', tag, 'v1'].join('-');
 
@@ -55,5 +55,34 @@ describe('the depth limit', () => {
     const blob = JSON.stringify(redactSecrets(node));
     expect(blob).not.toContain(value);
     expect(blob).not.toContain(TOO_DEEP);
+  });
+});
+
+describe('redactSecretsInText — the same judgement applied to a log line', () => {
+  it('blanks a secret assigned inside free text', () => {
+    const value = secret('line');
+    const out = redactSecretsInText(`auth failed apiKey=${value} status=401`);
+    expect(out).not.toContain(value);
+    expect(out).toContain('status=401');
+  });
+
+  it('blanks the token after an auth scheme, not just the scheme word', () => {
+    const value = secret('bearer');
+    expect(redactSecretsInText(`Authorization: Bearer ${value}`)).not.toContain(value);
+  });
+
+  it('blanks a secret in a quoted pair a JSON parse never reached', () => {
+    const value = secret('quoted');
+    expect(redactSecretsInText(`{"token":"${value}"}`)).not.toContain(value);
+  });
+
+  it('leaves fields that merely look secret alone', () => {
+    expect(redactSecretsInText('keyCount=3 monkey=curious keyword=key'))
+      .toBe('keyCount=3 monkey=curious keyword=key');
+  });
+
+  it('leaves text with no assignment in it untouched', () => {
+    expect(redactSecretsInText('Gateway server started on 127.0.0.1:1234'))
+      .toBe('Gateway server started on 127.0.0.1:1234');
   });
 });

--- a/typescript/src/security/redact.ts
+++ b/typescript/src/security/redact.ts
@@ -40,3 +40,32 @@ export function redactSecrets(obj: unknown, depth = 0): unknown {
   }
   return result;
 }
+
+/**
+ * Redact `key=value` / `key: value` pairs inside a line of free text.
+ *
+ * `redactSecrets` judges object keys, which is everything the config printer
+ * and the logger's `data` field need. A log *line* is different: by the time it
+ * reaches disk the secret is inside a string — `Authorization: Bearer ghp_…`,
+ * `apiKey=…` — where there is no object key left to judge, so `redactSecrets`
+ * passes it through untouched.
+ *
+ * This is deliberately not a second answer to "is this a secret?": the decision
+ * still belongs to `isSecretKey`, and the marker is still `REDACTED`. Only the
+ * shape being scanned differs, which is why it lives in this file rather than
+ * beside the one caller that needs it.
+ *
+ * Conservative by construction — an unrecognized shape is left alone, so this
+ * is a second line of defense behind "do not log the secret", never a licence
+ * to log one.
+ */
+const TEXT_PAIR =
+  /(["']?)([A-Za-z_][A-Za-z0-9_.\- ]*)\1(\s*[:=]\s*)("[^"]*"|'[^']*'|(?:Bearer|Basic|Token)\s+[^\s,;)\]}]+|[^\s,;)\]}]+)/gi;
+
+export function redactSecretsInText(text: string): string {
+  if (!text) return text;
+  return text.replace(TEXT_PAIR, (whole, quote: string, key: string, separator: string) => {
+    if (!isSecretKey(key.trim())) return whole;
+    return `${quote}${key}${quote}${separator}${REDACTED}`;
+  });
+}


### PR DESCRIPTION
## Reproduction

Both defects probed over HTTP JSON-RPC against a started `GatewayServer` (port from the kernel, temp `dataDir`), before any change:

```
logs.get       {"limit":100}                -> {"code":-32601,"message":"Method not found: logs.get"}
sessions.reset {"sessionKey":"probe-..."}   -> {"code":-32601,"message":"Method not found: sessions.reset"}
```

The session in the second probe was created first via `chat.session` and was listed by `chat.list`, so the failure is registration, not a missing session.

Call sites: `LogsViewModel.swift:45` → `RpcClient.getLogs(limit:)` → `logs.get`; `SessionsViewModel.swift:79` → `RpcClient.resetSession(sessionKey:)` → `sessions.reset`.

## Why the existing modules were not reused

`registerBuiltInMethods`' doc comment warns that `methods/*.ts` declare production names against disconnected dependencies. I probed rather than assumed — same live server, both register functions called by hand:

```
logs.get                    -> still -32601   (the module registers `logs.tail`, a name nothing calls)
logs.tail  {"limit":100}    -> {"entries":[]} (buffer whose only writer, `pushLog`, has zero callers in the repo)
sessions.reset {sessionKey} -> "Session not found: undefined"  (it reads `sessionId`; the Bar sends `sessionKey`)
sessions.reset {sessionId}  -> "Session not found: s1"         (for a session the live gateway had just created)
```

`session-methods.ts` defaults to `deps?.sessionStore ?? new Map()` — a store allocated at registration that nothing else ever writes — and its "reset" would have cleared a session the gateway does not own. That is #166's `cron.delete` shape exactly: success reported over the wrong state. Both are wired in `registerBuiltInMethods` instead; the dormant modules are untouched.

## Where the real state lives

**Sessions** — `GatewayServer.sessionStore`, the map `chat.list`, `chat.messages`, `chat.delete` and `chat.send` all use, persisted to `<dataDir>/sessions.json` by `saveSessions()`. `sessions.reset` clears `messages`, keeps the session (`SessionsViewModel` comments it as "clear messages but keep session"), bumps `updatedAt`, saves, and **aborts any run in flight for that session**. That last part is load-bearing: `executeAgentWithEvents` pushes the assistant reply into the session on completion, so a reset issued mid-answer would otherwise report success and be silently undone seconds later.

**Logs** — three candidates, one real:

| candidate | verdict |
|---|---|
| `methods/logs-methods.ts` in-memory buffer | never written (`pushLog` has no callers), wrong method name |
| `logging/logger.ts` `FileTransport`/`JsonTransport` | never installed by the shipped runtime; the global `logger` is console-only and used by two modules |
| launchd stdout/stderr files under `~/.openrappter` | where `logGatewayLifecycle` and every console line actually land, and they survive restarts |

So `logs.get` reads the daemon's log files out of the server's own data dir, covering both installers in the wild: `daemon.log` (`--daemon` plist, `index.ts`), `logs/gateway.{stdout,stderr}.log` (GUI LaunchAgent, `imessage-launchd.ts`), `logs/daemon.{stdout,stderr}.log` (delegated system daemon). It reads at most 256 KiB from the tail of each file — these rotate at 5–10 MB — parses each line into `{timestamp, level, message, source, timestampFrom}`, and returns a bare array because that is what `RpcClient.getLogs` decodes. `limit` is honoured and capped at 1000; the newest entries are returned, not the oldest. Lines that carry no timestamp report the file's mtime and say so via `timestampFrom: "file"` rather than claiming they happened now. Missing files return `[]` — a hand-started gateway has no launchd log, and that is the honest answer for it.

Both methods are registered `requiresAuth: true`, like `chat.delete`.

## Redaction evidence

No log content leaves the process unredacted, and there is still exactly one answer to "is this a secret?" (`security/secret-keys.ts#isSecretKey`):

- JSON log records are parsed and passed through `redactSecrets` (the shared structural redactor) before anything is read off them.
- Every message string then passes through `redactSecretsInText`, added to `security/redact.ts` itself — the same module, same `isSecretKey`, same `REDACTED` marker. It exists because once a credential is inside a log *line* (`apiKey=…`, `Authorization: Bearer …`) there is no object key left for the structural walk to judge, and `redactSecrets` passes it through untouched.
- Raw bytes are never returned: no file is returned as content, and a line longer than 2000 chars is truncated *after* redaction.

Tests build the secret at runtime from character codes and a random suffix, so secret scanning cannot rewrite it into a literal that makes a leak test pass for the wrong reason. Covered: a secret-named JSON field, a secret pasted into a plain line, an auth-scheme token, a field dumped beside a component/event record, and `2fa_token` — a digit-leading name the text scan cannot see as a key/value pair and only the structural pass catches. Non-secret fields (`keyCount`, `monkey`) stay readable, and a redacted line keeps its useful context (`status=401`).

## Mutation table

Each mutation applied to the shipped code, then `bar-logs-and-session-reset.test.ts` + `redact.test.ts` (37 tests) re-run.

| # | mutation | result |
|---|---|---|
| M1 | `logs.get` not registered | RED — 14 failed |
| M2 | `sessions.reset` not registered | RED — 9 failed |
| M3 | `logs.get` ignores the caller's `limit` | RED — 13 failed |
| M4 | return the oldest entries instead of the newest | RED — 1 failed |
| M5 | skip `redactSecretsInText` on log lines | RED — 1 failed |
| M6 | skip `redactSecrets` on JSON records | RED — 1 failed (the `2fa_token` case) |
| M7 | no message truncation | RED — 1 failed |
| M8 | stderr lines default to `info` | RED — 1 failed |
| M9 | reset reports success without clearing | RED — 3 failed |
| M10 | reset clears memory but does not persist | RED — 1 failed |
| M11 | reset ignores the run in flight | RED — 1 failed |
| M12 | reset reads `sessionId` only (ignores `sessionKey`) | RED — 6 failed |
| M13 | reset invents success for an unknown session | RED — 1 failed |
| M14 | `logs.get` drops `requiresAuth` | RED — 1 failed |
| M15 | text redactor stops at the auth-scheme word | RED — 2 failed |
| M16 | `sessions.reset` drops `requiresAuth` | RED — 1 failed |

Two corrections worth recording, since a mutation run is only as good as its anchors. M6 survived the first pass: with the structural pass removed, the text pass still caught every input I had written, so the test proved nothing about it — I hunted for a case only the key walk sees (`2fa_token`, a digit-leading field name the pair regex cannot match) and added it. M13 also "survived" at first because its patch anchor matched an identical line in `chat.messages` higher up the file; re-run against a unique anchor, it is red.

## Verification

- `vitest run` — 4968 passed, 21 skipped, 256 files
- `tsc --noEmit -p tsconfig.json` — clean
- `eslint` on every changed file — clean (one pre-existing warning at `server.ts:2389`, untouched)
- `swift build` — succeeds; `swift run RunTests` — 145 passed, 0 failed
- Live re-probe after the fix: `logs.get` returns redacted entries from a real daemon log file; `sessions.reset` returns `{reset:true,…}`, and `chat.messages` afterwards returns `[]` while `chat.list` still shows the session

Tests go over real HTTP and over the Bar's actual WebSocket frame protocol (connect handshake, then `{type:"req"}`) to a started `GatewayServer`, asserting the `{ok, payload}` shape the Swift client decodes. Nothing imports the method modules.

## Unverified / judgement calls

- **Not exercised against a real launchd daemon.** Tests write the log files the plists declare as `StandardOutPath`/`StandardErrorPath`, which is what launchd does, but no test installs a LaunchAgent. The file *names* are read from `index.ts` and `imessage-launchd.ts`, not guessed.
- **`requiresAuth` on the WebSocket path is asserted as registration metadata, not black-box.** The handshake gate in `handleMessage` rejects every non-`connect` frame before dispatch, so an unauthenticated WS caller cannot reach the per-method check to observe it. The HTTP 401 test is black-box, but HTTP is fail-closed for all non-public methods regardless of the flag, so it does not prove the flag either.
- **Timestamps for lines without one are the file's mtime**, reported as `timestampFrom: "file"`. It is an upper bound, not the truth; the alternative (omitting it) makes the Bar render "now", which is worse.
- **The Bar's Swift side is unchanged** and was not re-run against a live gateway end to end — `LogsViewModel` and `SessionsViewModel` already send what these handlers accept, which is what the WS contract tests assert.
- `logs.get` also accepts `since` and `level`; only `limit` is sent by the Bar today. `since`/`level` have no dedicated contract test.


## Known-missing list (#181)

Rebased onto `main` to pick up `client-rpc-coverage.test.ts`, and removed exactly two entries from `KNOWN_MISSING`: **`logs.get`** and **`sessions.reset`** — the two methods this PR registers against real state.

Nothing else was removed. `exec.pending`/`exec.respond` (approvals), `usage.stats`/`usage.history`, `skills.list`/`skills.install`, `connections.pair`/`connections.disconnect` and the dead client wrappers stay on the list: this branch does not wire any of them, and removing an entry without a working method behind it is the screen-that-looks-like-it-works that test exists to prevent.

Checked both directions rather than trusting the green: the file passes as committed, and putting the two entries back turns it red with `expected [ 'logs.get', 'sessions.reset' ] to deeply equal []`.

Post-rebase verification: `vitest run` — 4972 passed, 21 skipped, 257 files; `client-rpc-coverage.test.ts` — 4 passed; `tsc --noEmit` — clean; eslint — clean.


### Rebase onto #182 and #186 (conflict in the shared debt list)

`bar/exec` (#182) merged ahead of this branch and removed its own three entries (`exec.pending`, `exec.respond`, `exec.history`) from the same `KNOWN_MISSING` array, so the two branches conflicted on one list. Resolved by taking **both** sides: the resulting list contains neither the three `exec.*` entries that `main` deleted nor the two this branch deletes, and both explanatory comments are kept. Verified by diffing the entry lists rather than eyeballing the hunk — relative to `main` this branch removes exactly `logs.get` and `sessions.reset` and resurrects nothing.

Then rebased again onto #186, which added `contracts/gateway-rpc-parity.json` and its two runtime tests. The contract does not reserve `logs.get` or `sessions.reset` to Python (`python_only` is `agents.execute` only), so registering them does not cross the parity pin; `gateway-rpc-parity.test.ts` passes as-is and the contract needed no edit.

Verification at the final head: full `vitest run` — **4984 passed**, 21 skipped, 259 files; `gateway-rpc-parity.test.ts` + `client-rpc-coverage.test.ts` — 7 passed; `tsc --noEmit` — clean. Swift is untouched by both rebases (`swift build` + `swift run RunTests` 145/145 from the original run still stand).
