### PR TITLE
fix(gateway): the agent file browser and cron run history called methods that did not exist

### DIFF
--- a/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
+++ b/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
@@ -39,10 +39,19 @@ const KNOWN_MISSING = new Set<string>([
   'connections.info',
   'models.list',
   // Live UI call sites still unimplemented.
-  'agents.files.list',
-  'agents.files.read',
-  'agents.files.write',
-  'cron.runs',
+  //
+  // `skills.toggle` stays deliberately unimplemented, and this is the reason:
+  // nothing in this runtime consumes a skill's enabled state. Bundled skills
+  // never become agents (`ClawHubClient.loadAllSkills()` returns `[]`), no
+  // prompt path reads them, and the `enabled` flag `skills.list` reports is
+  // computed *eligibility* — whether the skill's required binaries and env vars
+  // are present — which is a fact about the machine, not a setting a switch can
+  // change. That listing does not even carry an `id`, so the UI sends
+  // `{ id: undefined }`. A handler that persisted a flag would return success,
+  // flip the toggle in the UI, change nothing about what the assistant can do,
+  // and revert on the next refresh: exactly the stub-reporting-success shape
+  // #176 found in `skills install`. Implementing it needs skills to mean
+  // something at runtime first.
   'skills.toggle',
   'zen.sessions',
   'zen.subscribe',

--- a/typescript/src/agents/AgentRegistry.ts
+++ b/typescript/src/agents/AgentRegistry.ts
@@ -13,21 +13,15 @@ import { BasicAgent } from './BasicAgent.js';
 import { PythonAgent, introspectPythonAgents } from './PythonAgent.js';
 import type { AgentInfo } from './types.js';
 import { logger } from '../logging/logger.js';
+import { RESERVED_AGENT_DIRS, isReservedAgentPath } from './reserved-paths.js';
 
 /**
- * Subdirectories a conforming kernel never auto-loads.
- *
- * KERNEL §2.3 freezes both names. Honouring them is not a spec nicety: without
- * it, moving an agent into `disabled_agents/` does not disable it, and "how do I
- * turn one off" is the very next question after drag-and-drop loading.
+ * The reserved-directory rules live in `./reserved-paths.js` so callers that
+ * must stay free of this module's dependencies can share one definition. They
+ * are re-exported here because this is where they have always been imported
+ * from.
  */
-export const RESERVED_AGENT_DIRS = ['experimental_agents', 'disabled_agents'] as const;
-
-/** True when `file` sits inside a reserved subdirectory of the agents tree. */
-export function isReservedAgentPath(relativePath: string): boolean {
-  const parts = relativePath.split(/[\\/]/);
-  return parts.some(seg => (RESERVED_AGENT_DIRS as readonly string[]).includes(seg));
-}
+export { RESERVED_AGENT_DIRS, isReservedAgentPath } from './reserved-paths.js';
 
 /**
  * Every agent file under `dir`, relative to it, excluding reserved directories.

--- a/typescript/src/agents/agent-files.ts
+++ b/typescript/src/agents/agent-files.ts
@@ -29,7 +29,7 @@
 
 import fs from 'fs/promises';
 import path from 'path';
-import { isReservedAgentPath, RESERVED_AGENT_DIRS } from './AgentRegistry.js';
+import { isReservedAgentPath, RESERVED_AGENT_DIRS } from './reserved-paths.js';
 
 /** One browsable file, as the dashboard's file tab renders it. */
 export interface AgentFileEntry {

--- a/typescript/src/agents/agent-files.ts
+++ b/typescript/src/agents/agent-files.ts
@@ -1,0 +1,258 @@
+/**
+ * Browsing and editing the files an agent is made of.
+ *
+ * This backs `agents.files.list` / `agents.files.read` / `agents.files.write`.
+ * Every one of those paths comes from a browser, and the directory they point
+ * at is the one `AgentRegistry` hot-loads `*.py` and `*_agent.js` from — so a
+ * write here is not "saving a document", it is handing the organism code it
+ * will execute. The guards below are written for that reading of the feature.
+ *
+ * What they enforce, and why each one exists:
+ *
+ *  1. **Resolve, then contain.** A prefix check on the raw string is
+ *     bypassable (`../` segments, absolute paths, a symlink that leaves the
+ *     tree). Every path is resolved to a real path first — including the
+ *     deepest existing ancestor when the leaf does not exist — and only then
+ *     checked for containment with `path.relative`, never `startsWith`.
+ *  2. **Reserved directories stay reserved.** `disabled_agents/` and
+ *     `experimental_agents/` are the documented way to switch an agent off
+ *     (KERNEL §2.3, `RESERVED_AGENT_DIRS`). A write API that can reach into
+ *     them turns "I disabled that" into a lie, so they are refused as an
+ *     agentId, skipped when listing, and rejected on read and write.
+ *  3. **Write edits, it does not plant.** The target must already exist as a
+ *     regular file. Creating a new file in the loaded agents tree is what
+ *     `/agents/import` is for: that path verifies the agent by loading it and
+ *     rolls back when it fails. Nothing here can verify a write, so it may
+ *     only change bytes in a file the tree already loads.
+ *  4. **Symlinks are never followed on write** and never escape on read.
+ */
+
+import fs from 'fs/promises';
+import path from 'path';
+import { isReservedAgentPath, RESERVED_AGENT_DIRS } from './AgentRegistry.js';
+
+/** One browsable file, as the dashboard's file tab renders it. */
+export interface AgentFileEntry {
+  name: string;
+  /** Always relative to the agent workspace, POSIX separators. */
+  path: string;
+  size: number;
+  modified: string;
+}
+
+/** Refuse to stream something enormous into a browser text area. */
+export const MAX_AGENT_FILE_BYTES = 1024 * 1024;
+
+/** A listing is a browser sidebar, not a filesystem crawl. */
+const MAX_LISTED_FILES = 500;
+
+/** Directories that are never part of an agent's editable surface. */
+const SKIPPED_DIRS = new Set<string>([...RESERVED_AGENT_DIRS, 'node_modules', '__pycache__']);
+
+/** True when `target` is `root` or sits underneath it. */
+function isInside(root: string, target: string): boolean {
+  if (target === root) return true;
+  const rel = path.relative(root, target);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+/**
+ * The real path of `target`, resolving as much of it as exists.
+ *
+ * `fs.realpath` throws on a path whose leaf is missing, which is exactly the
+ * case a naive guard skips — and skipping it is how `a-symlink/../../etc` gets
+ * through. So the deepest existing ancestor is resolved and the missing tail is
+ * re-appended, giving a path that is honest about every symlink on the way.
+ */
+async function realpathAsFarAsPossible(target: string): Promise<string> {
+  const missing: string[] = [];
+  let current = path.resolve(target);
+  for (;;) {
+    try {
+      const real = await fs.realpath(current);
+      return missing.length ? path.join(real, ...missing.reverse()) : real;
+    } catch {
+      const parent = path.dirname(current);
+      // Reached the filesystem root without finding anything real.
+      if (parent === current) return path.resolve(target);
+      missing.push(path.basename(current));
+      current = parent;
+    }
+  }
+}
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string' || value.trim() === '') {
+    throw new Error(`${field} is required`);
+  }
+  if (value.includes('\0')) throw new Error(`${field} contains an invalid character`);
+  return value;
+}
+
+/**
+ * The directory an agent's files live in.
+ *
+ * `<root>/<agentId>` when the agent has a folder of its own (a swarm or stack
+ * keeps several files together); otherwise the user agents directory itself,
+ * which is where a single-file agent sits. Both are inside `root`, and that is
+ * what everything downstream is contained to.
+ */
+export async function resolveAgentWorkspace(root: string, agentId: unknown): Promise<string> {
+  const id = requireString(agentId, 'agentId');
+
+  if (/[\\/]/.test(id)) throw new Error(`Invalid agentId: ${id}`);
+  if (id === '.' || id === '..') throw new Error(`Invalid agentId: ${id}`);
+  // An agentId naming a reserved directory would make the whole disabled tree
+  // browsable and writable — the one thing reserving it was supposed to stop.
+  if (isReservedAgentPath(id)) {
+    throw new Error(`${id} is a reserved agent directory, not an agent`);
+  }
+
+  const realRoot = await realpathAsFarAsPossible(root);
+  const candidate = path.join(realRoot, id);
+  const realCandidate = await realpathAsFarAsPossible(candidate);
+
+  if (isInside(realRoot, realCandidate)) {
+    try {
+      const stat = await fs.stat(realCandidate);
+      if (stat.isDirectory()) return realCandidate;
+    } catch {
+      // No folder of its own — fall through to the flat layout.
+    }
+  }
+
+  return realRoot;
+}
+
+/**
+ * Turn a client-supplied relative path into an absolute one inside `workspace`,
+ * or throw. This is the single choke point every read and write goes through.
+ */
+async function resolveInsideWorkspace(workspace: string, relPath: unknown): Promise<string> {
+  const raw = requireString(relPath, 'path');
+
+  if (path.isAbsolute(raw) || /^[A-Za-z]:[\\/]/.test(raw) || raw.startsWith('\\\\')) {
+    throw new Error(`Path must be relative to the agent directory: ${raw}`);
+  }
+
+  const segments = raw.split(/[\\/]/).filter((s) => s !== '' && s !== '.');
+  if (segments.length === 0) throw new Error('path is required');
+  if (segments.includes('..')) {
+    throw new Error(`Path escapes the agent directory: ${raw}`);
+  }
+  if (isReservedAgentPath(raw)) {
+    throw new Error(`${raw} is inside a reserved agent directory`);
+  }
+
+  const target = path.resolve(workspace, segments.join(path.sep));
+  const realTarget = await realpathAsFarAsPossible(target);
+  const realWorkspace = await realpathAsFarAsPossible(workspace);
+
+  // The check that matters: after every symlink and `..` has been resolved,
+  // is this still inside the directory the caller was granted?
+  if (!isInside(realWorkspace, realTarget) || realTarget === realWorkspace) {
+    throw new Error(`Path escapes the agent directory: ${raw}`);
+  }
+
+  return realTarget;
+}
+
+async function walk(dir: string, prefix: string, out: AgentFileEntry[]): Promise<void> {
+  if (out.length >= MAX_LISTED_FILES) return;
+  let entries: import('fs').Dirent[];
+  try {
+    entries = await fs.readdir(dir, { withFileTypes: true });
+  } catch {
+    return;
+  }
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (out.length >= MAX_LISTED_FILES) return;
+    // A symlink is not listed at all. Following one is how a listing starts
+    // describing files outside the tree it claims to describe.
+    if (entry.isSymbolicLink()) continue;
+    if (entry.name.startsWith('.')) continue;
+    const rel = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory()) {
+      if (SKIPPED_DIRS.has(entry.name)) continue;
+      await walk(path.join(dir, entry.name), rel, out);
+      continue;
+    }
+    if (!entry.isFile()) continue;
+    try {
+      const stat = await fs.stat(path.join(dir, entry.name));
+      out.push({
+        name: entry.name,
+        path: rel,
+        size: stat.size,
+        modified: stat.mtime.toISOString(),
+      });
+    } catch {
+      // Vanished between readdir and stat; nothing to report.
+    }
+  }
+}
+
+/** Files belonging to `agentId`. Empty when the agent has none — not an error. */
+export async function listAgentFiles(root: string, agentId: unknown): Promise<AgentFileEntry[]> {
+  const workspace = await resolveAgentWorkspace(root, agentId);
+  const out: AgentFileEntry[] = [];
+  await walk(workspace, '', out);
+  return out;
+}
+
+/** The text of one file inside the agent's directory. */
+export async function readAgentFile(
+  root: string,
+  agentId: unknown,
+  relPath: unknown,
+): Promise<string> {
+  const workspace = await resolveAgentWorkspace(root, agentId);
+  const target = await resolveInsideWorkspace(workspace, relPath);
+
+  const stat = await fs.stat(target).catch(() => null);
+  if (!stat) throw new Error(`No such agent file: ${String(relPath)}`);
+  if (!stat.isFile()) throw new Error(`Not a file: ${String(relPath)}`);
+  if (stat.size > MAX_AGENT_FILE_BYTES) {
+    throw new Error(`File is too large to edit (${stat.size} bytes)`);
+  }
+
+  return fs.readFile(target, 'utf-8');
+}
+
+/**
+ * Replace the contents of an existing agent file.
+ *
+ * Deliberately cannot create files: see the header. The caller is expected to
+ * have gated this on a credential (`requiresAuth`), because the bytes written
+ * here are executed by the next registry sweep.
+ */
+export async function writeAgentFile(
+  root: string,
+  agentId: unknown,
+  relPath: unknown,
+  content: unknown,
+): Promise<{ written: true; path: string; bytes: number }> {
+  if (typeof content !== 'string') throw new Error('content must be a string');
+  const bytes = Buffer.byteLength(content, 'utf-8');
+  if (bytes > MAX_AGENT_FILE_BYTES) {
+    throw new Error(`Refusing to write ${bytes} bytes; limit is ${MAX_AGENT_FILE_BYTES}`);
+  }
+
+  const workspace = await resolveAgentWorkspace(root, agentId);
+  const target = await resolveInsideWorkspace(workspace, relPath);
+
+  // lstat, not stat: writing through a symlink would put these bytes wherever
+  // the link points, which containment has no say over once the write starts.
+  const link = await fs.lstat(target).catch(() => null);
+  if (!link) {
+    throw new Error(
+      `No such agent file: ${String(relPath)}. Use /agents/import to install a new agent —`
+      + ' it verifies the file by loading it and rolls back when it fails.',
+    );
+  }
+  if (link.isSymbolicLink()) throw new Error(`Refusing to write through a symlink: ${String(relPath)}`);
+  if (!link.isFile()) throw new Error(`Not a file: ${String(relPath)}`);
+
+  await fs.writeFile(target, content, 'utf-8');
+  return { written: true, path: path.relative(workspace, target).split(path.sep).join('/'), bytes };
+}

