### PR TITLE
fix(gateway): the Bar's Skills and Nodes panes called methods that do not exist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,9 @@ build/
 !typescript/desktop/build/entitlements.mac.inherit.plist
 # Logs & temp
 *.log
+# Integration tests that bind real sockets keep their scratch data dirs
+# inside the repo rather than the system temp dir.
+.test-scratch/
 *.swp
 # Python envs
 __pycache__/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `JSONDecoder`, whose `.deferredToDate` strategy threw on the gateway's
   ISO-8601 strings; the throw was swallowed by `try?`, so a populated response
   was silently rendered as an empty list.
+- **The Bar's Skills and Nodes panes call methods that exist** — `skills.list`,
+  `skills.install` and `connections.disconnect` were answered with
+  `Method not found` by the live gateway; they are now registered in
+  `registerBuiltInMethods` against the real bundled `skills/` directory, the
+  real `SkillsRegistry`, and the gateway's own live connection map.
+  `skills.install` requires the gateway credential, because it fetches a
+  third-party manifest off the network and writes it where the agent will load
+  it.
+- **`skills.list` cannot report a packaging fault as an empty list** — a
+  missing bundled `skills/` directory now raises instead of answering `[]`,
+  which was indistinguishable from a machine that legitimately has no skills.
+- **`skills.list` and `connections.list` answer in the shape the Bar decodes** —
+  both payloads omitted fields the macOS `Skill`/`Node` decoders require, so
+  the Bar showed "No skills installed" over 52 shipped skills and an empty
+  Nodes pane over live connections. `RpcClient` no longer turns a decode
+  failure into an empty array either.
+- **`connections.disconnect` does not claim to have closed a connection that
+  was not there** — an unknown connection id is an error.
+- **`connections.pair` stays unregistered, deliberately** — nothing in the
+  gateway can record a remote peer, and `connections.list` reports inbound
+  sockets, so a successful pairing would be followed by a list that still
+  showed nothing. The Bar gets a refusal it can display instead.
 - **Python storage adapter is genuinely thread-safe** — `SqliteStorageAdapter`
   held an `RLock` (implying multi-threaded use) but opened its connection with
   sqlite3's default `check_same_thread=True`, so any call from a worker thread

--- a/macos/Sources/OpenRappterBar/Services/RpcClient.swift
+++ b/macos/Sources/OpenRappterBar/Services/RpcClient.swift
@@ -620,14 +620,27 @@ public struct RpcClient: RpcClientProtocol, Sendable {
 
     // MARK: - Skills Methods
 
+    /// List skills the gateway knows about — bundled and installed.
+    ///
+    /// A decode failure is surfaced, not swallowed. It used to return `[]`,
+    /// which the Skills pane renders as "No skills installed" — so a payload
+    /// the Bar could not read was indistinguishable from a machine with no
+    /// skills. The gateway ships 52 bundled skills, and the pane showed none
+    /// of them for exactly that reason.
     public func listSkills() async throws -> [Skill] {
         let response = try await connection.sendRequest(method: "skills.list")
-        guard response.ok else { throw RpcClientError.decodingFailed("Failed to list skills") }
-        let data = try JSONEncoder().encode(response.payload ?? AnyCodable([]))
-        if let skills = try? JSONDecoder().decode([Skill].self, from: data) {
-            return skills
+        guard response.ok else {
+            throw GatewayConnectionError.serverError(
+                code: response.error?.code ?? -1,
+                message: response.error?.message ?? "Failed to list skills"
+            )
         }
-        return []
+        let data = try JSONEncoder().encode(response.payload ?? AnyCodable([]))
+        do {
+            return try JSONDecoder().decode([Skill].self, from: data)
+        } catch {
+            throw RpcClientError.decodingFailed("skills.list returned a payload this build cannot read: \(error)")
+        }
     }
 
     public func installSkill(name: String) async throws {
@@ -640,14 +653,56 @@ public struct RpcClient: RpcClientProtocol, Sendable {
 
     // MARK: - Nodes Methods
 
+    /// List the connections attached to the gateway.
+    ///
+    /// A decode failure is surfaced rather than becoming an empty list. The
+    /// empty list is not harmless here: `disconnectNode` takes its
+    /// `connectionId` from a row of this list, so a payload the Bar could not
+    /// read left the Nodes pane empty AND made disconnect unreachable.
     public func listNodes() async throws -> [Node] {
         let response = try await connection.sendRequest(method: "connections.list")
-        guard response.ok else { throw RpcClientError.decodingFailed("Failed to list nodes") }
-        let data = try JSONEncoder().encode(response.payload ?? AnyCodable([]))
-        if let nodes = try? JSONDecoder().decode([Node].self, from: data) {
-            return nodes
+        guard response.ok else {
+            throw GatewayConnectionError.serverError(
+                code: response.error?.code ?? -1,
+                message: response.error?.message ?? "Failed to list nodes"
+            )
         }
-        return []
+        let data = try JSONEncoder().encode(response.payload ?? AnyCodable([]))
+        do {
+            return try Self.gatewayDecoder().decode([Node].self, from: data)
+        } catch {
+            throw RpcClientError.decodingFailed("connections.list returned a payload this build cannot read: \(error)")
+        }
+    }
+
+    /// A decoder for gateway payloads whose dates are ISO-8601 strings.
+    ///
+    /// `JSONDecoder`'s default `.deferredToDate` expects a number of seconds
+    /// since 2001, so an ISO-8601 string fails outright, and `.iso8601`
+    /// rejects the fractional seconds that JavaScript's `toISOString()`
+    /// always emits. Either failure fails the whole array.
+    static func gatewayDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            guard let str = try? container.decode(String.self) else {
+                throw DecodingError.dataCorruptedError(
+                    in: container,
+                    debugDescription: "expected an ISO-8601 date string"
+                )
+            }
+            let withFraction = ISO8601DateFormatter()
+            withFraction.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = withFraction.date(from: str) { return date }
+            let plain = ISO8601DateFormatter()
+            plain.formatOptions = [.withInternetDateTime]
+            if let date = plain.date(from: str) { return date }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "not an ISO-8601 date: \(str)"
+            )
+        }
+        return decoder
     }
 
     public func disconnectNode(connectionId: String) async throws {

--- a/macos/Tests/OpenRappterBarTests/RpcClientContractTests.swift
+++ b/macos/Tests/OpenRappterBarTests/RpcClientContractTests.swift
@@ -32,6 +32,17 @@ private func makeOkNullResponse(id: String) throws -> Data {
     return try JSONSerialization.data(withJSONObject: frame)
 }
 
+/// A refusal frame, as the gateway sends one.
+private func makeErrorResponse(id: String, code: Int = -32603, message: String) throws -> Data {
+    let frame: [String: Any] = [
+        "type": "res",
+        "id": id,
+        "ok": false,
+        "error": ["code": code, "message": message],
+    ]
+    return try JSONSerialization.data(withJSONObject: frame)
+}
+
 /// Connects a fresh mock-backed GatewayConnection (consumes request id
 /// "rpc-1" for the handshake) and returns it plus an RpcClient wrapping it,
 /// ready for a first RPC call at id "rpc-2".
@@ -827,6 +838,261 @@ func runRpcClientContractTests() async {
             }
 
             try expect(threw, "a refused approval must throw")
+            await conn.disconnect()
+        }
+    }
+
+    // MARK: - Skills and Nodes
+    //
+    // Four Bar calls resolved to methods the production gateway never
+    // registered. Probed against a real started `GatewayServer`:
+    //
+    //     skills.list              -> Method not found
+    //     skills.install           -> Method not found
+    //     connections.pair         -> Method not found
+    //     connections.disconnect   -> Method not found
+    //
+    // Registering them exposed a second defect underneath, the same shape as
+    // the one #176 found in `skills list`: the payload the gateway sent was
+    // not the payload this client decodes, and both `listSkills` and
+    // `listNodes` turned that failure into an empty array. A pane that says
+    // "No skills installed" over 52 shipped skills is not a smaller bug than
+    // a missing method, it is a quieter one.
+
+    await suite("RpcClient Skills Contract") {
+        await test("a gateway skills.list payload decodes into skills") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let skills = try await withDeferredResponse(
+                mock: mock,
+                // Copied from a live `skills.list` response.
+                response: try makeOkArrayResponse(id: "rpc-2", payload: [[
+                    "id": "weather",
+                    "name": "weather",
+                    "description": "Get current weather and forecasts (no API key required).",
+                    "version": "1.0.0",
+                    "installed": true,
+                    "enabled": true,
+                    "source": "builtin",
+                    "category": "weather",
+                ]])
+            ) {
+                try await rpc.listSkills()
+            }
+
+            try expectEqual(skills.count, 1)
+            try expectEqual(skills.first?.name, "weather")
+            try expectEqual(skills.first?.source, SkillSource.builtin)
+            try expect(skills.first?.installed == true)
+            await conn.disconnect()
+        }
+
+        await test("a payload this build cannot read is an error, not an empty list") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            // The shape `src/index.ts` used to send: no `id`, no `installed`,
+            // no `source`. It decoded to nothing and the pane said "No skills
+            // installed" — indistinguishable from a machine with no skills.
+            var threw = false
+            do {
+                _ = try await withDeferredResponse(
+                    mock: mock,
+                    response: try makeOkArrayResponse(id: "rpc-2", payload: [[
+                        "name": "weather",
+                        "description": "Get current weather and forecasts.",
+                        "category": "weather",
+                        "enabled": true,
+                        "version": "1.0.0",
+                    ]])
+                ) {
+                    try await rpc.listSkills()
+                }
+            } catch {
+                threw = true
+            }
+            try expect(threw, "an undecodable skills payload must not read as zero skills")
+            await conn.disconnect()
+        }
+
+        await test("a gateway error on skills.list reaches the caller") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            var threw = false
+            do {
+                _ = try await withDeferredResponse(
+                    mock: mock,
+                    response: try makeErrorResponse(
+                        id: "rpc-2",
+                        message: "Bundled skills directory not found — this install shipped without skills/"
+                    )
+                ) {
+                    try await rpc.listSkills()
+                }
+            } catch {
+                threw = true
+            }
+            try expect(threw, "a packaging fault must not render as an empty skills list")
+            await conn.disconnect()
+        }
+
+        await test("installSkill calls skills.install with the name") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkResponse(id: "rpc-2", payload: [
+                    "id": "kody-w/rappterverse",
+                    "name": "rappterverse",
+                    "version": "2.1.0",
+                    "installed": true,
+                ])
+            ) {
+                try await rpc.installSkill(name: "kody-w/rappterverse")
+            }
+
+            let sent = try await lastSentJSON(mock)
+            try expectEqual(sent?["method"] as? String, "skills.install")
+            let params = sent?["params"] as? [String: Any]
+            try expectEqual(params?["name"] as? String, "kody-w/rappterverse")
+            await conn.disconnect()
+        }
+
+        await test("an install that installed nothing is not reported as success") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            var threw = false
+            do {
+                try await withDeferredResponse(
+                    mock: mock,
+                    response: try makeErrorResponse(
+                        id: "rpc-2",
+                        message: "skills.install failed — nothing was written"
+                    )
+                ) {
+                    try await rpc.installSkill(name: "kody-w/rappterverse")
+                }
+            } catch {
+                threw = true
+            }
+            try expect(threw, "#176: install must not print success over a no-op")
+            await conn.disconnect()
+        }
+    }
+
+    await suite("RpcClient Nodes Contract") {
+        await test("a gateway connections.list payload decodes into nodes") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            let nodes = try await withDeferredResponse(
+                mock: mock,
+                // Copied from a live `connections.list` response.
+                response: try makeOkArrayResponse(id: "rpc-2", payload: [[
+                    "id": "conn_ab12cd34",
+                    "connectionId": "conn_ab12cd34",
+                    "name": "openrappter-bar",
+                    "host": "127.0.0.1",
+                    "port": 54321,
+                    "status": "online",
+                    "connectedAt": "2026-08-16T22:00:00.000Z",
+                    "lastSeen": "2026-08-16T22:00:01.500Z",
+                    "authenticated": true,
+                    "subscriptions": ["*"],
+                ]])
+            ) {
+                try await rpc.listNodes()
+            }
+
+            // `connectionId` is the whole point: `disconnectNode` takes it
+            // from a row here, so a list that cannot decode also makes
+            // disconnect unreachable from the UI.
+            try expectEqual(nodes.count, 1)
+            try expectEqual(nodes.first?.connectionId, "conn_ab12cd34")
+            try expectEqual(nodes.first?.status, NodeStatus.online)
+            try expectEqual(nodes.first?.host, "127.0.0.1")
+            try expectNotNil(nodes.first?.lastSeen)
+            await conn.disconnect()
+        }
+
+        await test("a payload without the Node fields is an error, not an empty list") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            var threw = false
+            do {
+                _ = try await withDeferredResponse(
+                    mock: mock,
+                    // The old `connections.list` shape: no name/host/port/status.
+                    response: try makeOkArrayResponse(id: "rpc-2", payload: [[
+                        "id": "conn_ab12cd34",
+                        "connectedAt": "2026-08-16T22:00:00.000Z",
+                        "authenticated": true,
+                        "subscriptions": ["*"],
+                    ]])
+                ) {
+                    try await rpc.listNodes()
+                }
+            } catch {
+                threw = true
+            }
+            try expect(threw, "an undecodable nodes payload must not read as zero nodes")
+            await conn.disconnect()
+        }
+
+        await test("disconnectNode calls connections.disconnect with the connection id") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            try await withDeferredResponse(
+                mock: mock,
+                response: try makeOkResponse(id: "rpc-2", payload: [
+                    "disconnected": true,
+                    "connectionId": "conn_ab12cd34",
+                ])
+            ) {
+                try await rpc.disconnectNode(connectionId: "conn_ab12cd34")
+            }
+
+            let sent = try await lastSentJSON(mock)
+            try expectEqual(sent?["method"] as? String, "connections.disconnect")
+            let params = sent?["params"] as? [String: Any]
+            try expectEqual(params?["connectionId"] as? String, "conn_ab12cd34")
+            await conn.disconnect()
+        }
+
+        await test("a disconnect the gateway refused is not reported as success") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            var threw = false
+            do {
+                try await withDeferredResponse(
+                    mock: mock,
+                    response: try makeErrorResponse(
+                        id: "rpc-2",
+                        message: "No connection 'conn_absent' is attached to this gateway"
+                    )
+                ) {
+                    try await rpc.disconnectNode(connectionId: "conn_absent")
+                }
+            } catch {
+                threw = true
+            }
+            try expect(threw)
+            await conn.disconnect()
+        }
+
+        // `connections.pair` is deliberately unregistered on the gateway —
+        // there is no registry of remote peers to record a pairing in, and
+        // `connections.list` reports inbound sockets, so a `{paired: true}`
+        // would be followed by a list that still showed nothing. What matters
+        // on this side is that the refusal reaches the owner instead of being
+        // swallowed into a silent no-op.
+        await test("pairing a peer the gateway will not pair surfaces as an error") {
+            let (conn, mock, rpc) = try await makeConnectedClient()
+            var threw = false
+            do {
+                try await withDeferredResponse(
+                    mock: mock,
+                    response: try makeErrorResponse(
+                        id: "rpc-2",
+                        code: -32601,
+                        message: "Method not found: connections.pair"
+                    )
+                ) {
+                    try await rpc.pairNode(host: "10.0.0.9", port: 18790)
+                }
+            } catch {
+                threw = true
+            }
+            try expect(threw, "an unreachable or unpairable peer must not read as paired")
             await conn.disconnect()
         }
     }

