### PR TITLE
Make the zen viewer work: back zen.* with live streaming state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Zen viewer works** — `<openrappter-zen>` is live UI, but `zen.sessions`,
+  `zen.subscribe` and `zen.unsubscribe` were never registered on the gateway,
+  so the page answered `-32601 Method not found` on load and rendered an empty
+  screen forever. They are now registered against live streaming state owned by
+  the running server. `src/gateway/methods/zen-methods.ts` was deliberately not
+  reused: it reads `peer-stream.ts`'s process-local `globalPeerStream`, whose
+  only writer (`openrappter bar --tui`) runs in a different process from the
+  daemon, so it could only ever have reported an empty list. Producers now feed
+  the daemon over the wire (`zen.publish`/`zen.end`, WebSocket only), the Bar's
+  pong screen publishes through it, frames reach only the connections that
+  subscribed, and a dropped connection releases its viewer slots and ends the
+  sessions it was producing. The client-RPC coverage guard now also walks
+  `ui/src/components`, not just `ui/src/services`: `zen.ts` is a component, so
+  the guard never saw the three broken calls — their debt entries had been
+  listed by hand rather than found.
 - **The Bar's usage screen shows real numbers** — `UsageViewModel` calls
   `usage.stats` and `usage.history`, and the live `GatewayServer` registered
   neither, so both answered `Method not found` and the screen only ever

--- a/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
+++ b/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
@@ -22,7 +22,16 @@ import { reserveTestPort } from '../support/test-port.js';
 
 const REPO = resolve(__dirname, '../../..');
 const SWIFT_RPC = join(REPO, '../macos/Sources/OpenRappterBar/Services/RpcClient.swift');
