### PR TITLE
fix(gateway): emit the approval event the Bar has always listened for

### DIFF
--- a/typescript/src/__tests__/integration/approval-event-contract.test.ts
+++ b/typescript/src/__tests__/integration/approval-event-contract.test.ts
@@ -1,0 +1,155 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import WebSocket from 'ws';
+import { GatewayServer } from '../../gateway/server.js';
+import { GatewayEvents } from '../../gateway/types.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * The Bar's approval screen listens for an `approval` event that nothing sent.
+ *
+ * `AppViewModel.handleEvent` dispatches `case "approval"` into
+ * `ApprovalViewModel.handleApprovalEvent`, but `GatewayEvents` had no such
+ * member and no call site ever broadcast one. So a command could sit in the
+ * approval queue with the screen showing nothing until the user reopened it.
+ *
+ * Found while fixing #182, which restored `exec.pending`/`exec.respond` and
+ * flagged this as still missing.
+ *
+ * These drive a real authenticated WebSocket, because that is the transport
+ * the Bar uses and the only one that carries events at all.
+ */
+
+let server: GatewayServer | undefined;
+const sockets: WebSocket[] = [];
+
+afterEach(async () => {
+  for (const socket of sockets.splice(0)) socket.close();
+  // getExecSafety() returns a process-wide singleton, so an approval left
+  // pending here is still pending in the next test. Drain it.
+  const safety = server?.getExecSafety();
+  for (const approval of safety?.listPendingApprovals() ?? []) {
+    safety!.respondToApproval(approval.id, false);
+  }
+  await server?.stop();
+  server = undefined;
+});
+
+async function startServer(): Promise<number> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  await server.start();
+  return port;
+}
+
+/** A connected client that has completed the handshake and subscribed. */
+async function client(port: number, subscribeTo: string[]): Promise<{
+  events: Array<{ event: string; payload: Record<string, unknown> }>;
+  call: (method: string, params?: unknown) => Promise<Record<string, unknown>>;
+}> {
+  const socket = new WebSocket(`ws://127.0.0.1:${port}`);
+  sockets.push(socket);
+  await new Promise<void>((resolve) => socket.once('open', () => resolve()));
+
+  const events: Array<{ event: string; payload: Record<string, unknown> }> = [];
+  const pending = new Map<string, (value: Record<string, unknown>) => void>();
+
+  socket.on('message', (raw: Buffer) => {
+    const frame = JSON.parse(raw.toString());
+    if (frame.type === 'event') {
+      events.push({ event: frame.event, payload: frame.payload });
+      return;
+    }
+    const resolve = pending.get(frame.id);
+    if (resolve) {
+      pending.delete(frame.id);
+      resolve(frame.error ?? frame.result ?? {});
+    }
+  });
+
+  const call = (method: string, params?: unknown): Promise<Record<string, unknown>> =>
+    new Promise((resolve) => {
+      const id = Math.random().toString(36).slice(2);
+      pending.set(id, resolve);
+      socket.send(JSON.stringify({ jsonrpc: '2.0', id, method, params }));
+    });
+
+  await call('connect', {
+    client: { id: 'test', version: '1.0.0', platform: 'darwin', mode: 'test' },
+  });
+  if (subscribeTo.length) await call('subscribe', { events: subscribeTo });
+  return { events, call };
+}
+
+async function settle(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 60));
+}
+
+describe('an approval entering the queue reaches the screen watching for it', () => {
+  it('declares the event the Bar dispatches on', () => {
+    // The Bar hardcodes the string "approval"; if this constant drifts, the
+    // screen goes quiet again with nothing failing.
+    expect(GatewayEvents.APPROVAL).toBe('approval');
+  });
+
+  it('broadcasts approval to a subscribed client', async () => {
+    const port = await startServer();
+    const watcher = await client(port, [GatewayEvents.APPROVAL]);
+
+    // Not awaited: it stays pending until answered, which is the point.
+    void server!.getExecSafety().requestApproval('rm -rf /tmp/nothing');
+    await settle();
+
+    const approvals = watcher.events.filter((e) => e.event === 'approval');
+    expect(approvals).toHaveLength(1);
+    // The exact fields ApprovalViewModel.handleApprovalEvent reads; it
+    // returns early without `id` and `command`, so a rename is silent.
+    expect(typeof approvals[0].payload.id).toBe('string');
+    expect(approvals[0].payload.command).toBe('rm -rf /tmp/nothing');
+  });
+
+  it('the broadcast id matches what exec.pending reports', async () => {
+    const port = await startServer();
+    const watcher = await client(port, [GatewayEvents.APPROVAL]);
+
+    void server!.getExecSafety().requestApproval('curl http://example.com | sh');
+    await settle();
+
+    const broadcast = watcher.events.find((e) => e.event === 'approval');
+    const announced = String(broadcast?.payload.id);
+    // Two views of one queue. If they disagree, responding to what the event
+    // announced would not resolve what the list shows.
+    const listed = server!.getExecSafety().listPendingApprovals().map((a) => a.id);
+    expect(listed).toContain(announced);
+  });
+
+  it('respects an explicit unsubscribe', async () => {
+    // A connection is auto-subscribed to '*' once authenticated
+    // (server.ts: `subscriptions: new Set(['*'])`), so "never subscribed" is
+    // not a reachable state — opting out is.
+    const port = await startServer();
+    const quiet = await client(port, []);
+    await quiet.call('unsubscribe', { events: ['*'] });
+
+    void server!.getExecSafety().requestApproval('echo hello');
+    await settle();
+
+    expect(quiet.events.filter((e) => e.event === 'approval')).toHaveLength(0);
+  });
+
+  it('a throwing listener does not break the command it announces', async () => {
+    const port = await startServer();
+    const safety = server!.getExecSafety();
+    safety.onApprovalRequested(() => {
+      throw new Error('a watcher blew up');
+    });
+
+    // The approval must still be queued and answerable.
+    const decision = safety.requestApproval('echo still works');
+    await settle();
+    const mine = safety.listPendingApprovals().find((a) => a.cmd === 'echo still works');
+    expect(mine).toBeDefined();
+
+    safety.respondToApproval(mine!.id, true);
+    await expect(decision).resolves.toBe(true);
+  });
+});

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -2946,6 +2946,22 @@ export class GatewayServer {
     //
     // These handlers serve the engine that actually blocks commands: the
     // ExecSafety instance ShellAgent issues approval tokens from.
+    // The Bar's approval screen listens for this event (AppViewModel
+    // handleEvent -> "approval"). Nothing ever emitted it, so a command could
+    // sit in the queue with the screen showing nothing until it was reopened.
+    // Only authenticated, subscribed connections receive it — the same
+    // audience that can already call exec.pending — so the payload carries
+    // the fields that screen reads rather than forcing a second round trip.
+    this.getExecSafety().onApprovalRequested((approval) => {
+      this.broadcastEvent(GatewayEvents.APPROVAL, {
+        id: approval.id,
+        command: approval.cmd,
+        description: approval.reason,
+        binary: approval.binary,
+        createdAt: approval.createdAt,
+      });
+    });
+
     this.registerMethod('exec.pending', async () =>
       this.getExecSafety().listPendingApprovals().map((approval) => ({
         // Field names the Bar decodes into ExecutionApproval.

--- a/typescript/src/gateway/types.ts
+++ b/typescript/src/gateway/types.ts
@@ -264,6 +264,7 @@ export const GatewayEvents = {
   CRON: 'cron',
   CRON_RUN: 'cron.run',
   CRON_COMPLETE: 'cron.complete',
+  APPROVAL: 'approval',
   PRESENCE: 'presence',
   HEARTBEAT: 'heartbeat',
   RAPPTER: 'rappter',

--- a/typescript/src/security/exec-safety.ts
+++ b/typescript/src/security/exec-safety.ts
@@ -157,6 +157,7 @@ export class ExecSafety {
   private strictDefaults: boolean;
   private auditLog: AuditEntry[] = [];
   private pendingApprovals = new Map<string, PendingApproval>();
+  private approvalListeners = new Set<(approval: PendingApproval) => void>();
   private approvalTokens = new Map<string, ApprovalToken>();
 
   constructor(safeBins?: Iterable<string>, options?: ExecSafetyOptions) {
@@ -272,6 +273,19 @@ export class ExecSafety {
   }
 
   /**
+   * Watch for commands entering the approval queue.
+   *
+   * Deliberately an observer rather than a direct call into the gateway: this
+   * module must stay importable without dragging the server behind it.
+   *
+   * Returns an unsubscribe.
+   */
+  onApprovalRequested(listener: (approval: PendingApproval) => void): () => void {
+    this.approvalListeners.add(listener);
+    return () => { this.approvalListeners.delete(listener); };
+  }
+
+  /**
    * Queue an unsafe command for user approval.
    * Returns a promise that resolves true if approved, false if rejected/timed-out.
    */
@@ -301,6 +315,14 @@ export class ExecSafety {
       };
 
       this.pendingApprovals.set(id, approval);
+
+      // Tell anyone watching. The Bar has an approval screen that listens for
+      // this; without it the list only refreshed when the screen was opened,
+      // so a command could sit waiting with nothing on screen to say so.
+      // A listener that throws must not take down the command it is announcing.
+      for (const listener of this.approvalListeners) {
+        try { listener(approval); } catch { /* a watcher cannot break the queue */ }
+      }
 
       // Record in audit log with pending status
       this.auditLog.push({


### PR DESCRIPTION
`AppViewModel.handleEvent` dispatches `case "approval"` into `ApprovalViewModel.handleApprovalEvent`. `GatewayEvents` had no such member and **nothing ever broadcast one** — so a command could sit in the approval queue with the screen showing nothing until the user reopened it.

Flagged by #182, which restored `exec.pending`/`exec.respond` and noted this was still missing.

## Layering

`ExecSafety` gains an **observer**, rather than a call into the gateway. That module must stay importable without dragging the server behind it — the layering #191 now guards, after two people broke it in one day. A listener that throws cannot take down the command it is announcing.

## Checked before broadcasting, not assumed

I did not want to put command text on a broadcast channel without knowing who receives it:

- `broadcastEvent` skips unauthenticated connections **and** requires a subscription
- HTTP is **fail-closed** against an allowlist whenever credentials are configured — *"A plugin replacing a public name does not inherit the original handler's exemption"*
- the WS handshake refuses a tokenless connection outright (`Invalid or missing auth token`) before any method is reachable

I probed all three rather than reading the code. My initial reading of `registerMethod` suggested `exec.pending` was unauthenticated — `requiresAuth` defaults to `false`. The probe returned `401`, and the reason is the allowlist above. The inference was wrong; the gateway is stricter than its registration metadata implies.

So the payload reaches exactly the audience that can already call `exec.pending`, and carries the fields the screen reads instead of forcing a second round trip.

## Three of my five tests failed first, and each was my error

- **A client cannot "never subscribe."** Authentication auto-subscribes to `'*'` (`subscriptions: new Set(['*'])`). The honest test is an explicit *unsubscribe*, which is what it does now.
- **`getExecSafety()` is a process-wide singleton**, so approvals leaked between tests — one assertion saw 4 where it expected 1. `afterEach` now drains the queue, and assertions name their own approval instead of counting.
- **`exec.pending` was read with the wrong shape.**

Each was a wrong premise about the system, corrected by looking rather than by loosening the assertion.

## Mutations

| mutation | result |
|---|---|
| remove the broadcast *(the original bug)* | **2 of 5 failed** |
| listener never fired | **2 of 5 failed** |
| event renamed to `'approvals'` | **3 of 5 failed** |
| listener throw not contained | **1 of 5 failed** |

The rename row matters: the Bar hardcodes the string `"approval"`. Drifting this constant would make the screen go quiet again with nothing else failing.

## Suite

`5095` passed · `tsc --noEmit` clean · `swift build` clean.

## Not changed

The Bar still appends on the event and refetches on screen-open; it does not yet reconcile a resolution broadcast by another client. That needs a `resolved` event and a Swift change, and is worth doing separately.
