### PR TITLE
docs(contract): say plainly that the parity file pins names, not shapes

### DIFF
--- a/contracts/gateway-rpc-parity.json
+++ b/contracts/gateway-rpc-parity.json
@@ -2,7 +2,7 @@
   "schema": "rapp-gateway-rpc-parity/1.0",
   "why": [
     "The two gateways drifted without anything noticing. TypeScript registers 54 RPC",
-    "methods and Python 10, which is expected — they have different scopes — but the",
+    "methods and Python 10, which is expected \u2014 they have different scopes \u2014 but the",
     "overlap must agree, and a method must not quietly appear in one runtime only.",
     "",
     "This file is the pin. Each runtime has a test asserting it registers everything",
@@ -35,9 +35,29 @@
   },
   "typescript_only_note": [
     "TypeScript registers many methods Python does not (cron.*, chat.*, twin.*,",
-    "surgeon.*, backup.*, auth.*, and others). That is by design — the TypeScript",
+    "surgeon.*, backup.*, auth.*, and others). That is by design \u2014 the TypeScript",
     "gateway is the full daemon. They are not enumerated here because the list moves",
     "with feature work; what matters is that the `shared` set stays in agreement and",
     "that `python_only` does not grow silently."
+  ],
+  "what_this_does_not_pin": [
+    "Response shapes. This file pins which method NAMES both runtimes answer to,",
+    "and nothing about what they answer with. That distinction matters more than",
+    "it sounds: `agents.list` is listed as shared and the two runtimes return",
+    "payloads with almost nothing in common.",
+    "",
+    "  TypeScript  [{ id, type, description }]           (index.ts setAgentList)",
+    "  Python      [{ name, description, parameters,     (cli.py list_agents)",
+    "               module, file, source }]",
+    "",
+    "A client written against one cannot read the other. Only `description`",
+    "overlaps; TypeScript's `id` is Python's `name`.",
+    "",
+    "`health` does agree \u2014 status, version, uptime, timestamp, checks \u2014 except",
+    "that Python never sends the optional `instance`, which TypeScript documents",
+    "as meaning 'unknown' when absent, so that is compatible by design.",
+    "",
+    "Tracked as an issue rather than fixed here: choosing a canonical shape",
+    "breaks whichever side's clients are not chosen, which is an owner decision."
   ]
 }

--- a/python/tests/test_gateway_rpc_parity.py
+++ b/python/tests/test_gateway_rpc_parity.py
@@ -26,6 +26,21 @@ def registered() -> set[str]:
     return set(getattr(GatewayServer(), "_methods", {}))
 
 
+class TestContractHonesty:
+    def test_it_says_what_it_does_not_pin(self):
+        """The contract pins names, not response shapes.
+
+        `agents.list` is shared and the two runtimes return payloads with
+        almost nothing in common, so a reader must not take "shared" to mean
+        a client can consume either. Losing that note would make this file
+        quietly overstate what it guarantees.
+        """
+        assert "what_this_does_not_pin" in CONTRACT
+        note = " ".join(CONTRACT["what_this_does_not_pin"])
+        assert "agents.list" in note
+        assert "Response shapes" in note
+
+
 class TestSharedSurface:
     def test_the_contract_lists_something(self):
         # Guards the rest: an empty contract would make every assertion vacuous.

--- a/typescript/src/__tests__/integration/gateway-rpc-parity.test.ts
+++ b/typescript/src/__tests__/integration/gateway-rpc-parity.test.ts
@@ -22,7 +22,11 @@ import { reserveTestPort } from '../support/test-port.js';
 
 const CONTRACT = JSON.parse(
   readFileSync(resolve(__dirname, '../../../../contracts/gateway-rpc-parity.json'), 'utf-8'),
-) as { shared: string[]; python_only: Record<string, string[]> };
+) as {
+  shared: string[];
+  python_only: Record<string, string[]>;
+  what_this_does_not_pin?: string[];
+};
 
 let server: GatewayServer | undefined;
 
@@ -42,6 +46,17 @@ describe('gateway RPC parity with the Python runtime', () => {
   it('the contract lists something', () => {
     // Guards the rest: an empty contract would make every assertion vacuous.
     expect(CONTRACT.shared.length).toBeGreaterThan(4);
+  });
+
+  it('says plainly that it does not pin response shapes', () => {
+    // `agents.list` is shared, and the two runtimes return payloads with
+    // almost nothing in common — TypeScript `{ id, type, description }`,
+    // Python `{ name, description, parameters, module, file, source }`.
+    // Without this note, "shared" reads as though a client could consume
+    // either, which it cannot.
+    const note = (CONTRACT.what_this_does_not_pin ?? []).join(' ');
+    expect(note).toContain('Response shapes');
+    expect(note).toContain('agents.list');
   });
 
   it('registers every shared method', async () => {


### PR DESCRIPTION
I wrote #186, and its framing overstates what it delivers. It says the overlap between the two gateways *"must agree"*, which reads as though a client could talk to either. **It pins method names and nothing about the payloads.**

## The divergence it was hiding

`agents.list` is listed as `shared`, and the two runtimes answer it with payloads that have almost nothing in common:

| runtime | shape | source |
|---|---|---|
| TypeScript | `[{ id, type, description }]` | `index.ts` `setAgentList` |
| Python | `[{ name, description, parameters, module, file, source }]` | `cli.py` `list_agents` |

Only `description` overlaps. TypeScript's `id` is Python's `name`. A client written against one cannot read the other — and #186 would have reported the two runtimes in agreement the entire time.

Verified from the call sites, not the type signatures: `index.ts:489` builds the TypeScript list literally, and `cli.py:214` builds Python's.

## What does agree

`health` — `status`, `version`, `uptime`, `timestamp`, `checks`. Python never sends the optional `instance`, which TypeScript documents as meaning *"unknown"* when absent, so that difference is compatible by design rather than drift. Worth stating, because it is the difference between a gap and a deliberate optional field.

## Not fixed here

Choosing a canonical shape breaks whichever side's clients are not chosen. That is an owner decision, filed separately. This PR makes the divergence **visible** rather than papering it over — the note names it, so the next reader is not misled the way the file previously invited.

Python's shape also discloses `file` (an absolute filesystem path) and `module` over RPC. Auth-gated, but more than a client needs; noted in the issue.

## Both runtimes assert the note

So it cannot be trimmed back into a claim the file does not support.

| mutation | TypeScript | Python |
|---|---|---|
| delete the note entirely | **1 failed** | **1 failed** |
| keep the note, drop the `agents.list` evidence | **1 failed** | **1 failed** |

## Suites

TypeScript `5102` passed · Python `1465` passed · `tsc --noEmit` clean.
