### PR TITLE
test: catch a dormant module wired one at a time, not just all at once

### DIFF
--- a/typescript/src/__tests__/integration/dormant-methods-stay-dormant.test.ts
+++ b/typescript/src/__tests__/integration/dormant-methods-stay-dormant.test.ts
@@ -30,6 +30,43 @@ import { reserveTestPort } from '../support/test-port.js';
  */
 
 const METHODS_DIR = resolve(__dirname, '../../gateway/methods');
+const SERVER = resolve(__dirname, '../../gateway/server.ts');
+
+/**
+ * The five modules `GatewayServer` is meant to invoke.
+ *
+ * Anything else being called is the bug this file exists to catch. Listed
+ * explicitly so wiring a sixth is a deliberate edit here, not a silent one.
+ */
+const INTENTIONALLY_INVOKED = new Set([
+  'registerAuthMethods',
+  'registerBackupMethods',
+  'registerRappterMethods',
+  'registerShowcaseMethods',
+  'registerSurgeonMethods',
+]);
+
+/** Every `registerXMethods` export under gateway/methods, with its file. */
+function registerFunctions(): Array<{ file: string; fn: string }> {
+  const found: Array<{ file: string; fn: string }> = [];
+  for (const file of readdirSync(METHODS_DIR)) {
+    if (!file.endsWith('.ts') || file.includes('.test.')) continue;
+    const source = readFileSync(join(METHODS_DIR, file), 'utf-8');
+    for (const match of source.matchAll(/export function (register[A-Za-z]+)/g)) {
+      found.push({ file, fn: match[1] });
+    }
+  }
+  return found;
+}
+
+/** Is this function actually called in server.ts (ignoring comments)? */
+function invokedByServer(fn: string): boolean {
+  const source = readFileSync(SERVER, 'utf-8')
+    .split('\n')
+    .filter((line) => !line.trimStart().startsWith('*') && !line.trimStart().startsWith('//'))
+    .join('\n');
+  return new RegExp(`\\b${fn}\\s*\\(`).test(source);
+}
 
 /** Names that appear only in the dormant modules and in no real handler. */
 const DEMO_ONLY = [
@@ -68,6 +105,34 @@ describe('the dormant RPC method modules stay out of the gateway', () => {
       .filter((line) => /registerAllMethods\s*\(/.test(line))
       .filter((line) => !line.trimStart().startsWith('*'));
     expect(invocations).toEqual([]);
+  });
+
+  it('invokes no dormant module, one at a time either', () => {
+    // The registerAllMethods check above only covers the one-line shortcut.
+    // Wiring a single module directly — `registerChannelsMethods(this)` —
+    // passed every assertion in this file, while that module declares
+    // channels.connect and channels.list, which the real server already
+    // registers. It would have overridden real handlers with disconnected
+    // demos, which is exactly what the doc comment on registerBuiltInMethods
+    // warns about.
+    const unexpected = registerFunctions()
+      .filter(({ fn }) => !INTENTIONALLY_INVOKED.has(fn) && invokedByServer(fn))
+      .map(({ file, fn }) => `${fn} (${file})`)
+      .sort();
+    expect(unexpected).toEqual([]);
+  });
+
+  it('the intentionally-invoked five really are invoked', () => {
+    // Guards the list above. If one is renamed or dropped, this fails rather
+    // than silently shrinking the set of things anyone is checking.
+    const missing = [...INTENTIONALLY_INVOKED].filter((fn) => !invokedByServer(fn)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  it('finds register functions to check', () => {
+    // A rename that makes the scan match nothing would leave both assertions
+    // above passing over an empty list.
+    expect(registerFunctions().length).toBeGreaterThan(15);
   });
 
   it('answers none of the demo-only method names', async () => {


### PR DESCRIPTION
#190 asserts `GatewayServer` never calls `registerAllMethods`. That is the one-line shortcut I had in mind when I wrote it — and it is not the only way in.

## Wiring a single module passed every assertion

```
registerChannelsMethods(this as never);   ->  3 of 3 tests still passed
```

`channels-methods.ts` declares `channels.connect` and `channels.list`, which the **real server already registers**. Wiring it would have overridden real, wired handlers with disconnected demos — the exact failure the doc comment on `registerBuiltInMethods` warns about, and the one #190 was written to prevent.

The name-based check could not see it either: `DEMO_ONLY` lists eight names I picked by hand, and `channels-methods` declares none of them.

## Derived instead of hand-listed

Every `registerXMethods` export under `gateway/methods` is now enumerated, and any invoked by `server.ts` other than the five that are meant to be is a failure. Wiring a sixth becomes a deliberate edit to the list here rather than a silent one.

Two supporting assertions:

- **The five are asserted to still be invoked**, so the intended set cannot quietly shrink — the mirror failure of the one this catches.
- **The scan is asserted non-empty**, so a rename cannot leave both checks walking nothing.

## Mutations

| mutation | result |
|---|---|
| wire one dormant module *(previously missed)* | **1 of 6 failed** |
| stop invoking one of the intended five | **1 of 6 failed** |
| register-function scan matches nothing | **1 of 6 failed** |

## The pattern

Same shape as #200, and #199, and #197: the guard was written against the instance in front of me and checked less than its name claimed. Deriving the scope from the code — rather than hardcoding what I happened to be debugging — is what fixed it every time.

This is the last of the five guards I had not re-audited.

## Suite

`5107` passed · `tsc --noEmit` clean.