--- a/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
+++ b/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
@@ -57,11 +57,19 @@ const KNOWN_MISSING = new Set<string>([
   // sessionStore. Usage left the same way — usage.stats/usage.history read
   // the Flight Recorder's recorded provider token counts, not the unwired
   // usage-methods.ts module, whose tracker nothing constructs and which
-  // answers a hardcoded zero.
-  'connections.disconnect',
+  // answers a hardcoded zero. Skills left it in the skills.list/skills.install
+  // fix, and connections.disconnect with them.
+  //
+  // `connections.pair` stays, and not because nobody got to it. There is no
+  // registry of remote peers for a pairing to be recorded in: `infra/roster.ts`
+  // holds loopback instances that each publish their *own* endpoint, and
+  // writing someone else's entry there is the forgery #132 ruled out
+  // ("a record nothing can vouch for is not an address"). `connections.list`
+  // reports inbound sockets, so a paired peer could never appear in it — the
+  // Bar would get `{paired:true}` and then an empty list. Registering it would
+  // buy a green line here at the cost of a screen that lies. See the block
+  // comment beside the `connections.*` registrations in gateway/server.ts.
   'connections.pair',
-  'skills.install',
-  'skills.list',
 ]);
 
 let server: GatewayServer | undefined;

--- a/typescript/src/__tests__/integration/skills-connections-contract.test.ts
+++ b/typescript/src/__tests__/integration/skills-connections-contract.test.ts
@@ -1,0 +1,555 @@
+/**
+ * The macOS Bar's skills and connections calls, against the gateway that runs.
+ *
+ * Probed before this suite existed, against a real started `GatewayServer`:
+ *
+ *     total registered: 54
+ *     skills.list              -> Method not found: skills.list
+ *     skills.install           -> Method not found: skills.install
+ *     connections.pair         -> Method not found: connections.pair
+ *     connections.disconnect   -> Method not found: connections.disconnect
+ *
+ * `gateway/methods/skills-methods.ts` and `gateway/methods/connections-methods.ts`
+ * declare some of those names, and are deliberately never registered (see the
+ * doc comment on `registerBuiltInMethods`). Importing them would prove nothing
+ * about production: `skills-methods.ts` hangs every handler off a
+ * `skillRegistry` dependency nothing in this repo supplies, and its
+ * `skills.list` answers `[]` when that dependency is missing — which is the
+ * defect, not a fix for it. So every test here goes over real HTTP or a real
+ * websocket to a real `GatewayServer`, driving the exact payloads
+ * `macos/Sources/OpenRappterBar/Services/RpcClient.swift` builds.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import WebSocket from 'ws';
+import { GatewayServer, type SkillsRegistryLike } from '../../gateway/server.js';
+import type { InstalledSkill } from '../../skills/registry.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/** Scratch roots live under the repo, never the system temp dir. */
+const SCRATCH_ROOT = join(process.cwd(), '.test-scratch');
+
+let server: GatewayServer | undefined;
+const scratchDirs: string[] = [];
+const sockets: WebSocket[] = [];
+
+afterEach(async () => {
+  for (const ws of sockets.splice(0)) {
+    try { ws.close(); } catch { /* already gone */ }
+  }
+  await server?.stop();
+  server = undefined;
+  for (const dir of scratchDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratch(prefix: string): string {
+  mkdirSync(SCRATCH_ROOT, { recursive: true });
+  const dir = mkdtempSync(join(SCRATCH_ROOT, prefix));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+interface StartOptions {
+  auth?: { mode: 'none' | 'token'; tokens?: string[] };
+  bundledSkillsDir?: string;
+  skillsRegistry?: SkillsRegistryLike;
+}
+
+async function startServer(options: StartOptions = {}): Promise<number> {
+  const port = await reserveTestPort();
+  const dataDir = scratch('skills-contract-');
+  server = new GatewayServer({
+    port,
+    bind: 'loopback',
+    auth: options.auth ?? { mode: 'none' },
+    dataDir,
+  });
+  await server.start();
+  if (options.bundledSkillsDir !== undefined) server.setBundledSkillsDir(options.bundledSkillsDir);
+  if (options.skillsRegistry) server.setSkillsRegistry(options.skillsRegistry);
+  return port;
+}
+
+interface RpcResult<T = unknown> {
+  result?: T;
+  error?: { code: number; message: string };
+}
+
+async function rpc<T = unknown>(
+  port: number,
+  method: string,
+  params?: Record<string, unknown>,
+  token?: string,
+): Promise<RpcResult<T>> {
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'contract-1', method, params }),
+  });
+  return (await res.json()) as RpcResult<T>;
+}
+
+/** A connected, handshaken websocket — what the Bar actually holds open. */
+async function connectBar(port: number, token?: string): Promise<{ ws: WebSocket; connectionId: string }> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  sockets.push(ws);
+  await new Promise<void>((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+  const reply = await wsRpc(ws, 'connect', {
+    client: { id: 'openrappter-bar', version: '1.0.0', platform: 'macos', mode: 'bar' },
+    ...(token ? { auth: { token } } : {}),
+  });
+  expect(reply.ok, `handshake failed: ${JSON.stringify(reply.error)}`).toBe(true);
+  const hello = reply.payload as { server: { connId: string } };
+  return { ws, connectionId: hello.server.connId };
+}
+
+/**
+ * Push a frame straight into `dispatchMethod` on a connection that never
+ * completed the handshake.
+ *
+ * The connect handshake already blocks everything pre-auth, so over a normal
+ * socket a per-method `requiresAuth` flag is invisible — and an invisible
+ * flag is one that can quietly become dead code. `integration/gateway.test.ts`
+ * measures it this way for the same reason.
+ */
+async function dispatchUnauthenticated(
+  port: number,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{ ok: boolean; payload?: unknown; error?: unknown }> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  sockets.push(ws);
+  await new Promise<void>((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+
+  const internal = server as unknown as {
+    connections: Map<string, { ws: WebSocket; info: { authenticated: boolean } }>;
+    dispatchMethod: (
+      connId: string,
+      ws: WebSocket,
+      info: { authenticated: boolean },
+      frame: { type: 'req'; id: string; method: string; params?: Record<string, unknown> },
+    ) => Promise<void>;
+  };
+
+  const deadline = Date.now() + 2000;
+  while (internal.connections.size === 0) {
+    if (Date.now() >= deadline) throw new Error('the server never registered the socket');
+    await new Promise((r) => setTimeout(r, 5));
+  }
+  const [connId, conn] = Array.from(internal.connections.entries()).at(-1)!;
+  expect(conn.info.authenticated, 'no handshake was sent, so this must be unauthenticated').toBe(false);
+
+  const reply = new Promise<{ ok: boolean; payload?: unknown; error?: unknown }>((resolve) => {
+    ws.on('message', (data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.id === 'direct-1') resolve(msg);
+    });
+  });
+
+  await internal.dispatchMethod(connId, conn.ws, conn.info, {
+    type: 'req', id: 'direct-1', method, params,
+  });
+
+  return reply;
+}
+
+function wsRpc(
+  ws: WebSocket,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{ ok: boolean; payload?: unknown; error?: { code: number; message: string } }> {
+  return new Promise((resolve, reject) => {
+    const id = `req_${Math.random().toString(36).slice(2)}`;
+    const timer = setTimeout(() => reject(new Error(`RPC timeout: ${method}`)), 5000);
+    const onMessage = (data: WebSocket.Data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.id !== id) return;
+      clearTimeout(timer);
+      ws.off('message', onMessage);
+      resolve(msg);
+    };
+    ws.on('message', onMessage);
+    ws.send(JSON.stringify({ type: 'req', id, method, params }));
+  });
+}
+
+/** The macOS Bar's `Skill` — every field its Codable decode requires. */
+interface BarSkill {
+  id: string;
+  name: string;
+  description?: string;
+  version?: string;
+  author?: string;
+  installed: boolean;
+  enabled: boolean;
+  source: string;
+}
+
+/** `SkillSource` in `macos/.../Models/SkillModels.swift`. */
+const BAR_SKILL_SOURCES = ['local', 'clawhub', 'builtin'];
+
+/** A registry that installs nothing and says so the way the real one does. */
+function registryThatInstallsNothing(): SkillsRegistryLike {
+  return {
+    initialize: async () => {},
+    // `SkillsRegistry.install` catches every failure and returns null.
+    install: async () => null,
+    getInstalled: () => [],
+  };
+}
+
+function registryThatInstalls(skill: InstalledSkill): SkillsRegistryLike {
+  const installed: InstalledSkill[] = [];
+  return {
+    initialize: async () => {},
+    install: async () => { installed.push(skill); return skill; },
+    getInstalled: () => installed,
+  };
+}
+
+// ── skills.list ────────────────────────────────────────────────────────
+
+describe('skills.list, against the wired gateway', () => {
+  it('is registered at all — the reproduction', async () => {
+    const port = await startServer();
+
+    const { error } = await rpc(port, 'skills.list');
+
+    expect(error, 'skills.list answered "Method not found" before this fix').toBeUndefined();
+  });
+
+  it('returns real bundled skills, named — not merely a successful empty list', async () => {
+    const port = await startServer();
+
+    const { result } = await rpc<BarSkill[]>(port, 'skills.list');
+
+    const names = (result ?? []).map((s) => s.name);
+    // Asserting a specific shipped skill, because "the call succeeded" and
+    // "the list has entries" are both satisfiable by an endpoint that has
+    // lost its skills directory. #165 is the whole reason.
+    expect(names).toContain('weather');
+    expect(names).toContain('github');
+    expect(names.length).toBeGreaterThanOrEqual(50);
+  });
+
+  it('answers in the shape `RpcClient.listSkills` decodes', async () => {
+    const port = await startServer();
+
+    const { result } = await rpc<BarSkill[]>(port, 'skills.list');
+    const weather = (result ?? []).find((s) => s.name === 'weather');
+
+    // The Bar decodes `[Skill]`, whose non-optional members are `id`,
+    // `installed`, `enabled` and `source`. Omitting any of them fails the
+    // decode for the WHOLE array, which the pane renders as "No skills
+    // installed" — a full list and an empty one look identical to the user.
+    expect(weather).toBeDefined();
+    expect(typeof weather!.id).toBe('string');
+    expect(weather!.id.length).toBeGreaterThan(0);
+    expect(typeof weather!.installed).toBe('boolean');
+    expect(typeof weather!.enabled).toBe('boolean');
+    expect(BAR_SKILL_SOURCES).toContain(weather!.source);
+
+    for (const skill of result ?? []) {
+      expect(BAR_SKILL_SOURCES, `source "${skill.source}" is outside the Bar's enum`)
+        .toContain(skill.source);
+      expect(typeof skill.id, `skill ${skill.name} has no id`).toBe('string');
+    }
+  });
+
+  it('refuses rather than reporting a missing skills directory as an empty list', async () => {
+    const port = await startServer({ bundledSkillsDir: join(scratch('no-skills-'), 'absent') });
+
+    const { result, error } = await rpc<BarSkill[]>(port, 'skills.list');
+
+    // The two causes of "zero skills" must not answer identically: an install
+    // that shipped without `skills/` is a fault, and `[]` would hide it.
+    expect(result).toBeUndefined();
+    expect(error?.message).toMatch(/shipped without skills/i);
+  });
+
+  it('an empty but present skills directory is an empty list, not an error', async () => {
+    const port = await startServer({ bundledSkillsDir: scratch('empty-skills-') });
+
+    const { result, error } = await rpc<BarSkill[]>(port, 'skills.list');
+
+    expect(error).toBeUndefined();
+    expect(result).toEqual([]);
+  });
+
+  it('includes skills the registry actually installed', async () => {
+    const registry = registryThatInstalls({
+      manifest: {
+        id: 'kody-w/rappterverse',
+        name: 'rappterverse',
+        version: '2.1.0',
+        description: 'a real installed skill',
+        author: 'kody-w',
+      },
+      path: '/somewhere/kody-w--rappterverse',
+      installedAt: new Date().toISOString(),
+      enabled: true,
+    });
+    const port = await startServer({ skillsRegistry: registry });
+
+    await rpc(port, 'skills.install', { name: 'kody-w/rappterverse' });
+    const { result } = await rpc<BarSkill[]>(port, 'skills.list');
+
+    const installed = (result ?? []).find((s) => s.id === 'kody-w/rappterverse');
+    expect(installed).toBeDefined();
+    expect(installed!.version).toBe('2.1.0');
+    expect(installed!.source).toBe('clawhub');
+  });
+});
+
+// ── skills.install ─────────────────────────────────────────────────────
+
+describe('skills.install, against the wired gateway', () => {
+  it('is registered at all — the reproduction', async () => {
+    const port = await startServer({ skillsRegistry: registryThatInstallsNothing() });
+
+    const { error } = await rpc(port, 'skills.install', { name: 'kody-w/rappterverse' });
+
+    expect(error?.message ?? '').not.toMatch(/Method not found/);
+  });
+
+  it('does not report success when the registry installed nothing', async () => {
+    const port = await startServer({ skillsRegistry: registryThatInstallsNothing() });
+
+    // Exactly the params `RpcClient.installSkill(name:)` builds.
+    const { result, error } = await rpc(port, 'skills.install', { name: 'kody-w/rappterverse' });
+
+    // #176 found `skills install` printing "Successfully installed" over a
+    // stub that wrote nothing. The real registry swallows every failure and
+    // returns null; turning that into `{installed: true}` would rebuild the
+    // same lie on top of real code.
+    expect(result).toBeUndefined();
+    expect(error?.message).toMatch(/nothing was written/i);
+  });
+
+  it('reports what was actually installed when the registry installs', async () => {
+    const port = await startServer({
+      skillsRegistry: registryThatInstalls({
+        manifest: { id: 'kody-w/rappterverse', name: 'rappterverse', version: '2.1.0', description: 'real' },
+        path: '/somewhere/kody-w--rappterverse',
+        installedAt: '2026-01-01T00:00:00.000Z',
+        enabled: true,
+      }),
+    });
+
+    const { result, error } = await rpc<{ installed: boolean; version: string; name: string }>(
+      port, 'skills.install', { name: 'kody-w/rappterverse' },
+    );
+
+    expect(error).toBeUndefined();
+    expect(result?.installed).toBe(true);
+    expect(result?.name).toBe('rappterverse');
+    expect(result?.version).toBe('2.1.0');
+  });
+
+  it('says what is wrong with a bare skill name instead of failing vaguely', async () => {
+    const port = await startServer({ skillsRegistry: registryThatInstallsNothing() });
+
+    const { error } = await rpc(port, 'skills.install', { name: 'weather' });
+
+    expect(error?.message).toMatch(/owner\/repo/);
+  });
+
+  it('requires the credential, and does not run the install without it', async () => {
+    let installCalls = 0;
+    const registry: SkillsRegistryLike = {
+      initialize: async () => {},
+      install: async () => { installCalls++; return null; },
+      getInstalled: () => [],
+    };
+    const port = await startServer({ auth: { mode: 'token', tokens: ['bar-secret'] }, skillsRegistry: registry });
+
+    const denied = await dispatchUnauthenticated(port, 'skills.install', { name: 'kody-w/rappterverse' });
+
+    // It fetches a third-party manifest off the network and writes it where
+    // the agent will load it. #171's reasoning for `/agents/import` applies
+    // unchanged: code entering the execution surface needs the credential.
+    //
+    // Dispatched straight at an unauthenticated connection, past the connect
+    // handshake, so what is measured is the per-method `requiresAuth` gate
+    // itself and not the handshake that happens to sit in front of it — the
+    // same technique `integration/gateway.test.ts` uses for `requiresAuth`.
+    expect(denied.ok).toBe(false);
+    expect((denied.error as { message: string }).message).toMatch(/requires authentication/i);
+    expect(installCalls, 'the handler must not run for an unauthenticated caller').toBe(0);
+  });
+
+  it('installs for a caller that presents the credential', async () => {
+    let installCalls = 0;
+    const registry: SkillsRegistryLike = {
+      initialize: async () => {},
+      install: async () => { installCalls++; return null; },
+      getInstalled: () => [],
+    };
+    const port = await startServer({ auth: { mode: 'token', tokens: ['bar-secret'] }, skillsRegistry: registry });
+
+    const allowed = await rpc(port, 'skills.install', { name: 'kody-w/rappterverse' }, 'bar-secret');
+
+    expect(allowed.error?.message ?? '').not.toMatch(/requires authentication/i);
+    expect(installCalls).toBe(1);
+  });
+
+  it('skills.list is not gated behind the credential', async () => {
+    const port = await startServer({ auth: { mode: 'token', tokens: ['bar-secret'] } });
+
+    const listed = await dispatchUnauthenticated(port, 'skills.list');
+
+    // Reading what ships with the product is not a privileged operation.
+    // (HTTP is fail-closed for every method once credentials are configured;
+    // this measures the per-method flag, which is what separates the two.)
+    expect((listed.error as { message?: string } | undefined)?.message ?? '')
+      .not.toMatch(/requires authentication/i);
+  });
+});
+
+// ── connections.list / connections.disconnect ──────────────────────────
+
+describe('connections.disconnect, against the wired gateway', () => {
+  it('is registered at all — the reproduction', async () => {
+    const port = await startServer();
+
+    const { error } = await rpc(port, 'connections.disconnect', { connectionId: 'conn_nope' });
+
+    expect(error?.message ?? '').not.toMatch(/Method not found/);
+  });
+
+  it('closes the live connection it names', async () => {
+    const port = await startServer();
+    const bar = await connectBar(port);
+    const victim = await connectBar(port);
+
+    const listed = await wsRpc(bar.ws, 'connections.list');
+    const ids = (listed.payload as Array<{ connectionId: string }>).map((c) => c.connectionId);
+    expect(ids).toContain(victim.connectionId);
+
+    const closed = new Promise<void>((resolve) => victim.ws.once('close', () => resolve()));
+    const result = await wsRpc(bar.ws, 'connections.disconnect', { connectionId: victim.connectionId });
+
+    expect(result.ok, `disconnect failed: ${JSON.stringify(result.error)}`).toBe(true);
+    await closed;
+
+    const after = await wsRpc(bar.ws, 'connections.list');
+    const remaining = (after.payload as Array<{ connectionId: string }>).map((c) => c.connectionId);
+    expect(remaining).not.toContain(victim.connectionId);
+  });
+
+  it('does not claim to have disconnected a connection that is not there', async () => {
+    const port = await startServer();
+
+    const { result, error } = await rpc(port, 'connections.disconnect', { connectionId: 'conn_absent' });
+
+    expect(result).toBeUndefined();
+    expect(error?.message).toMatch(/No connection/);
+  });
+
+  it('requires the credential', async () => {
+    const port = await startServer({ auth: { mode: 'token', tokens: ['bar-secret'] } });
+
+    const denied = await dispatchUnauthenticated(port, 'connections.disconnect', { connectionId: 'conn_absent' });
+
+    // It terminates other clients' sessions, so it is gated like every other
+    // mutating method here.
+    expect(denied.ok).toBe(false);
+    expect((denied.error as { message: string }).message).toMatch(/requires authentication/i);
+  });
+});
+
+describe('connections.list, in the shape the Bar decodes', () => {
+  it('carries the fields `Node` requires, so a row can be disconnected', async () => {
+    const port = await startServer();
+    const bar = await connectBar(port);
+
+    const listed = await wsRpc(bar.ws, 'connections.list');
+    const rows = listed.payload as Array<Record<string, unknown>>;
+    const self = rows.find((r) => r.connectionId === bar.connectionId);
+
+    // `Node` has non-optional `id`, `name`, `host`, `port`, `status`. Without
+    // them `RpcClient.listNodes` fails to decode the array, the Nodes pane is
+    // empty, and `disconnectNode` — which takes its id from a row here — can
+    // never be reached from the UI at all.
+    expect(self).toBeDefined();
+    expect(typeof self!.id).toBe('string');
+    expect(typeof self!.name).toBe('string');
+    expect(typeof self!.host).toBe('string');
+    expect(typeof self!.port).toBe('number');
+    expect(['online', 'offline', 'busy', 'error']).toContain(self!.status);
+    expect(self!.connectionId).toBe(bar.connectionId);
+  });
+
+  it('reports the peer address the socket actually had', async () => {
+    const port = await startServer();
+    const bar = await connectBar(port);
+
+    const listed = await wsRpc(bar.ws, 'connections.list');
+    const rows = listed.payload as Array<Record<string, unknown>>;
+    const self = rows.find((r) => r.connectionId === bar.connectionId)!;
+
+    // A loopback client really is on loopback; this is measured, not filled in.
+    expect(String(self.host)).toMatch(/127\.0\.0\.1|::1|::ffff:127\.0\.0\.1/);
+    expect(Number(self.port)).toBeGreaterThan(0);
+  });
+});
+
+// ── connections.pair ───────────────────────────────────────────────────
+
+describe('connections.pair is deliberately not registered', () => {
+  it('pairing an unreachable peer does not report success', async () => {
+    const port = await startServer();
+    // A port nothing is listening on — reserved and never bound.
+    const deadPort = await reserveTestPort();
+
+    const { result, error } = await rpc(port, 'connections.pair', {
+      host: '127.0.0.1',
+      port: deadPort,
+    });
+
+    // `RpcClient.pairNode` treats any non-`ok` reply as a thrown error, which
+    // the Bar surfaces as "Pair failed: …". That is the correct outcome:
+    // there is no registry of remote peers to record a pairing in, and
+    // `connections.list` reports INBOUND sockets, so `{paired: true}` would
+    // be followed by an empty list — success, then nothing. See the comment
+    // where `connections.pair` is NOT registered in gateway/server.ts.
+    expect(result).toBeUndefined();
+    expect(error).toBeDefined();
+  });
+
+  it('pairing a peer that IS reachable does not report success either', async () => {
+    const port = await startServer();
+
+    // This gateway pairing with itself: as reachable as a peer can be.
+    const { result, error } = await rpc(port, 'connections.pair', { host: '127.0.0.1', port });
+
+    // Reachability is not the reason it refuses. Nothing here can record a
+    // peer, so there is no pairing to report — and a truthful refusal beats a
+    // record that nothing can vouch for (#132).
+    expect(result).toBeUndefined();
+    expect(error).toBeDefined();
+  });
+
+  it('no registered method claims to pair a node', async () => {
+    const port = await startServer();
+
+    const { result } = await rpc<string[]>(port, 'methods');
+
+    expect(result).not.toContain('connections.pair');
+    expect(result).not.toContain('nodes.pair');
+    // The guard that keeps this from passing vacuously: the probe works.
+    expect(result).toContain('connections.list');
+    expect(result).toContain('connections.disconnect');
+  });
+});

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -46,7 +46,6 @@ import { VERSION } from '../version.js';
 import { buildChatEnvelope } from './chat-envelope.js';
 import { parseChatRequest } from './chat-request.js';
 import { buildTwinResponse, parseTwinEnvelope, sayText } from './twin-chat.js';
-import { readBundledSkillInfo } from '../skills/bundled.js';
 import type { InstalledSkill } from '../skills/registry.js';
 
 /**
@@ -2574,6 +2573,13 @@ export class GatewayServer {
     // decode failed and the Bar rendered "No skills installed" — #176's
     // `skills list` always printing `(none)`, one layer up.
     this.registerMethod('skills.list', async () => {
+      // Imported lazily, and it matters. `skills/bundled.ts` reaches
+      // `clawhub.ts` -> `agents/index.js` -> `AgentRegistry` -> `logging/
+      // logger.ts` -> `chalk`. Statically this pulls chalk into every module
+      // graph that touches GatewayServer, including `typescript/ui`, whose CI
+      // job installs only its own dependencies and so cannot resolve it. The
+      // dashboard's gateway test went red on an import it never asked for.
+      const { readBundledSkillInfo } = await import('../skills/bundled.js');
       const bundled = await readBundledSkillInfo(this.bundledSkillsDir);
 
       // An install that shipped without `skills/` and an install with no

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -46,6 +46,42 @@ import { VERSION } from '../version.js';
 import { buildChatEnvelope } from './chat-envelope.js';
 import { parseChatRequest } from './chat-request.js';
 import { buildTwinResponse, parseTwinEnvelope, sayText } from './twin-chat.js';
+import { readBundledSkillInfo } from '../skills/bundled.js';
+import type { InstalledSkill } from '../skills/registry.js';
+
+/**
+ * The part of `SkillsRegistry` the gateway needs.
+ *
+ * Structural rather than a class import so a test can substitute a registry
+ * rooted in a scratch directory, and so the gateway never grows a second
+ * install implementation. `install` returning `null` on failure is the
+ * registry's real signature — see `skills.install` for why that must not be
+ * allowed to reach a caller as success.
+ */
+export interface SkillsRegistryLike {
+  initialize(): Promise<void>;
+  install(skillId: string, version?: string): Promise<InstalledSkill | null>;
+  getInstalled(): InstalledSkill[];
+}
+
+/**
+ * One row of `skills.list`, in the shape the macOS Bar's `Skill` decodes.
+ *
+ * `source` is the Bar's `SkillSource` enum — `local | clawhub | builtin`. A
+ * value outside it fails the decode on the client, which is how this endpoint
+ * managed to return rows and still render "No skills installed".
+ */
+interface GatewaySkillRow {
+  id: string;
+  name: string;
+  description: string;
+  version: string;
+  author?: string;
+  installed: boolean;
+  enabled: boolean;
+  source: 'local' | 'clawhub' | 'builtin';
+  category: string;
+}
 import { currentInstanceDeclared, currentInstanceName } from '../infra/current-instance.js';
 import {
   GatewayMetrics,
@@ -259,6 +295,19 @@ export class GatewayServer {
    * screen that lists nothing and approves nothing while reporting success.
    */
   private execSafety?: ExecSafety;
+  /**
+   * Where third-party skills are installed to, and read back from.
+   *
+   * Injectable so a test can point it at a scratch directory instead of the
+   * owner's real `~/.openrappter/skills`. Left unset it is constructed lazily
+   * against `dataDir`, so production needs no wiring — `skills.install` that
+   * only works when someone remembered to call a setter is the failure mode
+   * this whole change exists to remove.
+   */
+  private skillsRegistry?: SkillsRegistryLike;
+  private skillsRegistryReady?: Promise<SkillsRegistryLike>;
+  /** Override for the bundled `skills/` directory. Tests only. */
+  private bundledSkillsDir?: string;
 
   constructor(config?: Partial<GatewayConfig>) {
     this.config = {
@@ -568,6 +617,48 @@ export class GatewayServer {
 
   getExecSafety(): ExecSafety {
     return (this.execSafety ??= getSharedExecSafety());
+  }
+
+  /**
+   * Point `skills.install`/`skills.list` at a specific skills registry.
+   *
+   * Production does not need to call this — see `skillsRegistry()`. It exists
+   * so a test can install into a scratch directory rather than the machine's
+   * real `~/.openrappter/skills`.
+   */
+  setSkillsRegistry(registry: SkillsRegistryLike): void {
+    this.skillsRegistry = registry;
+    this.skillsRegistryReady = undefined;
+  }
+
+  /** Point the bundled-skill reader at a specific directory. Tests only. */
+  setBundledSkillsDir(dir: string | undefined): void {
+    this.bundledSkillsDir = dir;
+  }
+
+  /**
+   * The installed-skills registry, created on first use.
+   *
+   * Lazy because constructing it mkdirs the skills directory, and a gateway
+   * that never touches skills should not create one. Rooted at `dataDir` so a
+   * test with a scratch `dataDir` is automatically contained.
+   */
+  private async skillsRegistryOrCreate(): Promise<SkillsRegistryLike> {
+    if (this.skillsRegistry) {
+      this.skillsRegistryReady ??= (async () => {
+        await this.skillsRegistry!.initialize();
+        return this.skillsRegistry!;
+      })();
+      return this.skillsRegistryReady;
+    }
+    this.skillsRegistryReady ??= (async () => {
+      const { SkillsRegistry } = await import('../skills/registry.js');
+      const registry = new SkillsRegistry(path.join(this.dataDir, 'skills'));
+      await registry.initialize();
+      this.skillsRegistry = registry;
+      return registry;
+    })();
+    return this.skillsRegistryReady;
   }
 
   setReadinessProvider(
@@ -1583,6 +1674,8 @@ export class GatewayServer {
       authenticated: false, // always start unauthenticated; connect handshake required
       subscriptions: new Set(['*']), // auto-subscribe to all events after auth
       lastActivity: Date.now(),
+      remoteAddress: req.socket?.remoteAddress ?? undefined,
+      remotePort: req.socket?.remotePort ?? undefined,
       metadata: {
         userAgent: req.headers['user-agent'],
         origin: req.headers['origin'],
@@ -2015,17 +2108,18 @@ export class GatewayServer {
    *
    * This is the *single* place production method names/handlers/auth
    * requirements are wired for the live GatewayServer — chat/channels/
-   * cron/connections/config here operate on this server's real state
-   * (`sessionStore`, `channelRegistry`, `cronStore`/`cronService`) and are
+   * cron/connections/config/skills here operate on this server's real state
+   * (`sessionStore`, `channelRegistry`, `cronStore`/`cronService`, the
+   * bundled `skills/` directory and the real `SkillsRegistry`) and are
    * the authoritative implementations for those names.
    *
    * `typescript/src/gateway/methods/*.ts` (aggregated by
    * `methods/index.ts#registerAllMethods`) are standalone, independently
    * unit-tested RPC method modules. Several of them declare the *same*
    * method names as the ones below (e.g. `chat.list`, `channels.connect`,
-   * `cron.*`, `connections.list`, `config.get`/`config.set`) against their
-   * own local/disconnected dependencies. `registerAllMethods` is
-   * intentionally **not** invoked here: doing so would silently duplicate
+   * `cron.*`, `connections.list`, `config.get`/`config.set`, `skills.*`)
+   * against their own local/disconnected dependencies. `registerAllMethods`
+   * is intentionally **not** invoked here: doing so would silently duplicate
    * or override the real, wired handlers below with divergent
    * implementations (the exact failure mode this method's doc-comment
    * exists to prevent). Do not call `registerAllMethods` from
@@ -2462,13 +2556,211 @@ export class GatewayServer {
       return { runs: [] };
     });
 
+    // ── Skills ────────────────────────────────────────────────────────
+    //
+    // `gateway/methods/skills-methods.ts` declares these names too, and is
+    // deliberately never registered (see this method's doc comment). It hangs
+    // every handler off an injected `skillRegistry` that nothing in this repo
+    // ever supplies, and its `skills.list` answers `[]` when that registry is
+    // absent — which is the shape of the two defects this replaces, not a fix
+    // for them. These handlers run on the real bundled skills directory and
+    // the real `SkillsRegistry`.
+    //
+    // The payload is the macOS Bar's `Skill` — `id`, `name`, `description`,
+    // `version`, `author`, `installed`, `enabled`, `source`. That is not
+    // cosmetic. `RpcClient.listSkills` decodes `[Skill]`, and the shape
+    // previously returned by `src/index.ts` (`{name, description, category,
+    // enabled, version}`) is missing `id`, `installed` and `source`, so the
+    // decode failed and the Bar rendered "No skills installed" — #176's
+    // `skills list` always printing `(none)`, one layer up.
+    this.registerMethod('skills.list', async () => {
+      const bundled = await readBundledSkillInfo(this.bundledSkillsDir);
+
+      // An install that shipped without `skills/` and an install with no
+      // skills are both "zero skills" to the loader, which is exactly how
+      // #165 went unnoticed for as long as it did. Refuse to answer rather
+      // than report the packaging fault as an empty, successful list.
+      if (!bundled.directoryPresent) {
+        throw new Error(
+          `Bundled skills directory not found at ${bundled.directory} — this install shipped without skills/. `
+          + 'Reporting an empty list here would be indistinguishable from having no skills.'
+        );
+      }
+
+      const skills: GatewaySkillRow[] = bundled.skills.map((skill) => ({
+        id: skill.name,
+        name: skill.name,
+        description: skill.description,
+        version: '1.0.0',
+        // It ships with the product; it is on disk whether or not its
+        // dependencies are met.
+        installed: true,
+        // Eligibility is the real enable/disable signal for a bundled skill:
+        // a skill whose required binary or credential is missing cannot run.
+        enabled: skill.eligibility.eligible === 'eligible',
+        source: 'builtin',
+        category: skill.category,
+      }));
+
+      const registry = await this.skillsRegistryOrCreate();
+      for (const entry of registry.getInstalled()) {
+        skills.push({
+          id: entry.manifest.id,
+          name: entry.manifest.name,
+          description: entry.manifest.description,
+          version: entry.manifest.version,
+          author: entry.manifest.author,
+          installed: true,
+          enabled: entry.enabled,
+          source: 'clawhub',
+          category: 'installed',
+        });
+      }
+
+      return skills;
+    });
+
+    /**
+     * Install a skill from a public GitHub repo.
+     *
+     * `requiresAuth: true`, for the same reason `/agents/import` does (#171):
+     * this fetches a third-party manifest and `SKILL.md` off the network and
+     * writes them where the agent will later load them. That is code entering
+     * the assistant's execution surface, and every other method here that
+     * changes what the machine will run — `config.set`, `cron.add`,
+     * `cron.create` — is gated the same way. An unauthenticated caller must
+     * not be able to plant a skill.
+     */
+    this.registerMethod('skills.install', async (params: { name?: string; source?: string; version?: string }) => {
+      const id = (params?.name ?? params?.source ?? '').trim();
+      if (!id) throw new Error('skills.install requires `name`');
+
+      // `SkillsRegistry.install` addresses skills as GitHub `owner/repo`.
+      // Checking here means a bare name gets a sentence that says what is
+      // wrong, instead of a 404 laundered into `null` and then into a
+      // generic failure.
+      if (!/^[\w.-]+\/[\w.-]+$/.test(id)) {
+        throw new Error(
+          `skills.install expects a GitHub "owner/repo" identifier; got "${id}". `
+          + 'Bundled skills ship with the product and are not installed.'
+        );
+      }
+
+      const registry = await this.skillsRegistryOrCreate();
+      const installed = await registry.install(id, params?.version);
+
+      // The registry logs and returns `null` on every failure — missing repo,
+      // no skill.json, unwritable directory. #176 found the ClawHub stub
+      // reporting `Successfully installed` over a no-op that wrote nothing;
+      // returning `{installed: true}` for a `null` here would be that defect
+      // rebuilt on a real registry.
+      if (!installed) {
+        throw new Error(
+          `skills.install failed for "${id}" — no skill.json was fetched and nothing was written. `
+          + 'Check the repo exists, is public, and has skill.json at its root.'
+        );
+      }
+
+      return {
+        id: installed.manifest.id,
+        name: installed.manifest.name,
+        description: installed.manifest.description,
+        version: installed.manifest.version,
+        author: installed.manifest.author,
+        installed: true,
+        enabled: installed.enabled,
+        source: 'clawhub',
+        path: installed.path,
+        installedAt: installed.installedAt,
+      };
+    }, { requiresAuth: true });
+
     // Connection methods
+    //
+    // The payload carries the macOS Bar's `Node` fields as well as the
+    // original ConnectionInfo ones. `RpcClient.listNodes` decodes `[Node]`,
+    // which requires `name`, `host`, `port` and `status`; without them the
+    // decode failed, `listNodes` swallowed it, and the Nodes pane was
+    // permanently empty — which also meant `connections.disconnect` could
+    // never be reached, because the Bar takes the connection id it
+    // disconnects from a row in that list.
     this.registerMethod('connections.list', async () => {
       return this.getConnections().map((c) => ({
         id: c.id, connectedAt: c.connectedAt, authenticated: c.authenticated,
         subscriptions: Array.from(c.subscriptions), deviceId: c.deviceId, deviceType: c.deviceType,
+        connectionId: c.id,
+        name: c.deviceId ?? c.deviceType ?? c.id,
+        // The peer's real socket address, recorded when the socket opened.
+        // Not a guess and not a placeholder: if the transport did not report
+        // one, this says so rather than inventing 127.0.0.1.
+        host: c.remoteAddress ?? 'unknown',
+        port: c.remotePort ?? 0,
+        // It is in `this.connections`, so it is attached right now.
+        status: 'online',
+        platform: c.deviceType,
+        lastSeen: new Date(c.lastActivity).toISOString(),
       }));
     });
+
+    /**
+     * Close a live connection to this gateway.
+     *
+     * Backed by `this.connections` — the same map `connections.list` reads
+     * and the same map `handleConnection` writes — so what it reports is what
+     * happened. An unknown id is an error, not a cheerful `{disconnected:
+     * true}`: the Bar's only reason to call this is to end a session it can
+     * see, and telling it the session ended when nothing was found is the
+     * kind of false success #176 was written about.
+     *
+     * `requiresAuth: true` — it terminates other clients' sessions.
+     */
+    this.registerMethod('connections.disconnect', async (params: { connectionId?: string; id?: string }) => {
+      const connectionId = (params?.connectionId ?? params?.id ?? '').trim();
+      if (!connectionId) throw new Error('connections.disconnect requires `connectionId`');
+
+      const target = this.connections.get(connectionId);
+      if (!target) {
+        throw new Error(`No connection '${connectionId}' is attached to this gateway`);
+      }
+
+      target.ws.close(1000, 'Disconnected by request');
+      this.connections.delete(connectionId);
+      this.rateLimits.delete(connectionId);
+
+      return { disconnected: true, connectionId };
+    }, { requiresAuth: true });
+
+    /**
+     * `connections.pair` is deliberately NOT registered.
+     *
+     * `RpcClient.pairNode(host:port:)` asks this gateway to pair with an
+     * arbitrary `host` and `port`. There is nothing here that can honestly
+     * accept it:
+     *
+     *  - There is no registry of remote peers to record a pairing in. The
+     *    real neighbourhood (`infra/roster.ts`) is loopback instances, and
+     *    each rappter writes its OWN `endpoint.json` after a successful
+     *    listen. Writing one on another process's behalf would forge exactly
+     *    the record #114/#118/#132 spent three passes learning not to trust.
+     *  - `connections.list` reports INBOUND websocket connections. A peer
+     *    paired outbound could never appear in it, so a `{paired: true}`
+     *    would be followed by the Bar's own `loadNodes()` showing nothing —
+     *    success, then an empty list. That is the lie, not the fix.
+     *  - Any loopback gateway worth pairing with is already in the roster,
+     *    by itself, because it recorded itself. Pairing would add a second
+     *    way to know a peer; `agents/NeighborAgent.ts` is explicit that "a
+     *    second way to contact a peer would be the next one" in this repo's
+     *    long run of two-derivations-of-one-thing defects.
+     *  - It takes a host. `NeighborAgent` refuses URLs on purpose — "an agent
+     *    taking a URL would hand a model a general HTTP POST primitive, which
+     *    is an SSRF vector" (#84 is open on DNS rebinding here).
+     *
+     * So the Bar gets `Method not found`, which is true, instead of a
+     * pairing that records an unverified peer as though it were reachable.
+     * Registering it needs a peer registry that probes on read, and that is
+     * a design decision, not a wiring fix.
+     */
+
     this.registerMethod('connection.identify', async (params: { deviceId?: string; deviceType?: string; metadata?: Record<string, unknown> }, conn) => {
       conn.deviceId = params.deviceId;
       conn.deviceType = params.deviceType;

--- a/typescript/src/gateway/types.ts
+++ b/typescript/src/gateway/types.ts
@@ -91,6 +91,14 @@ export interface ConnectionInfo {
   deviceId?: string;
   deviceType?: string;
   metadata?: Record<string, unknown>;
+  /**
+   * The peer's socket address, as the transport reported it when the socket
+   * opened. Optional because a transport need not report one — `undefined`
+   * means "not known", and callers must say so rather than substituting a
+   * plausible-looking loopback address.
+   */
+  remoteAddress?: string;
+  remotePort?: number;
 }
 
 export type RpcStreamCallback = (response: StreamingResponse) => void;

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -122,7 +122,6 @@ async function startGatewayInProcess(opts?: {
     listGatewayChannelStatuses,
     readIMessageConfig,
   } = await import('./channels/imessage-gateway.js');
-  const { listBundledSkills } = await import('./skills/bundled.js');
 
   const port = opts?.port ?? parseInt(process.env.OPENRAPPTER_PORT ?? '18790', 10);
   const token = process.env.OPENRAPPTER_TOKEN || undefined;
@@ -883,17 +882,12 @@ async function startGatewayInProcess(opts?: {
     return imessageRuntime.getStatus();
   });
 
-  // Register skills.list RPC method
-  server.registerMethod('skills.list', async () => {
-    const skills = await listBundledSkills();
-    return skills.map(s => ({
-      name: s.name,
-      description: s.description,
-      category: s.category,
-      enabled: s.eligibility.eligible === 'eligible',
-      version: '1.0.0',
-    }));
-  });
+  // `skills.list` is registered by `GatewayServer.registerBuiltInMethods`.
+  // It used to be registered here as well, and this copy won — it ran after
+  // `start()` and overwrote whatever the server had. Its payload omitted
+  // `id`, `installed` and `source`, so the macOS Bar's `[Skill]` decode
+  // failed and the pane showed "No skills installed" no matter how many
+  // skills were on disk. One method, one place.
 
   // ── Model switching RPC methods ──
   const { COPILOT_DEFAULT_MODELS, COPILOT_DEFAULT_MODEL } = await import('./providers/copilot.js');

--- a/typescript/src/skills/bundled.ts
+++ b/typescript/src/skills/bundled.ts
@@ -94,49 +94,86 @@ export function getBundledSkillsDir(): string {
 }
 
 /**
+ * A read of the bundled skills directory, including whether it was there.
+ *
+ * #165 shipped 52 skills that the published tarball had never carried, and
+ * recorded why nobody noticed: `loadBundledSkills` catches a missing directory
+ * and returns an empty list, so "this install shipped no skills" and "this
+ * install legitimately has none" are the same answer. That silent swallow is
+ * deliberate and stays — a caller with no skills directory is a legitimate
+ * case. But a caller that needs to tell the two apart had no way to ask.
+ *
+ * `directoryPresent` is the missing bit. It is false only when the directory
+ * could not be read at all; a readable but empty directory is present with
+ * zero skills, which is the honest distinction.
+ */
+export interface BundledSkillsRead<T> {
+  /** The directory that was read. */
+  directory: string;
+  /** The directory existed and could be listed. */
+  directoryPresent: boolean;
+  skills: T[];
+}
+
+/**
+ * Discover all bundled SKILL.md files, reporting whether the directory existed.
+ */
+export async function readBundledSkills(
+  skillsDir?: string
+): Promise<BundledSkillsRead<ClawHubSkill>> {
+  const dir = skillsDir ?? getBundledSkillsDir();
+  const skills: ClawHubSkill[] = [];
+
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    // Skills directory doesn't exist
+    return { directory: dir, directoryPresent: false, skills };
+  }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory()) continue;
+
+    const skillMdPath = join(dir, entry.name, 'SKILL.md');
+    try {
+      const skill = await parseSkillFile(skillMdPath);
+      if (skill) {
+        skills.push(skill);
+      }
+    } catch {
+      // Skip directories without valid SKILL.md
+    }
+  }
+
+  return { directory: dir, directoryPresent: true, skills };
+}
+
+/**
  * Discover all bundled SKILL.md files from the skills directory.
+ *
+ * Returns an empty list when the directory is absent. Callers that must not
+ * mistake a missing install for an empty one want `readBundledSkills`.
  */
 export async function loadBundledSkills(
   skillsDir?: string
 ): Promise<ClawHubSkill[]> {
-  const dir = skillsDir ?? getBundledSkillsDir();
-  const skills: ClawHubSkill[] = [];
-
-  try {
-    const entries = await readdir(dir, { withFileTypes: true });
-
-    for (const entry of entries) {
-      if (!entry.isDirectory()) continue;
-
-      const skillMdPath = join(dir, entry.name, 'SKILL.md');
-      try {
-        const skill = await parseSkillFile(skillMdPath);
-        if (skill) {
-          skills.push(skill);
-        }
-      } catch {
-        // Skip directories without valid SKILL.md
-      }
-    }
-  } catch {
-    // Skills directory doesn't exist
-  }
-
-  return skills;
+  return (await readBundledSkills(skillsDir)).skills;
 }
 
 /**
- * List all bundled skills with their eligibility status.
+ * List all bundled skills with their eligibility, reporting whether the
+ * bundled skills directory existed at all.
  */
-export async function listBundledSkills(
+export async function readBundledSkillInfo(
   skillsDir?: string,
   config?: Record<string, unknown>
-): Promise<BundledSkillInfo[]> {
+): Promise<BundledSkillsRead<BundledSkillInfo>> {
   const dir = skillsDir ?? getBundledSkillsDir();
-  const skills = await loadBundledSkills(dir);
+  const read = await readBundledSkills(dir);
   const results: BundledSkillInfo[] = [];
 
-  for (const skill of skills) {
+  for (const skill of read.skills) {
     const metadata = resolveSkillMetadata({
       metadata: skill.metadata,
     });
@@ -154,7 +191,17 @@ export async function listBundledSkills(
     });
   }
 
-  return results;
+  return { directory: read.directory, directoryPresent: read.directoryPresent, skills: results };
+}
+
+/**
+ * List all bundled skills with their eligibility status.
+ */
+export async function listBundledSkills(
+  skillsDir?: string,
+  config?: Record<string, unknown>
+): Promise<BundledSkillInfo[]> {
+  return (await readBundledSkillInfo(skillsDir, config)).skills;
 }
 
 /**


### PR DESCRIPTION
Four live Bar call sites resolved to methods the production gateway does not register. Probed against a **real started** `GatewayServer` (methods register in `start()`, not the constructor — #171's trap):

```
total registered: 54
skills.*      : []
connections.* : [ 'connections.list', 'connection.identify' ]

skills.list              -> {"code":-32601,"message":"Method not found: skills.list"}
skills.install           -> {"code":-32601,"message":"Method not found: skills.install"}
connections.list         -> []
connections.pair         -> {"code":-32601,"message":"Method not found: connections.pair"}
connections.disconnect   -> {"code":-32601,"message":"Method not found: connections.disconnect"}
```

After:

```
total registered: 57
skills.*      : [ 'skills.list', 'skills.install' ]
connections.* : [ 'connections.list', 'connections.disconnect', 'connection.identify' ]

skills.list              -> 52 rows, first: {"id":"1password","name":"1password",…,"source":"builtin"}
skills.install           -> refuses a bare name: expects a GitHub "owner/repo" identifier
connections.disconnect   -> "No connection 'conn_x' is attached to this gateway"
connections.pair         -> Method not found  (deliberate — see below)
```

## Why `methods/skills-methods.ts` was not the fix

`registerBuiltInMethods`' doc comment records that only 5 of 25 `methods/*.ts` modules are invoked and the rest declare the same names against disconnected dependencies. `skills-methods.ts` is a textbook case, not an oversight: every handler hangs off an injected `skillRegistry` that **nothing in this repo supplies**, and its `skills.list` answers `[]` when that dependency is absent. Calling `registerSkillsMethods(server)` would have registered four names that either throw "Skill registry not available" or return an empty list — the same silence one layer down. `connections.pair` and `connections.disconnect` exist in **no** TypeScript module at all; `connections-methods.ts` only declares `connections.list`.

## Where the real state lives

| thing | where |
|---|---|
| bundled skills (52 `SKILL.md`) | `typescript/skills/`, read by `src/skills/bundled.ts` |
| installed skills | `SkillsRegistry` (`src/skills/registry.ts`) — GitHub `owner/repo` → `skill.json` + `SKILL.md`, lock file |
| live connections | `GatewayServer.connections`, written by `handleConnection`, read by `connections.list` |
| node roster / neighbourhood | `src/infra/roster.ts` — loopback instances, each writing its **own** `endpoint.json`, liveness only ever answered by probing |

## What I registered, and what I left alone

**Registered — `skills.list`.** Real bundled directory + the real registry's lock file. Crucially, a **missing** bundled directory now raises rather than answering `[]`. #165 recorded exactly why this matters: `loadBundledSkills` swallows a missing directory, so "this install shipped without `skills/`" and "this machine has no skills" were the same answer. This endpoint can now tell them apart — a readable-but-empty directory is still `[]`, a missing one is an error.

**Registered — `skills.install`.** Runs on `SkillsRegistry.install`, which catches every failure and returns `null`. That `null` becomes a thrown error, never `{installed: true}`. #176 found `skills install` printing "Successfully installed" over a ClawHub stub that wrote nothing; rebuilding that on a real registry would be the same lie with better plumbing. A bare name (`weather`) gets a sentence saying the registry addresses skills as `owner/repo`, instead of a 404 laundered into `null`.

**Registered — `connections.disconnect`.** Closes the named socket in `GatewayServer.connections` — the same map `connections.list` reads and `handleConnection` writes. An unknown id is an error. The Bar's only reason to call this is to end a session it can see; reporting success over nothing found is #176's defect again.

**NOT registered — `connections.pair`. Deliberate.** Four reasons, in the code comment where it isn't registered:

1. **There is no registry of remote peers to record a pairing in.** The real neighbourhood (`infra/roster.ts`) is loopback instances, and each rappter writes its *own* `endpoint.json` after a successful listen. Writing one on another process's behalf is forging exactly the record #114 → #118 → #132 spent three passes learning not to trust.
2. **`connections.list` reports INBOUND websocket connections.** A peer paired outbound could never appear in it — so `{paired: true}` would be followed by the Bar's own `loadNodes()` showing nothing. Success, then an empty list. That is the lie, not the fix.
3. **Any loopback gateway worth pairing with is already in the roster, by itself.** Pairing would add a *second* way to know a peer, and `NeighborAgent.ts` is explicit that "a second way to contact a peer would be the next one" in this repo's run of two-derivations-of-one-thing defects (#101/#111, #107/#118, #113/#119, #121).
4. **It takes a host.** `NeighborAgent` refuses URLs on purpose: "an agent taking a URL would hand a model a general HTTP POST primitive, which is an SSRF vector" — #84 is open on DNS rebinding here.

So the Bar gets `Method not found`, which is true, and `NodesViewModel` renders "Pair failed: …". Registering it honestly needs a peer registry that probes on read — a design decision, not a wiring fix. I did not make it unilaterally. #176 made this same call for `memory`/`sessions`/`channels`/`send` and it was correct.

## `KNOWN_MISSING` (rebased onto #181)

#181 landed after this branch started. It asks a *running* `GatewayServer` what it registers and fails when an entry in its `KNOWN_MISSING` debt list starts existing, so the list cannot rot into a permanent excuse. Rebasing onto `origin/main` made it stale here, and it named exactly the three methods this PR registered — an independent confirmation of the claim above, arrived at by a test I did not write:

```
AssertionError: expected [ 'connections.disconnect', 'skills.install', 'skills.list' ] to deeply equal []
```

**Removed exactly those three.** Nothing else.

**`connections.pair` stays on the list**, and its entry now carries the reason inline, so the next person to see one lonely leftover does not delete it as an oversight. The short version, with the long one in `gateway/server.ts`: there is no registry of remote peers for a pairing to be recorded in, and `connections.list` reports inbound sockets, so a paired peer could never appear in it. Removing that entry would buy a green line at the price of the screen this test exists to prevent.

Also untouched: `skills.toggle` (no persisted per-skill enable state to back it) and `connections.info` (out of scope for this pass), both still listed.

Mutation-checked in both directions:

| Mutation | Result |
| --- | --- |
| Re-add a registered method to `KNOWN_MISSING` | **1 failed** — the self-cleaning test |
| Remove the `connections.pair` entry | **1 failed** — the Bar-coverage test |
| Restore the static `skills/bundled.js` import, root chalk hidden | **1 file failed** — `ui` gateway suite |


**Rebased four more times** onto `origin/main` as #182, #186, #183 and #184 landed (sibling fixes to the same `registerBuiltInMethods` block, the same `KNOWN_MISSING` list, the same Swift contract file and the same CHANGELOG section). #182 touched the same two files (`gateway/server.ts` fields/setters, `RpcClientContractTests.swift` appends) and the same `KNOWN_MISSING` block; all resolved by keeping both sides. Its removals (`exec.pending`, `exec.respond`, `exec.history`) and mine are both present. `swift run RunTests` is 166 = 156 on `main` + my 10, so nothing was lost in any resolution.

### One more defect this exposed, in CI rather than in the Bar

The `Dashboard UI` job went red on a file I never touched:

```
FAIL src/__tests__/gateway.integration.test.ts
Error: Cannot find package 'chalk' imported from typescript/src/logging/logger.ts
```

Registering `skills.list` added a *static* `import ... from '../skills/bundled.js'` to `gateway/server.ts`. That module reaches `clawhub.ts` → `agents/index.js` → `AgentRegistry` → `logging/logger.ts` → `chalk`, so every module graph touching `GatewayServer` suddenly needed chalk at import time — including `typescript/ui`, whose CI job installs only its own dependencies.

Invisible locally: Node resolves upward into `typescript/node_modules`, where chalk exists. I reproduced CI by hiding that copy (`mv node_modules/chalk node_modules/.chalk-hidden`), which turns the local dashboard run red on the identical error. Fixed by importing it lazily inside the handler, matching the `SkillsRegistry` import a few lines above. Verified green under the same hidden-chalk condition, and red again when the static import is restored.

I checked `main`'s own CI before blaming my branch: 92f9e59 and 09d41c2 are both green, so this was mine.

## Two defects underneath, which registration exposed

Exactly the #176 pattern — registering is where the work started.

1. **`src/index.ts` also registered `skills.list`**, after `start()`, so its copy silently won. Its payload was `{name, description, category, enabled, version}` — no `id`, no `installed`, no `source`. `RpcClient.listSkills` decodes `[Skill]`, whose non-optional members include all three, so the decode failed for the **whole array** and the pane rendered "No skills installed" over 52 shipped skills. This is #176's "`skills list` always printed `(none)`", one layer up. Removed; the gateway is the single place.
2. **`connections.list` omitted `name`, `host`, `port`, `status`**, so `[Node]` failed the same way. That was not merely cosmetic: `NodesViewModel.disconnectNode` takes `node.connectionId` from a row of that list, so an undecodable list made disconnect **unreachable from the UI** even once registered. The payload now carries the peer's real socket address (recorded from `req.socket` at connect), and says `"unknown"`/`0` rather than inventing a loopback address if the transport did not report one.

Both `RpcClient.listSkills` and `listNodes` swallowed the decode failure into `[]`. They now surface it, so a payload this build cannot read stops looking identical to a machine with nothing on it. `listNodes` also needed an explicit date strategy — the stock decoder expects seconds-since-2001 and `.iso8601` rejects the fractional seconds `toISOString()` always emits; either failure fails the whole array.

## The auth decision for `skills.install`

`requiresAuth: true`. It fetches a third-party manifest and `SKILL.md` off the network and writes them where the agent will later load them — code entering the assistant's execution surface. #171 noted `/agents/import` executes code and requires the credential; every other method here that changes what the machine will run (`config.set`, `config.apply`, `cron.add`, `cron.create`) is gated the same way. `connections.disconnect` is gated too, since it terminates other clients' sessions. `skills.list` is not gated — reading what ships with the product is not privileged.

The gate is measured by dispatching straight at an unauthenticated connection, past the handshake, the way `integration/gateway.test.ts` measures `requiresAuth`. Over a normal socket the handshake already blocks everything pre-auth, so a per-method flag is invisible — and an invisible flag is one that can quietly become dead code again.

## Tests

22 contract tests over real HTTP and real websockets to a real `GatewayServer`, driving the exact payloads `RpcClient.swift` builds, plus 10 Swift tests on the client decode. `skills.list` is asserted to contain **`weather` and `github` by name**, and ≥50 rows — "the call succeeded" and "the list is non-empty" are both satisfiable by an endpoint that has lost its skills directory.

## Mutations

Every fix reverted, every one goes red.

| mutation | result |
|---|---|
| un-register `skills.list` *(the original bug)* | **6 failed** |
| un-register `skills.install` *(the original bug)* | **7 failed** |
| un-register `connections.disconnect` *(the original bug)* | **5 failed** |
| `skills.list` answers `[]` for a missing skills directory instead of refusing | **1 failed** |
| `skills.list` returns an empty array *(is the "weather appears" assertion real?)* | **2 failed** |
| `skills.install` reports success when the registry installed nothing | **1 failed** |
| `skills.install` drops `requiresAuth` | **1 failed** |
| `connections.disconnect` claims success for a connection that is not there | **1 failed** |
| `connections.list` drops the fields the Bar's `Node` decode requires | **3 failed** |
| register `connections.pair` returning `{paired: true}` *(the tempting fake)* | **3 failed** |
| Swift `listSkills` swallows a decode failure back into `[]` | **1 failed** |
| Swift `listNodes` swallows a decode failure back into `[]` | **1 failed** |
| Swift `listNodes` decodes ISO-8601 dates with the stock strategy | **1 failed** |

## Suite

- `5036 passed | 21 skipped`, **0 failed** — `vitest run`
- `tsc --noEmit` clean
- `swift build` clean
- `166 passed, 0 failed` — `swift run RunTests` (156 on `main` + 10 here)

No pre-existing failures on this checkout; the 5 `copilot-cli-local.test.ts` failures reported by #165/#171 do not reproduce here.

## Unverified / left for a decision

- **The pairing UI still has no working action.** The gateway refusal is correct, but a user pressing Pair now gets an error rather than a feature. Fixing it properly means deciding whether this product wants a remote-peer registry at all — see the four reasons above. Not mine to decide unilaterally.
- **`skills.toggle` and `skills.update`** are declared in the dormant module and called by nothing in the Bar (`SkillsViewModel.toggleSkill` toggles locally and never sends). Left unregistered; there is no persisted per-skill enable state to back a toggle, only eligibility.
- **`connections.info`** (`RpcClient.getNodeInfo`) is also unregistered. Out of scope for this pass and not among the four reported; flagged rather than fixed.
- **Installing a *bundled* skill by name is not possible** and now says so. That is truthful — bundled skills ship with the product — but if the intent was "enable this bundled skill", that is a different method than `skills.install`.
- `SkillsRegistry.install` does real network I/O to `raw.githubusercontent.com`. No test performs a live install; the success path is measured against an injected registry, and the swallowed-failure path is measured against a registry that returns `null` exactly as the real one does.




---

**Final state:** rebased onto `efd9a58` (#184). All 18 CI checks pass; `MERGEABLE / CLEAN`. `KNOWN_MISSING` now retains, from my four: `connections.pair` only.
