### PR TITLE
test: pin the dormant method modules out, and stop a test claiming it covers the gateway

### DIFF
--- a/typescript/src/__tests__/integration/dormant-methods-stay-dormant.test.ts
+++ b/typescript/src/__tests__/integration/dormant-methods-stay-dormant.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import { readdirSync, readFileSync } from 'fs';
+import { resolve, join } from 'path';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * The dormant method modules stay dormant.
+ *
+ * `gateway/methods/*.ts` holds 25 standalone RPC modules. Only 5 are invoked by
+ * `GatewayServer`; the rest declare the same method names against their own
+ * disconnected dependencies. The doc comment on `registerBuiltInMethods` warns
+ * that wiring them would "silently duplicate or override the real, wired
+ * handlers with divergent implementations".
+ *
+ * That warning is the whole risk here. The obvious way to "fix" a missing
+ * method is to call `registerAllMethods` — and it would appear to work: the
+ * name would resolve, and `client-rpc-coverage.test.ts` would go green, because
+ * that test proves a name is *registered*, not that the handler is *real*.
+ *
+ * This was measured, not assumed. In #189 the agent swapped its real zen
+ * implementation for `registerZenMethods` and recorded the result: 14 of its
+ * contract tests failed while the coverage guard still passed.
+ *
+ * So this pins the other half. These names exist only inside the dormant
+ * modules — three separate agents rejected them in #182, #183 and #184 as the
+ * wrong names, backed by dependencies nothing supplies, returning hardcoded
+ * values. If any of them starts resolving on a running server, something wired
+ * the demos in.
+ */
+
+const METHODS_DIR = resolve(__dirname, '../../gateway/methods');
+
+/** Names that appear only in the dormant modules and in no real handler. */
+const DEMO_ONLY = [
+  'exec.approval.request',
+  'exec.approval.resolve',
+  'exec.approvals.get',
+  'exec.approvals.set',
+  'usage.status',
+  'usage.cost',
+  'logs.tail',
+  'config.patch',
+] as const;
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+async function registered(): Promise<Set<string>> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server.setSurgeonService({} as never);
+  server.setRappterManager({} as never);
+  await server.start();
+  return new Set((server as unknown as { methods: Map<string, unknown> }).methods.keys());
+}
+
+describe('the dormant RPC method modules stay out of the gateway', () => {
+  it('GatewayServer never calls registerAllMethods', () => {
+    // The single line that would wire all 25 modules at once.
+    const source = readFileSync(resolve(__dirname, '../../gateway/server.ts'), 'utf-8');
+    const invocations = source
+      .split('\n')
+      .filter((line) => /registerAllMethods\s*\(/.test(line))
+      .filter((line) => !line.trimStart().startsWith('*'));
+    expect(invocations).toEqual([]);
+  });
+
+  it('answers none of the demo-only method names', async () => {
+    const have = await registered();
+    const leaked = DEMO_ONLY.filter((name) => have.has(name)).sort();
+    expect(leaked).toEqual([]);
+  });
+
+  it('the demo-only names really are declared in those modules', () => {
+    // Guards the list above. If these modules are deleted or renamed, the
+    // assertion behind them becomes vacuous and should be revisited rather
+    // than left passing over names nothing declares any more.
+    const declared = readdirSync(METHODS_DIR)
+      .filter((file) => file.endsWith('.ts'))
+      .map((file) => readFileSync(join(METHODS_DIR, file), 'utf-8'))
+      .join('\n');
+    const missing = DEMO_ONLY.filter((name) => !declared.includes(`'${name}'`)).sort();
+    expect(missing).toEqual([]);
+  });
+});

--- a/typescript/src/__tests__/parity/gateway-rpc-methods.test.ts
+++ b/typescript/src/__tests__/parity/gateway-rpc-methods.test.ts
@@ -1,7 +1,28 @@
 /**
- * Parity test: Gateway RPC Methods
+ * Structure of the standalone RPC method modules in `gateway/methods/`.
  *
- * Tests the registration and structure of all RPC methods exposed by the gateway.
+ * This does NOT test the gateway's exposed methods, despite what it used to
+ * claim. It calls `registerAllMethods` against a mock, and `registerAllMethods`
+ * is deliberately never invoked by `GatewayServer` — see the doc comment on
+ * `registerBuiltInMethods`. Only 5 of the 25 modules are wired in production.
+ *
+ * So the names asserted below include several that no running gateway answers:
+ * `exec.approval.request`, `usage.status`, `usage.cost`, `logs.tail`,
+ * `skills.toggle`. Three separate agents rejected exactly those modules on
+ * inspection in #182, #183 and #184, because their names, dependencies or
+ * return shapes did not match anything real.
+ *
+ * That mismatch is a large part of why ten broken client features went
+ * unnoticed for so long: this file is green, lives under `parity/`, and read as
+ * though it covered the live surface.
+ *
+ * What actually covers production:
+ *   - client-rpc-coverage.test.ts  — every method a client calls is registered
+ *   - gateway-rpc-parity.test.ts   — the TS and Python gateways agree
+ *   - the *-contract.test.ts files — real HTTP against a real GatewayServer
+ *
+ * Keep this file for the module structure it does check, and do not read a
+ * passing run here as evidence that any of these methods work.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';


### PR DESCRIPTION
## A test that claimed to cover the gateway, and did not

`src/__tests__/parity/gateway-rpc-methods.test.ts` said:

> **Parity test: Gateway RPC Methods**
> Tests the registration and structure of **all RPC methods exposed by the gateway**.

It does not. It calls `registerAllMethods` against a mock — and `registerAllMethods` is **deliberately never invoked** by `GatewayServer`. 237 assertions, none of them about a running server.

Among the names it asserts exist:

```
exec.approval.request   usage.status   logs.tail
exec.approvals.get      usage.cost     skills.toggle
```

No gateway answers any of them. Three separate agents rejected those exact modules on inspection — #182 (`exec-methods.ts`: different names against an injected manager nothing supplies), #183 (`logs-methods.ts`: registers `logs.tail`, wrong name, over a buffer whose only writer has zero callers), #184 (`usage-methods.ts`: `usage.status`/`usage.cost` against a tracker nothing constructs, returning hardcoded zeros).

**This is a large part of why ten broken client features went unnoticed.** The file is green, lives under `parity/`, and reads as though it covers the live surface. Anyone asking "are these methods tested?" would have found that they were.

The header now states what it does and does not prove, and points at the three files that actually cover production.

## The guard

#189 measured a real gap in the coverage test I added in #181: swapping a genuine zen implementation for `registerZenMethods` **failed 14 contract tests while the coverage guard stayed green**. Coverage proves a name is *registered*, not that the handler is *real*.

The tempting way to fix a missing method is to call `registerAllMethods` — and it would look like it worked. The name resolves. The doc comment on `registerBuiltInMethods` warns this would "silently duplicate or override the real, wired handlers with divergent implementations".

So this pins that call site absent, and that no demo-only name ever answers on a running server.

## Why this is not redundant with #181

Measured, not assumed:

| wiring `registerAllMethods` | result |
|---|---|
| dormant guard *(this PR)* | **2 of 3 failed** |
| coverage guard (#181) | **1 of 4 failed** |

But I checked *which* coverage assertion fires:

```
× the known-missing list contains nothing that now exists
  → expected [ 'config.patch', 'models.list', 'skills.toggle' ] to deeply equal []
```

Only that one — the incidental path. It depends on the debt list happening to contain a name these modules declare. Once `config.patch`, `models.list` and `skills.toggle` are resolved, the list holds none of them and **that path goes silent**, while the dormant guard still catches it.

I initially tried to demonstrate this by emptying `KNOWN_MISSING`, but that conflated two changes — an empty list fails on its own, for unrelated reasons. The isolated result above is what I can actually support.

## The third test

It pins that the demo-only names really are declared in those modules. Delete or rename them and this file fails rather than passing vacuously over names nothing declares — the same trap guarded in #171, #181 and #186.

## Suite

`5088` passed · `tsc --noEmit` clean.
