### PR TITLE
Guard the six dormant CLI command modules (mirrors the dormant-methods guard)

### DIFF
--- a/typescript/src/__tests__/integration/dormant-cli-commands-stay-dormant.test.ts
+++ b/typescript/src/__tests__/integration/dormant-cli-commands-stay-dormant.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * The dormant CLI command modules stay dormant.
+ *
+ * `src/cli/index.ts` re-exports fifteen `register*Command` functions. Only nine
+ * are ever invoked by `src/index.ts`; the other six declare fully written
+ * commands against dependencies nothing wires — the CLI twin of the dormant
+ * `gateway/methods/*.ts` modules that `dormant-methods-stay-dormant.test.ts`
+ * pins.
+ *
+ * The trap here is specific to Commander. The root command declares
+ * `.argument('[message]', ...)`, so an *unregistered* command does not error —
+ * the token is read as a chat prompt and the process exits 0. `openrappter
+ * send hello` looks like it ran; it reached the model. So "the file exists and
+ * is exported" tells you nothing about whether the command is reachable, and
+ * "it exited 0" tells you nothing about whether it did what it said.
+ *
+ * Each of the six is dormant for a measured reason, not an oversight. Verified
+ * against the running gateway and the OAuth flow, not by reading:
+ *
+ *  - registerChannelCommand  — `openrappter channel` IS live, but as an inline
+ *    command in index.ts (release-channel status/switch/promote), and this
+ *    module is a duplicate of it. Wiring it double-registers `channel`.
+ *  - registerChannelsCommand — sends `{channel}`; `channels.connect` /
+ *    `channels.disconnect` read `params.type`, so both would pass `undefined`
+ *    to the registry.
+ *  - registerSendCommand     — sends `{channel, message, target}`;
+ *    `channels.send` reads `{channelId, conversationId, content}`, and `--all`
+ *    calls `channels.broadcast`, which the gateway never registers.
+ *  - registerSessionsCommand — calls `sessions.list/get/delete`, none of which
+ *    the gateway registers (the real ones are `chat.list/session/messages/
+ *    delete`); `sessions.reset` is registered but reads `sessionKey`, not the
+ *    `{id}` this sends, so even that throws "sessionKey required".
+ *  - registerLoginCommand    — `initiateOAuthFlow` persists nothing, yet the
+ *    command prints "Credentials have been saved to your config." Same lie the
+ *    memory CLI would tell (#204).
+ *  - registerMemoryCommand   — `MemoryManager` holds chunks in in-memory `Map`s
+ *    with zero file I/O, so every CLI process starts empty. Filed as #204.
+ *
+ * This asserts the source of truth — which functions `index.ts` actually calls.
+ * The neighbouring `cli-registration.test.ts` asks the built CLI which command
+ * *names* it exposes; together they cover both "the module is wired" and "the
+ * command is reachable". If any of the six starts being invoked here, someone
+ * wired a command that lies.
+ */
+
+const CLI_INDEX = resolve(__dirname, '../../cli/index.ts');
+const MAIN = resolve(__dirname, '../../index.ts');
+
+/**
+ * The six exports `index.ts` must never invoke, each with the evidence for why.
+ *
+ * Listed explicitly so wiring a seventh — or removing one of these six — is a
+ * deliberate edit here, not a silent one. The justifications are load-bearing:
+ * a later reader deciding "just register it" needs to see the failure first.
+ */
+const INTENTIONALLY_DORMANT = new Map<string, string>([
+  [
+    'registerChannelCommand',
+    'release-channel management is already live as an inline `channel` command in index.ts; this module duplicates it, so wiring double-registers `channel`',
+  ],
+  [
+    'registerChannelsCommand',
+    'sends {channel}; gateway channels.connect/disconnect read params.type, so both pass undefined to the channel registry',
+  ],
+  [
+    'registerSendCommand',
+    'sends {channel,message,target}; channels.send reads {channelId,conversationId,content}, and --all calls channels.broadcast which the gateway never registers',
+  ],
+  [
+    'registerSessionsCommand',
+    'calls sessions.list/get/delete (unregistered — real methods are chat.list/session/messages/delete); sessions.reset reads sessionKey, not the {id} this sends',
+  ],
+  [
+    'registerLoginCommand',
+    'initiateOAuthFlow persists nothing while the command prints "Credentials have been saved to your config" (identical to the memory case, #204)',
+  ],
+  [
+    'registerMemoryCommand',
+    'MemoryManager keeps chunks in in-memory Maps with zero file I/O, so every CLI process starts empty (#204)',
+  ],
+]);
+
+/** Every `register*Command(s)` export re-exported by cli/index.ts, in order. */
+function registerExports(): string[] {
+  const source = readFileSync(CLI_INDEX, 'utf-8');
+  const found: string[] = [];
+  for (const match of source.matchAll(/export\s*\{\s*(register[A-Za-z]+)\s*\}\s*from/g)) {
+    if (/Commands?$/.test(match[1])) found.push(match[1]);
+  }
+  return found;
+}
+
+/** index.ts with comment lines removed, so only real code is searched. */
+function mainCode(): string {
+  return readFileSync(MAIN, 'utf-8')
+    .split('\n')
+    .filter((line) => {
+      const t = line.trimStart();
+      return !t.startsWith('*') && !t.startsWith('//') && !t.startsWith('/*');
+    })
+    .join('\n');
+}
+
+/** Is `fn` actually called (not merely imported) in index.ts? */
+function invokedByMain(fn: string): boolean {
+  return new RegExp(`\\b${fn}\\s*\\(`).test(mainCode());
+}
+
+describe('the dormant CLI command modules stay out of the program', () => {
+  it('re-exports a non-trivial set of register* commands to classify', () => {
+    // Anti-vacuity for the cli/index.ts parser: if it matched nothing, every
+    // assertion below would pass over an empty list. There are fifteen today.
+    expect(registerExports().length).toBeGreaterThanOrEqual(12);
+  });
+
+  it('the invocation detector discriminates (control)', () => {
+    // If invokedByMain always returned false, "no dormant is invoked" would
+    // pass vacuously; if it always returned true, the wired check below would.
+    // A wired command reads as invoked; an invented one does not.
+    expect(invokedByMain('registerHubCommands')).toBe(true);
+    expect(invokedByMain('registerDefinitelyNotACommand')).toBe(false);
+  });
+
+  it('index.ts invokes none of the intentionally-dormant commands', () => {
+    // The heart of the file. Checked per-name, so wiring a single module
+    // directly — `registerSendCommand(program)` — is caught, not only a bulk
+    // loop (the lesson of #201). Each name carries its justification above.
+    const wired = [...INTENTIONALLY_DORMANT.keys()].filter(invokedByMain).sort();
+    expect(wired).toEqual([]);
+  });
+
+  it('index.ts invokes every command that is not on the dormant allowlist', () => {
+    // The other half of "exactly the intended set is invoked": the wired set is
+    // derived (exports minus the allowlist), never hardcoded, so it cannot rot
+    // out of sync. If a supposedly-wired command stops being called, this fails
+    // rather than silently shrinking what anyone checks.
+    const missing = registerExports()
+      .filter((fn) => !INTENTIONALLY_DORMANT.has(fn) && !invokedByMain(fn))
+      .sort();
+    expect(missing).toEqual([]);
+  });
+
+  it('every allowlisted name is still exported by cli/index.ts', () => {
+    // Guards the allowlist from rotting: if a dormant module is deleted or
+    // renamed, its justification here is stale and its dormancy claim becomes
+    // vacuous. Fail so it is revisited rather than left passing over a ghost.
+    const stray = [...INTENTIONALLY_DORMANT.keys()]
+      .filter((fn) => !registerExports().includes(fn))
+      .sort();
+    expect(stray).toEqual([]);
+  });
+
+  it('the allowlist and the wired set partition the exports exactly', () => {
+    // Per-parsing-path integrity, not a merged count: every export is either
+    // dormant-by-allowlist or wired-by-invocation, never both and never
+    // neither. A newly added command lands in neither and trips this.
+    const exports = registerExports();
+    const dormant = exports.filter((fn) => INTENTIONALLY_DORMANT.has(fn));
+    const wired = exports.filter((fn) => invokedByMain(fn));
+    expect(dormant.filter((fn) => wired.includes(fn))).toEqual([]);
+    expect([...dormant, ...wired].sort()).toEqual([...exports].sort());
+  });
+
+  it('registerChannelCommand stays dormant even though `channel` is a live command', () => {
+    // The subtle case the task calls out: a dormant module can coexist with a
+    // working command of the same name. `openrappter channel` works via an
+    // inline `.command('channel')` in index.ts (release channels), not via this
+    // module — which is a duplicate of that inline command. Pin both facts so
+    // deleting the inline command, or wiring the duplicate, is caught.
+    expect(invokedByMain('registerChannelCommand')).toBe(false);
+    expect(readFileSync(MAIN, 'utf-8')).toMatch(/\.command\('channel'\)/);
+  });
+});

--- a/typescript/src/cli/index.ts
+++ b/typescript/src/cli/index.ts
@@ -2,27 +2,36 @@
  * Command registrations.
  *
  * Being exported here is not the same as being reachable. #159 registered
- * `config` and `doctor`; this pass registers `skills`, `agents`, `models`,
- * `update` and the delegating `rappterhub`/`clawhub`, and moves `gateway` onto
+ * `config` and `doctor`; a later pass registered `skills`, `agents`, `models`,
+ * `update` and the delegating `rappterhub`/`clawhub`, and moved `gateway` onto
  * the daemon path in `index.ts`.
  *
- * Four modules are still deliberately unregistered, because registering them
- * would ship a command that lies:
+ * Six of the exports below are still deliberately unregistered, because
+ * registering them would ship a command that lies or duplicates one that
+ * already works. Verified against the running gateway and the OAuth flow, not
+ * by reading — `dormant-cli-commands-stay-dormant.test.ts` pins them:
  *
- * - `memory.ts` — `MemoryManager` holds chunks in two `Map`s and never touches
- *   disk, so `memory add` prints an id for a chunk that dies with the process
- *   and `memory list` can only ever say "No memories stored."
- * - `sessions.ts` — calls `sessions.list/get/delete/reset`; the gateway
- *   registers no method with a `sessions.` prefix at all (`chat.list`,
- *   `chat.session`, `chat.messages`, `chat.delete` are the real ones).
- * - `channels.ts` — sends `{channel}` where `channels.connect/disconnect`
- *   read `params.type`.
- * - `send.ts` — sends `{channel, message, target}` where `channels.send` reads
- *   `{channelId, conversationId, content}`, and calls `channels.broadcast`,
- *   which does not exist.
- * - `login.ts` — `initiateOAuthFlow` persists nothing, yet the command prints
- *   "Credentials have been saved to your config" and echoes 20 characters of
- *   the access token.
+ * - `memory.ts` (`registerMemoryCommand`) — `MemoryManager` holds chunks in two
+ *   `Map`s and never touches disk, so `memory add` prints an id for a chunk
+ *   that dies with the process and `memory list` can only ever say "No memories
+ *   stored." Filed as #204.
+ * - `sessions.ts` (`registerSessionsCommand`) — calls `sessions.list/get/delete`,
+ *   none of which the gateway registers (the real listing methods are
+ *   `chat.list`, `chat.session`, `chat.messages`, `chat.delete`); `sessions.reset`
+ *   IS registered but reads `sessionKey`, not the `{id}` this sends, so even
+ *   that throws "sessionKey required".
+ * - `channels.ts` (`registerChannelsCommand`) — sends `{channel}` where
+ *   `channels.connect`/`channels.disconnect` read `params.type`, so both pass
+ *   `undefined` to the registry.
+ * - `send.ts` (`registerSendCommand`) — sends `{channel, message, target}` where
+ *   `channels.send` reads `{channelId, conversationId, content}`, and `--all`
+ *   calls `channels.broadcast`, which the gateway does not register.
+ * - `login.ts` (`registerLoginCommand`) — `initiateOAuthFlow` persists nothing,
+ *   yet the command prints "Credentials have been saved to your config." (The
+ *   token-prefix echo was removed in #178; the false "saved" claim remains.)
+ * - `channel.ts` (`registerChannelCommand`) — release-channel management that is
+ *   already live as an inline `channel` command in `index.ts`; this module is a
+ *   duplicate of it, so wiring it would double-register `channel`.
  */
 
 export { registerConfigCommand } from './config.js';


### PR DESCRIPTION
## What

`src/cli/index.ts` re-exports **15** `register*Command` functions; `src/index.ts` invokes only **9**. The other **6** — `channel`, `channels`, `login`, `send`, `sessions`, `memory` — are implemented and exported but never wired. Because the root command declares `.argument('[message]')`, an unregistered command silently becomes a chat prompt and exits 0, so nothing goes red today.

This is the CLI-client twin of the `gateway/methods/*.ts` problem that `dormant-methods-stay-dormant.test.ts` (#190/#201) pins. It adds the matching guard and corrects the stale header in `cli/index.ts`.

## I judged each module — none should be blindly wired

Verified against a live `GatewayServer` and the OAuth flow, **not** by reading:

| Module | Reachable? | Would it work if wired? | Verdict |
|---|---|---|---|
| `channels` | no | `connect`/`disconnect` send `{channel}`; gateway reads `params.type` → passes `undefined` | stay dormant |
| `send` | no | `channels.send` reads `{channelId,conversationId,content}`, CLI sends `{channel,message,target}`; `--all` calls `channels.broadcast`, which the gateway never registers | stay dormant |
| `sessions` | no | `sessions.list/get/delete` are unregistered (real methods are `chat.*`); `sessions.reset` reads `sessionKey`, CLI sends `{id}` → always throws | stay dormant |
| `login` | no | `initiateOAuthFlow` persists nothing, yet prints "Credentials have been saved to your config" (same lie as #204; #178 already removed the token echo) | stay dormant |
| `channel` | **yes, inline** | duplicate of the live inline `channel` command in `index.ts`; wiring double-registers `channel` | stay dormant |
| `memory` | no | in-memory `Map`s, zero file I/O | stay dormant (#204) |

Evidence and the wire-or-delete options for all five are in **#206** (sibling of #204).

## The guard — `dormant-cli-commands-stay-dormant.test.ts`

- Derives the `register*Command` list by **parsing `cli/index.ts` at runtime** — never hardcoded, so it cannot rot.
- Asserts exactly the intended set is invoked in `index.ts`, with a documented `INTENTIONALLY_DORMANT` allowlist carrying a one-line, evidence-backed justification per module.
- Checked **per name**, so a single module wired directly (`registerSendCommand(program)`) is caught, not only bulk wiring (the lesson of #201).
- Asserts per parsing path (export size; allowlist names still exported; wired/dormant partition is disjoint and exhaustive; an explicit detector control) — no merged-total-only assertion.

**Mutation-checked:** wiring `registerSendCommand(program)` in `index.ts` made two assertions fail with `[ 'registerSendCommand' ]`; reverted.

## Verification

- `vitest run` new file → **7 passed**
- `tsc --noEmit` → clean
- full suite → **5114 passed, 21 skipped** (baseline 5107 + these 7; no regressions)

Please review — do not merge; the wire/delete calls in #206 are yours.
