### PR TITLE
docs: the changelog was missing the session's most consequential fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,61 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A published install had none of the 52 bundled skills** — `files` in
+  `package.json` never listed `skills/`, so every tarball carried
+  `dist/skills/bundled.js` and none of the `SKILL.md` files it reads. The
+  loader swallows a missing directory and returns an empty list, so an install
+  that shipped nothing looked exactly like one that legitimately had no
+  skills. The packaging test now asserts against what npm would really
+  publish, and asserts the count exactly, because shipping a subset is the
+  same silent failure in a smaller form.
+- **`cron.delete` reported success while the job kept running** — the alias
+  filtered only the file-backed store, so the live scheduler kept the job and
+  it fired on schedule after the user had been told it was gone. Deleting an
+  id that never existed also reported success. Both now go through one bound
+  removal that clears the scheduler and the store, and an unknown id is
+  refused.
+- **`cron.get` denied a job the gateway had just created** — it read only the
+  file fallback, never the live scheduler, so a job created in this process
+  was invisible until something persisted it. `cron.update` was not registered
+  at all, though the macOS Bar calls it. `list` and `get` now share one
+  mapping, so two readers of the same job cannot describe it differently.
+- **A Bar-created cron job ran with an empty prompt** — the Bar sent
+  `command` and the scheduler read `message`, so the job was created, reported
+  `scheduled: true`, got a `nextRun`, and fired on time carrying nothing.
+  `message` is canonical; `command` is accepted as an alias and normalised
+  away. An empty prompt is now refused rather than scheduled.
+- **Storage lied about three things** — a `transaction()` callback that
+  awaited kept writing after the rollback was reported, because better-sqlite3
+  rejects async transaction functions; migrations wrote their DDL and their
+  version marker separately, so a partial failure bricked every later start
+  with `duplicate column name`; and `INSERT OR REPLACE` on sessions and devices
+  is a delete-then-insert, which fired `ON DELETE SET NULL` and destroyed the
+  approval records pointing at them. Renaming a cron job cascaded away its run
+  logs the same way.
+- **The Bar's approval screen never worked** — `exec.pending` and
+  `exec.respond` were not registered, so the approve and deny buttons could not
+  function. They are now wired to the real `ExecSafety` engine that `ShellAgent`
+  blocks on: a deny genuinely denies, an approval is single-use, and unknown,
+  expired or already-resolved ids are refused instead of accepted. The gateway
+  also now emits the `approval` event the Bar has always listened for, so the
+  list no longer waits for the screen to be reopened.
+- **The Bar's Logs pane and session reset called nothing** — `logs.get` and
+  `sessions.reset` were unregistered. `logs.get` now reads the daemon's real
+  launchd log files, bounded and redacted through the shared secret redactor;
+  `sessions.reset` clears the real session store and aborts the run in flight,
+  because otherwise the reply repopulated the session after reporting success.
+- **The dashboard's agent file browser called nothing** — `agents.files.list`,
+  `agents.files.read` and `agents.files.write` were unregistered, and
+  `cron.runs` duplicated `cron.logs`. The file methods are treated as the
+  remote code-execution surface they are: the resolved real path must sit
+  inside the agent directory, reserved directories are refused as an agent id
+  and as any path segment, symlinks are never written through, and `write` may
+  only replace an existing file so it cannot plant a new agent.
+- **The zen list ignored the events announcing its own sessions** — the
+  gateway broadcasts `zen.session.start` and `zen.session.end`; nothing
+  listened, so the list was only as fresh as the moment the screen opened.
+
 - **Zen viewer works** — `<openrappter-zen>` is live UI, but `zen.sessions`,
   `zen.subscribe` and `zen.unsubscribe` were never registered on the gateway,
   so the page answered `-32601 Method not found` on load and rendered an empty
@@ -132,6 +187,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - The Electron desktop is the authority for OpenRappter Bar authentication,
   and desktop smoke tests were hardened for concurrent and Windows runs.
+
+### Security
+
+- **`openrappter login` printed both tokens** — it echoed the first 20
+  characters of the access token, and of the refresh token when one was
+  issued. A prefix is still credential material: it lands in terminal
+  scrollback and in CI logs, and it narrows a brute force. The command now
+  names the provider and says nothing derived from the secret. It remains
+  unregistered — it also persists nothing while claiming it saved — so this
+  was latent rather than live, which is exactly why it needed a test before
+  somebody registers it.
 
 ## [1.13.0] - 2026-08-14
 


### PR DESCRIPTION
The `[Unreleased]` section had 19 entries and omitted eleven merged changes — including the only security fix and all four data-integrity fixes.

## Missing, now written up

| | |
|---|---|
| #165 | a published install shipped none of the 52 bundled skills |
| #166 | `cron.delete` reported success while the job kept firing |
| #167 | storage lied about transactions, migrations and upserts |
| #174 | a Bar-created cron job ran with an empty prompt |
| #178 | `login` printed 20 characters of both tokens |
| #180 | `cron.get` denied a job it had just created |
| #182 | the Bar's approval screen never worked |
| #183 | the Bar's Logs pane and session reset called nothing |
| #188 | the dashboard's agent file browser called nothing |
| #192 | the gateway never emitted the `approval` event |
| #194 | the zen list ignored its own session events |

## Why this matters

A changelog that omits a credential leak and four data-integrity fixes has the same defect this session kept finding in code: **a thing that reads as complete and is not.** #163 already corrected this file once, for a false `keyCount` claim; the entries simply stopped keeping pace with merges after it.

## Judgement calls

- **`login` goes under Security.** It stays unregistered and persists nothing while reporting success, so the leak was latent. Said plainly rather than implying a live breach.
- **Section order is Fixed → Changed → Security,** matching 1.12.0 and 1.13.0 rather than the Keep a Changelog default.
- **Test-only work is deliberately excluded.** The guards added this session change nothing a user can observe.

Suite: **5107 passed**.