### PR TITLE
test: keep gateway/server.ts importable by the UI package

### DIFF
--- a/typescript/src/__tests__/integration/gateway-ui-importable.test.ts
+++ b/typescript/src/__tests__/integration/gateway-ui-importable.test.ts
@@ -1,0 +1,133 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'fs';
+import { resolve, dirname, join } from 'path';
+import { builtinModules } from 'module';
+
+/**
+ * `gateway/server.ts` must stay importable by the UI package.
+ *
+ * `typescript/ui/src/__tests__/gateway.integration.test.ts` imports
+ * `GatewayServer` directly and runs a real gateway to test the UI's client
+ * against it. That is a genuine contract test and worth keeping — but the UI
+ * package installs only its own dependencies in CI, and declares `ws` as a
+ * devDependency purely so that import resolves.
+ *
+ * So there is an invariant nothing stated: every package reachable from
+ * `server.ts` through *static* imports must be a Node builtin or declared by
+ * the UI package. Add one static import that transitively reaches something
+ * else and the Dashboard UI job fails, far from the change that caused it.
+ *
+ * That happened twice in a single day, to two different people:
+ *
+ *   #185  server.ts -> skills/bundled.ts -> clawhub.ts -> agents/index.js
+ *                   -> AgentRegistry.ts -> logging/logger.ts -> chalk
+ *   #188  server.ts -> agents/agent-files.ts -> AgentRegistry.ts
+ *                   -> logging/logger.ts -> chalk
+ *
+ * Both were fixed the right way — a lazy import inside the handler, and
+ * extracting the shared piece into a dependency-free module — but only after a
+ * remote CI round-trip and an error message (`Cannot find package 'chalk'`)
+ * that says nothing about the import that caused it.
+ *
+ * This fails locally instead, and prints the chain.
+ */
+
+const TS_ROOT = resolve(__dirname, '../..');
+const ENTRY = resolve(TS_ROOT, 'gateway/server.ts');
+const UI_PACKAGE = resolve(TS_ROOT, '../ui/package.json');
+
+function uiProvidedPackages(): Set<string> {
+  const pkg = JSON.parse(readFileSync(UI_PACKAGE, 'utf-8')) as {
+    dependencies?: Record<string, string>;
+    devDependencies?: Record<string, string>;
+  };
+  return new Set([
+    ...Object.keys(pkg.dependencies ?? {}),
+    ...Object.keys(pkg.devDependencies ?? {}),
+  ]);
+}
+
+/** Static `import`/`export … from` specifiers, ignoring `await import(...)`. */
+function staticSpecifiers(source: string): string[] {
+  const withoutComments = source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|[^:])\/\/.*$/gm, '$1');
+  const found: string[] = [];
+  // `export { X } from './y.js'` and `export * from './y.js'` are part of the
+  // static graph too. Missing them made an earlier version of this walker stop
+  // at agents/index.ts, which is nothing but re-exports — so it reported the
+  // graph clean while chalk was two hops further on.
+  for (const match of withoutComments.matchAll(
+    /(?:^|\n)\s*(?:import|export)\s[^;]*?from\s*['"]([^'"]+)['"]/g,
+  )) {
+    found.push(match[1]);
+  }
+  for (const match of withoutComments.matchAll(/(?:^|\n)\s*import\s+['"]([^'"]+)['"]/g)) {
+    found.push(match[1]);
+  }
+  return found;
+}
+
+function resolveLocal(fromFile: string, specifier: string): string | undefined {
+  const base = join(dirname(fromFile), specifier.replace(/\.js$/, ''));
+  for (const candidate of [`${base}.ts`, `${base}.tsx`, join(base, 'index.ts')]) {
+    if (existsSync(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/** Bare package specifiers reachable from the entry, with the chain that reached each. */
+function reachablePackages(): Map<string, string[]> {
+  const packages = new Map<string, string[]>();
+  const seen = new Set<string>();
+
+  const walk = (file: string, chain: string[]): void => {
+    if (seen.has(file)) return;
+    seen.add(file);
+    const here = [...chain, file.replace(`${TS_ROOT}/`, '')];
+
+    for (const specifier of staticSpecifiers(readFileSync(file, 'utf-8'))) {
+      if (specifier.startsWith('.')) {
+        const next = resolveLocal(file, specifier);
+        if (next) walk(next, here);
+        continue;
+      }
+      if (specifier.startsWith('node:')) continue;
+      const name = specifier.startsWith('@')
+        ? specifier.split('/').slice(0, 2).join('/')
+        : specifier.split('/')[0];
+      if (builtinModules.includes(name)) continue;
+      if (!packages.has(name)) packages.set(name, here);
+    }
+  };
+
+  walk(ENTRY, []);
+  return packages;
+}
+
+describe('the gateway stays importable by the UI package', () => {
+  it('finds a non-trivial import graph', () => {
+    // Guards the walker. If resolution silently stops at the entry file, the
+    // assertion below would pass over almost nothing.
+    expect(reachablePackages().size).toBeGreaterThan(0);
+    expect(Array.from(new Set(reachablePackages().values())).length).toBeGreaterThan(0);
+  });
+
+  it('reaches no package the UI does not install', () => {
+    const provided = uiProvidedPackages();
+    const offenders = [...reachablePackages().entries()]
+      .filter(([name]) => !provided.has(name))
+      .map(([name, chain]) => `${name}\n      via ${chain.join('\n        -> ')}`);
+
+    expect(
+      offenders,
+      offenders.length
+        ? `gateway/server.ts statically imports packages the UI package does not install.\n` +
+            `The Dashboard UI CI job imports GatewayServer with only its own deps, so this breaks it.\n` +
+            `Fix by importing lazily inside the handler, or by extracting the shared piece into a\n` +
+            `dependency-free module — do not add the package to typescript/ui.\n\n` +
+            offenders.join('\n\n')
+        : undefined,
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Two people broke the same invariant on the same day, and neither could have known it existed.

```
#185  server.ts -> skills/bundled.ts -> clawhub.ts -> agents/index.ts
                -> AgentRegistry.ts -> logging/logger.ts -> chalk

#188  server.ts -> agents/agent-files.ts -> AgentRegistry.ts
                -> logging/logger.ts -> chalk
```

### The invariant

`typescript/ui/src/__tests__/gateway.integration.test.ts` imports `GatewayServer` and runs a real gateway against the UI's client. That is a genuine contract test and worth keeping — it is one of the few things that exercises the UI against the real server.

But the UI package installs **only its own dependencies** in CI, and declares `ws` as a devDependency purely so that import resolves.

So every package reachable from `server.ts` through **static** imports must be a Node builtin or declared by the UI package. Nothing said so, and nothing checked. Both authors found out from a remote CI job whose error —

```
Cannot find package 'chalk' imported from typescript/src/logging/logger.ts
```

— names neither the import they added nor the chain that reached it. Both then spent a debug cycle rediscovering the same path.

This fails locally instead, and prints the chain.

### My first version of this test was useless and passed

It followed `import` but not `export … from`. So it stopped at `agents/index.ts` — a file that is *nothing but re-exports* — and reported the graph clean while `chalk` sat two hops further on.

I found it by mutating: reintroduce #185's import and watch the guard stay green. Had I trusted the passing run, I would have shipped a test that could never fail, which is the exact failure mode this session has been about.

### Mutations

| mutation | result |
|---|---|
| reintroduce #185's static import | **1 of 2 failed** |
| reintroduce #188's static import | **1 of 2 failed** |
| walker ignores re-exports, leak present | **2 passed** ← the bug above |

That third row is the reason the second row can be trusted.

### Not undoing the real fixes

Both were the right shape and both stand: a lazy import inside the handler (#185), and extracting the shared rules into a dependency-free module (#188). The failure message points at both approaches, and says explicitly **not** to fix it by adding the package to `typescript/ui` — that would ship a terminal colour library into a browser bundle and make the leak permanent.

### Suite

`5090` passed · `tsc --noEmit` clean.