--- a/typescript/src/agents/reserved-paths.ts
+++ b/typescript/src/agents/reserved-paths.ts
@@ -1,0 +1,29 @@
+/**
+ * The agent subdirectories a conforming kernel never auto-loads.
+ *
+ * These live in their own module, apart from `AgentRegistry`, because the rule
+ * is needed by code that must not drag the registry's dependencies along.
+ * `AgentRegistry` imports the logger, which imports `chalk`; the dashboard UI
+ * package runs its gateway integration test against `GatewayServer` with only
+ * `typescript/ui`'s dependencies installed, so anything reachable from the
+ * gateway that pulls in a root-only package breaks that suite. Keeping the two
+ * reserved-directory rules dependency-free lets both the registry and the
+ * `agents.files.*` guards share one definition instead of duplicating it.
+ *
+ * `AgentRegistry` re-exports both names, so existing importers are unaffected.
+ */
+
+/**
+ * Subdirectories a conforming kernel never auto-loads.
+ *
+ * KERNEL §2.3 freezes both names. Honouring them is not a spec nicety: without
+ * it, moving an agent into `disabled_agents/` does not disable it, and "how do I
+ * turn one off" is the very next question after drag-and-drop loading.
+ */
+export const RESERVED_AGENT_DIRS = ['experimental_agents', 'disabled_agents'] as const;
+
+/** True when `file` sits inside a reserved subdirectory of the agents tree. */
+export function isReservedAgentPath(relativePath: string): boolean {
+  const parts = relativePath.split(/[\\/]/);
+  return parts.some(seg => (RESERVED_AGENT_DIRS as readonly string[]).includes(seg));
+}