-const UI_SERVICES = join(REPO, 'ui/src/services');
+/**
+ * Both halves of the web UI call the gateway directly.
+ *
+ * This scan used to cover `ui/src/services` alone, which is how
+ * `ui/src/components/zen.ts` — a live `<openrappter-zen>` element rendered by
+ * the app shell — called three methods nobody had registered without this file
+ * noticing: its entries were listed below by hand, not found. Components make
+ * `gateway.call(...)` as freely as services do, so both are walked.
+ */
+const UI_SOURCES = [join(REPO, 'ui/src/services'), join(REPO, 'ui/src/components')];
 
 /**
  * Methods a client calls that the gateway still does not register.
@@ -53,9 +62,6 @@ const KNOWN_MISSING = new Set<string>([
   // #176 found in `skills install`. Implementing it needs skills to mean
   // something at runtime first.
   'skills.toggle',
-  'zen.sessions',
-  'zen.subscribe',
-  'zen.unsubscribe',
   // Live macOS Bar screens that cannot work: node pairing and skills.
   // Being fixed now; each entry is removed as its method lands, and the last
   // test in this file fails if one is left here after it starts existing.
@@ -124,7 +130,7 @@ function uiMethods(): string[] {
       }
     }
   };
-  walk(UI_SERVICES);
+  for (const dir of UI_SOURCES) walk(dir);
   return names;
 }
 

--- a/typescript/src/__tests__/integration/zen-contract.test.ts
+++ b/typescript/src/__tests__/integration/zen-contract.test.ts
@@ -1,0 +1,392 @@
+/**
+ * Zen viewer RPC contract, against the wired gateway.
+ *
+ * `ui/src/components/zen.ts` is live UI (`<openrappter-zen>`, rendered from
+ * `ui/src/main.ts`) and it called three methods the production gateway never
+ * registered:
+ *
+ *     zen.sessions     → -32601 Method not found: zen.sessions
+ *     zen.subscribe    → -32601 Method not found: zen.subscribe
+ *     zen.unsubscribe  → -32601 Method not found: zen.unsubscribe
+ *
+ * `src/gateway/methods/zen-methods.ts` declares those names, but it is
+ * deliberately never registered (see the doc comment on
+ * `registerBuiltInMethods`) *and* it reads a process-local singleton
+ * (`peer-stream.ts`'s `globalPeerStream`) whose only writer, `src/tui/bar.ts`,
+ * runs in the Bar's process — never the daemon's. Registering it would have
+ * turned "Method not found" into a permanently empty session list, which the
+ * user cannot tell apart from "nothing is streaming right now".
+ *
+ * These tests therefore drive a real `GatewayServer` over real HTTP and real
+ * WebSocket connections. A test importing the method module would prove
+ * nothing about the server the dashboard talks to.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import WebSocket from 'ws';
+import { GatewayServer } from '../../gateway/server.js';
+import { TuiGatewayClient } from '../../tui/gateway-client.js';
+import { createZenPublisher } from '../../tui/zen-publisher.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+let server: GatewayServer | undefined;
+const clients: TestClient[] = [];
+
+afterEach(async () => {
+  for (const client of clients.splice(0)) client.close();
+  await server?.stop();
+  server = undefined;
+});
+
+async function startServer(): Promise<number> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  await server.start();
+  return port;
+}
+
+async function httpRpc(
+  port: number,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<{ result?: Record<string, unknown>; error?: { code: number; message: string } }> {
+  const res = await fetch(`http://127.0.0.1:${port}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 'zen-test', method, params }),
+  });
+  return (await res.json()) as { result?: Record<string, unknown>; error?: { code: number; message: string } };
+}
+
+/** A minimal client speaking the gateway's real frame protocol over ws. */
+class TestClient {
+  private ws: WebSocket;
+  private nextId = 0;
+  private pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
+  readonly events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+
+  private constructor(port: number) {
+    this.ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    this.ws.on('message', (data) => {
+      const frame = JSON.parse(data.toString());
+      if (frame.type === 'res') {
+        const pending = this.pending.get(frame.id);
+        if (!pending) return;
+        this.pending.delete(frame.id);
+        if (frame.ok) pending.resolve(frame.payload);
+        else pending.reject(new Error(frame.error?.message ?? 'rpc error'));
+      } else if (frame.type === 'event') {
+        this.events.push({ event: frame.event, payload: frame.payload });
+      }
+    });
+  }
+
+  static async connect(port: number): Promise<TestClient> {
+    const client = new TestClient(port);
+    clients.push(client);
+    await new Promise<void>((resolve, reject) => {
+      client.ws.once('open', () => resolve());
+      client.ws.once('error', reject);
+    });
+    await client.call('connect', {
+      client: { id: 'zen-test', version: 'test', platform: process.platform, mode: 'test' },
+    });
+    return client;
+  }
+
+  call<T = Record<string, unknown>>(method: string, params?: Record<string, unknown>): Promise<T> {
+    const id = `t${++this.nextId}`;
+    return new Promise<T>((resolve, reject) => {
+      this.pending.set(id, { resolve: resolve as (v: unknown) => void, reject });
+      this.ws.send(JSON.stringify({ type: 'req', id, method, params }));
+      setTimeout(() => {
+        if (this.pending.delete(id)) reject(new Error(`timeout: ${method}`));
+      }, 5000);
+    });
+  }
+
+  framesFor(sessionId: string): Array<{ sessionId: string; frame: string }> {
+    return this.events
+      .filter((e) => e.event === 'zen.frame')
+      .map((e) => e.payload as unknown as { sessionId: string; frame: string })
+      .filter((p) => p.sessionId === sessionId);
+  }
+
+  close(): void {
+    try { this.ws.close(); } catch { /* already gone */ }
+  }
+}
+
+/** Let a broadcast or a socket close reach the server and settle. */
+async function settle(ms = 120): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+interface ZenSessionCard {
+  id: string;
+  name: string;
+  startedAt: string;
+  frameCount: number;
+  viewerCount: number;
+}
+
+async function listSessions(port: number): Promise<ZenSessionCard[]> {
+  const { result, error } = await httpRpc(port, 'zen.sessions');
+  expect(error).toBeUndefined();
+  return (result as unknown as { sessions: ZenSessionCard[] }).sessions;
+}
+
+describe('zen RPC contract, against the wired gateway', () => {
+  it('zen.sessions is registered and returns the { sessions } shape zen.ts destructures', async () => {
+    const port = await startServer();
+
+    const { result, error } = await httpRpc(port, 'zen.sessions');
+
+    expect(error).toBeUndefined();
+    // `zen.ts` does `result.sessions ?? []`; an array is what it maps over.
+    expect(Array.isArray((result as unknown as { sessions: unknown }).sessions)).toBe(true);
+    expect((result as unknown as { sessions: unknown[] }).sessions).toEqual([]);
+  });
+
+  it('lists a session a connected producer published, with the fields the card renders', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+
+    await producer.call('zen.publish', {
+      sessionId: 'bar-pong',
+      name: 'Pong — You vs AI',
+      frame: 'frame one',
+    });
+
+    const [session, ...rest] = await listSessions(port);
+    expect(rest).toEqual([]);
+    expect(session.id).toBe('bar-pong');
+    expect(session.name).toBe('Pong — You vs AI');
+    expect(session.frameCount).toBe(1);
+    expect(session.viewerCount).toBe(0);
+    expect(Number.isNaN(Date.parse(session.startedAt))).toBe(false);
+    // The card renders five fields; a screenful of ANSI per entry is not one.
+    expect(session).not.toHaveProperty('lastFrame');
+  });
+
+  it('zen.subscribe returns { subscribed, lastFrame } and then streams zen.frame events', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+    await producer.call('zen.publish', { sessionId: 'bar-pong', name: 'Pong', frame: 'caught-up' });
+
+    const viewer = await TestClient.connect(port);
+    const subscription = await viewer.call<{ subscribed: boolean; lastFrame?: string }>(
+      'zen.subscribe',
+      { sessionId: 'bar-pong' },
+    );
+
+    // zen.ts gates everything on `result.subscribed` and paints `lastFrame`.
+    expect(subscription.subscribed).toBe(true);
+    expect(subscription.lastFrame).toBe('caught-up');
+
+    await producer.call('zen.publish', { sessionId: 'bar-pong', frame: 'live-frame' });
+    await settle();
+
+    // zen.ts's handler reads payload.sessionId and payload.frame.
+    expect(viewer.framesFor('bar-pong')).toEqual([
+      { sessionId: 'bar-pong', frame: 'live-frame', frameNumber: 2 },
+    ]);
+  });
+
+  it('sends frames only to subscribers, not to every connection', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+    await producer.call('zen.publish', { sessionId: 'bar-pong', name: 'Pong', frame: 'f1' });
+
+    const viewer = await TestClient.connect(port);
+    const bystander = await TestClient.connect(port);
+    await viewer.call('zen.subscribe', { sessionId: 'bar-pong' });
+
+    await producer.call('zen.publish', { sessionId: 'bar-pong', frame: 'f2' });
+    await settle();
+
+    expect(viewer.framesFor('bar-pong')).toHaveLength(1);
+    expect(bystander.framesFor('bar-pong')).toHaveLength(0);
+  });
+
+  it('zen.unsubscribe releases the viewer slot and stops the frames', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+    await producer.call('zen.publish', { sessionId: 'bar-pong', name: 'Pong', frame: 'f1' });
+    const viewer = await TestClient.connect(port);
+    await viewer.call('zen.subscribe', { sessionId: 'bar-pong' });
+    expect((await listSessions(port))[0].viewerCount).toBe(1);
+
+    const result = await viewer.call<{ unsubscribed: boolean }>('zen.unsubscribe', {
+      sessionId: 'bar-pong',
+    });
+
+    expect(result.unsubscribed).toBe(true);
+    // Releasing means the slot is gone, not merely that the call said ok.
+    expect((await listSessions(port))[0].viewerCount).toBe(0);
+
+    await producer.call('zen.publish', { sessionId: 'bar-pong', frame: 'after-unsub' });
+    await settle();
+    expect(viewer.framesFor('bar-pong')).toHaveLength(0);
+  });
+
+  it('a viewer that disconnects without unsubscribing does not leak a viewer slot', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+    await producer.call('zen.publish', { sessionId: 'bar-pong', name: 'Pong', frame: 'f1' });
+    const viewer = await TestClient.connect(port);
+    await viewer.call('zen.subscribe', { sessionId: 'bar-pong' });
+    expect((await listSessions(port))[0].viewerCount).toBe(1);
+
+    viewer.close();
+    await settle();
+
+    expect((await listSessions(port))[0].viewerCount).toBe(0);
+  });
+
+  it('a producer that disconnects ends its session instead of stranding it', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+    const watcher = await TestClient.connect(port);
+    await producer.call('zen.publish', { sessionId: 'bar-pong', name: 'Pong', frame: 'f1' });
+    expect(await listSessions(port)).toHaveLength(1);
+
+    producer.close();
+    await settle();
+
+    expect(await listSessions(port)).toEqual([]);
+    expect(watcher.events.filter((e) => e.event === 'zen.session.end')).toEqual([
+      { event: 'zen.session.end', payload: { id: 'bar-pong' } },
+    ]);
+  });
+
+  it('refuses to subscribe to a session that does not exist instead of reporting success', async () => {
+    const port = await startServer();
+    const viewer = await TestClient.connect(port);
+
+    await expect(viewer.call('zen.subscribe', { sessionId: 'ghost' })).rejects.toThrow(
+      /Unknown zen session: ghost/,
+    );
+    await expect(viewer.call('zen.lastframe', { sessionId: 'ghost' })).rejects.toThrow(
+      /Unknown zen session: ghost/,
+    );
+  });
+
+  it('tells an HTTP caller it is not streaming rather than claiming a subscription', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+    await producer.call('zen.publish', { sessionId: 'bar-pong', name: 'Pong', frame: 'only-frame' });
+
+    const { result } = await httpRpc(port, 'zen.subscribe', { sessionId: 'bar-pong' });
+
+    // HTTP has no channel for zen.frame events, so `subscribed: true` would be
+    // a success report over nothing.
+    expect(result?.subscribed).toBe(false);
+    expect(String(result?.reason)).toMatch(/WebSocket/);
+    expect(result?.lastFrame).toBe('only-frame');
+    // …and the honest fallback it points at works.
+    const { result: last } = await httpRpc(port, 'zen.lastframe', { sessionId: 'bar-pong' });
+    expect(last?.frame).toBe('only-frame');
+    // No viewer was counted for a caller that cannot receive frames.
+    expect((await listSessions(port))[0].viewerCount).toBe(0);
+  });
+
+  it('rejects publishing from a connection the gateway cannot outlive-check', async () => {
+    const port = await startServer();
+
+    const { error } = await httpRpc(port, 'zen.publish', { sessionId: 'x', frame: 'y' });
+
+    expect(error?.message).toMatch(/WebSocket/);
+    expect(await listSessions(port)).toEqual([]);
+  });
+
+  it('requires sessionId and frame instead of inventing them', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+
+    await expect(producer.call('zen.subscribe', {})).rejects.toThrow(/sessionId required/);
+    await expect(producer.call('zen.publish', { frame: 'f' })).rejects.toThrow(/sessionId required/);
+    await expect(producer.call('zen.publish', { sessionId: 's' })).rejects.toThrow(/frame required/);
+  });
+
+  it('caps frame size so a publisher cannot post arbitrary payloads', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+
+    await expect(
+      producer.call('zen.publish', { sessionId: 'huge', frame: 'x'.repeat(256 * 1024 + 1) }),
+    ).rejects.toThrow(/exceeds/);
+    expect(await listSessions(port)).toEqual([]);
+  });
+
+  it('streams frames past the 100/min control budget without spending it', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+
+    // 30fps for four seconds is 120 frames — more than the control-plane
+    // budget for a whole minute, which is why frames are accounted separately.
+    for (let i = 0; i < 110; i++) {
+      const ack = await producer.call<{ published: boolean; frameNumber: number }>('zen.publish', {
+        sessionId: 'bar-pong',
+        name: 'Pong',
+        frame: `frame-${i}`,
+      });
+      expect(ack.published).toBe(true);
+      expect(ack.frameNumber).toBe(i + 1);
+    }
+
+    // The same connection can still make ordinary calls afterwards.
+    const sessions = await producer.call<{ sessions: ZenSessionCard[] }>('zen.sessions');
+    expect(sessions.sessions[0].frameCount).toBe(110);
+  });
+
+  it('bounds the frame budget too — a publisher above 60fps is rate limited', async () => {
+    const port = await startServer();
+    const producer = await TestClient.connect(port);
+
+    const results = await Promise.allSettled(
+      Array.from({ length: 200 }, (_, i) =>
+        producer.call('zen.publish', { sessionId: 'flood', name: 'Flood', frame: `f${i}` }),
+      ),
+    );
+
+    const rejected = results.filter((r) => r.status === 'rejected');
+    expect(rejected.length).toBeGreaterThan(0);
+    expect(String((rejected[0] as PromiseRejectedResult).reason)).toMatch(/Rate limit/);
+  });
+
+  it('carries the Bar\'s pong frames end to end: publisher → gateway → viewer', async () => {
+    const port = await startServer();
+    // The exact client the TUI Bar uses, driving the exact publisher it uses.
+    const bar = new TuiGatewayClient();
+    await bar.connect(`ws://127.0.0.1:${port}`);
+    const publisher = createZenPublisher({
+      call: (method, params) => bar.call(method, params),
+      sessionId: 'bar-pong',
+      name: 'Pong — You vs AI',
+      minIntervalMs: 0,
+    });
+
+    publisher.publish('\u001b[32mPONG\u001b[0m');
+    await settle();
+
+    const [card] = await listSessions(port);
+    expect(card).toMatchObject({ id: 'bar-pong', name: 'Pong — You vs AI', frameCount: 1 });
+
+    const viewer = await TestClient.connect(port);
+    const subscription = await viewer.call<{ subscribed: boolean; lastFrame?: string }>(
+      'zen.subscribe',
+      { sessionId: 'bar-pong' },
+    );
+    expect(subscription.subscribed).toBe(true);
+    expect(subscription.lastFrame).toBe('\u001b[32mPONG\u001b[0m');
+
+    publisher.publish('\u001b[32mPONG 2\u001b[0m');
+    await settle();
+    expect(viewer.framesFor('bar-pong').map((f) => f.frame)).toEqual(['\u001b[32mPONG 2\u001b[0m']);
+
+    // Quitting the Bar takes the session away with it.
+    await publisher.end();
+    expect(await listSessions(port)).toEqual([]);
+    bar.disconnect();
+  });
+});

