### PR TITLE
fix: PythonAgent failed to load on every single run

### DIFF
--- a/typescript/src/__tests__/integration/builtin-agents-load.test.ts
+++ b/typescript/src/__tests__/integration/builtin-agents-load.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { fileURLToPath } from 'node:url';
+import { BasicAgent } from '../../agents/BasicAgent.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const agentsSrcDir = path.resolve(__dirname, '../../agents');
+
+/**
+ * Every built-in agent file must survive discovery.
+ *
+ * `AgentRegistry` loads built-ins by importing each `*Agent` file and calling
+ * `new` on every export that extends `BasicAgent`. `PythonAgent` is a wrapper
+ * the registry builds once per descriptor found in a user's `.py` file, so it
+ * requires `(file, descriptor)` — and discovery reached it, threw on
+ * `descriptor.name`, and logged
+ *
+ *     WARN [agents] Agent file failed to load {"file":".../PythonAgent.js",
+ *       "reason":"Cannot read properties of undefined (reading 'name')"}
+ *
+ * on every single CLI invocation, while recording a permanent false entry in
+ * `getLoadFailures()`.
+ *
+ * The warning was the only symptom, and it had been printing in plain sight
+ * above `--list-agents` output. This test is the thing that would have failed.
+ *
+ * Note on the fix: constructor arity looks like a tidy way to detect "cannot be
+ * built bare", and is wrong. An optional TypeScript parameter still counts
+ * toward `Function.length`, so `ShellAgent` reports arity 1 while constructing
+ * perfectly well with no arguments. Only an explicit marker distinguishes a
+ * template from an agent, which is why `isTemplate` exists.
+ */
+
+/** The built-in agent files exactly as `AgentRegistry` selects them. */
+function builtinAgentFiles(): string[] {
+  return fs
+    .readdirSync(agentsSrcDir)
+    .filter((f) => f.endsWith('Agent.ts'))
+    .filter((f) => !f.startsWith('Basic') && !f.startsWith('_'))
+    .filter((f) => !f.endsWith('.test.ts'));
+}
+
+describe('built-in agent discovery', () => {
+  it('finds a non-trivial number of built-in agent files', () => {
+    // Anti-vacuity: a broken filter would otherwise make every assertion below
+    // pass by having nothing to assert against.
+    expect(builtinAgentFiles().length).toBeGreaterThan(20);
+  });
+
+  it('constructs every discoverable built-in agent with no arguments', async () => {
+    const failures: string[] = [];
+    let constructed = 0;
+    let templatesSkipped = 0;
+
+    for (const file of builtinAgentFiles()) {
+      const modulePath = path.join(agentsSrcDir, file);
+      let mod: Record<string, unknown>;
+      try {
+        mod = (await import(pathToFileURL(modulePath).href)) as Record<string, unknown>;
+      } catch (error) {
+        failures.push(`${file} failed to import: ${(error as Error).message}`);
+        continue;
+      }
+
+      for (const [exportName, exported] of Object.entries(mod)) {
+        if (typeof exported !== 'function') continue;
+        if (!(exported.prototype instanceof BasicAgent)) continue;
+
+        // Mirrors the registry's own skip, so a template is not a failure.
+        if ((exported as { isTemplate?: boolean }).isTemplate) {
+          templatesSkipped++;
+          continue;
+        }
+
+        try {
+          new (exported as new () => BasicAgent)();
+          constructed++;
+        } catch (error) {
+          failures.push(
+            `${file} → ${exportName} cannot be constructed with no arguments: ` +
+              `${(error as Error).message}. Either give it a no-argument path, or mark it ` +
+              `\`static readonly isTemplate = true\` if the registry builds it some other way.`,
+          );
+        }
+      }
+    }
+
+    expect(constructed, 'discovery should construct many agents').toBeGreaterThan(20);
+    expect(failures, failures.join('\n')).toEqual([]);
+    // PythonAgent is the template this test was written for; if it stops being
+    // one, the assertion above starts covering it instead.
+    expect(templatesSkipped).toBeGreaterThan(0);
+  }, 120_000);
+});