--- a/typescript/src/gateway/__tests__/agent-files-rpc.test.ts
+++ b/typescript/src/gateway/__tests__/agent-files-rpc.test.ts
@@ -1,0 +1,437 @@
+/**
+ * The agent file browser, against the gateway that actually runs.
+ *
+ * Reproduced first, on a started `GatewayServer` over HTTP:
+ *
+ *   agents.files.list  -> {"code":-32601,"message":"Method not found: agents.files.list"}
+ *   agents.files.read  -> {"code":-32601,"message":"Method not found: agents.files.read"}
+ *   agents.files.write -> {"code":-32601,"message":"Method not found: agents.files.write"}
+ *
+ * `typescript/src/gateway/methods/agents-methods.ts` declares all three, which
+ * is what makes grepping the source misleading — that module is never
+ * registered, and had it been, it forwarded to `agentRegistry.readAgentFile` /
+ * `writeAgentFile`, which no registry in this repo implements, with no path
+ * validation and no auth requirement.
+ *
+ * These tests go over real HTTP for the reason #170 exists: a test that called
+ * the method module directly would have passed against a gateway where the
+ * feature did not exist at all.
+ *
+ * The traversal cases are the point of the file. `agents.files.write` puts
+ * bytes into the directory `AgentRegistry` loads `*.py` and `*_agent.js` from
+ * and executes, so an escapable path here is remote code execution, not a
+ * mis-rendered file tree.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GatewayServer } from '../server.js';
+import { reserveTestPort } from '../../__tests__/support/test-port.js';
+import { userAgentsDir } from '../../agents/agent-import.js';
+
+let server: GatewayServer | undefined;
+const temps: string[] = [];
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+  while (temps.length) rmSync(temps.pop()!, { recursive: true, force: true });
+});
+
+interface Fixture {
+  port: number;
+  /** The agents tree the gateway is allowed to see. */
+  agentsRoot: string;
+  /** A directory OUTSIDE the tree, holding a secret nothing may reach. */
+  outside: string;
+  secretPath: string;
+}
+
+/**
+ * A gateway with a real agents tree:
+ *
+ *   <root>/hello_agent.py          flat, single-file agent
+ *   <root>/Swarm/main_agent.py     an agent with a folder of its own
+ *   <root>/Swarm/notes.md
+ *   <root>/disabled_agents/off_agent.py   deliberately switched off
+ *   <root>/escape -> <outside>            a symlink out of the tree
+ *   <outside>/secret.txt
+ */
+async function boot(): Promise<Fixture> {
+  const base = mkdtempSync(join(tmpdir(), 'agent-files-rpc-'));
+  temps.push(base);
+  const dataDir = join(base, 'data');
+  const agentsRoot = join(dataDir, 'agents');
+  const outside = join(base, 'outside');
+  mkdirSync(join(agentsRoot, 'Swarm'), { recursive: true });
+  mkdirSync(join(agentsRoot, 'disabled_agents'), { recursive: true });
+  mkdirSync(outside, { recursive: true });
+
+  writeFileSync(join(agentsRoot, 'hello_agent.py'), 'print("hello")\n');
+  writeFileSync(join(agentsRoot, 'Swarm', 'main_agent.py'), 'print("swarm")\n');
+  writeFileSync(join(agentsRoot, 'Swarm', 'notes.md'), '# notes\n');
+  writeFileSync(join(agentsRoot, 'disabled_agents', 'off_agent.py'), 'print("off")\n');
+  const secretPath = join(outside, 'secret.txt');
+  writeFileSync(secretPath, 'TOP SECRET\n');
+  symlinkSync(outside, join(agentsRoot, 'escape'), 'dir');
+
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  await server.start();
+  return { port, agentsRoot, outside, secretPath };
+}
+
+async function rpc(
+  port: number,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{ result?: Record<string, unknown>; error?: { code: number; message: string } }> {
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'a1', method, params }),
+  });
+  return (await res.json()) as { result?: Record<string, unknown>; error?: { code: number; message: string } };
+}
+
+describe('agents.files.* exist on the running gateway', () => {
+  it('answers all three instead of "Method not found"', async () => {
+    const { port } = await boot();
+    for (const [method, params] of [
+      ['agents.files.list', { agentId: 'Swarm' }],
+      ['agents.files.read', { agentId: 'Swarm', path: 'notes.md' }],
+      ['agents.files.write', { agentId: 'Swarm', path: 'notes.md', content: '# edited\n' }],
+    ] as Array<[string, Record<string, unknown>]>) {
+      const { error } = await rpc(port, method, params);
+      expect(error?.code, `${method} must exist`).not.toBe(-32601);
+    }
+  });
+});
+
+describe('the shapes the dashboard destructures', () => {
+  it('agents.files.list returns { files } with the entry fields the UI reads', async () => {
+    const { port } = await boot();
+    const { result } = await rpc(port, 'agents.files.list', { agentId: 'Swarm' });
+
+    // ui/src/components/agents.ts: `result?.files ?? ...`, then name/path/size/modified.
+    const files = result?.files as Array<Record<string, unknown>>;
+    expect(Array.isArray(files)).toBe(true);
+    expect(files.map((f) => f.path).sort()).toEqual(['main_agent.py', 'notes.md']);
+    const entry = files.find((f) => f.path === 'notes.md')!;
+    expect(entry.name).toBe('notes.md');
+    expect(typeof entry.size).toBe('number');
+    expect(typeof entry.modified).toBe('string');
+  });
+
+  it('agents.files.read returns { content }', async () => {
+    const { port } = await boot();
+    const { result } = await rpc(port, 'agents.files.read', { agentId: 'Swarm', path: 'notes.md' });
+    // The UI does `typeof result === 'string' ? result : result?.content ?? ''`.
+    expect(result?.content).toBe('# notes\n');
+  });
+
+  it('agents.files.write really changes the bytes on disk', async () => {
+    const { port, agentsRoot } = await boot();
+    const { result, error } = await rpc(port, 'agents.files.write', {
+      agentId: 'Swarm',
+      path: 'main_agent.py',
+      content: 'print("edited")\n',
+    });
+
+    expect(error).toBeUndefined();
+    expect(result?.written).toBe(true);
+    // Writing always "succeeds" — only the file proves it.
+    expect(readFileSync(join(agentsRoot, 'Swarm', 'main_agent.py'), 'utf-8')).toBe('print("edited")\n');
+  });
+
+  it('an agent without a folder of its own browses the agents tree it loads from', async () => {
+    const { port } = await boot();
+    const { result } = await rpc(port, 'agents.files.list', { agentId: 'Hello' });
+    const paths = (result?.files as Array<{ path: string }>).map((f) => f.path);
+    expect(paths).toContain('hello_agent.py');
+    expect(paths).toContain('Swarm/main_agent.py');
+  });
+});
+
+describe('path traversal is impossible', () => {
+  it('rejects ../ escapes on read and write', async () => {
+    const { port, outside, secretPath } = await boot();
+
+    for (const path_ of ['../../secret.txt', '../outside/secret.txt', 'Swarm/../../../outside/secret.txt']) {
+      const read = await rpc(port, 'agents.files.read', { agentId: 'Swarm', path: path_ });
+      expect(read.result, `read ${path_}`).toBeUndefined();
+      expect(read.error?.message).toMatch(/escapes the agent directory/);
+
+      const write = await rpc(port, 'agents.files.write', {
+        agentId: 'Swarm',
+        path: path_,
+        content: 'PWNED',
+      });
+      expect(write.result, `write ${path_}`).toBeUndefined();
+    }
+
+    expect(readFileSync(secretPath, 'utf-8')).toBe('TOP SECRET\n');
+    expect(readFileSync(join(outside, 'secret.txt'), 'utf-8')).not.toContain('PWNED');
+  });
+
+  it('rejects ".." even when it lands back inside the tree', async () => {
+    // `Swarm/../Swarm/notes.md` resolves to a legal file, so containment alone
+    // would allow it. It is refused anyway: a path containing `..` is never
+    // what the file tab sent, and normalising one away is how the next
+    // traversal bug gets in through a case the resolver happens to smooth over
+    // (`missing_dir/../secret` normalises before anything is resolved).
+    const { port } = await boot();
+    const { result, error } = await rpc(port, 'agents.files.read', {
+      agentId: 'Swarm',
+      path: 'Swarm/../Swarm/notes.md',
+    });
+    expect(result?.content).toBeUndefined();
+    expect(error?.message).toMatch(/escapes the agent directory/);
+  });
+
+  it('rejects absolute paths', async () => {
+    const { port, secretPath } = await boot();
+
+    const read = await rpc(port, 'agents.files.read', { agentId: 'Swarm', path: secretPath });
+    expect(read.result).toBeUndefined();
+    expect(read.error?.message).toMatch(/must be relative/);
+
+    const write = await rpc(port, 'agents.files.write', {
+      agentId: 'Swarm',
+      path: secretPath,
+      content: 'PWNED',
+    });
+    expect(write.result).toBeUndefined();
+    expect(readFileSync(secretPath, 'utf-8')).toBe('TOP SECRET\n');
+  });
+
+  it('rejects a symlink that leaves the tree, even though every segment is legal', async () => {
+    // `escape` is a real directory entry inside the root and `secret.txt` is a
+    // real file: nothing about the string is suspicious. Only resolving it
+    // reveals that it lands outside, which is why containment is checked after
+    // resolution rather than on the raw path.
+    const { port, secretPath } = await boot();
+
+    const read = await rpc(port, 'agents.files.read', { agentId: 'Hello', path: 'escape/secret.txt' });
+    expect(read.result?.content, 'must not leak a file outside the agents tree').toBeUndefined();
+    expect(read.error?.message).toMatch(/escapes the agent directory/);
+
+    const write = await rpc(port, 'agents.files.write', {
+      agentId: 'Hello',
+      path: 'escape/secret.txt',
+      content: 'PWNED',
+    });
+    expect(write.result).toBeUndefined();
+    expect(readFileSync(secretPath, 'utf-8')).toBe('TOP SECRET\n');
+  });
+
+  it('an agentId cannot be used to climb out either', async () => {
+    const { port } = await boot();
+    for (const agentId of ['..', '../outside', '/etc', 'a/../..']) {
+      const { result, error } = await rpc(port, 'agents.files.list', { agentId });
+      expect(result?.files, `agentId ${agentId}`).toBeUndefined();
+      expect(error?.message).toMatch(/Invalid agentId|is required/);
+    }
+  });
+
+  it('does not follow a symlinked directory when listing', async () => {
+    const { port } = await boot();
+    const { result } = await rpc(port, 'agents.files.list', { agentId: 'Hello' });
+    const paths = (result?.files as Array<{ path: string }>).map((f) => f.path);
+    expect(paths.some((p) => p.includes('escape'))).toBe(false);
+    expect(paths.some((p) => p.includes('secret'))).toBe(false);
+  });
+});
+
+describe('reserved agent directories stay reserved', () => {
+  it('never lists a disabled agent', async () => {
+    const { port } = await boot();
+    const { result } = await rpc(port, 'agents.files.list', { agentId: 'Hello' });
+    const paths = (result?.files as Array<{ path: string }>).map((f) => f.path);
+    expect(paths.some((p) => p.includes('disabled_agents'))).toBe(false);
+  });
+
+  it('refuses to read or write inside disabled_agents/', async () => {
+    const { port, agentsRoot } = await boot();
+    const target = join(agentsRoot, 'disabled_agents', 'off_agent.py');
+
+    const read = await rpc(port, 'agents.files.read', {
+      agentId: 'Hello',
+      path: 'disabled_agents/off_agent.py',
+    });
+    expect(read.result).toBeUndefined();
+    expect(read.error?.message).toMatch(/reserved/);
+
+    // A directory that does not disable anything means an agent someone
+    // deliberately switched off keeps running.
+    const write = await rpc(port, 'agents.files.write', {
+      agentId: 'Hello',
+      path: 'disabled_agents/off_agent.py',
+      content: 'print("resurrected")\n',
+    });
+    expect(write.result).toBeUndefined();
+    expect(readFileSync(target, 'utf-8')).toBe('print("off")\n');
+  });
+
+  it('refuses a reserved directory as an agentId', async () => {
+    const { port } = await boot();
+    for (const agentId of ['disabled_agents', 'experimental_agents']) {
+      const { result, error } = await rpc(port, 'agents.files.list', { agentId });
+      expect(result?.files).toBeUndefined();
+      expect(error?.message).toMatch(/reserved/);
+    }
+  });
+});
+
+describe('write edits, it does not plant', () => {
+  it('refuses to create a new file the loader would execute', async () => {
+    const { port, agentsRoot } = await boot();
+    const { result, error } = await rpc(port, 'agents.files.write', {
+      agentId: 'Swarm',
+      path: 'evil_agent.py',
+      content: 'import os; os.system("id")\n',
+    });
+
+    expect(result).toBeUndefined();
+    expect(error?.message).toMatch(/No such agent file/);
+    expect(() => readFileSync(join(agentsRoot, 'Swarm', 'evil_agent.py'))).toThrow();
+  });
+
+  it('refuses to write through a symlinked file', async () => {
+    const { port, agentsRoot, secretPath } = await boot();
+    symlinkSync(secretPath, join(agentsRoot, 'Swarm', 'link.txt'));
+
+    const { result } = await rpc(port, 'agents.files.write', {
+      agentId: 'Swarm',
+      path: 'link.txt',
+      content: 'PWNED',
+    });
+
+    expect(result).toBeUndefined();
+    expect(readFileSync(secretPath, 'utf-8')).toBe('TOP SECRET\n');
+  });
+});
+
+describe('the browser points at the tree that actually runs', () => {
+  it('defaults to the directory AgentRegistry hot-loads from', async () => {
+    // Editing files the loader never reads would be the quiet version of this
+    // bug: a tab that saves happily and changes nothing the assistant can do.
+    // `AgentRegistry`'s default user dir and `/agents/import`'s target are both
+    // `~/.openrappter/agents`; the gateway's default data dir is
+    // `~/.openrappter`, so the browser lands on the same tree.
+    const bare = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
+    const root = (bare as unknown as { agentFilesRoot: string }).agentFilesRoot;
+    expect(root).toBe(userAgentsDir());
+  });
+
+  it('a gateway given its own data dir can never reach the real user tree', async () => {
+    const { agentsRoot } = await boot();
+    const root = (server as unknown as { agentFilesRoot: string }).agentFilesRoot;
+    expect(root).toBe(agentsRoot);
+    expect(root).not.toBe(userAgentsDir());
+  });
+});
+
+describe('bad input is refused, not half-applied', () => {
+  it('rejects a write with no content instead of blanking the file', async () => {
+    const { port, agentsRoot } = await boot();
+    const { result, error } = await rpc(port, 'agents.files.write', {
+      agentId: 'Swarm',
+      path: 'notes.md',
+    });
+    expect(result).toBeUndefined();
+    expect(error?.message).toMatch(/content must be a string/);
+    expect(readFileSync(join(agentsRoot, 'Swarm', 'notes.md'), 'utf-8')).toBe('# notes\n');
+  });
+
+  it('rejects a missing or empty agentId and path', async () => {
+    const { port } = await boot();
+    expect((await rpc(port, 'agents.files.list', {})).error?.message).toMatch(/agentId is required/);
+    expect((await rpc(port, 'agents.files.read', { agentId: 'Swarm' })).error?.message)
+      .toMatch(/path is required/);
+    expect((await rpc(port, 'agents.files.read', { agentId: 'Swarm', path: '   ' })).error?.message)
+      .toMatch(/path is required/);
+  });
+
+  it('reports a missing file rather than inventing empty content', async () => {
+    const { port } = await boot();
+    const { result, error } = await rpc(port, 'agents.files.read', {
+      agentId: 'Swarm',
+      path: 'nope.md',
+    });
+    expect(result).toBeUndefined();
+    expect(error?.message).toMatch(/No such agent file/);
+  });
+});
+
+describe('mutating and content-bearing calls require the credential', () => {
+  /** Same policy as `/agents/import` (#171): these bytes get executed. */
+  async function bootWithToken(): Promise<{ port: number; agentsRoot: string }> {
+    const base = mkdtempSync(join(tmpdir(), 'agent-files-auth-'));
+    temps.push(base);
+    const dataDir = join(base, 'data');
+    const agentsRoot = join(dataDir, 'agents');
+    mkdirSync(agentsRoot, { recursive: true });
+    writeFileSync(join(agentsRoot, 'hello_agent.py'), 'print("hello")\n');
+
+    const port = await reserveTestPort();
+    server = new GatewayServer({
+      port,
+      bind: 'loopback',
+      auth: { mode: 'token', tokens: ['s3cret'] },
+      dataDir,
+    });
+    await server.start();
+    return { port, agentsRoot };
+  }
+
+  it('agents.files.write and read are registered with requiresAuth', async () => {
+    const { port } = await boot();
+    const methods = (server as unknown as {
+      methods: Map<string, { requiresAuth: boolean }>;
+    }).methods;
+    expect(methods.get('agents.files.write')!.requiresAuth).toBe(true);
+    expect(methods.get('agents.files.read')!.requiresAuth).toBe(true);
+    // Names, sizes and mtimes for agents `agents.list` already names.
+    expect(methods.get('agents.files.list')!.requiresAuth).toBe(false);
+    expect(port).toBeGreaterThan(0);
+  });
+
+  it('rejects an unauthenticated write and leaves the file alone', async () => {
+    const { port, agentsRoot } = await bootWithToken();
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'x',
+        method: 'agents.files.write',
+        params: { agentId: 'Hello', path: 'hello_agent.py', content: 'print("pwned")\n' },
+      }),
+    });
+
+    expect(res.status).toBe(401);
+    expect(readFileSync(join(agentsRoot, 'hello_agent.py'), 'utf-8')).toBe('print("hello")\n');
+  });
+
+  it('accepts the same write with the credential', async () => {
+    const { port, agentsRoot } = await bootWithToken();
+    const res = await fetch(`http://127.0.0.1:${port}/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Authorization: 'Bearer s3cret' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'x',
+        method: 'agents.files.write',
+        params: { agentId: 'Hello', path: 'hello_agent.py', content: 'print("edited")\n' },
+      }),
+    });
+
+    const body = (await res.json()) as { result?: { written?: boolean }; error?: unknown };
+    expect(body.error).toBeUndefined();
+    expect(body.result?.written).toBe(true);
+    expect(readFileSync(join(agentsRoot, 'hello_agent.py'), 'utf-8')).toBe('print("edited")\n');
+  });
+});

--- a/typescript/src/gateway/__tests__/cron-runs-alias.test.ts
+++ b/typescript/src/gateway/__tests__/cron-runs-alias.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `cron.runs` is the dashboard's name for `cron.logs`.
+ *
+ * Reproduced first, over HTTP against a started gateway:
+ *
+ *   cron.runs {"jobId":"job1"} -> {"code":-32601,"message":"Method not found: cron.runs"}
+ *   cron.logs {"jobId":"job1"} -> {"result":{"runs":[]}}
+ *
+ * So the run-history panel in `ui/src/components/cron.ts` was empty for a
+ * feature the gateway already had, under a second name. The fix aliases the
+ * canonical handler rather than writing a second implementation — the mistake
+ * `cron.delete` made in #166, where an alias with its own body kept the old bug
+ * after the original was fixed. `methods/cron-methods.ts` does declare
+ * `cron.runs`, but over its own in-memory `cronStore` and with a `{ limit }`
+ * parameter the UI does not send; it is never registered.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GatewayServer } from '../server.js';
+import { reserveTestPort } from '../../__tests__/support/test-port.js';
+
+let server: GatewayServer | undefined;
+const temps: string[] = [];
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+  while (temps.length) rmSync(temps.pop()!, { recursive: true, force: true });
+});
+
+/** A scheduler that has actually run something. */
+function schedulerWithHistory() {
+  const logs = [
+    { jobId: 'job1', timestamp: 1, success: true, durationMs: 12 },
+    { jobId: 'job2', timestamp: 2, success: false, durationMs: 5, error: 'boom' },
+    { jobId: 'job1', timestamp: 3, success: false, durationMs: 7, error: 'again' },
+  ];
+  return {
+    list: () => [{ id: 'job1', name: 'one', schedule: '* * * * *', enabled: true }],
+    run: async () => {},
+    enable: async () => {},
+    disable: async () => {},
+    getRunLogs: (jobId?: string) => (jobId ? logs.filter((l) => l.jobId === jobId) : [...logs]),
+  };
+}
+
+async function boot(): Promise<number> {
+  const dataDir = mkdtempSync(join(tmpdir(), 'cron-runs-alias-'));
+  temps.push(dataDir);
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  await server.start();
+  server.setCronService(schedulerWithHistory() as never);
+  return port;
+}
+
+async function rpc(port: number, method: string, params?: Record<string, unknown>) {
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'r1', method, params }),
+  });
+  return (await res.json()) as { result?: Record<string, unknown>; error?: { code: number; message: string } };
+}
+
+describe('cron.runs', () => {
+  it('exists on the running gateway', async () => {
+    const port = await boot();
+    const { error } = await rpc(port, 'cron.runs', { jobId: 'job1' });
+    expect(error?.code).not.toBe(-32601);
+  });
+
+  it('returns { runs } for the requested job, the shape the UI destructures', async () => {
+    const port = await boot();
+    // ui/src/components/cron.ts: `const res = await gateway.call(...); this.runs = res.runs ?? []`
+    const { result } = await rpc(port, 'cron.runs', { jobId: 'job1' });
+    const runs = result?.runs as Array<{ jobId: string }>;
+    expect(Array.isArray(runs)).toBe(true);
+    expect(runs).toHaveLength(2);
+    expect(runs.every((r) => r.jobId === 'job1')).toBe(true);
+  });
+
+  it('agrees with cron.logs call for call', async () => {
+    const port = await boot();
+    for (const params of [{ jobId: 'job1' }, { jobId: 'job2' }, {}]) {
+      const runs = await rpc(port, 'cron.runs', params);
+      const logs = await rpc(port, 'cron.logs', params);
+      expect(runs.result).toEqual(logs.result);
+    }
+  });
+
+  it('is the same handler object as cron.logs, not a copy of it', async () => {
+    // #166's lesson: an alias that re-derives the lookup drifts from the
+    // implementation it is supposed to be an alias for.
+    await boot();
+    const methods = (server as unknown as {
+      methods: Map<string, { handler: unknown }>;
+    }).methods;
+    expect(methods.get('cron.runs')!.handler).toBe(methods.get('cron.logs')!.handler);
+  });
+
+  it('answers { runs: [] } when no scheduler is wired, rather than throwing', async () => {
+    const dataDir = mkdtempSync(join(tmpdir(), 'cron-runs-bare-'));
+    temps.push(dataDir);
+    const port = await reserveTestPort();
+    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+    await server.start();
+
+    const { result, error } = await rpc(port, 'cron.runs', { jobId: 'job1' });
+    expect(error).toBeUndefined();
+    expect(result?.runs).toEqual([]);
+  });
+});

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -37,6 +37,11 @@ import {
   collectUsageStats,
 } from './usage.js';
 import { getFlightRecorder } from '../flight-recorder/recorder.js';
+import {
+  listAgentFiles,
+  readAgentFile,
+  writeAgentFile,
+} from '../agents/agent-files.js';
 import { readAnatomy } from './anatomy.js';
 import { readGatewayLogs } from './log-store.js';
 import { renderAnatomyPage } from './anatomy-page.js';
@@ -418,6 +423,26 @@ export class GatewayServer {
 
   private get cronStorePath(): string {
     return path.join(this.dataDir, 'cron.json');
+  }
+
+  /**
+   * The directory the agent file browser is allowed to see.
+   *
+   * The same tree `AgentRegistry` hot-loads and `/agents/import` writes into:
+   * with the default data dir this is `~/.openrappter/agents`, so what the
+   * dashboard edits is what the organism runs. A gateway pointed at another
+   * data dir (every test does this) gets that dir's `agents/` and can never
+   * reach the real user's agents by accident.
+   */
+  private get agentFilesRoot(): string {
+    return this.agentFilesRootOverride ?? path.join(this.dataDir, 'agents');
+  }
+
+  private agentFilesRootOverride?: string;
+
+  /** Point the file browser somewhere else. For embedders and tests. */
+  setAgentFilesRoot(dir: string): void {
+    this.agentFilesRootOverride = dir;
   }
 
   private loadCronStore() {
@@ -2075,6 +2100,48 @@ export class GatewayServer {
     // Agents
     this.registerMethod('agents.list', async () => this.agentList ? this.agentList() : []);
 
+    /**
+     * Agent file browser — the dashboard's Files tab.
+     *
+     * These names existed in `methods/agents-methods.ts`, which is never
+     * registered (see the doc comment on this method): it forwarded to an
+     * `agentRegistry.readAgentFile`/`writeAgentFile` pair that no registry in
+     * this repo implements, with no path validation and no auth. So the tab
+     * answered `Method not found`, and the module that looked like the
+     * implementation would have been an unauthenticated arbitrary-path write
+     * into the directory the loader executes.
+     *
+     * The guards live in `agents/agent-files.ts`. The two decisions made here:
+     *
+     *  - `read` and `write` require the credential. `write` because these bytes
+     *    are executed by the next registry sweep — the same reason
+     *    `/agents/import` requires it (#171) — and `read` because agent source
+     *    is where a generated agent's keys end up.
+     *  - `list` does not: it returns names, sizes and mtimes for agents that
+     *    `agents.list` already names without a credential, and the file tab
+     *    has to be able to render before anything is opened.
+     */
+    this.registerMethod('agents.files.list', async (params: { agentId?: string }) => {
+      const files = await listAgentFiles(this.agentFilesRoot, params?.agentId);
+      return { files };
+    });
+    this.registerMethod('agents.files.read', async (params: { agentId?: string; path?: string }) => {
+      const content = await readAgentFile(this.agentFilesRoot, params?.agentId, params?.path);
+      return { content };
+    }, { requiresAuth: true });
+    this.registerMethod(
+      'agents.files.write',
+      async (params: { agentId?: string; path?: string; content?: string }) => {
+        return writeAgentFile(
+          this.agentFilesRoot,
+          params?.agentId,
+          params?.path,
+          params?.content,
+        );
+      },
+      { requiresAuth: true },
+    );
+
     // What the assistant is running on, and what to do when it cannot run.
     this.registerMethod('backend.status', async () => this.backendStatus);
 
@@ -2451,7 +2518,7 @@ export class GatewayServer {
       this.saveCronStore();
       return job;
     }, { requiresAuth: true });
-    this.registerMethod('cron.logs', async (params: Record<string, unknown>) => {
+    const cronRunLogs = async (params: Record<string, unknown>) => {
       if (this.cronService) {
         const svc = this.cronService as unknown as { getRunLogs?: (jobId?: string) => unknown[] };
         if (svc.getRunLogs) {
@@ -2460,7 +2527,19 @@ export class GatewayServer {
         }
       }
       return { runs: [] };
-    });
+    };
+    this.registerMethod('cron.logs', cronRunLogs);
+    /**
+     * `cron.runs` is the dashboard's spelling of `cron.logs`, not a second
+     * feature: both mean "the run history of this job", both take `{ jobId }`,
+     * and `CronService.getRunLogs(jobId)` already answers it. It shares the
+     * handler *object* rather than re-deriving the lookup, for the reason
+     * `cron.delete` had to (#166) — an alias with its own body kept the old bug
+     * after the original was fixed, and reported success over a store nothing
+     * was running from. A test asserts the two handlers are the same reference.
+     */
+    this.registerMethod('cron.runs', cronRunLogs);
+
 
     // Connection methods
     this.registerMethod('connections.list', async () => {


### PR DESCRIPTION
## What was broken

Reproduced first, over real HTTP against a started `GatewayServer` (`auth: none`, temp data dir), before touching anything:

```
agents.files.list  {"agentId":"Shell"}                    -> {"code":-32601,"message":"Method not found: agents.files.list"}
agents.files.read  {"agentId":"Shell","path":"..."}       -> {"code":-32601,"message":"Method not found: agents.files.read"}
agents.files.write {"agentId":"Shell","path":"...","content":"x"} -> {"code":-32601,"message":"Method not found: agents.files.write"}
skills.toggle      {"id":"weather","enabled":false}       -> {"code":-32601,"message":"Method not found: skills.toggle"}
cron.runs          {"jobId":"job1"}                       -> {"code":-32601,"message":"Method not found: cron.runs"}
cron.logs          {"jobId":"job1"}                       -> {"result":{"runs":[]}}          <- already works
skills.list        {}                                     -> {"code":-32601,"message":"Method not found: skills.list"}
```

So the agent Files tab, the skills switch and the cron run-history panel were all dead. `gateway/methods/agents-methods.ts`, `cron-methods.ts` and `skills-methods.ts` declare these names — which is exactly what makes grepping the source misleading. None of those modules is registered (only 5 of 25 are; see the doc comment on `registerBuiltInMethods`).

**Registering them as they stand would have been worse than the missing feature.** `agents-methods.ts#agents.files.write` forwards a client-supplied `path` straight to `agentRegistry.writeAgentFile(agentId, path, content)` — a method no registry in this repo implements — with no containment check, no reserved-directory check and no `requiresAuth`. `cron-methods.ts` is backed by its own module-local `const cronStore = []` (the `config-methods.ts` shape #170 found) and its `cron.runs` takes `{ limit }`, not the `{ jobId }` the UI sends.

## `agents.files.*` — security analysis

`agents.files.write` writes into the directory `AgentRegistry` walks and **executes** (`*.py` through the Python bridge, `*_agent.js` through dynamic `import()`). This is an RCE surface, so it is treated as one.

New module `typescript/src/agents/agent-files.ts` is the single choke point. What it enforces:

| Guard | Why |
|---|---|
| Resolve, **then** contain | Every path is resolved to a real path first — including the deepest *existing* ancestor when the leaf does not exist — then checked with `path.relative`, never `startsWith`. A raw-string prefix check is bypassable. |
| `..` segments refused | Refused even when they resolve back inside, so a case the resolver smooths over (`missing_dir/../secret`) can never become the next hole. |
| Absolute / drive / UNC paths refused | `/etc/passwd`, `C:\…`, `\\host\share`. |
| Reserved dirs refused | `disabled_agents/` and `experimental_agents/` (`RESERVED_AGENT_DIRS`) are refused as an `agentId`, refused as any path segment on read and write, and skipped when listing. A directory that does not disable anything means an agent someone deliberately switched off keeps running. |
| Symlinks | Never listed, never written through (`lstat` before write), and a symlinked directory that leaves the tree fails the post-resolution containment check on read. |
| `write` edits, never plants | The target must already exist as a regular file. Creating a new agent stays with `/agents/import`, which verifies by loading and rolls back (#171); nothing here can verify a write. |
| 1 MiB cap on read and write | A browser text area is not a file transfer. |
| Root is the tree that actually runs | `<dataDir>/agents`, which with the default data dir is `~/.openrappter/agents` — the same directory `AgentRegistry` hot-loads and `/agents/import` writes to. A test pins it against `userAgentsDir()`, so the tab cannot end up editing files the loader never reads. Any gateway with its own data dir (every test) is automatically isolated from the real user's agents. |

### Traversal evidence

Each case was confirmed to fail **before** the corresponding guard existed (guard removed, test run — see the mutation table). Fixture: a secret file outside the tree, plus `<root>/escape -> <outside>` and `<root>/Swarm/link.txt -> <outside>/secret.txt`.

* `../../secret.txt`, `../outside/secret.txt`, `Swarm/../../../outside/secret.txt` — refused on read and write; the file on disk is byte-for-byte unchanged afterwards.
* `Swarm/../Swarm/notes.md` (lands back inside) — refused.
* An absolute path to the secret — refused on read and write.
* `escape/secret.txt` — **every segment is a real, legal entry inside the root**, and only resolution reveals it lands outside. Refused. With containment done on the raw string instead of the resolved path, this one leaks `TOP SECRET` — that mutation is in the table.
* `agentId` of `..`, `../outside`, `/etc`, `a/../..` — refused.
* `disabled_agents/off_agent.py` — refused on read and write; the disabled agent's bytes are unchanged.

### Auth decisions

| Method | `requiresAuth` | Reason |
|---|---|---|
| `agents.files.write` | **true** | The bytes are executed by the next registry sweep. Same rule `/agents/import` follows (#171). |
| `agents.files.read` | **true** | Returns agent *source*, which is where a generated agent's keys and tokens end up. |
| `agents.files.list` | false | Names, sizes and mtimes for agents `agents.list` already names without a credential, and the tab must render before anything is opened. No file contents cross this boundary. |

This costs the dashboard nothing: any WS client that completes the `connect` handshake is `authenticated`, and over HTTP with a token configured every non-health method already requires the credential. Proven both ways with a token-mode server: unauthenticated `agents.files.write` → **401** with the file unchanged; the same call with `Authorization: Bearer …` → `{written:true}` with the new bytes on disk.

## `cron.runs` aliases `cron.logs` — yes

Same meaning ("the run history of this job"), same `{ jobId }` parameter, and `CronService.getRunLogs(jobId)` already filters by job. It shares the handler **object** rather than getting a second body — the mistake `cron.delete` made in #166, where an alias with its own implementation kept the old bug after the original was fixed. A test asserts `methods.get('cron.runs').handler === methods.get('cron.logs').handler`, and another asserts the two agree call-for-call for `{jobId:'job1'}`, `{jobId:'job2'}` and `{}`.

## Shapes the UI destructures

* `agents.files.list` → `{ files: [{ name, path, size, modified }] }` (`result?.files ?? …`)
* `agents.files.read` → `{ content }` (`typeof result === 'string' ? result : result?.content ?? ''`)
* `agents.files.write` → `{ written: true, path, bytes }`
* `cron.runs` → `{ runs }` (`res.runs ?? []`)

Each is asserted over real HTTP, not against the method module — a test that imported `agents-methods.ts` would have passed against a gateway where the feature did not exist at all.

## Mutation table

Every fix reverted, one at a time; the listed test file re-run.

| # | Mutation | Result |
|---|---|---|
| 1 | Unregister `agents.files.*` (the original defect) | RED — `answers all three instead of "Method not found"`, both shape tests |
| 2 | Unregister `cron.runs` (the original defect) | RED — `exists on the running gateway`, `{ runs }` shape, `agrees with cron.logs` |
| 3 | Drop the post-resolution containment check | RED — symlink escape, symlink write |
| 4 | Contain by raw string prefix instead of resolved real path | RED — `rejects a symlink that leaves the tree, even though every segment is legal` |
| 5 | Drop the `..` segment rejection | RED — `rejects ".." even when it lands back inside the tree` |
| 6 | Drop the absolute-path rejection | RED — `rejects absolute paths` |
| 7 | Drop the reserved-directory rejection on paths | RED — `refuses to read or write inside disabled_agents/` |
| 8 | Drop the reserved-directory rejection on `agentId` | RED — `refuses a reserved directory as an agentId` |
| 9 | Let `write` create new files | RED — `refuses to create a new file the loader would execute` |
| 10 | Follow symlinks when listing (`stat` instead of dirent checks) | RED — `does not follow a symlinked directory when listing` |
| 11 | `agents.files.write` without `requiresAuth` | RED — `registered with requiresAuth` |
| 12 | `agents.files.list` returns a bare array instead of `{ files }` | RED — three shape/listing tests |
| 13 | `cron.runs` as a second implementation instead of an alias | RED — `is the same handler object as cron.logs, not a copy of it` |
| 14 | Agent files root pointed away from the loaded tree (`dataDir` instead of `dataDir/agents`) | RED — all three shape tests |
| 15 | Leave a stale `KNOWN_MISSING` entry behind | RED — `the known-missing list contains nothing that now exists` |

No survivors. (Two earlier survivors — the `..` rejection and the symlink-listing skip, both shadowed by a second guard — were killed by adding the `Swarm/../Swarm/notes.md` test and by mutating *both* dirent checks; the table above is the final run.)

## `KNOWN_MISSING` entries removed

`agents.files.list`, `agents.files.read`, `agents.files.write`, `cron.runs`.

## Left unimplemented, with the reason: `skills.toggle`

Kept in `KNOWN_MISSING` with the evidence written into the list, because a handler here would be the #176 shape exactly — a stub reporting success:

* **Nothing consumes a skill's enabled state.** `ClawHubClient.loadAllSkills()` returns `[]`; no skill ever becomes an agent; no prompt path reads bundled skills. Disabling one would change nothing about what the assistant can do.
* **`enabled` is not a setting.** The gateway's `skills.list` (registered in `src/index.ts`, not on `GatewayServer` — which is why it is *also* still in `KNOWN_MISSING`) computes `enabled` from `checkSkillEligibility`: whether the skill's required binaries, env vars and OS are present. A switch cannot install a binary, and the next refresh would flip the toggle straight back.
* **The payload has no `id`.** `skills.list` returns `{name, description, category, enabled, version}`, so both UI call sites send `{ id: undefined, enabled }`.

Making this real means giving skills a runtime meaning first (loading them as agents, and honouring a persisted disable in that load). That is a feature, not a wiring fix, and shipping a toggle before it exists is the lie this PR is trying not to tell.

## Verification

* `npx vitest run` — **4971 passed, 21 skipped, 258 files**, 0 failures.
* `npx tsc --noEmit -p tsconfig.json` — clean.
* `npx eslint` on all changed files — 0 errors (one pre-existing `_ignored` warning in `server.ts`, untouched by this change).
