### PR TITLE
fix: the published container ran everything as root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # Copy Python package
 COPY python/ ./python/
 RUN cd python && pip3 install --break-system-packages .
+
+# Run as a non-root user. node:22-slim ships an unprivileged `node` account, and
+# every step above needs root (apt, pip), so the switch comes last.
+# HOME is set explicitly because the app resolves its config directory from
+# os.homedir(); leaving Docker's default HOME=/root would send an unprivileged
+# process at a directory it cannot write.
+ENV HOME=/home/node
+RUN mkdir -p /app/data /home/node/.openrappter \
+    && chown -R node:node /app /home/node
+USER node
+
 # Health check
 HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
     CMD node -e "fetch('http://localhost:18790/health').then(r => r.ok ? process.exit(0) : process.exit(1)).catch(() => process.exit(1))"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
       - "18790:18790"
     volumes:
       - openrappter-data:/app/data
-      - openrappter-config:/root/.openrappter
+      - openrappter-config:/home/node/.openrappter
     environment:
       - NODE_ENV=production
       - OPENRAPPTER_HOST=0.0.0.0

--- a/typescript/src/__tests__/parity/docker.test.ts
+++ b/typescript/src/__tests__/parity/docker.test.ts
@@ -7,13 +7,13 @@
  *
  *   - "should use pnpm for package management" — the real Dockerfile uses
  *     `npm ci` / `npm run build`; pnpm appears nowhere.
- *   - "should run as non-root user" (user = 'node') — the real Dockerfile
- *     defines NO `USER` directive, so the container runs as root. The compose
- *     file even mounts config at `/root/.openrappter`, confirming root. This
- *     vacuous test claimed a security property the image does not have. It is
- *     reported as a hardening gap rather than re-asserted (see PR notes); the
- *     suite must not codify the insecure state as "expected", nor go red for a
- *     pre-existing infra gap.
+ *   - "should run as non-root user" (user = 'node') — at the time of that
+ *     audit the real Dockerfile defined NO `USER` directive, so the container
+ *     ran as root, and the compose file mounted config at `/root/.openrappter`
+ *     to match. The vacuous test claimed a security property the image did not
+ *     have. Rather than codify the insecure state, it was reported as a
+ *     hardening gap; the image has since been fixed and the property is now
+ *     asserted against the real file below.
  *   - "should define gateway service" / optional `ollama` service / a
  *     `networks: { openrappter: { driver: bridge } }` block — the real
  *     docker-compose.yml defines services `openrappter` and `openrappter-dev`,
@@ -76,6 +76,25 @@ describe('Docker Parity', () => {
     it('runs the compiled entrypoint and sets production env', () => {
       expect(dockerfile).toMatch(/CMD\s+\[.*dist\/index\.js.*\]/);
       expect(dockerfile).toMatch(/NODE_ENV=production/);
+    });
+
+    it('drops root before running the app', () => {
+      // The image previously had no USER directive at all and ran as root.
+      const user = /^USER\s+(\S+)/m.exec(dockerfile);
+      expect(user, 'the Dockerfile must declare a USER').not.toBeNull();
+      expect(user![1]).not.toBe('root');
+
+      // A USER that comes before the privileged steps would be undone by them,
+      // so position matters as much as presence.
+      expect(dockerfile.indexOf('USER ')).toBeGreaterThan(dockerfile.indexOf('pip3 install'));
+    });
+
+    it('points HOME at a directory the unprivileged user owns', () => {
+      // The app resolves its config directory from os.homedir(). Left at
+      // Docker's default HOME=/root, an unprivileged process would be sent at a
+      // directory it cannot write.
+      expect(dockerfile).toMatch(/ENV\s+HOME=\/home\/node/);
+      expect(dockerfile).toMatch(/chown -R node:node/);
     });
   });
 


### PR DESCRIPTION
The root `Dockerfile` declared **no `USER`**, so the image ran the gateway as uid 0 — and `docker-compose.yml` mounted the config volume at `/root/.openrappter` to match.

Anything that gets code execution inside that container — and **this process runs a shell agent by design** — is root in it, with the credential directory mounted in.

The repo already knew how to do this: `typescript/Dockerfile` creates an unprivileged account and switches to it. Only the root image was missed.

## `node:22-slim` already ships a suitable account

From the official image definition:

```dockerfile
groupadd --gid 1000 node \
  && useradd --uid 1000 --gid node --shell /bin/bash --create-home node
```

So `USER node` needs no account creation, and `--create-home` means `/home/node` exists. **I checked the upstream Dockerfile rather than assume it**, because `typescript/Dockerfile` creates its own uid 1001 account — which suggested the built-in one might not be relied upon.

## Three things had to move together

- **`USER node` comes last.** `apt` and `pip` need root; a `USER` before them would be undone by them.
- **`ENV HOME=/home/node`.** The app resolves its config directory from `os.homedir()`. Left at Docker's default `HOME=/root`, an unprivileged process is pointed at a directory it cannot write — which fails at *runtime*, not at build.
- **The compose mount follows `HOME`** to `/home/node/.openrappter`, or the volume attaches to a path nothing reads.

## Provenance

Found by the vacuous-test audit in #213. The old parity suite asserted *"should run as non-root user"* against a hand-written literal and **passed while the real image had no `USER` at all** — a security property claimed by a test that never looked at the artifact. That agent was right not to codify the insecure state; this is the other half.

**Mutation-checked against the real file:**

| mutation | result |
|---|---|
| no `USER` directive (the bug as found) | 1 failed |
| `USER root` | 1 failed |
| `USER` before apt/pip | 1 failed |
| `HOME` left at Docker default | 1 failed |
| restored | 15 passed |

**Not verified:** no Docker daemon on this host, so the image was not built. The assertions are static, and the account and home directory are confirmed from the upstream image definition.

Suite: **4859 passed**, 21 skipped. `tsc` clean.