### PR TITLE
fix(test): the watchmaker tie test measured the machine, not the agents

### DIFF
--- a/typescript/src/__tests__/parity/watchmaker.test.ts
+++ b/typescript/src/__tests__/parity/watchmaker.test.ts
@@ -5,7 +5,7 @@
  * capabilities, A/B tests competing versions, and promotes winners.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { WatchmakerAgent } from '../../agents/WatchmakerAgent.js';
 import { BasicAgent } from '../../agents/BasicAgent.js';
 
@@ -417,6 +417,18 @@ describe('WatchmakerAgent', () => {
     });
 
     it('should tie when agents are equal', async () => {
+      // Both mocks return immediately, so each measured latency is 0-1ms of
+      // scheduler noise. The tiebreaker fires when |delta| >= 5ms and the
+      // relative difference exceeds 20%, and on a loaded runner one call can
+      // land 5ms after the other while the average stays tiny — which reads
+      // as a 100%+ difference and picks a winner. CI failed exactly that way:
+      //   expected 'A' to be 'tie'
+      // Freezing the clock makes both latencies genuinely equal, so this
+      // asserts what it means — equal agents tie — rather than measuring the
+      // machine it runs on.
+      const frozen = Date.now();
+      const now = vi.spyOn(Date, 'now').mockReturnValue(frozen);
+      try {
       registerStrong(watchmaker, '1.0');
       // Register a second strong agent as candidate
       await watchmaker.perform({
@@ -436,6 +448,9 @@ describe('WatchmakerAgent', () => {
       const parsed = JSON.parse(result);
 
       expect(parsed.comparison.winner).toBe('tie');
+      } finally {
+        now.mockRestore();
+      }
     });
 
     it('should use latency tiebreaker when quality is similar', async () => {


### PR DESCRIPTION
CI failed on a PR that touched neither the agent nor its test:

```
× WatchmakerAgent > compare action > should tie when agents are equal
  → expected 'A' to be 'tie'
```

## Why two identical agents had a winner

Both mocks return immediately, so each measured latency is 0–1ms of scheduler noise. The tiebreaker fires when `|delta| >= 5ms` **and** the relative difference exceeds 20%:

```ts
const avgLatency = (resultA.latencyMs + resultB.latencyMs) / 2;
const latencyThreshold = avgLatency > 0 ? Math.abs(latencyDelta) / avgLatency : 0;
if (latencyThreshold > 0.2 && Math.abs(latencyDelta) >= 5) { ... }
```

On a loaded runner one call lands a few milliseconds after the other while the average stays tiny — which reads as a 100%+ difference and picks a winner. Two identical agents, and the test decides one of them won.

## Reproduced, not guessed

Skewing **only B's end timestamp** by 7ms fails the test exactly as CI did:

```
× should tie when agents are equal      1 failed | 44 passed
```

With the clock frozen, that same skew passes. My first attempt at reproducing shifted both of B's timestamps equally, so B's latency stayed 0 and nothing failed — the skew has to land between B's start and end, which is what a scheduler actually does.

## The fix

Freeze `Date.now` for this test. Both latencies are then genuinely equal, so it asserts what it means — equal quality and equal latency tie — instead of asserting something about the machine it happens to run on.

**The production tiebreaker is untouched.** Loosening the 5ms threshold to quiet the test would have hidden the same noise one runner later, and would have changed real comparison behaviour to fix a test problem.

## Verified pre-existing

Ran it five times on clean `main` before blaming anything: 45 passed each time. The flake needs contention this machine did not have, which is why it surfaced remotely and not locally.

Same family as #177, where the burrow beacon guessed its ports and failed on an unrelated PR.

## Suite

`5100` passed.
