### PR TITLE
test: the inert-test guard missed a real test and scanned one package of two

### DIFF
--- a/typescript/src/__tests__/integration/no-inert-tests.test.ts
+++ b/typescript/src/__tests__/integration/no-inert-tests.test.ts
@@ -3,7 +3,21 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..');
+const packageRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../..');
+const repoRoot = path.resolve(packageRoot, '..');
+
+/**
+ * The roots that ship tests.
+ *
+ * The UI is a separate package with its own vitest run, and the first version
+ * of this guard scanned only `typescript/src` — the same narrowness that #199,
+ * #200 and #201 each had to correct in an earlier guard of mine. A rule that
+ * covers one package of two is not a rule.
+ */
+const TEST_ROOTS = [
+  path.join(packageRoot, 'src'),
+  path.join(repoRoot, 'typescript', 'ui', 'src'),
+].filter((dir) => fs.existsSync(dir));
 
 /**
  * No test file may be added that cannot fail.
@@ -31,15 +45,15 @@ const srcRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../.
 const KNOWN_INERT = new Set([
   // Catalogued by the #213 audit as having no product unit to target, or
   // wrapping external I/O that is mocked end to end.
-  'src/__tests__/parity/advanced.test.ts',
-  'src/__tests__/parity/browser.test.ts',
-  'src/__tests__/parity/media.test.ts',
-  'src/__tests__/parity/multiagent.test.ts',
-  'src/__tests__/parity/network.test.ts',
-  'src/__tests__/parity/onboarding.test.ts',
-  'src/__tests__/parity/power-prompts-2.test.ts',
-  'src/__tests__/parity/power-prompts.test.ts',
-  'src/__tests__/parity/voice.test.ts',
+  'typescript/src/__tests__/parity/advanced.test.ts',
+  'typescript/src/__tests__/parity/browser.test.ts',
+  'typescript/src/__tests__/parity/media.test.ts',
+  'typescript/src/__tests__/parity/multiagent.test.ts',
+  'typescript/src/__tests__/parity/network.test.ts',
+  'typescript/src/__tests__/parity/onboarding.test.ts',
+  'typescript/src/__tests__/parity/power-prompts-2.test.ts',
+  'typescript/src/__tests__/parity/power-prompts.test.ts',
+  'typescript/src/__tests__/parity/voice.test.ts',
   // Three former entries — src/config/schema.test.ts, src/providers/providers.test.ts
   // and src/__tests__/imessage-channel.test.ts — were deleted rather than
   // catalogued: each was already covered by a real suite (parity/config*.test.ts
@@ -48,55 +62,85 @@ const KNOWN_INERT = new Set([
   // shrink-only.
 ]);
 
-/** Every test file in the TypeScript package. */
-function testFiles(dir = srcRoot, found: string[] = []): string[] {
-  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
-    const full = path.join(dir, entry.name);
-    if (entry.isDirectory()) {
-      if (entry.name !== 'node_modules') testFiles(full, found);
-    } else if (/\.test\.tsx?$/.test(entry.name)) {
-      found.push(full);
+/** Every test file in the TypeScript and UI packages. */
+function testFiles(): string[] {
+  const found: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (entry.name !== 'node_modules') walk(full);
+      } else if (/\.test\.[tj]sx?$/.test(entry.name)) {
+        found.push(full);
+      }
     }
-  }
+  };
+  for (const root of TEST_ROOTS) walk(root);
   return found;
 }
 
 /**
  * Whether a test file reaches the product at all.
  *
- * Two ways count, because both are used in this repo and only one is an
- * `import`: a relative import of a module, or reading/running a real artifact.
- * `install-ps1-gateway.test.ts` runs the CLI through `execFile` and imports
- * nothing but `vitest`; `cli-flags.test.ts` reads `index.ts` off disk. Neither
- * is inert, and a detector that looked only at imports would call both dead.
+ * Three ways count, because all three are used in this repo and only one of
+ * them is a plain `import … from`:
+ *
+ *   - a relative import with bindings
+ *   - a bare side-effect import, `import '../components/show-and-tell.js'`,
+ *     which is how the UI's custom elements are registered before a test
+ *     drives them. It has no `from` clause, so a `from`-shaped pattern walks
+ *     straight past it — this guard called that file inert on its first run,
+ *     and it is a real test.
+ *   - reading or running a real artifact. `install-ps1-gateway.test.ts` runs
+ *     the CLI through `execFile` and imports nothing but `vitest`;
+ *     `cli-flags.test.ts` reads `index.ts` off disk.
+ *
+ * Miss any one of them and the guard fails a legitimate test file, which is
+ * the more expensive direction to be wrong in.
  */
 function reachesProduct(source: string): boolean {
-  const relativeImport = /^\s*import\s[\s\S]*?from\s+['"][^'"]*\.[./][^'"]*['"]/m.test(source);
+  const boundImport = /^\s*import\s[\s\S]*?from\s+['"][^'"]*\.[./][^'"]*['"]/m.test(source);
+  const sideEffectImport = /^\s*import\s+['"][^'"]*\.[./][^'"]*['"]/m.test(source);
   const dynamicAccess = /await\s+import\(|\brequire\(|\bexecFile|\bexecSync|\bspawn|\breadFile|\bcreateRequire|\bfetch\(/.test(source);
-  return relativeImport || dynamicAccess;
+  return boundImport || sideEffectImport || dynamicAccess;
 }
 
 function relative(file: string): string {
-  return path.relative(path.resolve(srcRoot, '..'), file).split(path.sep).join('/');
+  return path.relative(repoRoot, file).split(path.sep).join('/');
 }
 
 describe('no test file may be added that cannot fail', () => {
   const files = testFiles();
 
-  it('scans a realistic number of test files', () => {
+  it('scans a realistic number of test files, in both packages', () => {
     // Anti-vacuity: a broken walker would make every assertion below pass by
     // having nothing to look at — which is the exact failure being guarded.
     expect(files.length).toBeGreaterThan(200);
+
+    // Per root, not on the merged total. A combined count stays healthy when
+    // one root stops being scanned, because the other keeps it up — the trap
+    // this repo has now hit four times.
+    for (const root of TEST_ROOTS) {
+      const inRoot = files.filter((f) => f.startsWith(root + path.sep));
+      expect(inRoot.length, `no test files found under ${relative(root)}`).toBeGreaterThan(0);
+    }
+    expect(TEST_ROOTS.length, 'both the CLI and UI packages should be scanned').toBe(2);
   });
 
-  it('recognises both ways a test reaches the product', () => {
+  it('recognises all three ways a test reaches the product', () => {
     // Detector control. If `reachesProduct` returned false for everything, the
     // inert set would swallow the whole suite; if it returned true for
     // everything, the guard would never fire again.
     expect(reachesProduct("import { thing } from '../../agents/BasicAgent.js';")).toBe(true);
     expect(reachesProduct("const out = await execFile(cli, ['--help']);")).toBe(true);
     expect(reachesProduct("const src = await fs.readFile(entry, 'utf-8');")).toBe(true);
+
+    // The case that fooled the first version of this guard: a bare side-effect
+    // import registering a custom element. It has no `from` clause.
+    expect(reachesProduct("import '../components/show-and-tell.js';")).toBe(true);
+
     expect(reachesProduct("import { describe, it, expect } from 'vitest';")).toBe(false);
+    expect(reachesProduct("import 'vitest';")).toBe(false);
   });
 
   it('adds no new test file that never touches the product', () => {


### PR DESCRIPTION
Two faults in the guard I added in #215, found by turning it on the rest of the repo.

## 1. It called a real test inert

`ui/src/__tests__/show-and-tell-component.test.ts` registers a custom element and drives it:

```ts
import '../components/show-and-tell.js';
```

A bare **side-effect import has no `from` clause**, so a `from`-shaped pattern walks straight past it. This is the same miss I made earlier in the session on `import './components/zen.js'` — which is what made the wrong answer here recognisable.

**The direction matters.** Over-flagging fails a legitimate test file and blocks whoever wrote it — a more expensive way to be wrong than letting one inert file through.

## 2. It scanned one package of two

The guard only ever looked at `typescript/src`. The UI is a **separate package with its own vitest run**, so a rule about "no test that cannot fail" covered half the tests.

That is exactly what #199, #200 and #201 each had to correct in an earlier guard of mine: **the rule was right and its reach was narrower than its wording.**

Since two roots are now scanned, `KNOWN_INERT` paths carry the package prefix so they cannot be ambiguous. The anti-vacuity assertion is now **per root** rather than on the merged total — a combined count stays healthy when one root stops being scanned, because the other keeps it up. That trap has now caught this repo four times.

**No entry changed status:** the 9 remaining files are inert under both the old and new detector, and the UI file is the only one the fix rescues.

**Mutation-checked:**

| mutation | result |
|---|---|
| detector forgets side-effect imports (the bug) | 2 failed |
| UI package dropped from the scan | 1 failed |
| a new inert test file appears | 1 failed |
| restored | 4 passed |

TypeScript **4816 passed**, UI **123 passed**, `tsc` clean.