--- a/typescript/src/__tests__/unit/zen-publisher.test.ts
+++ b/typescript/src/__tests__/unit/zen-publisher.test.ts
@@ -1,0 +1,136 @@
+/**
+ * The Bar's frame publisher — the producer half of `zen.*`.
+ *
+ * Its job is to keep a 30fps screen inside a gateway connection's frame
+ * budget without ever letting a slow gateway build a backlog of stale
+ * screens. These tests pin the drop rules, because "publish every frame and
+ * hope" is exactly what the gateway's rate limiter would reject.
+ */
+import { describe, it, expect, vi } from 'vitest';
+import { createZenPublisher } from '../../tui/zen-publisher.js';
+
+function deferred() {
+  let resolve!: () => void;
+  let reject!: (e: Error) => void;
+  const promise = new Promise<void>((res, rej) => {
+    resolve = () => res();
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe('zen publisher', () => {
+  it('publishes a frame with the session identity the viewer lists', async () => {
+    const call = vi.fn().mockResolvedValue({ published: true });
+    const publisher = createZenPublisher({
+      call,
+      sessionId: 'bar-pong',
+      name: 'Pong — You vs AI',
+      now: () => 0,
+    });
+
+    publisher.publish('ANSI');
+    await flush();
+
+    expect(call).toHaveBeenCalledWith('zen.publish', {
+      sessionId: 'bar-pong',
+      name: 'Pong — You vs AI',
+      frame: 'ANSI',
+    });
+    expect(publisher.stats.published).toBe(1);
+  });
+
+  it('drops frames rendered faster than the minimum interval', async () => {
+    const call = vi.fn().mockResolvedValue({});
+    let clock = 0;
+    const publisher = createZenPublisher({
+      call,
+      sessionId: 's',
+      name: 'n',
+      minIntervalMs: 100,
+      now: () => clock,
+    });
+
+    publisher.publish('f1');
+    await flush();
+    clock = 50;
+    publisher.publish('f2');
+    await flush();
+    clock = 150;
+    publisher.publish('f3');
+    await flush();
+
+    expect(call.mock.calls.map((c) => (c[1] as { frame: string }).frame)).toEqual(['f1', 'f3']);
+    expect(publisher.stats.dropped).toBe(1);
+  });
+
+  it('never queues behind a publish that has not answered yet', async () => {
+    const gate = deferred();
+    const call = vi.fn().mockReturnValue(gate.promise);
+    let clock = 0;
+    const publisher = createZenPublisher({
+      call,
+      sessionId: 's',
+      name: 'n',
+      minIntervalMs: 0,
+      now: () => clock,
+    });
+
+    publisher.publish('f1');
+    clock = 1000;
+    publisher.publish('f2');
+    clock = 2000;
+    publisher.publish('f3');
+    await flush();
+
+    // A stalled gateway must cost dropped frames, not an unbounded backlog.
+    expect(call).toHaveBeenCalledTimes(1);
+    expect(publisher.stats.dropped).toBe(2);
+
+    gate.resolve();
+    await flush();
+    clock = 3000;
+    publisher.publish('f4');
+    await flush();
+    expect(call).toHaveBeenCalledTimes(2);
+  });
+
+  it('stops publishing to a gateway that keeps refusing, instead of once per frame', async () => {
+    const call = vi.fn().mockRejectedValue(new Error('Method not found: zen.publish'));
+    let clock = 0;
+    const publisher = createZenPublisher({
+      call,
+      sessionId: 's',
+      name: 'n',
+      minIntervalMs: 0,
+      maxConsecutiveFailures: 3,
+      now: () => clock,
+    });
+
+    for (let i = 0; i < 10; i++) {
+      clock += 100;
+      publisher.publish(`f${i}`);
+      await flush();
+    }
+
+    expect(call).toHaveBeenCalledTimes(3);
+    expect(publisher.stats.disabled).toBe(true);
+    expect(publisher.stats.lastError).toMatch(/Method not found/);
+  });
+
+  it('ends only a session it actually started', async () => {
+    const call = vi.fn().mockResolvedValue({});
+    const publisher = createZenPublisher({ call, sessionId: 'bar-pong', name: 'n', now: () => 0 });
+
+    await publisher.end();
+    expect(call).not.toHaveBeenCalled();
+
+    publisher.publish('f1');
+    await flush();
+    await publisher.end();
+
+    expect(call).toHaveBeenLastCalledWith('zen.end', { sessionId: 'bar-pong' });
+  });
+});

--- a/typescript/src/gateway/methods/zen-methods.ts
+++ b/typescript/src/gateway/methods/zen-methods.ts
@@ -6,6 +6,12 @@
  *   zen.subscribe       — Subscribe to a session (get frames via events)
  *   zen.unsubscribe     — Stop receiving frames
  *   zen.lastframe       — Get latest frame (for late joiners)
+ *
+ * ⚠️  Never registered, and not the implementation the dashboard reaches: see
+ * the doc comment on `GatewayServer.registerBuiltInMethods`. It reads
+ * `globalPeerStream`, a per-process singleton no gateway ever writes to, so
+ * registering it would answer `zen.sessions` with a list that is empty by
+ * construction. The live handlers are `gateway/zen-stream.ts`.
  */
 
 import { globalPeerStream } from '../peer-stream.js';

--- a/typescript/src/gateway/peer-stream.ts
+++ b/typescript/src/gateway/peer-stream.ts
@@ -10,6 +10,14 @@
  *   Browser connects via WS → subscribes to 'zen.frame' events → renders ANSI
  *
  * Sessions allow multiple zen screens (pong, future games) running in parallel.
+ *
+ * ⚠️  Not the live path. `globalPeerStream` below is a per-process singleton,
+ * and every zen producer (`openrappter bar --tui`, `node pong.js zen`) runs in
+ * its own process — never the daemon's — so nothing written here is visible to
+ * a `GatewayServer`. The wired implementation, fed by producers over the
+ * `zen.publish` RPC, is `gateway/zen-stream.ts`; this module and
+ * `gateway/methods/zen-methods.ts` remain only as the standalone,
+ * independently unit-tested pair described on `registerBuiltInMethods`.
  */
 
 export interface ZenStreamSession {

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -42,6 +42,7 @@ import {
   readAgentFile,
   writeAgentFile,
 } from '../agents/agent-files.js';
+import { ZenStreamHub, registerZenStreamMethods } from './zen-stream.js';
 import { readAnatomy } from './anatomy.js';
 import { readGatewayLogs } from './log-store.js';
 import { renderAnatomyPage } from './anatomy-page.js';
@@ -100,6 +101,16 @@ const DEFAULT_CONNECTION_TIMEOUT = 120000;
 const DEFAULT_SHUTDOWN_TIMEOUT = 250;
 const RATE_LIMIT_WINDOW_MS = 60000;
 const RATE_LIMIT_MAX_REQUESTS = 100;
+/**
+ * `zen.publish` carries rendered terminal frames, not control-plane calls: a
+ * 30fps screen is 1800 requests a minute, which the 100/minute control budget
+ * exists to stop. Frames get their own, separately accounted budget so a
+ * stream cannot starve (or be starved by) everything else on the connection.
+ * 120 frames per 2s window sustains 60fps and still bounds a rogue publisher.
+ */
+const FRAME_RATE_LIMIT_WINDOW_MS = 2000;
+const FRAME_RATE_LIMIT_MAX_FRAMES = 120;
+const FRAME_RATE_LIMITED_METHODS = new Set(['zen.publish']);
 const PROTOCOL_VERSION = 3;
 const LOOPBACK_HOSTS = new Set(['localhost', '127.0.0.1', '::1']);
 
@@ -220,6 +231,11 @@ export class GatewayServer {
   private methods = new Map<string, { handler: RpcMethodHandler; requiresAuth: boolean }>();
   private publicHttpMethods = new Map<string, { handler: RpcMethodHandler; requiresAuth: boolean }>();
   private rateLimits = new Map<string, RateLimitEntry>();
+  private frameRateLimits = new Map<string, RateLimitEntry>();
+  /** Live zen streaming state — see gateway/zen-stream.ts. */
+  private zenStreams = new ZenStreamHub((event, payload, filter) =>
+    this.broadcastEvent(event, payload, filter),
+  );
   /**
    * Largest HTTP POST body this gateway will read, in bytes.
    *
@@ -777,8 +793,12 @@ export class GatewayServer {
     for (const { ws } of this.connections.values()) {
       ws.close(1000, 'Server shutting down');
     }
+    for (const connId of [...this.connections.keys()]) {
+      this.zenStreams.releaseConnection(connId);
+    }
     this.connections.clear();
     this.rateLimits.clear();
+    this.frameRateLimits.clear();
 
     const wss = this.wss;
     const httpServer = this.httpServer;
@@ -1716,6 +1736,10 @@ export class GatewayServer {
     ws.on('close', () => {
       this.connections.delete(connId);
       this.rateLimits.delete(connId);
+      this.frameRateLimits.delete(connId);
+      // A browser that closes its tab never sends zen.unsubscribe, and a
+      // killed producer never sends zen.end. Both are released here.
+      this.zenStreams.releaseConnection(connId);
       if (info.authenticated) {
         this.broadcastEvent(GatewayEvents.PRESENCE, {
           type: 'disconnect',
@@ -1796,7 +1820,10 @@ export class GatewayServer {
     if (!this.isGenerationActive(dispatchGeneration)) return;
 
     // Rate limit
-    if (!this.checkRateLimit(connId)) {
+    const withinBudget = FRAME_RATE_LIMITED_METHODS.has(frame.method)
+      ? this.checkFrameRateLimit(connId)
+      : this.checkRateLimit(connId);
+    if (!withinBudget) {
       this.metrics.recordRequest('rate_limited');
       logGatewayRequest('gateway', 'rpc.dispatch', { transport: 'ws', outcome: 'rate_limited', durationMs: Date.now() - startedAt });
       this.sendFrame(ws, { type: 'res', id: frame.id, ok: false, error: { code: RPC_ERROR.RATE_LIMITED, message: 'Rate limit exceeded' } });
@@ -2121,6 +2148,20 @@ export class GatewayServer {
       return true;
     }
     if (entry.count >= RATE_LIMIT_MAX_REQUESTS) return false;
+    entry.count++;
+    return true;
+  }
+
+  /** Budget for frame-carrying methods, accounted separately from the
+   * control-plane limit above so neither can consume the other's allowance. */
+  private checkFrameRateLimit(connId: string): boolean {
+    const now = Date.now();
+    const entry = this.frameRateLimits.get(connId);
+    if (!entry || now - entry.windowStart > FRAME_RATE_LIMIT_WINDOW_MS) {
+      this.frameRateLimits.set(connId, { count: 1, windowStart: now });
+      return true;
+    }
+    if (entry.count >= FRAME_RATE_LIMIT_MAX_FRAMES) return false;
     entry.count++;
     return true;
   }
@@ -3026,6 +3067,18 @@ export class GatewayServer {
 
     // Backup & restore methods
     registerBackupMethods(this, { dataDir: this.dataDir });
+
+    // Zen streaming (live terminal screens relayed to browsers).
+    //
+    // `methods/zen-methods.ts` declares these same names against
+    // `peer-stream.ts`'s process-local `globalPeerStream`, which no gateway
+    // ever writes to — registering it would answer the dashboard's
+    // `zen.sessions` with a list that is empty by construction. These handlers
+    // are backed by this server's own hub, fed by connected producers.
+    registerZenStreamMethods(this, {
+      hub: this.zenStreams,
+      isLiveConnection: (connectionId: string) => this.connections.has(connectionId),
+    });
 
     // Rappter multi-soul methods
     if (this.rappterManager) {

--- a/typescript/src/gateway/zen-stream.ts
+++ b/typescript/src/gateway/zen-stream.ts
@@ -1,0 +1,320 @@
+/**
+ * Zen streaming — the live state behind the `zen.*` RPC methods.
+ *
+ * A "zen session" is an ambient terminal screen (Bar pong, a ZenScreen
+ * subclass, …) whose ANSI frames are relayed to browsers. The producer is a
+ * *client* of the gateway, not the gateway itself: `openrappter bar --tui`
+ * runs in its own process and reaches the daemon over WebSocket. That is why
+ * this hub is fed by an RPC ingest method (`zen.publish`) rather than by the
+ * process-local `globalPeerStream` singleton in `peer-stream.ts` — writes to
+ * that singleton happen in the Bar's process and can never be observed by the
+ * daemon's `zen.sessions`, so a viewer wired to it would list nothing, forever.
+ *
+ * Everything here is derived from what a connection actually did:
+ *   - a session exists only while a producer connection keeps publishing to it
+ *   - `viewerCount` is the number of connections currently subscribed, counted
+ *     from the viewer map rather than an incremented integer, so it cannot
+ *     drift when a browser closes its tab without calling `zen.unsubscribe`
+ *   - dropping a connection releases its viewer slots and ends the sessions it
+ *     produced
+ */
+
+import type { ConnectionInfo } from './types.js';
+
+/** What `ui/src/components/zen.ts` renders for each card. */
+export interface ZenSessionSummary {
+  id: string;
+  name: string;
+  startedAt: string;
+  frameCount: number;
+  viewerCount: number;
+}
+
+interface ZenSessionState {
+  id: string;
+  name: string;
+  startedAt: string;
+  frameCount: number;
+  lastFrame: string;
+  producerId: string;
+}
+
+export type ZenBroadcast = (
+  event: string,
+  payload: unknown,
+  filter?: (conn: ConnectionInfo) => boolean,
+) => void;
+
+/** Frames are rendered terminals, not uploads. 256 KiB is ~10x a 4k-wide screen. */
+export const ZEN_MAX_FRAME_BYTES = 256 * 1024;
+
+export class ZenStreamHub {
+  private sessions = new Map<string, ZenSessionState>();
+  /** connection id → session ids that connection is watching. */
+  private viewers = new Map<string, Set<string>>();
+
+  constructor(private readonly broadcast: ZenBroadcast) {}
+
+  has(sessionId: string): boolean {
+    return this.sessions.has(sessionId);
+  }
+
+  name(sessionId: string): string | undefined {
+    return this.sessions.get(sessionId)?.name;
+  }
+
+  lastFrame(sessionId: string): string | null {
+    return this.sessions.get(sessionId)?.lastFrame ?? null;
+  }
+
+  viewerCount(sessionId: string): number {
+    let count = 0;
+    for (const watched of this.viewers.values()) {
+      if (watched.has(sessionId)) count++;
+    }
+    return count;
+  }
+
+  isViewer(connectionId: string, sessionId: string): boolean {
+    return this.viewers.get(connectionId)?.has(sessionId) ?? false;
+  }
+
+  list(): ZenSessionSummary[] {
+    // `lastFrame` is deliberately not included: a list of screens should not
+    // carry a screenful of ANSI per entry.
+    return [...this.sessions.values()].map((s) => ({
+      id: s.id,
+      name: s.name,
+      startedAt: s.startedAt,
+      frameCount: s.frameCount,
+      viewerCount: this.viewerCount(s.id),
+    }));
+  }
+
+  /** Record a frame, creating the session on first publish. */
+  publish(
+    sessionId: string,
+    frame: string,
+    producerId: string,
+    name?: string,
+  ): { frameNumber: number; viewerCount: number; created: boolean } {
+    let session = this.sessions.get(sessionId);
+    const created = !session;
+    if (!session) {
+      session = {
+        id: sessionId,
+        name: name?.trim() || sessionId,
+        startedAt: new Date().toISOString(),
+        frameCount: 0,
+        lastFrame: '',
+        producerId,
+      };
+      this.sessions.set(sessionId, session);
+    } else {
+      // Ownership follows the live publisher so a restarted producer can
+      // resume a session id it previously owned.
+      session.producerId = producerId;
+      if (name?.trim()) session.name = name.trim();
+    }
+
+    session.frameCount++;
+    session.lastFrame = frame;
+
+    if (created) {
+      this.broadcast('zen.session.start', { id: session.id, name: session.name });
+    }
+    const sid = session.id;
+    this.broadcast(
+      'zen.frame',
+      { sessionId: sid, frame, frameNumber: session.frameCount },
+      (conn) => this.isViewer(conn.id, sid),
+    );
+
+    return {
+      frameNumber: session.frameCount,
+      viewerCount: this.viewerCount(sessionId),
+      created,
+    };
+  }
+
+  /** End a session and drop every viewer's interest in it. */
+  end(sessionId: string): boolean {
+    if (!this.sessions.delete(sessionId)) return false;
+    for (const [connId, watched] of this.viewers) {
+      watched.delete(sessionId);
+      if (watched.size === 0) this.viewers.delete(connId);
+    }
+    this.broadcast('zen.session.end', { id: sessionId });
+    return true;
+  }
+
+  addViewer(connectionId: string, sessionId: string): boolean {
+    if (!this.sessions.has(sessionId)) return false;
+    let watched = this.viewers.get(connectionId);
+    if (!watched) {
+      watched = new Set();
+      this.viewers.set(connectionId, watched);
+    }
+    watched.add(sessionId);
+    return true;
+  }
+
+  removeViewer(connectionId: string, sessionId: string): boolean {
+    const watched = this.viewers.get(connectionId);
+    if (!watched) return false;
+    const removed = watched.delete(sessionId);
+    if (watched.size === 0) this.viewers.delete(connectionId);
+    return removed;
+  }
+
+  /**
+   * Release everything a dropped connection held: its viewer slots, and the
+   * sessions it was producing. Without this a closed browser tab counts as a
+   * viewer forever and a killed Bar leaves a session that never ends.
+   */
+  releaseConnection(connectionId: string): { released: string[]; ended: string[] } {
+    const released = [...(this.viewers.get(connectionId) ?? [])];
+    this.viewers.delete(connectionId);
+
+    const ended: string[] = [];
+    for (const session of [...this.sessions.values()]) {
+      if (session.producerId === connectionId) {
+        this.end(session.id);
+        ended.push(session.id);
+      }
+    }
+    return { released, ended };
+  }
+}
+
+interface MethodRegistrar {
+  registerMethod<P = unknown, R = unknown>(
+    name: string,
+    handler: (params: P, connection: ConnectionInfo) => Promise<R>,
+    options?: { requiresAuth?: boolean },
+  ): void;
+}
+
+export interface ZenStreamDeps {
+  hub: ZenStreamHub;
+  /** True only for a live WebSocket connection, which is the only transport
+   * that can receive the `zen.frame` events a subscription promises. */
+  isLiveConnection: (connectionId: string) => boolean;
+}
+
+function requireSessionId(params: { sessionId?: string } | undefined): string {
+  const sessionId = params?.sessionId?.trim();
+  if (!sessionId) throw new Error('sessionId required');
+  return sessionId;
+}
+
+/**
+ * Wire `zen.*` onto a hub owned by the caller.
+ *
+ * Registered from `GatewayServer.registerBuiltInMethods` with that server's
+ * own hub — unlike `methods/zen-methods.ts`, which is never registered and
+ * talks to a singleton no gateway ever writes to.
+ */
+export function registerZenStreamMethods(
+  server: MethodRegistrar,
+  deps: ZenStreamDeps,
+): void {
+  const { hub, isLiveConnection } = deps;
+
+  server.registerMethod('zen.sessions', async () => ({ sessions: hub.list() }));
+
+  server.registerMethod(
+    'zen.subscribe',
+    async (params: { sessionId?: string }, conn) => {
+      const sessionId = requireSessionId(params);
+      if (!hub.has(sessionId)) throw new Error(`Unknown zen session: ${sessionId}`);
+
+      const lastFrame = hub.lastFrame(sessionId) ?? undefined;
+      const name = hub.name(sessionId);
+
+      // Saying `subscribed: true` to a caller that cannot receive events would
+      // be a success report over nothing: HTTP has no channel for `zen.frame`.
+      if (!isLiveConnection(conn.id)) {
+        return {
+          subscribed: false,
+          sessionId,
+          name,
+          lastFrame,
+          reason:
+            'zen.subscribe streams over WebSocket; poll zen.lastframe from HTTP instead',
+        };
+      }
+
+      hub.addViewer(conn.id, sessionId);
+      return {
+        subscribed: true,
+        sessionId,
+        name,
+        lastFrame,
+        viewerCount: hub.viewerCount(sessionId),
+      };
+    },
+  );
+
+  server.registerMethod(
+    'zen.unsubscribe',
+    async (params: { sessionId?: string }, conn) => {
+      const sessionId = requireSessionId(params);
+      const removed = hub.removeViewer(conn.id, sessionId);
+      return {
+        unsubscribed: true,
+        sessionId,
+        wasSubscribed: removed,
+        viewerCount: hub.viewerCount(sessionId),
+      };
+    },
+  );
+
+  server.registerMethod(
+    'zen.lastframe',
+    async (params: { sessionId?: string }) => {
+      const sessionId = requireSessionId(params);
+      const frame = hub.lastFrame(sessionId);
+      if (frame === null) throw new Error(`Unknown zen session: ${sessionId}`);
+      return { sessionId, frame };
+    },
+  );
+
+  server.registerMethod(
+    'zen.publish',
+    async (
+      params: { sessionId?: string; name?: string; frame?: string },
+      conn,
+    ) => {
+      const sessionId = requireSessionId(params);
+      // A session lives exactly as long as the connection producing it. An
+      // HTTP publisher has no connection to close, so its session could only
+      // ever be cleaned up by a caller remembering to send `zen.end`.
+      if (!isLiveConnection(conn.id)) {
+        throw new Error('zen.publish requires a WebSocket connection');
+      }
+      const frame = params?.frame;
+      if (typeof frame !== 'string') throw new Error('frame required');
+      if (Buffer.byteLength(frame, 'utf-8') > ZEN_MAX_FRAME_BYTES) {
+        throw new Error(`frame exceeds ${ZEN_MAX_FRAME_BYTES} bytes`);
+      }
+      const { frameNumber, viewerCount } = hub.publish(
+        sessionId,
+        frame,
+        conn.id,
+        params.name,
+      );
+      return { published: true, sessionId, frameNumber, viewerCount };
+    },
+    { requiresAuth: true },
+  );
+
+  server.registerMethod(
+    'zen.end',
+    async (params: { sessionId?: string }) => {
+      const sessionId = requireSessionId(params);
+      return { ended: hub.end(sessionId), sessionId };
+    },
+    { requiresAuth: true },
+  );
+}

--- a/typescript/src/tui/bar.ts
+++ b/typescript/src/tui/bar.ts
@@ -19,7 +19,7 @@ import { LispyVM, STRATEGIES } from './lispy.js';
 import type { LispAction } from './lispy.js';
 import { LispyCoach } from './lispy-coach.js';
 import type { GameSituation } from './lispy-coach.js';
-import { globalPeerStream } from '../gateway/peer-stream.js';
+import { createZenPublisher, type ZenPublisher } from './zen-publisher.js';
 
 export interface TuiBarOptions {
   port?: number;
@@ -438,6 +438,10 @@ export async function startTuiBar(options: TuiBarOptions = {}): Promise<void> {
 
   // Try to connect to gateway
   let client: any = null;
+  // Pong frames go to browser viewers through the gateway (zen.publish), which
+  // is the only path that reaches it: the Bar is a separate process from the
+  // daemon, so writing to an in-process frame buffer relayed nothing.
+  let zenPublisher: ZenPublisher | null = null;
   try {
     const { TuiGatewayClient } = await import('./gateway-client.js');
     client = new TuiGatewayClient();
@@ -492,9 +496,11 @@ export async function startTuiBar(options: TuiBarOptions = {}): Promise<void> {
       pongTick(state.pong);
       render(state);
       // Broadcast frame to web viewers
-      const { cols } = getTermSize();
-      const pongLines = renderPongView(state.pong, cols, cols - 4);
-      globalPeerStream.pushFrame('bar-pong', pongLines.join('\n'));
+      if (zenPublisher) {
+        const { cols } = getTermSize();
+        const pongLines = renderPongView(state.pong, cols, cols - 4);
+        zenPublisher.publish(pongLines.join('\n'));
+      }
     }
   }, 1000 / 30);
 
@@ -511,7 +517,7 @@ export async function startTuiBar(options: TuiBarOptions = {}): Promise<void> {
       clearInterval(uptimeInterval);
       clearInterval(renderInterval);
       clearInterval(pongInterval);
-      globalPeerStream.endSession('bar-pong');
+      await zenPublisher?.end();
       if (process.stdin.isTTY) process.stdin.setRawMode(false);
       client?.disconnect();
       process.exit(0);
@@ -530,7 +536,13 @@ export async function startTuiBar(options: TuiBarOptions = {}): Promise<void> {
         const fh = 16;
         state.pong = createPongState(fw, fh);
         // Start streaming session for web viewers
-        globalPeerStream.createSession('bar-pong', 'Pong — You vs AI');
+        if (client && state.connected) {
+          zenPublisher = createZenPublisher({
+            call: (method, params) => client.call(method, params),
+            sessionId: 'bar-pong',
+            name: 'Pong — You vs AI',
+          });
+        }
         // Countdown timer
         let cd = 3;
         const cdTimer = setInterval(() => {

--- a/typescript/src/tui/zen-publisher.ts
+++ b/typescript/src/tui/zen-publisher.ts
@@ -1,0 +1,113 @@
+/**
+ * Zen frame publisher — the producer half of the `zen.*` gateway contract.
+ *
+ * A zen screen (Bar pong today) runs in its own process and reaches the
+ * daemon over WebSocket, so publishing is an RPC, not a call into a
+ * process-local singleton. Frames arrive at whatever rate the screen renders
+ * at, which is faster than a gateway connection should be asked to carry:
+ *
+ *   - at most one publish is in flight at a time, so a slow or stalled
+ *     gateway drops frames instead of queueing an ever-growing backlog of
+ *     screens nobody will ever see
+ *   - frames closer together than `minIntervalMs` are dropped, keeping the
+ *     stream inside the gateway's frame budget
+ *   - the newest frame always wins; a dropped frame is simply superseded
+ *
+ * Publishing stops after `maxConsecutiveFailures` errors, so a daemon without
+ * `zen.publish` (an older build) costs one round of failed calls, not one per
+ * rendered frame.
+ */
+
+export type ZenRpcCall = (
+  method: string,
+  params?: Record<string, unknown>,
+) => Promise<unknown>;
+
+export interface ZenPublisherOptions {
+  call: ZenRpcCall;
+  sessionId: string;
+  name: string;
+  /** Minimum gap between published frames. Default 100ms (10fps). */
+  minIntervalMs?: number;
+  maxConsecutiveFailures?: number;
+  now?: () => number;
+}
+
+export interface ZenPublisherStats {
+  published: number;
+  dropped: number;
+  failures: number;
+  disabled: boolean;
+  lastError?: string;
+}
+
+export interface ZenPublisher {
+  publish(frame: string): void;
+  end(): Promise<void>;
+  readonly stats: ZenPublisherStats;
+}
+
+export function createZenPublisher(options: ZenPublisherOptions): ZenPublisher {
+  const {
+    call,
+    sessionId,
+    name,
+    minIntervalMs = 100,
+    maxConsecutiveFailures = 3,
+    now = Date.now,
+  } = options;
+
+  let inFlight = false;
+  let lastSentAt = -Infinity;
+  let started = false;
+  let consecutiveFailures = 0;
+  const stats: ZenPublisherStats = {
+    published: 0,
+    dropped: 0,
+    failures: 0,
+    disabled: false,
+  };
+
+  return {
+    stats,
+
+    publish(frame: string): void {
+      if (stats.disabled) return;
+      if (inFlight || now() - lastSentAt < minIntervalMs) {
+        stats.dropped++;
+        return;
+      }
+      inFlight = true;
+      lastSentAt = now();
+      void Promise.resolve(
+        call('zen.publish', { sessionId, name, frame }),
+      ).then(
+        () => {
+          started = true;
+          consecutiveFailures = 0;
+          stats.published++;
+        },
+        (err: unknown) => {
+          stats.failures++;
+          stats.lastError = err instanceof Error ? err.message : String(err);
+          if (++consecutiveFailures >= maxConsecutiveFailures) {
+            stats.disabled = true;
+          }
+        },
+      ).finally(() => {
+        inFlight = false;
+      });
+    },
+
+    async end(): Promise<void> {
+      if (!started) return;
+      started = false;
+      try {
+        await call('zen.end', { sessionId });
+      } catch {
+        // The gateway ends a session when its producer's connection drops, so
+        // a failed goodbye is not a leak.
+      }
+    },
+  };
+}


### PR DESCRIPTION
## The defect, reproduced first

`typescript/ui/src/components/zen.ts` is live UI: imported by `ui/src/main.ts:19`, rendered as `<openrappter-zen>`. Against a real `GatewayServer` (`bind: loopback`, `auth: none`), every call it makes:

```
zen.sessions     {"error":{"code":-32601,"message":"Method not found: zen.sessions"}}
zen.subscribe    {"error":{"code":-32601,"message":"Method not found: zen.subscribe"}}
zen.unsubscribe  {"error":{"code":-32601,"message":"Method not found: zen.unsubscribe"}}
zen.lastframe    {"error":{"code":-32601,"message":"Method not found: zen.lastframe"}}
zen methods registered: []
```

The page therefore loaded, swallowed the error in `loadSessions`'s `catch`, and showed “No active zen sessions” forever — advertising `openrappter --exec Pong` as the way to fill it.

## Two limits of the #181 coverage guard this PR found

Both are stated with the numbers, because they are the argument for contract tests over real HTTP:

**1. It proves a name is registered, not that a handler is genuine.** Swapping my registration for `registerZenMethods(this)` — the naive fix, wiring the unregistered `methods/zen-methods.ts` — leaves the gateway with `zen.sessions`, `zen.subscribe` and `zen.unsubscribe` registered, so:

| Suite under that mutation | Result |
|---|---|
| `client-rpc-coverage.test.ts` | **4 / 4 pass** |
| `gateway-rpc-parity.test.ts` | **3 / 3 pass** |
| `zen-contract.test.ts` (this PR) | **14 of 15 fail** |

A registry diff cannot see a handler bound to state nothing writes to. Only a test that starts a server, publishes a frame through it and reads the frame back out can.

**2. It was not looking at half the web UI.** `uiMethods()` walked `ui/src/services` only. `zen.ts` is a *component*, so the guard never saw these three call sites at all — their `KNOWN_MISSING` entries had been written by hand, not discovered. Verified: with `zen.*` unregistered and its entries removed, the guard as written stayed **green (4/4)**.

This PR widens the scan to `ui/src/services` **and** `ui/src/components`. With the widening, the same mutation is caught:

```
FAIL  the web UI calls nothing the gateway lacks
      expected [ 'zen.sessions', 'zen.subscribe', 'zen.unsubscribe' ] to deeply equal []
```

The widened scan needed **no new debt entries** — every other component call site is already registered or already listed. `ui/src/components` was carrying exactly one class of broken call, and it is the one this PR fixes.

## What Zen mode is, and what backs it

A zen session is an **ambient terminal screen whose ANSI frames are relayed to browsers**: a `ZenScreen`-style screen (Bar pong today) renders a frame, the frame is broadcast over the gateway's WebSocket, and the browser converts ANSI → HTML. `dojo.html` and `docs/blog/zen-pong.html` describe the same pipeline: `Terminal (ANSI) → PeerStreamManager → Gateway WebSocket → browser`.

So a zen "session" is **not** a chat session — it has `frameCount`/`viewerCount`, not messages — and mapping `zen.*` onto `sessionStore`/`chat.*` would have fabricated a different concept.

The state was real but **unreachable**: the only writer of `peer-stream.ts`'s `globalPeerStream` is `src/tui/bar.ts`, and the Bar is a *client* process (`TuiGatewayClient` → `ws://127.0.0.1:port`). A module singleton is per-process, so nothing the Bar wrote could ever be observed by the daemon. The missing link was an ingest path, not a store.

## Why `methods/zen-methods.ts` was not reused

Registering it is the #170 mistake in a new costume — it turns “Method not found” into a **permanently empty list the user cannot distinguish from “nothing is streaming right now”**:

1. **Backed by nothing reachable.** It reads `globalPeerStream` in the daemon's process, which no producer ever writes to.
2. **No ingest at all.** Nothing can populate it, so the emptiness is structural, not incidental.
3. **Ignores the connection.** Its handlers take `(params, connection)` and never use `connection`, so viewers are a bare integer: it cannot address events to a subscriber, and a browser closing its tab leaks a viewer forever.
4. **Reports failure as success** (#176's shape): an unknown session returns `{ error: 'Session not found' }` as an *ok* result; `zen.ts` checks `result.subscribed`, so the UI silently does nothing.

`zen-methods.ts` and `peer-stream.ts` are left in place — they are independently unit-tested and `parity/gateway-rpc-methods.test.ts` asserts the `zen` group exists in `registerAllMethods` — each now carrying a header warning that it is not the live path.

## What was implemented

New `typescript/src/gateway/zen-stream.ts` (`ZenStreamHub` + `registerZenStreamMethods`), registered from `GatewayServer.registerBuiltInMethods` with the server's own hub — the deps-injection shape of `registerAuthMethods`/`registerBackupMethods`.

**Read side — exactly the shapes `zen.ts` destructures:**
- `zen.sessions` → `{ sessions: [{ id, name, startedAt, frameCount, viewerCount }] }` (no `lastFrame`: a list of screens should not carry a screenful of ANSI per entry).
- `zen.subscribe { sessionId }` → `{ subscribed: true, sessionId, name, lastFrame, viewerCount }`; unknown session **throws** instead of returning a false success.
- `zen.unsubscribe { sessionId }` → `{ unsubscribed: true, sessionId, wasSubscribed, viewerCount }`.
- `zen.lastframe { sessionId }` → `{ sessionId, frame }`.

**Ingest — the established mechanism, not a new one.** Streaming is the gateway's existing event broadcast (`broadcastEvent('zen.frame', …)`, `type: 'event'` frames), which `zen.ts`'s `gateway.on('zen.frame', …)` and `dojo.html` already listen for; `zen.subscribe` scopes delivery per connection through `broadcastEvent`'s filter. Producers feed it with `zen.publish { sessionId, name?, frame }` (auth required, **WebSocket only**, 256 KiB frame cap) and `zen.end { sessionId }`.

HTTP callers get honesty rather than a promise: `zen.subscribe` over HTTP returns `subscribed: false` with a reason pointing at `zen.lastframe`, and counts no viewer, because HTTP has no channel to deliver `zen.frame` on. `zen.publish` over HTTP is refused — a session's lifetime is its producer's connection, and an HTTP publisher has none to close.

**Leaks fixed (tested as releases, not as “returned ok”):** `viewerCount` is *derived* by counting connections in the viewer map, so it cannot drift; a closed WS connection releases its viewer slots **and ends the sessions it produced**.

**Rate limiting.** `zen.publish` is accounted against a separate frame budget (120 frames / 2s → a 60fps ceiling) instead of the 100-requests/minute control budget, which a 30fps screen (1800/min) would blow in ~3 seconds. The control budget is untouched for every other method, and neither budget can consume the other's allowance.

**Producer wired.** `src/tui/bar.ts` no longer writes pong frames into the in-process buffer that reached nothing; it publishes through `src/tui/zen-publisher.ts` on its existing gateway client (10fps, at most one publish in flight, newest frame wins, gives up after 3 consecutive failures so an older daemon costs 3 failed calls rather than one per frame).

## Mutation table

Every fix reverted individually, targeted tests re-run each time; all re-verified after the rebase onto `main` (#182–#188).

| # | Mutation | Result | Test that went red |
|---|---|---|---|
| M1 | Don't register `zen.*` (the defect) | 🔴 | all 15 zen contract tests, **plus** `the web UI calls nothing the gateway lacks` — the latter only because this PR widens the UI scan; with the old scan it stayed green |
| M2 | Register `methods/zen-methods.ts` instead (the known mistake) | 🔴 | 14 of 15 contract tests, while `client-rpc-coverage` (4/4) and `gateway-rpc-parity` (3/3) stay green |
| M3 | Drop `releaseConnection` from the `ws.close` handler | 🔴 | `a viewer that disconnects without unsubscribing does not leak a viewer slot`; `a producer that disconnects ends its session instead of stranding it` |
| M4 | `zen.unsubscribe` reports ok without releasing the slot | 🔴 | `zen.unsubscribe releases the viewer slot and stops the frames` |
| M5 | Broadcast frames to every connection (no viewer filter) | 🔴 | `sends frames only to subscribers, not to every connection`; `zen.unsubscribe releases…` |
| M6 | Claim `subscribed: true` for HTTP callers | 🔴 | `tells an HTTP caller it is not streaming rather than claiming a subscription` |
| M7 | Charge frames to the control-plane budget | 🔴 | `streams frames past the 100/min control budget without spending it` |
| M8 | Put `lastFrame` back into the session list | 🔴 | `lists a session a connected producer published, with the fields the card renders` |
| M9 | Return `{ error: 'Session not found' }` as a success result | 🔴 | `refuses to subscribe to a session that does not exist instead of reporting success` |
| M10 | Publisher without the in-flight guard | 🔴 | `never queues behind a publish that has not answered yet` |
| M11 | Publisher without the interval guard | 🔴 | `drops frames rendered faster than the minimum interval` |
| M12 | Publisher retries forever after failures | 🔴 | `stops publishing to a gateway that keeps refusing, instead of once per frame` |

(An earlier M3 attempt patched the `stop()` call site instead of the `ws.close` one and stayed green — wrong anchor, not a weak test; re-run against the close handler it is red as shown.)

## Tests

- `src/__tests__/integration/zen-contract.test.ts` (15) — real `GatewayServer`, real HTTP JSON-RPC and real `ws` connections, including the end-to-end Bar path: `TuiGatewayClient` + `createZenPublisher` → gateway → subscribed viewer receives the ANSI frame.
- `src/__tests__/unit/zen-publisher.test.ts` (5) — the producer's drop/backpressure/give-up rules.

Full suite after rebase: **5085 passed, 21 skipped, 266 files**. `tsc --noEmit`: clean. `eslint` on changed files: clean.

## `KNOWN_MISSING` entries removed

`zen.sessions`, `zen.subscribe`, `zen.unsubscribe`. Diffed against `origin/main` after the rebase: those three lines are the **only** removals — every entry #182–#188 deleted stays deleted, and none is resurrected.

## Parity contract

`gateway-rpc-parity.test.ts` (added in #186) passes unchanged. `contracts/gateway-rpc-parity.json` enumerates the shared surface and `python_only`; `zen.publish`/`zen.end` are TypeScript-only and appear in neither list, so the contract asserts nothing about them and needed no edit. Nothing was changed to silence it.

## What I could not verify

- **The browser itself.** `typescript/ui` has no installed `node_modules` in this environment (`lit`, `dompurify`, `jsdom` absent), so the UI vitest project and `tsc -p ui/tsconfig.json` could not run. No UI source was changed; the contract tests instead assert the exact field names `zen.ts` destructures (`sessions`, `subscribed`, `lastFrame`, and the `{ sessionId, frame }` event payload) against the real server.
- **`dojo.html`** still cannot connect: it sends `zen.sessions` as its first frame without the `connect` handshake the gateway requires. Pre-existing, unrelated, left alone.
- **UI refresh on session start.** `zen.ts` lists sessions once in `connectedCallback`; the gateway now emits `zen.session.start`/`zen.session.end`, but the component does not listen for them, so a session started while the page is open appears only after navigating back to the view. Left as a follow-up rather than an unverifiable UI edit.
- **A real Bar session on a TTY** was not driven end to end (it needs an interactive terminal); the exact client and publisher it uses are covered by the integration test instead.
