### PR TITLE
test: pin the two gateways' shared RPC surface against each other

### DIFF
--- a/contracts/gateway-rpc-parity.json
+++ b/contracts/gateway-rpc-parity.json
@@ -1,0 +1,43 @@
+{
+  "schema": "rapp-gateway-rpc-parity/1.0",
+  "why": [
+    "The two gateways drifted without anything noticing. TypeScript registers 54 RPC",
+    "methods and Python 10, which is expected — they have different scopes — but the",
+    "overlap must agree, and a method must not quietly appear in one runtime only.",
+    "",
+    "This file is the pin. Each runtime has a test asserting it registers everything",
+    "listed under `shared`, and that nothing in `typescript_only` or `python_only` has",
+    "silently crossed over. Adding a method to one runtime now requires saying which",
+    "list it belongs in."
+  ],
+  "shared": [
+    "agents.list",
+    "channels.connect",
+    "channels.disconnect",
+    "channels.list",
+    "channels.probe",
+    "channels.send",
+    "health",
+    "ping",
+    "status"
+  ],
+  "python_only": {
+    "agents.execute": [
+      "Runs a named agent from the registry with kwargs, auth-required.",
+      "TypeScript has no equivalent: its `agent` method is the legacy chat handler,",
+      "which dispatches an AgentRequest rather than executing a named agent.",
+      "The macOS Bar carries an `executeAgent()` wrapper for this name that nothing",
+      "calls, so a Bar pointed at a Python gateway could execute agents and the same",
+      "Bar pointed at a TypeScript gateway could not.",
+      "Whether TypeScript should gain this is an owner decision: it is a remote",
+      "code-execution surface. Tracked as an issue rather than added unilaterally."
+    ]
+  },
+  "typescript_only_note": [
+    "TypeScript registers many methods Python does not (cron.*, chat.*, twin.*,",
+    "surgeon.*, backup.*, auth.*, and others). That is by design — the TypeScript",
+    "gateway is the full daemon. They are not enumerated here because the list moves",
+    "with feature work; what matters is that the `shared` set stays in agreement and",
+    "that `python_only` does not grow silently."
+  ]
+}

