### PR TITLE
test: replace 5 vacuous parity suites with real product-code tests

### DIFF
--- a/typescript/src/__tests__/parity/config.test.ts
+++ b/typescript/src/__tests__/parity/config.test.ts
@@ -1,321 +1,119 @@
 /**
  * Config System Parity Tests
- * Tests that openrappter config system matches openclaw:
- * - Zod schema validation
- * - JSON5/YAML loading
- * - File watcher for hot reload
- * - All config domains (agent, channels, gateway, models, etc.)
+ *
+ * Exercises the real config loader and schema (src/config/loader.ts,
+ * src/config/schema.ts). The previous version of this file built literal config
+ * objects and asserted on their own shape — e.g. "should reject invalid config
+ * values" built an array of `{ port, error }` literals and only checked that the
+ * `error` strings it had just written were defined, never calling the validator.
+ * It also encoded claims that are wrong for the real schema (gateway.auth.mode
+ * has no 'token' option; chunkTokens has no positivity constraint). These tests
+ * call the real validateConfig / mergeConfigs / substituteEnvVars /
+ * parseConfigContent.
+ *
+ * config-system.test.ts covers mergePatch / expandEnvVars / migrateConfig; this
+ * file covers the loader.ts helpers and the Zod range/enum constraints.
  */
 
 import { describe, it, expect } from 'vitest';
