### PR TITLE
test: the CLI is a client too, and the coverage guard never looked at it

### DIFF
--- a/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
+++ b/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
@@ -32,6 +32,24 @@ const SWIFT_RPC = join(REPO, '../macos/Sources/OpenRappterBar/Services/RpcClient
  * `gateway.call(...)` as freely as services do, so both are walked.
  */
 const UI_SOURCES = [join(REPO, 'ui/src/services'), join(REPO, 'ui/src/components')];
+/**
+ * The CLI is a client too.
+ *
+ * It was missed for the same reason `ui/src/components` was: this file grew
+ * from the two clients I happened to be looking at. `src/cli/` talks to the
+ * gateway over the same JSON-RPC wire as the Bar and the dashboard.
+ */
+const CLI_SOURCE = join(REPO, 'src/cli');
+
+/**
+ * Not RPC methods.
+ *
+ * `connect` is the WebSocket handshake, handled before method dispatch — a
+ * connection that has not sent it is refused with "Handshake required" — so it
+ * never appears in the method registry. Listing it as missing would claim a
+ * break that does not exist.
+ */
+const PROTOCOL_PRIMITIVES = new Set(['connect', 'subscribe', 'unsubscribe']);
 
 /**
  * Methods a client calls that the gateway still does not register.
@@ -85,6 +103,13 @@ const KNOWN_MISSING = new Set<string>([
   // buy a green line here at the cost of a screen that lies. See the block
   // comment beside the `connections.*` registrations in gateway/server.ts.
   'connections.pair',
+  // Called from CLI modules that #176 deliberately left unregistered, having
+  // found them backed by nothing real. Unreachable today, so not a live break
+  // — but whoever registers `sessions` or `channels` inherits these.
+  'channels.broadcast',
+  'sessions.delete',
+  'sessions.get',
+  'sessions.list',
 ]);
 
 let server: GatewayServer | undefined;
@@ -134,18 +159,53 @@ function uiMethods(): string[] {
   return names;
 }
 
+/** Method names the CLI sends over the wire. */
+function cliMethods(): string[] {
+  const names: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir)) {
+      const full = join(dir, entry);
+      if (statSync(full).isDirectory()) {
+        if (entry !== '__tests__') walk(full);
+        continue;
+      }
+      if (!entry.endsWith('.ts') || entry.includes('.test.')) continue;
+      const source = readFileSync(full, 'utf-8');
+      for (const m of source.matchAll(/\.(?:call|request)\(\s*'([a-z][a-zA-Z.]+)'/g)) {
+        names.push(m[1]);
+      }
+      for (const m of source.matchAll(/method:\s*'([a-z][a-zA-Z.]+)'/g)) {
+        names.push(m[1]);
+      }
+    }
+  };
+  walk(CLI_SOURCE);
+  return names;
+}
+
 describe('every RPC method a client calls exists on the gateway', () => {
   it('finds call sites in both clients', () => {
     // Guards the parsers. If a rename makes either match nothing, the
     // assertions below would pass over an empty list and prove nothing.
+    // Asserted per source. A combined count hides one parser breaking because
+    // the others keep the total up — the trap this file fell into twice.
     expect(swiftMethods().length).toBeGreaterThan(20);
     expect(uiMethods().length).toBeGreaterThan(10);
+    expect(cliMethods().length).toBeGreaterThan(5);
   });
 
   it('the macOS Bar calls nothing the gateway lacks', async () => {
     const registered = await registeredMethods();
     const missing = [...new Set(swiftMethods())]
       .filter((m) => !registered.has(m) && !KNOWN_MISSING.has(m))
+      .sort();
+    expect(missing).toEqual([]);
+  });
+
+  it('the CLI calls nothing the gateway lacks', async () => {
+    const registered = await registeredMethods();
+    const missing = [...new Set(cliMethods())]
+      .filter((m) => !registered.has(m) && !KNOWN_MISSING.has(m) && !PROTOCOL_PRIMITIVES.has(m))
       .sort();
     expect(missing).toEqual([]);
   });


### PR DESCRIPTION
I wrote #181 and its docstring claims it checks *"every RPC method a client calls"*. It checked **two** clients. `src/cli/` talks to the gateway over the same JSON-RPC wire and was never scanned.

## What scanning it finds

```
channels.broadcast
sessions.delete
sessions.get
sessions.list
```

None are registered by any gateway.

All four come from CLI modules that **#176 deliberately left unregistered**, having found them backed by nothing real. So nothing is broken today — but whoever registers `sessions` or `channels` inherits four calls that answer `Method not found`. That is exactly the landmine this guard exists to prevent, so they are recorded as debt rather than treated as fine.

## Third widening, same cause

- originally: Swift client only
- **#189**: `ui/src/components` added, after the zen work showed most UI listeners were invisible to it
- **here**: the CLI

The file grew from whichever clients I happened to be looking at, and the claim in its docstring kept outrunning the code. That is the honest reason, and it is why the docstring now names the sources it scans.

## A fifth name that is *not* a defect

`connect` came back too. It is the WebSocket handshake, refused before method dispatch — *"Handshake required: first message must be connect"* — so it never appears in the method registry. Listing it as missing would have claimed a break that does not exist. Excluded as a protocol primitive alongside `subscribe`/`unsubscribe`.

## Two process notes

- My **hand-written** list of missing methods had four entries. The scanner found five. That is why the scanner is the authority and not my reading of the diff.
- My first attempt to add them to `KNOWN_MISSING` **silently matched nothing** — #189 had already removed the anchor I keyed on. The failing test is what caught it, which is the argument for landing the assertion before the allowlist entry.

## Mutations

| mutation | result |
|---|---|
| drop `sessions.list` from the debt list | **1 of 5 failed** |
| break the CLI parser only | **1 of 5 failed** |
| stop excluding protocol primitives | **1 of 5 failed** |

The CLI parser is asserted on its own rather than folded into a combined count — the aggregation trap this file already fell into twice.

## Suite

`5103` passed · `tsc --noEmit` clean.
