### PR TITLE
fix: config validate called a mostly-inert config file valid

### DIFF
--- a/typescript/src/__tests__/unit/config-ignored-keys.test.ts
+++ b/typescript/src/__tests__/unit/config-ignored-keys.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest';
+import { ignoredConfigKeys } from '../../cli/config.js';
+
+/**
+ * `config validate` used to call a mostly-inert file valid.
+ *
+ * Zod strips unknown keys instead of rejecting them, so a config can parse
+ * cleanly while almost nothing in it is read. `openrappter config validate`
+ * printed "Configuration is valid." for a file whose `memory`, `shell` and
+ * `skills` sections did nothing at all.
+ *
+ * That is how the published documentation came to describe a config format
+ * that no longer exists: the tool whose entire job is to check the file agreed
+ * with it. The only guard was `unsupportedConfigErrors`, a hand-written list
+ * naming exactly three keys — `agent`, `gateway.host`, `memory.chunkSize` —
+ * and missing everything else.
+ *
+ * These tests pin the derived replacement, including the two ways it could go
+ * wrong: staying silent when it should speak, and flagging keys that are
+ * legitimately free-form.
+ */
+
+describe('ignoredConfigKeys', () => {
+  it('reports keys the schema will silently discard', () => {
+    const documented = {
+      gateway: { enabled: true, port: 8765, rate_limit: 100 },
+      memory: { backend: 'sqlite', chunk_size: 512 },
+      shell: { require_approval: false },
+      skills: { auto_load: true },
+    };
+
+    expect(ignoredConfigKeys(documented).sort()).toEqual([
+      'gateway.enabled',
+      'gateway.rate_limit',
+      'memory.backend',
+      'memory.chunk_size',
+      'shell',
+      'skills',
+    ]);
+  });
+
+  it('says nothing about a config the schema fully understands', () => {
+    const real = {
+      gateway: { port: 18790, bind: 'loopback' },
+      memory: { provider: 'local', chunkTokens: 512 },
+      cron: { enabled: true },
+    };
+
+    expect(ignoredConfigKeys(real)).toEqual([]);
+  });
+
+  it('does not flag arbitrary keys inside a record', () => {
+    // `channels` is a z.record, so any channel name is legal. Treating those
+    // as unknown keys would make the warning useless noise for anyone who
+    // actually configures a channel.
+    const withChannels = {
+      channels: { 'my-slack': { enabled: true }, another: { enabled: false } },
+    };
+
+    expect(ignoredConfigKeys(withChannels)).toEqual([]);
+  });
+
+  it('descends more than one level', () => {
+    expect(ignoredConfigKeys({ gateway: { auth: { mode: 'password', nope: 1 } } }))
+      .toEqual(['gateway.auth.nope']);
+  });
+
+  it('reports a whole unknown section once, not each leaf inside it', () => {
+    const result = ignoredConfigKeys({ totallyMadeUp: { a: 1, b: { c: 2 } } });
+    expect(result).toEqual(['totallyMadeUp']);
+  });
+
+  it('is quiet on empty and non-object input', () => {
+    expect(ignoredConfigKeys({})).toEqual([]);
+    expect(ignoredConfigKeys(null)).toEqual([]);
+    expect(ignoredConfigKeys('not a config')).toEqual([]);
+  });
+
+  it('reads a real shape rather than defaulting to silence', () => {
+    // Anti-vacuity. If the Zod internals move again and the shape reader
+    // returns null for everything, every assertion above would pass by
+    // reporting nothing. This one fails instead.
+    expect(ignoredConfigKeys({ definitelyNotAKey: 1 })).toEqual(['definitelyNotAKey']);
+  });
+});

--- a/typescript/src/cli/config.ts
+++ b/typescript/src/cli/config.ts
@@ -23,7 +23,7 @@ import {
   mergeConfigObjects,
   saveConfig,
 } from '../env.js';
-import { validateConfig as validateConfigSchema } from '../config/schema.js';
+import { validateConfig as validateConfigSchema, openRappterConfigSchema } from '../config/schema.js';
 export { redactSecrets } from '../security/redact.js';
 import { redactSecrets } from '../security/redact.js';
 import { isSecretKey } from '../security/secret-keys.js';
@@ -87,6 +87,67 @@ function formatValidationErrors(error: string): string[] {
   } catch {
     return [error];
   }