+import { validateConfig } from '../../config/schema.js';
+import { mergeConfigs, substituteEnvVars, parseConfigContent } from '../../config/loader.js';
+import type { OpenRappterConfig, GatewayConfig } from '../../config/types.js';
 
 describe('Config System Parity', () => {
-  describe('Config Schema Validation', () => {
-    it('should validate agent config', () => {
-      const agentConfig = {
-        id: 'main',
-        name: 'Main Agent',
-        model: 'claude-3-sonnet',
-        workspace: '~/.openrappter/workspace',
-        skills: ['shell', 'memory'],
-        temperature: 0.7,
-        maxTokens: 4096,
-      };
-
-      expect(agentConfig.id).toBeDefined();
-      expect(agentConfig.model).toBeDefined();
-      expect(agentConfig.temperature).toBeGreaterThanOrEqual(0);
-      expect(agentConfig.temperature).toBeLessThanOrEqual(2);
+  describe('Schema validation (validateConfig)', () => {
+    it('accepts an empty config', () => {
+      expect(validateConfig({}).success).toBe(true);
     });
 
-    it('should validate channel config', () => {
-      const channelConfig = {
-        telegram: {
-          enabled: true,
-          token: 'bot_token',
-          allowFrom: ['user_123'],
-          mentionGating: true,
-        },
-        discord: {
-          enabled: false,
-          token: 'discord_token',
-          guildId: 'guild_123',
-        },
-      };
-
-      expect(channelConfig.telegram.enabled).toBe(true);
-      expect(typeof channelConfig.telegram.mentionGating).toBe('boolean');
+    it('accepts a valid gateway config', () => {
+      const result = validateConfig({ gateway: { port: 18790, bind: 'loopback' } });
+      expect(result.success).toBe(true);
+      expect(result.data?.gateway?.port).toBe(18790);
     });
 
-    it('should validate gateway config', () => {
-      const gatewayConfig = {
-        port: 18790,
-        bind: 'loopback' as const,
-        auth: {
-          mode: 'token' as const,
-          token: 'secret_token',
-        },
-        tls: {
-          enabled: false,
-          cert: '',
-          key: '',
-        },
-      };
-
-      expect(gatewayConfig.port).toBe(18790);
-      expect(['loopback', 'all', 'lan', 'tailscale']).toContain(gatewayConfig.bind);
-      expect(['none', 'password', 'token']).toContain(gatewayConfig.auth.mode);
+    it('rejects a gateway port below the valid range', () => {
+      expect(validateConfig({ gateway: { port: -1 } }).success).toBe(false);
     });
 
-    it('should validate model config', () => {
-      const modelConfig = {
-        id: 'claude-3',
-        provider: 'anthropic' as const,
-        model: 'claude-3-sonnet-20240229',
-        auth: {
-          type: 'api-key' as const,
-          tokenEnv: 'ANTHROPIC_API_KEY',
-        },
-        fallbacks: ['openai:gpt-4'],
-      };
-
-      expect(modelConfig.provider).toBe('anthropic');
-      expect(['anthropic', 'openai', 'gemini', 'ollama', 'copilot']).toContain(modelConfig.provider);
+    it('rejects a gateway port above 65535', () => {
+      expect(validateConfig({ gateway: { port: 99999 } }).success).toBe(false);
     });
 
-    it('should validate memory config', () => {
-      const memoryConfig = {
-        provider: 'openai' as const,
-        chunkTokens: 512,
-        chunkOverlap: 64,
-        searchThreshold: 0.7,
-      };
-
-      expect(memoryConfig.chunkTokens).toBeGreaterThan(0);
-      expect(memoryConfig.chunkOverlap).toBeLessThan(memoryConfig.chunkTokens);
+    it('rejects a non-integer gateway port', () => {
+      expect(validateConfig({ gateway: { port: 18790.5 } }).success).toBe(false);
     });
 
-    it('should validate cron config', () => {
-      const cronConfig = {
-        enabled: true,
-        jobs: [
-          {
-            name: 'health-check',
-            schedule: '*/5 * * * *',
-            agent: 'main',
-            message: 'Run health check',
-          },
-        ],
-      };
-
-      expect(cronConfig.enabled).toBe(true);
-      expect(cronConfig.jobs.length).toBeGreaterThan(0);
+    it('rejects an unknown gateway bind value', () => {
+      expect(validateConfig({ gateway: { bind: 'everywhere' } }).success).toBe(false);
     });
 
-    it('should validate approval config', () => {
-      const approvalConfig = {
-        policy: 'allowlist' as const,
-        rules: [
-          { tool: 'bash', action: 'allow', patterns: ['ls *', 'cat *'] },
-          { tool: 'bash', action: 'deny', patterns: ['rm -rf *'] },
-        ],
-      };
-
-      expect(['deny', 'allowlist', 'full']).toContain(approvalConfig.policy);
-    });
-
-    it('should validate TTS config', () => {
-      const ttsConfig = {
-        enabled: false,
-        provider: 'openai' as const,
-        voice: 'alloy',
-        speed: 1.0,
-      };
-
-      expect(typeof ttsConfig.enabled).toBe('boolean');
-      expect(ttsConfig.speed).toBeGreaterThan(0);
-    });
-
-    it('should reject invalid config values', () => {
-      const invalidConfigs = [
-        { port: -1, error: 'Port must be positive' },
-        { port: 99999, error: 'Port must be less than 65536' },
-        { temperature: 3, error: 'Temperature must be between 0 and 2' },
-        { chunkTokens: 0, error: 'Chunk tokens must be positive' },
-      ];
-
-      invalidConfigs.forEach((invalid) => {
-        expect(invalid.error).toBeDefined();
+    it('rejects an unknown model provider', () => {
+      const result = validateConfig({
+        models: [{ id: 'm', provider: 'not-a-provider', model: 'x', auth: { type: 'api-key' } }],
       });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts a valid model provider', () => {
+      const result = validateConfig({
+        models: [{ id: 'm', provider: 'anthropic', model: 'claude', auth: { type: 'api-key' } }],
+      });
+      expect(result.success).toBe(true);
     });
   });
 
-  describe('Config File Loading', () => {
-    it('should load JSON5 config', () => {
-      const json5Content = `{
-        // Comments are allowed in JSON5
-        agent: {
-          model: "claude-3-sonnet",
-          temperature: 0.7,
-        },
+  describe('Config merging (mergeConfigs)', () => {
+    it('lets a later config override earlier gateway fields while preserving the rest', () => {
+      const defaults: Partial<OpenRappterConfig> = { gateway: { port: 18790, bind: 'loopback' } };
+      const user: Partial<OpenRappterConfig> = { gateway: { port: 9999 } as GatewayConfig };
+
+      const merged = mergeConfigs(defaults, user);
+      expect(merged.gateway?.port).toBe(9999);
+      expect(merged.gateway?.bind).toBe('loopback');
+    });
+
+    it('concatenates model lists across configs', () => {
+      const merged = mergeConfigs(
+        { models: [{ id: 'a', provider: 'anthropic', model: 'claude', auth: { type: 'api-key' } }] },
+        { models: [{ id: 'b', provider: 'openai', model: 'gpt', auth: { type: 'api-key' } }] }
+      );
+      expect(merged.models?.map((m) => m.id)).toEqual(['a', 'b']);
+    });
+  });
+
+  describe('Environment variable substitution (substituteEnvVars)', () => {
+    it('substitutes a defined ${VAR}', () => {
+      const key = 'OPENRAPPTER_PARITY_TEST_VAR';
+      process.env[key] = 'super-secret';
+      try {
+        expect(substituteEnvVars(`token-\${${key}}`)).toBe('token-super-secret');
+      } finally {
+        delete process.env[key];
+      }
+    });
+
+    it('substitutes an undefined ${VAR} with an empty string', () => {
+      const key = 'OPENRAPPTER_PARITY_UNSET_VAR';
+      delete process.env[key];
+      expect(substituteEnvVars(`x-\${${key}}-y`)).toBe('x--y');
+    });
+  });
+
+  describe('JSON5 parsing (parseConfigContent)', () => {
+    it('parses JSON5 with comments and trailing commas', () => {
+      const parsed = parseConfigContent(`{
+        // gateway settings
         gateway: {
           port: 18790,
         },
-      }`;
+      }`) as { gateway: { port: number } };
 
-      expect(json5Content).toContain('//');
-      expect(json5Content).toContain('agent');
+      expect(parsed.gateway.port).toBe(18790);
     });
 
-    it('should load YAML config', () => {
-      const yamlContent = `
-agent:
-  model: claude-3-sonnet
-  temperature: 0.7
-
-gateway:
-  port: 18790
-  bind: loopback
-`;
-
-      expect(yamlContent).toContain('agent:');
-      expect(yamlContent).toContain('gateway:');
-    });
-
-    it('should support environment variable substitution', () => {
-      const configWithEnvVars = {
-        agent: {
-          model: '${MODEL_NAME:-claude-3-sonnet}',
-        },
-        channels: {
-          telegram: {
-            token: '${TELEGRAM_BOT_TOKEN}',
-          },
-        },
-      };
-
-      expect(configWithEnvVars.channels.telegram.token).toContain('$');
-    });
-
-    it('should merge default config with user config', () => {
-      const defaults = {
-        gateway: { port: 18790, bind: 'loopback' },
-        agent: { temperature: 0.7 },
-      };
-
-      const userConfig = {
-        gateway: { port: 9999 },
-        agent: { model: 'gpt-4' },
-      };
-
-      const merged = {
-        gateway: { ...defaults.gateway, ...userConfig.gateway },
-        agent: { ...defaults.agent, ...userConfig.agent },
-      };
-
-      expect(merged.gateway.port).toBe(9999);
-      expect(merged.gateway.bind).toBe('loopback');
-      expect(merged.agent.temperature).toBe(0.7);
-      expect(merged.agent.model).toBe('gpt-4');
-    });
-
-    it('should resolve config file from standard paths', () => {
-      const searchPaths = [
-        './openrappter.config.json5',
-        './openrappter.config.yaml',
-        '~/.openrappter/config.json5',
-        '~/.openrappter/config.yaml',
-      ];
-
-      expect(searchPaths.length).toBeGreaterThanOrEqual(4);
-    });
-  });
-
-  describe('Config Hot Reload', () => {
-    it('should watch config file for changes', () => {
-      const watcher = {
-        path: '~/.openrappter/config.json5',
-        watching: true,
-        debounceMs: 500,
-      };
-
-      expect(watcher.watching).toBe(true);
-      expect(watcher.debounceMs).toBeGreaterThan(0);
-    });
-
-    it('should emit change events', () => {
-      const changeEvent = {
-        type: 'config:changed',
-        path: '~/.openrappter/config.json5',
-        changedKeys: ['agent.model', 'gateway.port'],
-        timestamp: new Date().toISOString(),
-      };
-
-      expect(changeEvent.changedKeys.length).toBeGreaterThan(0);
-    });
-
-    it('should validate before applying changes', () => {
-      const reloadResult = {
-        success: true,
-        validationErrors: [] as string[],
-        appliedAt: new Date().toISOString(),
-      };
-
-      expect(reloadResult.success).toBe(true);
-      expect(reloadResult.validationErrors).toHaveLength(0);
-    });
-
-    it('should rollback on invalid config', () => {
-      const reloadResult = {
-        success: false,
-        validationErrors: ['Invalid port: -1'],
-        rolledBack: true,
-      };
-
-      expect(reloadResult.success).toBe(false);
-      expect(reloadResult.rolledBack).toBe(true);
-    });
-  });
-
-  describe('Config RPC Methods', () => {
-    it('should support config.get', () => {
-      const request = { method: 'config.get', params: { key: 'agent.model' } };
-      const response = { result: 'claude-3-sonnet' };
-
-      expect(request.params.key).toBeDefined();
-      expect(response.result).toBeDefined();
-    });
-
-    it('should support config.set', () => {
-      const request = { method: 'config.set', params: { key: 'agent.model', value: 'gpt-4' } };
-      const response = { result: { success: true } };
-
-      expect(request.params.value).toBeDefined();
-      expect(response.result.success).toBe(true);
-    });
-
-    it('should support config.patch', () => {
-      const request = {
-        method: 'config.patch',
-        params: { patch: { agent: { temperature: 0.5 } } },
-      };
-
-      expect(request.params.patch).toBeDefined();
-    });
-
-    it('should support config.schema', () => {
-      const response = {
-        result: {
-          type: 'object',
-          properties: {
-            agent: { type: 'object' },
-            gateway: { type: 'object' },
-            channels: { type: 'object' },
-          },
-        },
-      };
-
-      expect(response.result.properties.agent).toBeDefined();
+    it('throws on malformed content instead of returning a partial object', () => {
+      expect(() => parseConfigContent('{ not valid : : }')).toThrow();
     });
   });
 });

--- a/typescript/src/__tests__/parity/providers.test.ts
+++ b/typescript/src/__tests__/parity/providers.test.ts
@@ -1,251 +1,126 @@
 /**
  * Provider Parity Tests
- * Tests that openrappter model providers match openclaw:
- * - OpenAI, Anthropic, Gemini, Ollama
- * - Failover chains
- * - Embedding support
- * - Auth flows per provider
+ *
+ * Exercises the real ProviderRegistry (src/providers/registry.ts) — registration,
+ * lookup, availability filtering, and chat failover. The previous version of this
+ * file built literal arrays/objects and asserted on their own shape (e.g.
+ * `const chain = ['anthropic','openai','ollama']; expect(chain[0]).toBe('anthropic')`),
+ * so it passed no matter what the registry did. These tests register real and
+ * mock providers and assert on the registry's behaviour.
  */
 
 import { describe, it, expect } from 'vitest';
+import { ProviderRegistry, createDefaultRegistry } from '../../providers/registry.js';
+import type { LLMProvider, ProviderResponse, Message } from '../../providers/types.js';
+
+function mockProvider(
+  id: string,
+  behaviour: { response?: Partial<ProviderResponse>; throws?: boolean; available?: boolean }
+): LLMProvider {
+  return {
+    id,
+    name: id,
+    async chat(): Promise<ProviderResponse> {
+      if (behaviour.throws) throw new Error(`${id} failed`);
+      return { content: `from-${id}`, tool_calls: null, ...behaviour.response };
+    },
+    async isAvailable(): Promise<boolean> {
+      return behaviour.available ?? true;
+    },
+  };
+}
+
+const messages: Message[] = [{ role: 'user', content: 'hi' }];
 
 describe('Provider Parity', () => {
-  describe('Provider Registry', () => {
-    it('should support all required providers', () => {
-      const requiredProviders = ['anthropic', 'openai', 'gemini', 'ollama'];
-      expect(requiredProviders.length).toBeGreaterThanOrEqual(4);
+  describe('Default registry', () => {
+    it('registers the built-in providers', () => {
+      const registry = createDefaultRegistry();
+      expect(registry.list().sort()).toEqual(['anthropic', 'ollama', 'openai']);
+      expect(registry.has('anthropic')).toBe(true);
+      expect(registry.get('openai')?.id).toBe('openai');
     });
 
-    it('should register and retrieve providers', () => {
-      const registry = new Map<string, { id: string; name: string }>();
-      registry.set('anthropic', { id: 'anthropic', name: 'Anthropic' });
-      registry.set('openai', { id: 'openai', name: 'OpenAI' });
-      registry.set('ollama', { id: 'ollama', name: 'Ollama' });
-      registry.set('gemini', { id: 'gemini', name: 'Google Gemini' });
-
-      expect(registry.size).toBe(4);
-      expect(registry.get('anthropic')?.name).toBe('Anthropic');
+    it('does not report a provider that was never registered', () => {
+      const registry = createDefaultRegistry();
+      expect(registry.has('gemini')).toBe(false);
+      expect(registry.get('gemini')).toBeUndefined();
     });
   });
 
-  describe('Chat Interface', () => {
-    it('should send chat messages', () => {
-      const messages = [
-        { role: 'system' as const, content: 'You are a helpful assistant.' },
-        { role: 'user' as const, content: 'Hello' },
-      ];
+  describe('Registration and lookup', () => {
+    it('registers and retrieves a provider by id', () => {
+      const registry = new ProviderRegistry();
+      const provider = mockProvider('custom', {});
+      registry.register(provider);
 
-      expect(messages.length).toBe(2);
-      expect(messages[0].role).toBe('system');
+      expect(registry.get('custom')).toBe(provider);
+      expect(registry.has('custom')).toBe(true);
+      expect(registry.list()).toContain('custom');
     });
 
-    it('should return chat response', () => {
-      const response = {
-        content: 'Hello! How can I help you today?',
-        model: 'claude-3-sonnet',
-        usage: {
-          inputTokens: 20,
-          outputTokens: 15,
-        },
-        toolCalls: null,
-      };
-
-      expect(response.content).toBeDefined();
-      expect(response.usage.inputTokens).toBeGreaterThan(0);
-    });
-
-    it('should support tool calls', () => {
-      const response = {
-        content: null,
-        toolCalls: [
-          {
-            id: 'tc_1',
-            type: 'function' as const,
-            function: {
-              name: 'bash',
-              arguments: '{"command":"ls -la"}',
-            },
-          },
-        ],
-      };
-
-      expect(response.toolCalls).toHaveLength(1);
-      expect(response.toolCalls![0].function.name).toBe('bash');
-    });
-
-    it('should support streaming', () => {
-      const chunks = [
-        { content: 'Hello', done: false },
-        { content: ' world', done: false },
-        { content: '!', done: true, usage: { inputTokens: 5, outputTokens: 3 } },
-      ];
-
-      expect(chunks[chunks.length - 1].done).toBe(true);
-    });
-
-    it('should support chat options', () => {
-      const options = {
-        model: 'claude-3-sonnet',
-        temperature: 0.7,
-        maxTokens: 4096,
-        stream: true,
-        tools: [
-          {
-            type: 'function' as const,
-            function: {
-              name: 'bash',
-              description: 'Execute a bash command',
-              parameters: {
-                type: 'object',
-                properties: {
-                  command: { type: 'string' },
-                },
-                required: ['command'],
-              },
-            },
-          },
-        ],
-      };
-
-      expect(options.temperature).toBeGreaterThanOrEqual(0);
-      expect(options.tools!.length).toBeGreaterThan(0);
+    it('replaces a provider registered under the same id', () => {
+      const registry = new ProviderRegistry();
+      registry.register(mockProvider('dup', { response: { content: 'first' } }));
+      registry.register(mockProvider('dup', { response: { content: 'second' } }));
+      expect(registry.list()).toEqual(['dup']);
     });
   });
 
-  describe('Failover', () => {
-    it('should try providers in chain order', () => {
-      const chain = ['anthropic', 'openai', 'ollama'];
-      expect(chain[0]).toBe('anthropic');
-      expect(chain.length).toBeGreaterThan(1);
-    });
+  describe('Availability filtering', () => {
+    it('returns only providers that report themselves available', async () => {
+      const registry = new ProviderRegistry();
+      registry.register(mockProvider('up', { available: true }));
+      registry.register(mockProvider('down', { available: false }));
 
-    it('should fall back on provider error', () => {
-      const results = [
-        { provider: 'anthropic', success: false, error: 'Rate limited' },
-        { provider: 'openai', success: true, response: 'Hello!' },
-      ];
-
-      const firstSuccess = results.find((r) => r.success);
-      expect(firstSuccess?.provider).toBe('openai');
-    });
-
-    it('should retry with delay', () => {
-      const retryConfig = {
-        maxRetries: 2,
-        delayMs: 1000,
-        backoffMultiplier: 2,
-      };
-
-      expect(retryConfig.maxRetries).toBeGreaterThan(0);
-      expect(retryConfig.delayMs).toBeGreaterThan(0);
-    });
-
-    it('should fail if all providers fail', () => {
-      const allFailed = [
-        { provider: 'anthropic', error: 'Rate limited' },
-        { provider: 'openai', error: 'API key invalid' },
-        { provider: 'ollama', error: 'Connection refused' },
-      ];
-
-      expect(allFailed.every((r) => 'error' in r)).toBe(true);
+      const available = await registry.getAvailable();
+      expect(available.map((p) => p.id)).toEqual(['up']);
     });
   });
 
-  describe('Embedding Support', () => {
-    it('should generate embeddings', () => {
-      const request = {
-        texts: ['Hello world', 'How are you'],
-        model: 'text-embedding-3-small',
-      };
+  describe('Chat failover', () => {
+    it('falls over to the next provider when the first throws', async () => {
+      const registry = new ProviderRegistry();
+      registry.register(mockProvider('primary', { throws: true }));
+      registry.register(mockProvider('secondary', { response: { content: 'rescued' } }));
 
-      expect(request.texts.length).toBe(2);
+      const response = await registry.chatWithFailover(
+        ['primary', 'secondary'],
+        messages,
+        undefined,
+        { maxRetries: 0, retryDelayMs: 0 }
+      );
+      expect(response.content).toBe('rescued');
     });
 
-    it('should return embedding vectors', () => {
-      const response = {
-        embeddings: [
-          new Float32Array([0.1, 0.2, 0.3]),
-          new Float32Array([0.4, 0.5, 0.6]),
-        ],
-        model: 'text-embedding-3-small',
-        dimensions: 3,
-      };
+    it('returns the first provider that succeeds without trying the rest', async () => {
+      const registry = new ProviderRegistry();
+      registry.register(mockProvider('first', { response: { content: 'first-wins' } }));
+      registry.register(mockProvider('second', { response: { content: 'unused' } }));
 
-      expect(response.embeddings.length).toBe(2);
-      expect(response.dimensions).toBe(3);
+      const response = await registry.chatWithFailover(
+        ['first', 'second'],
+        messages,
+        undefined,
+        { maxRetries: 0, retryDelayMs: 0 }
+      );
+      expect(response.content).toBe('first-wins');
     });
 
-    it('should support batch embedding', () => {
-      const batchSize = 100;
-      const texts = Array.from({ length: 150 }, (_, i) => `Text ${i}`);
+    it('throws when every provider in the chain fails', async () => {
+      const registry = new ProviderRegistry();
+      registry.register(mockProvider('only', { throws: true }));
 
-      const batches = [];
-      for (let i = 0; i < texts.length; i += batchSize) {
-        batches.push(texts.slice(i, i + batchSize));
-      }
-
-      expect(batches.length).toBe(2);
-    });
-  });
-
-  describe('Availability Check', () => {
-    it('should check provider availability', () => {
-      const availabilityChecks = [
-        { provider: 'anthropic', available: true, latencyMs: 150 },
-        { provider: 'openai', available: true, latencyMs: 200 },
-        { provider: 'ollama', available: false, error: 'Connection refused' },
-        { provider: 'gemini', available: true, latencyMs: 180 },
-      ];
-
-      const available = availabilityChecks.filter((c) => c.available);
-      expect(available.length).toBeGreaterThan(0);
-    });
-  });
-
-  describe('Provider Auth', () => {
-    it('should support API key auth', () => {
-      const auth = {
-        type: 'api-key' as const,
-        tokenEnv: 'ANTHROPIC_API_KEY',
-      };
-
-      expect(auth.type).toBe('api-key');
+      await expect(
+        registry.chatWithFailover(['only'], messages, undefined, { maxRetries: 0, retryDelayMs: 0 })
+      ).rejects.toThrow(/All providers failed/);
     });
 
-    it('should support OAuth auth', () => {
-      const auth = {
-        type: 'oauth' as const,
-        clientId: 'client_123',
-        scopes: ['chat', 'embeddings'],
-      };
-
-      expect(auth.type).toBe('oauth');
-    });
-
-    it('should support device flow auth', () => {
-      const auth = {
-        type: 'device' as const,
-        deviceCode: 'device_abc',
-        userCode: 'USER-1234',
-        verificationUrl: 'https://provider.com/device',
-      };
-
-      expect(auth.type).toBe('device');
-    });
-  });
-
-  describe('Models RPC Method', () => {
-    it('should support models.list', () => {
-      const response = {
-        models: [
-          { id: 'claude-3-sonnet', provider: 'anthropic', available: true },
-          { id: 'gpt-4', provider: 'openai', available: true },
-          { id: 'llama3', provider: 'ollama', available: false },
-          { id: 'gemini-pro', provider: 'gemini', available: true },
-        ],
-      };
-
-      expect(response.models.length).toBeGreaterThanOrEqual(4);
+    it('reports a chain entry that is not registered as a failure', async () => {
+      const registry = new ProviderRegistry();
+      await expect(
+        registry.chatWithFailover(['ghost'], messages, undefined, { maxRetries: 0, retryDelayMs: 0 })
+      ).rejects.toThrow(/All providers failed/);
     });
   });
 });

--- a/typescript/src/__tests__/parity/security.test.ts
+++ b/typescript/src/__tests__/parity/security.test.ts
@@ -1,250 +1,203 @@
 /**
  * Security & Approvals Parity Tests
- * Tests that openrappter security system matches openclaw:
- * - Execution approvals (request, resolve, policies)
- * - Scope-based authorization
- * - Audit logging
- * - Device auth scopes
+ *
+ * Exercises the real ApprovalManager (src/security/approvals.ts) — the product
+ * code that actually enforces tool-execution policy. An earlier version of this
+ * file built literal objects and asserted on their own shape, so it passed no
+ * matter what the product did (proven: mutating checkApproval's deny branch to
+ * `allowed: true` left every test green). These tests call the real manager and
+ * assert on its decisions, and they deliberately cover ground that
+ * showcase-auth-fortress.test.ts does not: per-sender scoping, allowlist by
+ * command prefix, blocked tools/commands, and the request expiration path.
  */
 
 import { describe, it, expect } from 'vitest';
+import { createApprovalManager } from '../../security/approvals.js';
+import type { ApprovalContext, ApprovalRule } from '../../security/approvals.js';
 
-describe('Security Parity', () => {
-  describe('Execution Approvals', () => {
-    it('should request approval for tool execution', () => {
-      const request = {
-        id: 'approval_123',
-        tool: 'bash',
-        args: { command: 'rm -rf /tmp/old-data' },
-        agentId: 'main',
-        sessionId: 'session_456',
-        requestedAt: new Date().toISOString(),
-        expiresAt: new Date(Date.now() + 300000).toISOString(),
-      };
+function rule(overrides: Partial<ApprovalRule> & Pick<ApprovalRule, 'id' | 'policy'>): ApprovalRule {
+  return {
+    name: overrides.id,
+    priority: 10,
+    enabled: true,
+    ...overrides,
+  };
+}
 
-      expect(request.id).toBeDefined();
-      expect(request.tool).toBe('bash');
+describe('Security & Approvals Parity', () => {
+  describe('Base policies (checkApproval)', () => {
+    it('deny policy blocks every tool call', () => {
+      const manager = createApprovalManager();
+      manager.setDefaultPolicy('deny');
+
+      const result = manager.checkApproval({ toolName: 'bash', toolArgs: { command: 'ls' } });
+      expect(result.allowed).toBe(false);
+      expect(result.requiresApproval).toBe(false);
+      expect(result.reason).toContain('denied');
     });
 
-    it('should resolve approval (approve)', () => {
-      const resolution = {
-        method: 'exec.approval.resolve',
-        params: {
-          requestId: 'approval_123',
-          decision: 'approved' as const,
-          resolvedBy: 'user_admin',
-        },
-      };
+    it('full policy allows every tool call', () => {
+      const manager = createApprovalManager();
+      manager.setDefaultPolicy('full');
 
-      expect(resolution.params.decision).toBe('approved');
+      const result = manager.checkApproval({ toolName: 'bash', toolArgs: { command: 'rm -rf /' } });
+      expect(result.allowed).toBe(true);
+      expect(result.requiresApproval).toBe(false);
     });
 
-    it('should resolve approval (deny)', () => {
-      const resolution = {
-        method: 'exec.approval.resolve',
-        params: {
-          requestId: 'approval_123',
-          decision: 'denied' as const,
-          reason: 'Too dangerous',
-        },
-      };
+    it('allowlist allows listed tools and requires approval for the rest', () => {
+      const manager = createApprovalManager();
+      manager.addRule(rule({ id: 'safe', policy: 'allowlist', allowedTools: ['read', 'list'] }));
 
-      expect(resolution.params.decision).toBe('denied');
+      expect(manager.checkApproval({ toolName: 'read', toolArgs: {} }).allowed).toBe(true);
+
+      const denied = manager.checkApproval({ toolName: 'bash', toolArgs: {} });
+      expect(denied.allowed).toBe(false);
+      expect(denied.requiresApproval).toBe(true);
+      expect(denied.reason).toContain('allowlist');
     });
 
-    it('should expire pending approvals', () => {
-      const expiredRequest = {
-        id: 'approval_old',
-        status: 'expired' as const,
-        expiresAt: '2024-01-01T00:00:00Z',
-      };
+    it('allowlist matches a command by prefix via allowedCommands', () => {
+      const manager = createApprovalManager();
+      manager.addRule(rule({ id: 'ls-only', policy: 'allowlist', allowedCommands: ['ls', 'cat'] }));
 
-      expect(expiredRequest.status).toBe('expired');
-    });
-
-    it('should list pending approvals', () => {
-      const response = {
-        method: 'exec.approvals.get',
-        result: {
-          pending: [
-            { id: 'approval_1', tool: 'bash', args: { command: 'npm install' } },
-            { id: 'approval_2', tool: 'write', args: { path: '/etc/config' } },
-          ],
-        },
-      };
-
-      expect(response.result.pending.length).toBeGreaterThan(0);
+      expect(manager.checkApproval({ toolName: 'bash', toolArgs: { command: 'ls -la /' } }).allowed).toBe(true);
+      expect(manager.checkApproval({ toolName: 'bash', toolArgs: { command: 'cat file' } }).allowed).toBe(true);
+      expect(manager.checkApproval({ toolName: 'bash', toolArgs: { command: 'rm file' } }).allowed).toBe(false);
     });
   });
 
-  describe('Approval Policies', () => {
-    it('should support deny-all policy', () => {
-      const policy = { mode: 'deny' as const };
-      expect(policy.mode).toBe('deny');
+  describe('Blocklists override the policy', () => {
+    it('blockedTools are refused even under a full policy', () => {
+      const manager = createApprovalManager();
+      manager.addRule(rule({ id: 'no-rm-tool', policy: 'full', blockedTools: ['dangerous'] }));
+
+      expect(manager.checkApproval({ toolName: 'read', toolArgs: {} }).allowed).toBe(true);
+
+      const blocked = manager.checkApproval({ toolName: 'dangerous', toolArgs: {} });
+      expect(blocked.allowed).toBe(false);
+      expect(blocked.reason).toContain('blocked');
     });
 
-    it('should support allowlist policy', () => {
-      const policy = {
-        mode: 'allowlist' as const,
-        rules: [
-          { tool: 'bash', allow: ['ls *', 'cat *', 'echo *'] },
-          { tool: 'read', allow: ['*'] },
-          { tool: 'write', deny: ['/etc/*', '/sys/*'] },
-        ],
-      };
+    it('blockedCommands match on substring inside the command args', () => {
+      const manager = createApprovalManager();
+      manager.addRule(rule({ id: 'no-rmrf', policy: 'full', blockedCommands: ['rm -rf'] }));
 
-      expect(policy.mode).toBe('allowlist');
-      expect(policy.rules.length).toBeGreaterThan(0);
+      expect(manager.checkApproval({ toolName: 'bash', toolArgs: { command: 'ls -la' } }).allowed).toBe(true);
+      expect(manager.checkApproval({ toolName: 'bash', toolArgs: { command: 'sudo rm -rf /' } }).allowed).toBe(false);
     });
 
-    it('should support full-access policy', () => {
-      const policy = { mode: 'full' as const };
-      expect(policy.mode).toBe('full');
-    });
+    it('blockedPatterns match via regex over the serialized args', () => {
+      const manager = createApprovalManager();
+      manager.addRule(rule({ id: 'regex-block', policy: 'full', blockedPatterns: ['rm\\s+-rf'] }));
 
-    it('should support per-channel policies', () => {
-      const channelPolicies = {
-        telegram: { mode: 'allowlist' as const },
-        discord: { mode: 'deny' as const },
-        cli: { mode: 'full' as const },
-      };
-
-      expect(channelPolicies.cli.mode).toBe('full');
-      expect(channelPolicies.discord.mode).toBe('deny');
-    });
-
-    it('should support per-sender policies', () => {
-      const senderPolicies = {
-        'user_admin': { mode: 'full' as const },
-        'user_guest': { mode: 'deny' as const },
-      };
-
-      expect(senderPolicies['user_admin'].mode).toBe('full');
-    });
-
-    it('should support per-agent policies', () => {
-      const agentPolicies = {
-        main: { mode: 'allowlist' as const },
-        readonly: { mode: 'deny' as const },
-      };
-
-      expect(agentPolicies.readonly.mode).toBe('deny');
-    });
-
-    it('should match patterns with wildcards', () => {
-      const matchPattern = (command: string, pattern: string): boolean => {
-        const regex = new RegExp('^' + pattern.replace(/\*/g, '.*') + '$');
-        return regex.test(command);
-      };
-
-      expect(matchPattern('ls -la', 'ls *')).toBe(true);
-      expect(matchPattern('rm -rf /', 'ls *')).toBe(false);
-      expect(matchPattern('cat file.txt', 'cat *')).toBe(true);
-    });
-
-    it('should prioritize rules correctly', () => {
-      const rules = [
-        { priority: 10, tool: 'bash', pattern: 'rm *', action: 'deny' },
-        { priority: 5, tool: 'bash', pattern: '*', action: 'allow' },
-        { priority: 1, tool: '*', pattern: '*', action: 'deny' },
-      ];
-
-      const sorted = [...rules].sort((a, b) => b.priority - a.priority);
-      expect(sorted[0].action).toBe('deny');
-      expect(sorted[0].pattern).toBe('rm *');
+      expect(manager.checkApproval({ toolName: 'bash', toolArgs: { command: 'echo hi' } }).allowed).toBe(true);
+      expect(manager.checkApproval({ toolName: 'bash', toolArgs: { command: 'rm   -rf /' } }).allowed).toBe(false);
     });
   });
 
-  describe('Scope-Based Authorization', () => {
-    it('should define authorization scopes', () => {
-      const scopes = [
-        'operator.admin',
-        'operator.read',
-        'operator.write',
-        'operator.approvals',
-        'operator.pairing',
-      ];
+  describe('Rule scoping', () => {
+    it('scopes a rule by channel', () => {
+      const manager = createApprovalManager();
+      manager.addRule(rule({ id: 'discord-deny', policy: 'deny', channels: ['discord'] }));
 
-      expect(scopes.length).toBeGreaterThanOrEqual(5);
+      const onDiscord: ApprovalContext = { toolName: 'bash', toolArgs: {}, channelId: 'discord' };
+      const onCli: ApprovalContext = { toolName: 'bash', toolArgs: {}, channelId: 'cli' };
+
+      expect(manager.checkApproval(onDiscord).allowed).toBe(false);
+      // cli doesn't match the discord-only rule and falls through to the default policy
+      expect(manager.checkApproval(onCli).rule?.id).toBeUndefined();
     });
 
-    it('should check scope authorization', () => {
-      const checkScope = (userScopes: string[], requiredScope: string): boolean => {
-        if (userScopes.includes('operator.admin')) return true;
-        return userScopes.includes(requiredScope);
-      };
+    it('scopes a rule by sender', () => {
+      const manager = createApprovalManager();
+      manager.addRule(rule({ id: 'guest-deny', policy: 'deny', senders: ['user_guest'] }));
 
-      expect(checkScope(['operator.admin'], 'operator.write')).toBe(true);
-      expect(checkScope(['operator.read'], 'operator.write')).toBe(false);
-      expect(checkScope(['operator.read', 'operator.write'], 'operator.write')).toBe(true);
+      const asGuest: ApprovalContext = { toolName: 'bash', toolArgs: {}, senderId: 'user_guest' };
+      const asAdmin: ApprovalContext = { toolName: 'bash', toolArgs: {}, senderId: 'user_admin' };
+
+      expect(manager.checkApproval(asGuest).allowed).toBe(false);
+      expect(manager.checkApproval(asGuest).rule?.id).toBe('guest-deny');
+      expect(manager.checkApproval(asAdmin).rule?.id).toBeUndefined();
     });
 
-    it('should assign scopes to device tokens', () => {
-      const deviceToken = {
-        deviceId: 'device_123',
-        token: 'token_abc',
-        scopes: ['operator.read', 'operator.write'],
-        expiresAt: new Date(Date.now() + 86400000 * 30).toISOString(),
-      };
+    it('scopes a rule by agent', () => {
+      const manager = createApprovalManager();
+      manager.addRule(rule({ id: 'shell-full', policy: 'full', agents: ['ShellAgent'] }));
 
-      expect(deviceToken.scopes).toContain('operator.read');
+      const shell: ApprovalContext = { toolName: 'bash', toolArgs: {}, agentId: 'ShellAgent' };
+      const other: ApprovalContext = { toolName: 'bash', toolArgs: {}, agentId: 'OtherAgent' };
+
+      expect(manager.checkApproval(shell).allowed).toBe(true);
+      expect(manager.checkApproval(other).rule?.id).toBeUndefined();
+    });
+
+    it('applies the highest-priority matching rule first', () => {
+      const manager = createApprovalManager();
+      manager.addRule(rule({ id: 'allow-bash', policy: 'full', tools: ['bash'], priority: 1 }));
+      manager.addRule(rule({ id: 'block-bash', policy: 'deny', tools: ['bash'], priority: 100 }));
+
+      const result = manager.checkApproval({ toolName: 'bash', toolArgs: {} });
+      expect(result.allowed).toBe(false);
+      expect(result.rule?.id).toBe('block-bash');
     });
   });
 
-  describe('Node-Level Approvals', () => {
-    it('should get node approval status', () => {
-      const response = {
-        nodeId: 'node_123',
-        policy: 'allowlist',
-        rules: [
-          { method: 'screenshot', allowed: true },
-          { method: 'database', allowed: false },
-        ],
-      };
+  describe('Request / approve / reject flow', () => {
+    it('creates a pending request and resolves it on approval', async () => {
+      const manager = createApprovalManager();
+      manager.setDefaultPolicy('allowlist'); // nothing allowlisted -> approval required
 
-      expect(response.rules.length).toBeGreaterThan(0);
+      const pending = manager.requestApproval({ toolName: 'bash', toolArgs: { command: 'npm i' } });
+
+      const requests = manager.getPendingRequests();
+      expect(requests).toHaveLength(1);
+      expect(requests[0].status).toBe('pending');
+
+      expect(manager.approveRequest(requests[0].id, 'admin')).toBe(true);
+
+      const result = await pending;
+      expect(result.allowed).toBe(true);
+      expect(result.reason).toContain('Approved');
+      // once resolved it is no longer pending
+      expect(manager.getPendingRequests()).toHaveLength(0);
     });
 
-    it('should set node approval policy', () => {
-      const request = {
-        method: 'exec.approvals.node.set',
-        params: {
-          nodeId: 'node_123',
+    it('creates a pending request and resolves it on rejection', async () => {
+      const manager = createApprovalManager();
+      manager.setDefaultPolicy('allowlist');
+
+      const pending = manager.requestApproval({ toolName: 'bash', toolArgs: {} });
+      const [req] = manager.getPendingRequests();
+
+      expect(manager.rejectRequest(req.id, 'Too dangerous', 'admin')).toBe(true);
+
+      const result = await pending;
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('Rejected');
+
+      const stored = manager.getRequest(req.id);
+      expect(stored?.status).toBe('rejected');
+      expect(stored?.reason).toBe('Too dangerous');
+    });
+
+    it('expires a request that is never resolved within its timeout', async () => {
+      const manager = createApprovalManager();
+      manager.addRule(
+        rule({
+          id: 'needs-approval',
           policy: 'allowlist',
-          allowedMethods: ['screenshot', 'notification'],
-        },
-      };
+          allowedTools: ['bash'],
+          requireApproval: true,
+          approvalTimeout: 30,
+        })
+      );
 
-      expect(request.params.allowedMethods).toContain('screenshot');
-    });
-  });
-
-  describe('Audit Logging', () => {
-    it('should log approval decisions', () => {
-      const auditEntry = {
-        timestamp: new Date().toISOString(),
-        type: 'approval_decision',
-        requestId: 'approval_123',
-        tool: 'bash',
-        args: { command: 'npm install' },
-        decision: 'approved',
-        resolvedBy: 'user_admin',
-      };
-
-      expect(auditEntry.type).toBe('approval_decision');
-      expect(auditEntry.decision).toBeDefined();
-    });
-
-    it('should log security events', () => {
-      const securityEvent = {
-        timestamp: new Date().toISOString(),
-        type: 'auth_failure',
-        deviceId: 'unknown',
-        reason: 'Invalid token',
-        ip: '192.168.1.100',
-      };
-
-      expect(securityEvent.type).toBe('auth_failure');
+      const result = await manager.requestApproval({ toolName: 'bash', toolArgs: {} });
+      expect(result.allowed).toBe(false);
+      expect(result.reason).toContain('timed out');
+      expect(result.requestId).toBeDefined();
+      expect(manager.getRequest(result.requestId!)?.status).toBe('expired');
     });
   });
 });

--- a/typescript/src/__tests__/parity/sessions.test.ts
+++ b/typescript/src/__tests__/parity/sessions.test.ts
@@ -1,189 +1,162 @@
 /**
  * Session Management Parity Tests
- * Tests that openrappter session system matches openclaw:
- * - Session isolation
- * - Session CRUD (list, preview, patch, reset, delete, compact)
- * - Context persistence
- * - JSONL transcript storage
+ *
+ * Exercises the real StorageAdapter (src/storage/sqlite.ts, in-memory mode) —
+ * the code that actually persists sessions. The previous version of this file
+ * built literal session/response objects and asserted on their own shape, so it
+ * passed no matter what the product did (e.g. it "verified" transcript storage
+ * with `expect('~/.openrappter/sessions/x.jsonl').toContain('.jsonl')`, a string
+ * compared against a substring of itself). These tests save real sessions and
+ * assert on what comes back out.
+ *
+ * showcase-persistence-vault.test.ts covers the save/get/delete happy path and
+ * channelId filtering; this file deliberately covers the rest of the isolation
+ * surface — userId / conversationId / agentId filtering, message + tool-call
+ * round-tripping, and metadata updates via upsert.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { createStorageAdapter } from '../../storage/index.js';
+import type { StorageAdapter, Session } from '../../storage/types.js';
+
+let storage: StorageAdapter;
+
+beforeEach(async () => {
+  storage = createStorageAdapter({ type: 'memory', inMemory: true });
+  await storage.initialize();
+});
+
+afterEach(async () => {
+  await storage.close();
+});
+
+function makeSession(overrides: Partial<Session> & Pick<Session, 'id'>): Session {
+  const now = new Date().toISOString();
+  return {
+    channelId: 'cli',
+    conversationId: 'conv',
+    agentId: 'main',
+    metadata: {},
+    messages: [],
+    createdAt: now,
+    updatedAt: now,
+    ...overrides,
+  };
+}
 
 describe('Session Management Parity', () => {
   describe('Session CRUD', () => {
-    it('should create session with unique ID', () => {
-      const session = {
-        id: 'session_abc123',
-        channelType: 'telegram',
-        channelId: 'chat_456',
-        userId: 'user_789',
-        agentId: 'main',
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
-        messages: [],
-        metadata: {},
-      };
-
-      expect(session.id).toBeDefined();
-      expect(session.messages).toHaveLength(0);
-    });
-
-    it('should list sessions with filters', () => {
-      const response = {
-        sessions: [
-          { id: 'session_1', channelType: 'telegram', userId: 'user_1', messageCount: 10 },
-          { id: 'session_2', channelType: 'telegram', userId: 'user_2', messageCount: 5 },
-        ],
-        total: 2,
-      };
-
-      expect(response.sessions.length).toBeGreaterThan(0);
-      expect(response.total).toBe(2);
-    });
-
-    it('should preview session (summary without full messages)', () => {
-      const response = {
-        id: 'session_1',
-        channelType: 'telegram',
-        userId: 'user_1',
-        messageCount: 50,
-        lastMessage: 'Thanks for the help!',
-        lastActivity: '2024-01-01T12:00:00Z',
-        tokenUsage: { total: 5000, prompt: 3000, completion: 2000 },
-      };
-
-      expect(response.messageCount).toBeGreaterThan(0);
-      expect(response.tokenUsage.total).toBeGreaterThan(0);
-    });
-
-    it('should patch session metadata', () => {
-      const request = {
-        method: 'sessions.patch',
-        params: {
-          sessionId: 'session_1',
-          metadata: { topic: 'code-review', priority: 'high' },
-        },
-      };
-
-      expect(request.params.metadata).toBeDefined();
-    });
-
-    it('should reset session (clear messages but keep session)', () => {
-      const response = {
-        success: true,
-        sessionId: 'session_1',
-        messagesCleared: 50,
-      };
-
-      expect(response.success).toBe(true);
-      expect(response.messagesCleared).toBeGreaterThan(0);
-    });
-
-    it('should delete session entirely', () => {
-      const response = { deleted: true };
-      expect(response.deleted).toBe(true);
-    });
-
-    it('should compact sessions (remove old data)', () => {
-      const response = {
-        compacted: 15,
-        freedBytes: 1024000,
-      };
-
-      expect(response.compacted).toBeGreaterThan(0);
-    });
-
-    it('should resolve session by channel + user', () => {
-      const response = {
-        sessionId: 'session_abc123',
-        isNew: false,
-      };
-
-      expect(response.sessionId).toBeDefined();
-    });
-  });
-
-  describe('Session Isolation', () => {
-    it('should isolate sessions per user', () => {
-      const sessions = new Map<string, { userId: string; messages: unknown[] }>();
-      sessions.set('session_1', { userId: 'user_A', messages: [{ content: 'secret A' }] });
-      sessions.set('session_2', { userId: 'user_B', messages: [{ content: 'secret B' }] });
-
-      expect(sessions.get('session_1')?.userId).toBe('user_A');
-      expect(sessions.get('session_2')?.userId).toBe('user_B');
-    });
-
-    it('should isolate sessions per channel', () => {
-      const sessionKey = (channelType: string, channelId: string, userId: string) =>
-        `${channelType}:${channelId}:${userId}`;
-
-      const key1 = sessionKey('telegram', 'chat_1', 'user_1');
-      const key2 = sessionKey('discord', 'ch_1', 'user_1');
-
-      expect(key1).not.toBe(key2);
-    });
-
-    it('should isolate agent state per session', () => {
-      const session1 = { agentId: 'main', systemPrompt: 'You are a code helper' };
-      const session2 = { agentId: 'main', systemPrompt: 'You are a writing assistant' };
-
-      expect(session1.systemPrompt).not.toBe(session2.systemPrompt);
-    });
-  });
-
-  describe('Context Persistence', () => {
-    it('should persist message history', () => {
-      const messages = [
-        { role: 'user', content: 'Hello' },
-        { role: 'assistant', content: 'Hi! How can I help?' },
-        { role: 'user', content: 'Write a function' },
-        { role: 'assistant', content: 'function hello() { ... }' },
-      ];
-
-      expect(messages.length).toBe(4);
-    });
-
-    it('should track token usage per session', () => {
-      const tokenUsage = {
-        totalTokens: 5000,
-        promptTokens: 3000,
-        completionTokens: 2000,
-        messages: 20,
-      };
-
-      expect(tokenUsage.totalTokens).toBe(
-        tokenUsage.promptTokens + tokenUsage.completionTokens
+    it('round-trips a session by id, including messages and metadata', async () => {
+      await storage.saveSession(
+        makeSession({
+          id: 'session_abc123',
+          userId: 'user_789',
+          metadata: { topic: 'code-review' },
+          messages: [
+            { id: 'm1', role: 'user', content: 'Hello', timestamp: new Date().toISOString() },
+            { id: 'm2', role: 'assistant', content: 'Hi!', timestamp: new Date().toISOString() },
+          ],
+        })
       );
+
+      const got = await storage.getSession('session_abc123');
+      expect(got).not.toBeNull();
+      expect(got!.userId).toBe('user_789');
+      expect(got!.metadata.topic).toBe('code-review');
+      expect(got!.messages).toHaveLength(2);
+      expect(got!.messages[1].content).toBe('Hi!');
     });
 
-    it('should track tool call history', () => {
-      const toolCalls = [
-        { id: 'tc_1', name: 'bash', args: { command: 'ls' }, result: 'file1.ts\nfile2.ts' },
-        { id: 'tc_2', name: 'read', args: { path: 'file1.ts' }, result: '// code...' },
-      ];
+    it('returns null for a session that was never saved', async () => {
+      expect(await storage.getSession('missing')).toBeNull();
+    });
 
-      expect(toolCalls.length).toBe(2);
+    it('deletes only the target session', async () => {
+      await storage.saveSession(makeSession({ id: 's1' }));
+      await storage.saveSession(makeSession({ id: 's2' }));
+
+      await storage.deleteSession('s1');
+
+      expect(await storage.getSession('s1')).toBeNull();
+      expect(await storage.getSession('s2')).not.toBeNull();
+    });
+
+    it('updates session metadata via upsert without creating a duplicate', async () => {
+      await storage.saveSession(makeSession({ id: 's1', metadata: { priority: 'low' } }));
+      await storage.saveSession(makeSession({ id: 's1', metadata: { priority: 'high' } }));
+
+      const all = await storage.listSessions();
+      expect(all).toHaveLength(1);
+      expect((await storage.getSession('s1'))!.metadata.priority).toBe('high');
     });
   });
 
-  describe('JSONL Transcript Storage', () => {
-    it('should store messages as JSONL', () => {
-      const jsonlLines = [
-        '{"role":"user","content":"Hello","timestamp":"2024-01-01T00:00:00Z"}',
-        '{"role":"assistant","content":"Hi!","timestamp":"2024-01-01T00:00:01Z"}',
-      ];
-
-      jsonlLines.forEach((line) => {
-        const parsed = JSON.parse(line);
-        expect(parsed.role).toBeDefined();
-        expect(parsed.content).toBeDefined();
-        expect(parsed.timestamp).toBeDefined();
-      });
+  describe('Session isolation via filters', () => {
+    beforeEach(async () => {
+      await storage.saveSession(makeSession({ id: 's_alice', userId: 'alice', channelId: 'telegram', conversationId: 'c1', agentId: 'main' }));
+      await storage.saveSession(makeSession({ id: 's_bob', userId: 'bob', channelId: 'telegram', conversationId: 'c2', agentId: 'writer' }));
+      await storage.saveSession(makeSession({ id: 's_bob2', userId: 'bob', channelId: 'discord', conversationId: 'c2', agentId: 'main' }));
     });
 
-    it('should append to transcript file', () => {
-      const transcriptPath = '~/.openrappter/sessions/session_abc123.jsonl';
-      expect(transcriptPath).toContain('.jsonl');
+    it('isolates sessions per user', async () => {
+      const alice = await storage.listSessions({ userId: 'alice' });
+      expect(alice.map((s) => s.id)).toEqual(['s_alice']);
+
+      const bob = await storage.listSessions({ userId: 'bob' });
+      expect(bob.map((s) => s.id).sort()).toEqual(['s_bob', 's_bob2']);
+    });
+
+    it('isolates sessions per channel', async () => {
+      const discord = await storage.listSessions({ channelId: 'discord' });
+      expect(discord.map((s) => s.id)).toEqual(['s_bob2']);
+    });
+
+    it('filters sessions by conversationId', async () => {
+      const c2 = await storage.listSessions({ conversationId: 'c2' });
+      expect(c2.map((s) => s.id).sort()).toEqual(['s_bob', 's_bob2']);
+    });
+
+    it('filters sessions by agentId', async () => {
+      const main = await storage.listSessions({ agentId: 'main' });
+      expect(main.map((s) => s.id).sort()).toEqual(['s_alice', 's_bob2']);
+    });
+
+    it('respects the limit on listSessions', async () => {
+      const limited = await storage.listSessions({ limit: 2 });
+      expect(limited).toHaveLength(2);
+    });
+  });
+
+  describe('Context persistence', () => {
+    it('persists tool-call records on messages', async () => {
+      await storage.saveSession(
+        makeSession({
+          id: 'with_tools',
+          messages: [
+            {
+              id: 'm1',
+              role: 'assistant',
+              content: '',
+              timestamp: new Date().toISOString(),
+              toolCalls: [
+                { id: 'tc_1', type: 'function', function: { name: 'bash', arguments: '{"command":"ls"}' } },
+              ],
+            },
+            {
+              id: 'm2',
+              role: 'tool',
+              content: 'file1.ts\nfile2.ts',
+              toolCallId: 'tc_1',
+              timestamp: new Date().toISOString(),
+            },
+          ],
+        })
+      );
+
+      const got = await storage.getSession('with_tools');
+      expect(got!.messages[0].toolCalls).toHaveLength(1);
+      expect(got!.messages[0].toolCalls![0].function.name).toBe('bash');
+      expect(got!.messages[1].toolCallId).toBe('tc_1');
     });
   });
 });

--- a/typescript/src/__tests__/parity/skills.test.ts
+++ b/typescript/src/__tests__/parity/skills.test.ts
@@ -1,275 +1,161 @@
 /**
  * Skills Ecosystem Parity Tests
- * Tests that openrappter skills system matches openclaw:
- * - Skill registry with search/install/load
- * - Skill binaries
- * - Built-in skill categories
- * - Skill creator
+ *
+ * Exercises the real SkillsRegistry (src/skills/registry.ts) — discovery,
+ * install/enable lifecycle, and the on-disk lock file. The previous version of
+ * this file built literal objects and asserted on their own shape, so it passed
+ * no matter what the product did. Its most misleading test claimed skills store
+ * their lock file at `~/.openrappter/skills/.clawhub/lock.json` and "verified"
+ * it with `expect(lockPath).toContain('.clawhub/lock.json')` — a string
+ * compared against a substring of itself. That path is a Python-runtime concept
+ * (python/openrappter/clawhub.py); the TypeScript SkillsRegistry actually writes
+ * `openrappter-skills.lock`. These tests use the real registry against a scratch
+ * directory and assert the real behaviour.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { createSkillsRegistry } from '../../skills/registry.js';
+import type { SkillManifest } from '../../skills/registry.js';
+
+/** Scratch roots live under the repo's gitignored temp dir, never /tmp. */
+const SCRATCH_ROOT = join(process.cwd(), '.vitest-tmp');
+const scratchDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of scratchDirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+});
+
+function scratch(): string {
+  mkdirSync(SCRATCH_ROOT, { recursive: true });
+  const dir = mkdtempSync(join(SCRATCH_ROOT, 'skills-'));
+  scratchDirs.push(dir);
+  return dir;
+}
+
+function seedSkill(skillsDir: string, manifest: SkillManifest, skillMd?: string): void {
+  const dir = join(skillsDir, manifest.id.replace('/', '--'));
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, 'manifest.json'), JSON.stringify(manifest, null, 2));
+  if (skillMd !== undefined) writeFileSync(join(dir, 'SKILL.md'), skillMd);
+}
+
+const weather: SkillManifest = {
+  id: 'weather',
+  name: 'Weather',
+  version: '1.0.0',
+  description: 'Get weather forecasts',
+  author: 'openrappter',
+  tags: ['weather', 'utility'],
+};
 
 describe('Skills Ecosystem Parity', () => {
-  describe('Skill Registry', () => {
-    it('should search for skills', () => {
-      const response = {
-        results: [
-          { name: 'apple-notes', description: 'Access Apple Notes', version: '1.0.0' },
-          { name: 'obsidian', description: 'Obsidian vault integration', version: '1.4.0' },
-        ],
-      };
-
-      expect(response.results.length).toBeGreaterThan(0);
+  describe('Installed skills discovery', () => {
+    it('reports no installed skills for a fresh registry', async () => {
+      const registry = createSkillsRegistry(scratch());
+      await registry.initialize();
+      expect(registry.getInstalled()).toHaveLength(0);
     });
 
-    it('should install skill from ClawHub', () => {
-      const response = {
-        success: true,
-        skill: 'apple-notes',
-        version: '1.0.0',
-        installedAt: new Date().toISOString(),
-      };
+    it('discovers a skill seeded on disk via its manifest', async () => {
+      const dir = scratch();
+      seedSkill(dir, weather);
 
-      expect(response.success).toBe(true);
-    });
+      const registry = createSkillsRegistry(dir);
+      await registry.initialize();
 
-    it('should list installed skills', () => {
-      const response = {
-        skills: [
-          { name: 'shell', enabled: true, builtin: true },
-          { name: 'memory', enabled: true, builtin: true },
-          { name: 'apple-notes', enabled: true, builtin: false },
-        ],
-      };
-
-      expect(response.skills.length).toBeGreaterThan(0);
-    });
-
-    it('should get skill status', () => {
-      const response = {
-        method: 'skills.status',
-        result: {
-          totalInstalled: 10,
-          enabled: 8,
-          disabled: 2,
-          lastUpdated: '2024-01-01T00:00:00Z',
-        },
-      };
-
-      expect(response.result.totalInstalled).toBeGreaterThan(0);
-    });
-
-    it('should update installed skill', () => {
-      const response = {
-        updated: true,
-        from: '1.0.0',
-        to: '1.1.0',
-      };
-
-      expect(response.updated).toBe(true);
+      const installed = registry.getInstalled();
+      expect(installed).toHaveLength(1);
+      expect(installed[0].manifest.id).toBe('weather');
+      expect(installed[0].manifest.description).toBe('Get weather forecasts');
     });
   });
 
-  describe('Skill Format', () => {
-    it('should parse SKILL.md with YAML frontmatter', () => {
-      const skillMd = `---
-name: weather
-description: Get weather forecasts
-version: 1.0.0
-author: openrappter
-tags: [weather, utility]
----
+  describe('Lock file', () => {
+    it('writes the lock file as openrappter-skills.lock (not .clawhub/lock.json)', async () => {
+      const dir = scratch();
+      seedSkill(dir, weather);
 
-# Weather Skill
+      const registry = createSkillsRegistry(dir);
+      await registry.initialize(); // scanning an unseen dir persists the lock file
 
-Get current weather and forecasts for any location.
-
-## Usage
-
-Ask about weather in any city.
-`;
-
-      expect(skillMd).toContain('---');
-      expect(skillMd).toContain('name: weather');
+      expect(existsSync(join(dir, 'openrappter-skills.lock'))).toBe(true);
+      // The `.clawhub/lock.json` path claimed by the old test belongs to the
+      // Python runtime only; the TypeScript registry never creates it.
+      expect(existsSync(join(dir, '.clawhub', 'lock.json'))).toBe(false);
     });
 
-    it('should parse inline metadata', () => {
-      const skillMd = `name: Calculator
-description: Perform calculations
+    it('records installed skills inside the lock file', async () => {
+      const dir = scratch();
+      seedSkill(dir, weather);
 
-# Calculator Skill
+      await createSkillsRegistry(dir).initialize();
 
-Perform mathematical calculations.
-`;
-
-      const lines = skillMd.split('\n');
-      const nameMatch = lines[0].match(/^name:\s*(.+)$/);
-      expect(nameMatch?.[1]).toBe('Calculator');
-    });
-
-    it('should support skill scripts directory', () => {
-      const skillStructure = {
-        'SKILL.md': 'Skill documentation',
-        'scripts/': {
-          'main.py': 'Python implementation',
-          'run.sh': 'Shell implementation',
-        },
-      };
-
-      expect(skillStructure['scripts/']).toBeDefined();
+      const lock = JSON.parse(
+        readFileSync(join(dir, 'openrappter-skills.lock'), 'utf8')
+      ) as { skills: Array<{ manifest: SkillManifest }> };
+      expect(lock.skills.map((s) => s.manifest.id)).toContain('weather');
     });
   });
 
-  describe('Skill Execution', () => {
-    it('should wrap skill as agent', () => {
-      const skillAgent = {
-        name: 'weather',
-        type: 'skill',
-        metadata: {
-          name: 'weather',
-          description: 'Get weather forecasts',
-        },
-        execute: async (query: string) => `Weather for: ${query}`,
-      };
+  describe('Enable / disable lifecycle', () => {
+    it('excludes a disabled skill from getEnabled but keeps it installed', async () => {
+      const dir = scratch();
+      seedSkill(dir, weather);
+      const registry = createSkillsRegistry(dir);
+      await registry.initialize();
 
-      expect(skillAgent.type).toBe('skill');
-      expect(typeof skillAgent.execute).toBe('function');
+      expect(registry.getEnabled().map((s) => s.manifest.id)).toContain('weather');
+
+      expect(await registry.disableSkill('weather')).toBe(true);
+      expect(registry.getEnabled()).toHaveLength(0);
+      expect(registry.getInstalled()).toHaveLength(1); // still installed, just off
+
+      expect(await registry.enableSkill('weather')).toBe(true);
+      expect(registry.getEnabled().map((s) => s.manifest.id)).toContain('weather');
     });
 
-    it('should execute Python scripts', () => {
-      const execution = {
-        skill: 'weather',
-        script: 'scripts/main.py',
-        args: ['San Francisco'],
-        timeout: 30000,
-      };
-
-      expect(execution.script.endsWith('.py')).toBe(true);
-    });
-
-    it('should execute shell scripts', () => {
-      const execution = {
-        skill: 'system-info',
-        script: 'scripts/run.sh',
-        args: [],
-        timeout: 10000,
-      };
-
-      expect(execution.script.endsWith('.sh')).toBe(true);
+    it('returns false when enabling a skill that is not installed', async () => {
+      const registry = createSkillsRegistry(scratch());
+      await registry.initialize();
+      expect(await registry.enableSkill('does-not-exist')).toBe(false);
     });
   });
 
-  describe('Built-in Skill Categories', () => {
-    it('should have productivity skills', () => {
-      const productivitySkills = [
-        'apple-notes',
-        'apple-reminders',
-        'notion',
-        'obsidian',
-        'things',
-        'trello',
-      ];
+  describe('Uninstall', () => {
+    it('removes the skill from the registry and deletes its directory', async () => {
+      const dir = scratch();
+      seedSkill(dir, weather);
+      const registry = createSkillsRegistry(dir);
+      await registry.initialize();
 
-      expect(productivitySkills.length).toBeGreaterThanOrEqual(5);
-    });
+      const skillDir = join(dir, 'weather');
+      expect(existsSync(skillDir)).toBe(true);
 
-    it('should have media skills', () => {
-      const mediaSkills = [
-        'canvas',
-        'camsnap',
-        'video-frames',
-        'openai-image-gen',
-      ];
-
-      expect(mediaSkills.length).toBeGreaterThanOrEqual(3);
-    });
-
-    it('should have AI/ML skills', () => {
-      const aiSkills = [
-        'openai-whisper',
-        'summarize',
-        'coding-agent',
-      ];
-
-      expect(aiSkills.length).toBeGreaterThanOrEqual(3);
-    });
-
-    it('should have smart home skills', () => {
-      const homeSkills = [
-        'openhue',
-        'sonos-cli',
-        'spotify-player',
-      ];
-
-      expect(homeSkills.length).toBeGreaterThanOrEqual(3);
-    });
-
-    it('should have utility skills', () => {
-      const utilitySkills = [
-        'weather',
-        'local-places',
-        'health-check',
-        'model-usage',
-      ];
-
-      expect(utilitySkills.length).toBeGreaterThanOrEqual(3);
+      expect(await registry.uninstall('weather')).toBe(true);
+      expect(registry.getInstalled()).toHaveLength(0);
+      expect(existsSync(skillDir)).toBe(false);
     });
   });
 
-  describe('Skill Creator', () => {
-    it('should generate skill template', () => {
-      const template = {
-        name: 'my-custom-skill',
-        description: 'A custom skill',
-        files: [
-          'SKILL.md',
-          'scripts/main.py',
-        ],
-      };
+  describe('Loading a skill', () => {
+    it('loads manifest-derived fields for an installed skill', async () => {
+      const dir = scratch();
+      seedSkill(dir, weather);
+      const registry = createSkillsRegistry(dir);
+      await registry.initialize();
 
-      expect(template.files).toContain('SKILL.md');
+      const skill = await registry.loadSkill('weather');
+      expect(skill).not.toBeNull();
+      expect(skill?.name).toBe('Weather');
+      expect(skill?.version).toBe('1.0.0');
     });
 
-    it('should validate skill structure', () => {
-      const validate = (skill: { name?: string; description?: string }): string[] => {
-        const errors: string[] = [];
-        if (!skill.name) errors.push('name is required');
-        if (!skill.description) errors.push('description is required');
-        return errors;
-      };
-
-      expect(validate({ name: 'test', description: 'desc' })).toHaveLength(0);
-      expect(validate({ name: 'test' })).toHaveLength(1);
-    });
-  });
-
-  describe('Skill Binaries', () => {
-    it('should support skill binary download', () => {
-      const response = {
-        available: true,
-        url: 'https://clawhub.dev/bins/whisper/darwin-arm64',
-        size: 50000000,
-      };
-
-      expect(response.available).toBe(true);
-    });
-  });
-
-  describe('Lock File', () => {
-    it('should track installed skills in lock file', () => {
-      const lockFile = {
-        installed: {
-          'apple-notes': { version: '1.0.0', installedAt: '2024-01-01T00:00:00Z' },
-          'weather': { version: '2.0.0', installedAt: '2024-01-02T00:00:00Z' },
-        },
-      };
-
-      expect(Object.keys(lockFile.installed).length).toBe(2);
-    });
-
-    it('should store lock file at ~/.openrappter/skills/.clawhub/lock.json', () => {
-      const lockPath = '~/.openrappter/skills/.clawhub/lock.json';
-      expect(lockPath).toContain('.clawhub/lock.json');
+    it('returns null when loading a skill that is not installed', async () => {
+      const registry = createSkillsRegistry(scratch());
+      await registry.initialize();
+      expect(await registry.loadSkill('nope')).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Vacuous tests: find every TS test that cannot fail, and deal with each honestly

A test suite that reports green while some fraction of it is tautological is the
same class of defect this session has been finding everywhere else — something
that reads as complete and protects nothing. This PR hunts that defect in the
safety net itself.

### Method

A regex sweep alone produces false positives and misses real cases, so every
vacuity claim here is backed by **one of two proofs**:

1. **Mutation** — break the real product code the test claims to protect and
   confirm the test *still passes* (for a vacuous test) / *now fails* (for a
   rewrite). This is the gold standard and is recorded for every rewrite below.
2. **Structural** — the plain fact, which the task explicitly accepts as proof,
   that a test **imports nothing but `vitest`** and therefore cannot protect any
   product behaviour no matter what it asserts.

### Scope examined

- All **273** test files under `typescript/src/__tests__/` were scanned for
  product-code imports; **96** are in `parity/`.
- **28** parity suites import only from `vitest`. Seven of those actually touch
  real product artifacts via `fs`/`child_process`/dynamic `import()`
  (`auth-caching`, `cli-commands`, `cli-registration`, `dashboard-rpc`,
  `learn-new-agent`, `single-file-agent`, `speech-seam-parity`) — they run real
  code and are **not vacuous**, so they were left alone.
- That leaves **21 whole-file-vacuous parity suites** (vitest-only, no product
  import, no real I/O), **642** `it()` blocks in total. **5 rewritten here; 16
  catalogued below (544 `it()`).**

---

### Proven findings — rewritten (5 files, mutation-verified both directions)

The representative vacuity proof: with the *old* `security.test.ts` in place,
mutating the real deny branch of `ApprovalManager.checkApproval`
(`allowed: false` → `true`) left it **20/20 green**, while the genuine
`showcase-auth-fortress.test.ts` went **3 red**. Every rewrite was then verified
by breaking product code (test must fail) and reverting (test must pass).

| File | Now exercises (real product code) | Rewrite mutation evidence (break → fail) |
|---|---|---|
| `parity/security.test.ts` | `ApprovalManager` (`src/security/approvals.ts`) | deny→allow: 4 fail · `allowedCommands` startsWith removed: 1 fail · priority sort reversed: 1 fail |
| `parity/skills.test.ts` | `SkillsRegistry` (`src/skills/registry.ts`) | lock file rename `openrappter-skills.lock`→other: 2 fail · `disableSkill` made a no-op: 1 fail |
| `parity/sessions.test.ts` | `StorageAdapter` (`src/storage/sqlite.ts`, memory mode) | `userId` filter ignored: 1 fail · messages not persisted: 2 fail |
| `parity/config.test.ts` | `validateConfig`/`mergeConfigs`/`substituteEnvVars`/`parseConfigContent` | gateway override dropped in merge: 1 fail · `substituteEnvVars` broken: 2 fail · port `min` loosened: 1 fail |
| `parity/providers.test.ts` | `ProviderRegistry` (`src/providers/registry.ts`) | default registry drops `openai`: 1 fail · `getAvailable` ignores `isAvailable()`: 1 fail |

**The flagged example is fixed.** The old `skills.test.ts` "verified" the lock
file with `expect(lockPath).toContain('.clawhub/lock.json')` — a string compared
against a substring of itself, for a path that only exists in the **Python**
runtime (`python/openrappter/clawhub.py`). The rewrite asserts the real
TypeScript registry writes **`openrappter-skills.lock`** and that
`.clawhub/lock.json` is **never** created.

Two assertions the old `config.test.ts` encoded were also **wrong for the real
schema** and were dropped rather than preserved: `gateway.auth.mode` has no
`'token'` option, and `memory.chunkTokens` has no positivity constraint.

Net effect: **98 vacuous → 56 real tests** (−42), all failing for real reasons
when the product breaks.

---

### Catalogued for follow-up (16 files — proven vacuous structurally, not yet rewritten)

Each imports **only `vitest`** and performs no real I/O, so it cannot protect any
product behaviour (`grep -oE "from '[^']+'"` yields `vitest` and nothing else).
Left in place rather than mass-deleted, so intended-parity intent is preserved
for a reviewer. Prioritised roughly by risk:

| File | `it()` blocks | Note |
|---|---:|---|
| `parity/memory.test.ts` | 43 | Mocks `better-sqlite3` and asserts on the mock (pattern 7); never imports the real memory system. Persistence-adjacent — best next rewrite target. |
| `parity/docker.test.ts` | 51 | Dockerfile/compose claims against literals. |
| `parity/gateway.test.ts` | 44 | Gateway RPC/protocol claims, all against literals. |
| `parity/channels.test.ts` | 44 | Channel routing/scoping against literals. |
| `parity/multiagent.test.ts` | 36 | Multi-agent orchestration against literals. |
| `parity/power-prompts-2.test.ts` | 77 | Prompt templates against literals. |
| `parity/power-prompts.test.ts` | 68 | Prompt templates against literals. |
| `parity/browser.test.ts` | 30 | |
| `parity/advanced.test.ts` | 27 | |
| `parity/onboarding.test.ts` | 21 | |
| `parity/nodes.test.ts` | 21 | |
| `parity/cron.test.ts` | 21 | |
| `parity/cli.test.ts` | 18 | |
| `parity/voice.test.ts` | 16 | |
| `parity/media.test.ts` | 15 | |
| `parity/network.test.ts` | 12 | |

There is also at least one vacuous case **outside** `parity/` (the
literal-vs-itself pattern in `src/providers/providers.test.ts`); a full sweep of
non-parity suites is future work.

---

### Verification

From `typescript/`:

- `./node_modules/.bin/vitest run --silent` → **5065 passed, 21 skipped, 0 failed**
  (baseline on `main` was 5107 passed / 21 skipped; the −42 delta is exactly the
  vacuous tests replaced by fewer, meatier ones).
- `./node_modules/.bin/tsc --noEmit` → **clean (exit 0)**.

One caveat, investigated and cleared: on one full-suite run,
`src/gateway/gateway.protocol.test.ts` (a 504-timeout timing assertion I did
**not** touch) flaked once under parallel load. It passes 22/22 in isolation
across repeated runs, passed on a clean-`main` full run, and passed on a re-run
with these changes. It is a pre-existing intermittent flake unrelated to this PR.

### What I could NOT verify

- The 16 catalogued files are proven vacuous **structurally** (import only
  `vitest`) and by the representative security mutation; I did **not**
  individually mutation-test each of their ~480 `it()` blocks.
- Non-parity suites were scanned for product imports but not exhaustively
  audited for subtler vacuity (loop-over-empty, swallowed throws, etc.).
- `typescript/ui` is a separate package (123 tests, run from `typescript/ui`);
  it was **not** touched by this PR and was not re-run.

**Do not merge — for review.**
