### PR TITLE
fix: a slow PowerShell start aborted Windows ACL hardening

### DIFF
--- a/typescript/src/flight-recorder/permissions-retry.test.ts
+++ b/typescript/src/flight-recorder/permissions-retry.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  isTransientSpawnFailure,
+  withTransientRetry,
+} from './permissions.js';
+
+/**
+ * The retry policy guarding Windows ACL hardening.
+ *
+ * `hardenPrivatePath` spawns a fresh `powershell.exe` for every private path,
+ * and the ACL script loads .NET security types, so a cold start on a loaded
+ * machine is slow. CI hit `spawnSync powershell.exe ETIMEDOUT` inside
+ * `ShowAndTellStore.initialize`, which aborts the operation that asked for a
+ * private directory. On a user's machine the same timeout would stop
+ * Show-and-Tell from starting at all.
+ *
+ * Retrying is only safe because of a distinction these tests exist to pin: a
+ * refused or unverifiable ACL exits 1 from the script and must fail
+ * immediately, while a process that never got off the ground may be retried.
+ * If that line ever blurs, a real permissions failure would be retried and then
+ * reported as if it were flaky — the opposite of failing closed.
+ */
+
+/** A spawn failure as Node reports it: an Error carrying an errno `code`. */
+function spawnError(code: string): NodeJS.ErrnoException {
+  const error = new Error(`spawnSync powershell.exe ${code}`) as NodeJS.ErrnoException;
+  error.code = code;
+  return error;
+}
+
+/** A script that ran and rejected the ACL: non-zero `status`, no errno code. */
+function aclRejected(): Error & { status: number } {
+  const error = new Error('Command failed: powershell.exe') as Error & { status: number };
+  error.status = 1;
+  return error;
+}
+
+describe('transient spawn failures are distinguished from ACL failures', () => {
+  it('treats a timed-out or unstartable process as transient', () => {
+    expect(isTransientSpawnFailure(spawnError('ETIMEDOUT'))).toBe(true);
+    expect(isTransientSpawnFailure(spawnError('EAGAIN'))).toBe(true);
+    expect(isTransientSpawnFailure(spawnError('EBUSY'))).toBe(true);
+  });
+
+  it('does NOT treat a rejected ACL as transient', () => {
+    // The security-critical case: the script ran, verification failed, exit 1.
+    expect(isTransientSpawnFailure(aclRejected())).toBe(false);
+  });
+
+  it('does not treat permission or missing-binary errors as transient', () => {
+    expect(isTransientSpawnFailure(spawnError('EACCES'))).toBe(false);
+    expect(isTransientSpawnFailure(spawnError('ENOENT'))).toBe(false);
+    expect(isTransientSpawnFailure(null)).toBe(false);
+    expect(isTransientSpawnFailure(new Error('no code'))).toBe(false);
+  });
+});
+
+describe('withTransientRetry', () => {
+  it('retries a timeout once and returns the eventual success', () => {
+    const operation = vi
+      .fn(() => 'hardened')
+      .mockImplementationOnce(() => { throw spawnError('ETIMEDOUT'); });
+
+    expect(withTransientRetry(operation)).toBe('hardened');
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('rethrows a rejected ACL immediately, without a second attempt', () => {
+    const operation = vi.fn(() => { throw aclRejected(); });
+
+    expect(() => withTransientRetry(operation)).toThrow(/Command failed/);
+    // The important assertion: hardening is not attempted again, so a genuine
+    // permissions failure can never be reported as a flake.
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+
+  it('gives up after the attempt budget and surfaces the last failure', () => {
+    const operation = vi.fn(() => { throw spawnError('ETIMEDOUT'); });
+
+    expect(() => withTransientRetry(operation)).toThrow(/ETIMEDOUT/);
+    expect(operation).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a successful call', () => {
+    const operation = vi.fn(() => 'ok');
+    expect(withTransientRetry(operation)).toBe('ok');
+    expect(operation).toHaveBeenCalledTimes(1);
+  });
+});

--- a/typescript/src/flight-recorder/permissions.ts
+++ b/typescript/src/flight-recorder/permissions.ts
@@ -9,6 +9,50 @@ import {
 } from "node:fs";
 import path from "node:path";
 
+/**
+ * PowerShell is spawned fresh for every hardened path, and a cold start pays
+ * for the shell plus the .NET types the ACL script uses. 15s was enough on an
+ * idle machine and not on a loaded one: CI failed with
+ * `spawnSync powershell.exe ETIMEDOUT` while hardening a Show-and-Tell
+ * directory, which aborts the operation that asked for the private path.
+ */
+const ACL_TIMEOUT_MS = 60_000;
+const ACL_ATTEMPTS = 2;
+
+/**
+ * Whether a failure is the spawn never getting off the ground, rather than the
+ * ACL work itself failing.
+ *
+ * The distinction is the whole safety argument for retrying. A refused or
+ * unverifiable ACL exits 1 from the script, which surfaces as a non-zero
+ * `status` and no `code`, so it is never retried and never softened — the
+ * caller still fails closed. Only a transient inability to start or run the
+ * process is tried again.
+ */
+export function isTransientSpawnFailure(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException | null)?.code;
+  return code === "ETIMEDOUT" || code === "EAGAIN" || code === "EBUSY";
+}
+
+/**
+ * Run an idempotent operation, retrying only transient spawn failures.
+ *
+ * Exported so the retry policy can be tested on any platform; the ACL script
+ * itself only runs on Windows.
+ */
+export function withTransientRetry<T>(
+  operation: () => T,
+  attempts = ACL_ATTEMPTS,
+): T {
+  for (let attempt = 1; ; attempt++) {
+    try {
+      return operation();
+    } catch (error) {
+      if (attempt >= attempts || !isTransientSpawnFailure(error)) throw error;
+    }
+  }
+}
+
 export function hardenPrivatePath(
   target: string,
   directory = false,
@@ -61,16 +105,18 @@ try {
   exit 1
 }
 `;
-  execFileSync(
-    "powershell.exe",
-    ["-NoProfile", "-NonInteractive", "-Command", command],
-    {
-      encoding: "utf8",
-      stdio: ["ignore", "pipe", "pipe"],
-      windowsHide: true,
-      timeout: 15_000,
-      env: { ...process.env, HF_TARGET: target, HF_USER: user },
-    },
+  withTransientRetry(() =>
+    execFileSync(
+      "powershell.exe",
+      ["-NoProfile", "-NonInteractive", "-Command", command],
+      {
+        encoding: "utf8",
+        stdio: ["ignore", "pipe", "pipe"],
+        windowsHide: true,
+        timeout: ACL_TIMEOUT_MS,
+        env: { ...process.env, HF_TARGET: target, HF_USER: user },
+      },
+    ),
   );
 }
 


### PR DESCRIPTION
`hardenPrivatePath` spawns a fresh `powershell.exe` for every private path and capped it at **15 seconds**. The script loads .NET security types, so a cold start on a loaded machine can exceed that — and the failure is not soft:

```
Error: spawnSync powershell.exe ETIMEDOUT
    at Module.hardenPrivatePath (flight-recorder/permissions.ts:64:3)
    at privateDirectory (show-and-tell/store.ts:112:3)
    at ShowAndTellStore.initialize (show-and-tell/store.ts:150:5)
```

## This is not a CI-only problem

That trace came from CI, but nothing about it is CI-specific. Every caller that asks for a private path — the recorder, the ledger, `process-owner`, Show-and-Tell — takes the throw. **On a busy Windows machine, Show-and-Tell simply fails to start.**

The path is hit repeatedly, and each hit pays for another PowerShell cold start — which is what makes a 15s budget tight in the first place.

Raised to **60s**, retried **once**.

## The retry needed care

This is a privacy control, so the wrong retry would be worse than the bug. The two failures are not the same event:

| failure | how it surfaces | retried? |
|---|---|---|
| script ran, **ACL rejected** | `exit 1` → non-zero `status`, no errno `code` | **no** |
| process never started | `ETIMEDOUT` / `EAGAIN` / `EBUSY` | yes |

A refused or unverifiable ACL still fails on the first attempt and **still fails closed**. Retrying it would report a real permissions failure as if it were flaky.

## Testable on every platform

The ACL script only runs on Windows, and the existing Windows tests are `describe.skipIf(process.platform !== "win32")` — so the policy would have been tested *nowhere*. It is extracted into `isTransientSpawnFailure` and `withTransientRetry` and tested everywhere instead.

**Mutation-checked, both directions:**

| mutation | result |
|---|---|
| treat every failure as transient | 3 failed |
| drop the retry (the bug as found) | 2 failed |
| restored | 7 passed |

flight-recorder + show-and-tell: **242 passed**, 2 skipped. `tsc` clean.

Found while verifying whether a failing Windows check on #203 was caused by that PR. It was not — that job runs only three test files, none of them mine.