+}
+
+/**
+ * Config keys the schema will silently discard.
+ *
+ * Zod strips unknown keys rather than rejecting them, so a config file can be
+ * mostly inert and still parse. `openrappter config validate` reported
+ * "Configuration is valid." for a file whose `memory`, `shell` and `skills`
+ * sections did nothing at all — which is how the published documentation came
+ * to describe a config format that has not existed for some time: the tool
+ * whose job is to check the file agreed with it.
+ *
+ * Derived from the schema rather than listed here, because a hand-maintained
+ * list is what `unsupportedConfigErrors` already is: it names exactly three
+ * keys and misses everything else.
+ */
+export function ignoredConfigKeys(
+  value: unknown,
+  schema: unknown = openRappterConfigSchema,
+  prefix = '',
+): string[] {
+  if (!isPlainObject(value)) return [];
+
+  const shape = zodObjectShape(schema);
+  // A record accepts arbitrary keys (channels), and anything we cannot read the
+  // shape of is not evidence of a problem — stay quiet rather than guess.
+  if (!shape) return [];
+
+  const ignored: string[] = [];
+  for (const [key, nested] of Object.entries(value)) {
+    const path = prefix ? `${prefix}.${key}` : key;
+    if (!(key in shape)) {
+      ignored.push(path);
+      continue;
+    }
+    ignored.push(...ignoredConfigKeys(nested, shape[key], path));
+  }
+  return ignored;
+}
+
+/**
+ * The `shape` of a Zod object, looking through the wrappers a schema uses.
+ *
+ * `gateway` is `z.object({…}).optional()`, so the shape is one unwrap away;
+ * defaults add another. Zod 4 exposes `.shape` directly on object schemas and
+ * no longer carries `_def.typeName`, so the presence of `.shape` is the test.
+ * Returns null for anything that is not an object schema, including records,
+ * which legitimately accept any key.
+ */
+function zodObjectShape(schema: unknown): Record<string, unknown> | null {
+  let current = schema as { shape?: unknown; _def?: { innerType?: unknown } } | undefined;
+
+  for (let depth = 0; current && depth < 10; depth++) {
+    const shape = current.shape;
+    if (shape && typeof shape === 'object') return shape as Record<string, unknown>;
+
+    const inner = current._def?.innerType;
+    if (!inner) return null;
+    current = inner as typeof current;
+  }
+  return null;
 }
 
 function unsupportedConfigErrors(config: Record<string, unknown>): string[] {
@@ -226,6 +287,15 @@ export function registerConfigCommand(program: Command): void {
           return;
         }
         console.log('Configuration is valid.');
+
+        // Valid is not the same as effective: everything below parsed, and
+        // will then be dropped. Saying so is the whole point.
+        const ignored = ignoredConfigKeys(cfg);
+        if (ignored.length > 0) {
+          console.log('');
+          console.log(`${ignored.length} key(s) are not part of the schema and will be ignored:`);
+          for (const key of ignored) console.log(`  - ${key}`);
+        }
       } catch (error) {
         console.log('Configuration validation failed:');
         console.log(`  - ${(error as Error).message}`);


### PR DESCRIPTION
Zod strips unknown keys rather than rejecting them, so a config file can parse cleanly while almost nothing in it is ever read. Given this file:

```yaml
gateway: { enabled: true, port: 8765, rate_limit: 100 }
memory:  { backend: sqlite, chunk_size: 512, embedding_model: … }
shell:   { require_approval: false }
skills:  { auto_load: true }
```

`openrappter config validate` printed:

```
Configuration is valid.
```

**Of that file, exactly one key is read: `gateway.port`.** The gateway schema has `port`, `bind`, `auth`; the memory schema has `provider`, `chunkTokens`, `chunkOverlap`; there is no `shell` or `skills` section at all. Everything else is discarded in silence — including a section I invented to check.

## This is why the docs drifted

`docs.html` described exactly that config format (corrected in #209), and **the tool whose entire job is to check the file agreed with it.** Nobody was going to catch it by hand.

The only existing guard was `unsupportedConfigErrors` — a hand-written list naming three keys (`agent`, `gateway.host`, `memory.chunkSize`). Same shape of mistake as the rest of this session: a curated list that reads as exhaustive and names three of everything.

## The fix

`ignoredConfigKeys` derives the answer from the schema, so it cannot fall behind it. Validation still **passes** — these are not errors, and failing would break every existing config — but it now says what will be ignored:

```
Configuration is valid.

8 key(s) are not part of the schema and will be ignored:
  - gateway.enabled
  - gateway.rate_limit
  - memory.backend
  …
```

Two things it must not do, both tested: stay silent when the schema moves, and flag keys that are legitimately free-form. **`channels` is a `z.record`**, so any channel name is legal — treating those as unknown would make the warning noise for the people most likely to read it.

## An instrument that failed silently

Zod 4 dropped `_def.typeName` and exposes `.shape` directly. I wrote the unwrapper against Zod 3 internals first and it returned null for everything — **reporting no ignored keys at all, which looks exactly like success.** The anti-vacuity test exists because of that.

**Mutation-checked:**

| mutation | result |
|---|---|
| shape reader always null (silent) | 4 failed |
| no recursion into sections | 2 failed |
| restored | 7 passed |

Suite: **5133 passed**, 21 skipped. `tsc` clean.