--- a/typescript/src/agents/AgentRegistry.ts
+++ b/typescript/src/agents/AgentRegistry.ts
@@ -119,7 +119,14 @@ export class AgentRegistry {
             const ExportedClass = mod[exportName];
             if (
               typeof ExportedClass === 'function' &&
-              ExportedClass.prototype instanceof BasicAgent
+              ExportedClass.prototype instanceof BasicAgent &&
+              // A template is constructed per descriptor elsewhere and cannot be
+              // instantiated bare; calling `new` on it here throws and records a
+              // permanent, false load failure. Constructor arity cannot be used
+              // to detect this — an optional parameter still counts toward
+              // `Function.length`, so ShellAgent reports arity 1 while loading
+              // perfectly well.
+              !(ExportedClass as { isTemplate?: boolean }).isTemplate
             ) {
               const instance = new ExportedClass() as BasicAgent;
               this.agents.set(instance.name, instance);

--- a/typescript/src/agents/PythonAgent.ts
+++ b/typescript/src/agents/PythonAgent.ts
@@ -161,6 +161,18 @@ export async function introspectPythonAgents(
  * is what lets a dropped file be usable in the very next message.
  */
 export class PythonAgent extends BasicAgent {
+  /**
+   * Not a standalone agent.
+   *
+   * This class is a wrapper the registry constructs once per descriptor found
+   * in a user's `.py` file, so it needs `(file, descriptor)` and cannot be
+   * instantiated bare. Built-in discovery instantiates every exported subclass
+   * of `BasicAgent` with no arguments, which meant it reached this constructor,
+   * threw on `descriptor.name`, and recorded `PythonAgent.js` as a failed agent
+   * file on every single run. The marker is what tells discovery to skip it.
+   */
+  static readonly isTemplate = true;
+
   private readonly file: string;
   private readonly agentName: string;
   private readonly python: string;


### PR DESCRIPTION
Every invocation of the CLI printed this, directly above its own output:

```
WARN [agents] Agent file failed to load
  {"file":".../dist/agents/PythonAgent.js",
   "reason":"Cannot read properties of undefined (reading 'name')"}
```

## Cause

Built-in discovery imports each `*Agent` file and calls `new` on every export extending `BasicAgent`. **`PythonAgent` is not a standalone agent** — it is a wrapper the registry builds once per descriptor found in a user's `.py` file, so it requires `(file, descriptor)`.

Discovery reached it anyway, threw on `descriptor.name`, and recorded `PythonAgent.js` in `getLoadFailures()` as a broken agent file — permanently and falsely, on every run.

Nothing was lost (`--list-agents` reports **37 before and after**, because PythonAgent was never one of them), but the registry has been reporting a failure that is its own doing, and anyone reading load failures to debug a *genuinely* broken agent had to know to ignore this one.

Fixed with `static readonly isTemplate = true`, which discovery now skips.

## Constructor arity would have been the wrong fix

Filtering on "needs arguments" is the obvious approach and it is **wrong**: an optional TypeScript parameter still counts toward `Function.length`.

| class | arity | constructs bare? |
|---|---|---|
| `ShellAgent` | **1** | yes |
| `PythonAgent` | 2 | no |

Filtering on arity would have skipped a real agent. Only an explicit marker separates a template from an agent — I found this only because I measured the arities instead of assuming them.

## The guard is general

It constructs every built-in the way discovery does and fails on any that cannot be built, naming the file and both ways to resolve it. **PythonAgent was the only one of 34.**

- **Mutation-checked** — removing the marker fails with `PythonAgent cannot be constructed with no arguments`.
- **Verified end to end** — rebuilt; the warning is gone from `--list-agents`, count unchanged at 37.

Suite: **5109 passed**, 21 skipped. `tsc` clean.