--- a/python/tests/test_gateway_rpc_parity.py
+++ b/python/tests/test_gateway_rpc_parity.py
@@ -1,0 +1,51 @@
+"""The Python gateway registers exactly the shared RPC surface it promises.
+
+The two gateways drifted and nothing noticed: Python registers `agents.execute`
+and TypeScript does not, while the macOS Bar carries a wrapper for that name.
+Different scopes are fine — TypeScript is the full daemon — but the overlap has
+to agree, and a method must not quietly appear in one runtime only.
+
+`contracts/gateway-rpc-parity.json` is the pin. TypeScript has the matching test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openrappter.gateway.server import GatewayServer
+
+CONTRACT = json.loads(
+    (Path(__file__).resolve().parents[2] / "contracts" / "gateway-rpc-parity.json").read_text(
+        encoding="utf-8"
+    )
+)
+
+
+def registered() -> set[str]:
+    return set(getattr(GatewayServer(), "_methods", {}))
+
+
+class TestSharedSurface:
+    def test_the_contract_lists_something(self):
+        # Guards the rest: an empty contract would make every assertion vacuous.
+        assert len(CONTRACT["shared"]) > 4
+
+    def test_every_shared_method_is_registered(self):
+        missing = sorted(set(CONTRACT["shared"]) - registered())
+        assert missing == [], f"Python stopped registering shared methods: {missing}"
+
+    def test_python_only_methods_are_still_python_only(self):
+        # If one of these is removed here, it is either gone or was promoted to
+        # shared; either way the contract must be updated rather than drift.
+        absent = sorted(set(CONTRACT["python_only"]) - registered())
+        assert absent == [], f"declared python-only but not registered: {absent}"
+
+    def test_nothing_is_registered_that_the_contract_does_not_explain(self):
+        # The whole point: a new method cannot appear without being classified.
+        explained = set(CONTRACT["shared"]) | set(CONTRACT["python_only"])
+        unexplained = sorted(registered() - explained)
+        assert unexplained == [], (
+            "these Python gateway methods are in neither `shared` nor `python_only`; "
+            f"add them to contracts/gateway-rpc-parity.json: {unexplained}"
+        )

--- a/typescript/src/__tests__/integration/gateway-rpc-parity.test.ts
+++ b/typescript/src/__tests__/integration/gateway-rpc-parity.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * The TypeScript gateway registers the shared RPC surface, and nothing that the
+ * contract says belongs to Python alone.
+ *
+ * The two gateways drifted and nothing noticed: Python registers
+ * `agents.execute` and TypeScript does not, while the macOS Bar carries an
+ * `executeAgent()` wrapper for that name. So the same Bar could execute agents
+ * against a Python gateway and not against a TypeScript one.
+ *
+ * Different sizes are expected — TypeScript is the full daemon, with cron, chat,
+ * twin, surgeon and more. What must not happen is the *overlap* disagreeing, or
+ * a method appearing in one runtime only without anyone saying so.
+ *
+ * `contracts/gateway-rpc-parity.json` is the pin. Python has the matching test.
+ */
+
+const CONTRACT = JSON.parse(
+  readFileSync(resolve(__dirname, '../../../../contracts/gateway-rpc-parity.json'), 'utf-8'),
+) as { shared: string[]; python_only: Record<string, string[]> };
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+async function registered(): Promise<Set<string>> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  await server.start();
+  return new Set((server as unknown as { methods: Map<string, unknown> }).methods.keys());
+}
+
+describe('gateway RPC parity with the Python runtime', () => {
+  it('the contract lists something', () => {
+    // Guards the rest: an empty contract would make every assertion vacuous.
+    expect(CONTRACT.shared.length).toBeGreaterThan(4);
+  });
+
+  it('registers every shared method', async () => {
+    const have = await registered();
+    const missing = CONTRACT.shared.filter((m) => !have.has(m)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  it('does not register anything the contract reserves to Python', async () => {
+    // If TypeScript gains one of these, it is no longer python-only and the
+    // contract must move it to `shared` — with the security thinking that
+    // implies for `agents.execute`, which executes a named agent.
+    const have = await registered();
+    const crossed = Object.keys(CONTRACT.python_only).filter((m) => have.has(m)).sort();
+    expect(crossed).toEqual([]);
+  });
+});


### PR DESCRIPTION
The two gateways drifted and nothing noticed. Enumerated from both, at runtime:

```
TypeScript registers 54 methods
Python registers     10
in Python but NOT TypeScript:  agents.execute
```

Different sizes are expected — TypeScript is the full daemon, with cron, chat, twin, surgeon and more. The **overlap disagreeing** is not, and the nine shared names were only agreeing by luck.

### `agents.execute` is a real capability gap, not a naming difference

I checked whether TypeScript's `agent` was the same thing under another name. It is not:

- **Python `agents.execute`** — takes `{name, kwargs}`, resolves it through `agent_registry.get_agent(name)`, executes it. Auth-required.
- **TypeScript `agent`** — commented "Legacy agent method", dispatches an `AgentRequest` to the chat `agentHandler`.

So TypeScript has no way to execute a named agent over RPC. And the macOS Bar carries an `executeAgent()` wrapper for that name which **nothing calls** — so the same Bar could execute agents against a Python gateway and not against a TypeScript one.

**Deliberately not added to TypeScript here.** Executing an arbitrary named agent over RPC is a remote code-execution surface, and adding a capability is an owner decision, not a mechanical parity fix. Filed separately.

### The pin

`contracts/gateway-rpc-parity.json` follows the pattern already used by `contracts/agent-result-status-vectors.json` (#169) — one file both runtimes are held to.

Each runtime asserts it registers everything in `shared`. The Python test additionally fails when a method appears that the contract does not classify, so a new method cannot be added without saying which runtime owns it.

### Mutations — each caught by the runtime that should catch it

| mutation | TypeScript | Python |
|---|---|---|
| a `shared` method neither registers | **1 failed** | **1 failed** |
| `agents.execute` promoted to `shared` | **1 failed** | passes — correctly, it has it |
| Python registers an unexplained method | — | **1 failed** |

Both suites also guard that the contract is non-empty. An empty `shared` list would make every other assertion pass vacuously — the same trap I hit in #171 and #181.

### Suites

TypeScript `4945` passed · Python `1464` passed · `tsc --noEmit` clean.
