### PR TITLE
fix: GoogleVoiceAgent never loaded in the Python runtime

### DIFF
--- a/python/openrappter/cli.py
+++ b/python/openrappter/cli.py
@@ -104,7 +104,21 @@ class AgentRegistry:
             from openrappter.agents.basic_agent import BasicAgent
         except ImportError:
             BasicAgent = None
-        
+
+        # Agents written to the portability contract import `agents.basic_agent`
+        # and nothing else from the tree, so the same file runs in the grail
+        # brainstem unchanged. This loader already gives discovered modules a
+        # synthetic `agents.` namespace, but it skips basic_agent.py, so that
+        # import resolved to nothing and the agent failed to load here while
+        # loading fine in the grail. Alias it, without clobbering a real
+        # top-level `agents` package if one is present.
+        if BasicAgent is not None:
+            import openrappter.agents as _agents_pkg
+            import openrappter.agents.basic_agent as _basic_agent_mod
+
+            sys.modules.setdefault("agents", _agents_pkg)
+            sys.modules.setdefault("agents.basic_agent", _basic_agent_mod)
+
         # Scan for agent files
         for file_path in self.agents_dir.glob("*_agent.py"):
             if file_path.name.startswith("_") or file_path.name == "basic_agent.py":

--- a/python/tests/test_builtin_agents_load.py
+++ b/python/tests/test_builtin_agents_load.py
@@ -1,0 +1,143 @@
+"""Every built-in agent must survive discovery.
+
+`AgentRegistry.discover_agents` scans this package's own `agents/` directory,
+loads each `*_agent.py`, and instantiates every `BasicAgent` subclass it finds.
+A module that raises on import is caught, logged and skipped, so the agent
+simply does not exist at runtime while everything else keeps working.
+
+That is what happened to `google_voice_agent.py`. Every `--list-agents` printed
+
+    WARNING: Failed to load .../google_voice_agent.py: No module named 'agents'
+
+and listed 18 agents where TypeScript listed a working `GoogleVoice`, so the
+two runtimes disagreed about which agents exist.
+
+The agent was not at fault, and changing it would have been the wrong fix.
+`tests/test_google_voice_agent.py` pins an "article VII portability" contract
+whose allowed imports are exactly `{json, hashlib, datetime, uuid, agents,
+agents.basic_agent}` — the file is deliberately written so the same source runs
+in the grail brainstem. Importing `openrappter.agents.basic_agent` instead does
+load it here and breaks that contract; I tried exactly that, and that test
+failed, which is how the real cause surfaced.
+
+The loader was at fault. It builds a synthetic `agents.` namespace for the
+modules it discovers but skips `basic_agent.py`, so the one import a portable
+agent is allowed to make resolved to nothing. It now aliases the package's
+`basic_agent` into that namespace with `setdefault`, which leaves a real
+top-level `agents` package alone if one exists.
+
+A logged warning is not a test. This is the test.
+"""
+
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+import openrappter.agents as agents_pkg
+from openrappter.cli import AgentRegistry
+
+AGENTS_DIR = Path(agents_pkg.__file__).parent
+
+
+def agent_files() -> list[str]:
+    """The files the registry will try to load, selected the way it selects them."""
+    return sorted(
+        path.name
+        for path in AGENTS_DIR.glob("*_agent.py")
+        if not path.name.startswith("_") and path.name != "basic_agent.py"
+    )
+
+
+@pytest.fixture(scope="module")
+def discovered() -> dict:
+    return AgentRegistry().discover_agents()
+
+
+def test_finds_a_realistic_number_of_agent_files():
+    # Anti-vacuity: a glob that matched nothing would let every assertion below
+    # pass by having nothing to load.
+    assert len(agent_files()) > 10
+
+
+def test_discovery_registers_a_realistic_number_of_agents(discovered):
+    assert len(discovered) > 10
+
+
+@pytest.mark.parametrize("filename", agent_files())
+def test_no_agent_file_fails_to_load(caplog, filename):
+    """Asserted per file rather than on a total.
+
+    A count alone stays healthy when one agent stops loading, because the others
+    keep it up — which is exactly how this went unnoticed for so long.
+
+    The property is that discovery raises no failure for the file, not that the
+    file is credited with an agent. The loader instantiates every `BasicAgent`
+    subclass visible in a module, including ones the module merely imports, so
+    `ComputerUse` is recorded against `demo_recorder_agent` — which imports it —
+    rather than against its own file. That misattribution is real but separate;
+    the agent loads either way.
+    """
+    with caplog.at_level(logging.WARNING):
+        AgentRegistry().discover_agents()
+
+    failures = [
+        record.getMessage()
+        for record in caplog.records
+        if "Failed to load" in record.getMessage() and filename in record.getMessage()
+    ]
+    assert failures == [], (
+        f"{filename} failed to load: {failures}. The loader catches this and "
+        "logs a warning, so the agent silently does not exist at runtime."
+    )
+
+
+@pytest.fixture
+def clean_agents_namespace():
+    """Discovery as production sees it, not as the test session leaves it.
+
+    Several suites — `test_google_voice_agent.py`, `test_brainstem_compliance.py`,
+    `test_twin_agent.py` — install a *stub* `agents` / `agents.basic_agent` into
+    `sys.modules` at import time to simulate the grail brainstem, and those stubs
+    persist for the rest of the run. Under the full suite the loader's
+    `setdefault` then finds the stub already present and leaves it, so portable
+    agents subclass a different BasicAgent than the registry checks against.
+
+    Nothing installs those stubs in production. Removing them for the duration
+    of this test measures the loader rather than the test session, and they are
+    put back so the suites that rely on them are unaffected.
+    """
+    saved = {
+        name: sys.modules.pop(name)
+        for name in ("agents", "agents.basic_agent")
+        if name in sys.modules
+    }
+    try:
+        yield
+    finally:
+        sys.modules.update(saved)
+
+
+@pytest.fixture
+def discovered_clean(clean_agents_namespace) -> dict:
+    return AgentRegistry().discover_agents()
+
+
+def test_google_voice_is_registered(discovered_clean):
+    """The specific regression, named so it cannot be lost in a parametrised list."""
+    assert "GoogleVoice" in discovered_clean
+
+
+def test_portable_agents_can_import_the_namespace_they_are_restricted_to(
+    discovered_clean,
+):
+    """The portability contract allows `agents.basic_agent` and little else, so
+    discovery has to make that name resolve. If this breaks, portable agents
+    stop loading and the only symptom is a warning."""
+    assert "agents.basic_agent" in sys.modules
+
+    from agents.basic_agent import BasicAgent as via_portable_name
+    from openrappter.agents.basic_agent import BasicAgent as via_package_name
+
+    assert via_portable_name is via_package_name


### PR DESCRIPTION
Every `--list-agents` printed this and carried on:

```
WARNING: Failed to load .../agents/google_voice_agent.py:
         No module named 'agents'
```

Python listed **18** agents while TypeScript listed **19**, including a working `GoogleVoice`. The two runtimes disagreed about which agents exist, and the only symptom was a warning nobody had a reason to read.

## The obvious fix is wrong

The agent imports `agents.basic_agent` where the other seventeen import `openrappter.agents.basic_agent`, so changing that one line looks like the whole job — and `tests/test_google_voice_agent.py` fails the moment you do.

It pins an **"article VII portability"** contract whose allowed imports are exactly:

```python
ALLOWED = {"json", "hashlib", "datetime", "uuid", "agents.basic_agent", "agents"}
```

The file is deliberately written so the same source runs unmodified in the grail brainstem. **I made that change, watched the portability test go red, and that is how the real cause surfaced.**

## The loader was at fault

`discover_agents` gives each module it finds a synthetic `agents.` namespace — then explicitly skips `basic_agent.py`, so the one import a portable agent is permitted to make resolved to nothing.

It now aliases the package's `basic_agent` into that namespace. **`setdefault`, not assignment**, so a real top-level `agents` package in the grail is left alone.

**The agent file is untouched, and both contracts hold.**

## The test needed the same care

Three suites — `test_google_voice_agent`, `test_brainstem_compliance`, `test_twin_agent` — install a *stub* `agents` / `agents.basic_agent` at import time to simulate the grail, and those stubs **persist for the rest of the session**. Under the full suite the loader's `setdefault` then finds a stub already there, so portable agents subclass a different `BasicAgent` than the registry checks against — my tests failed while passing in isolation. Nothing installs those stubs in production, so the fixture removes them for the duration and puts them back.

Assertions are **per file**, not on a count: a total stays healthy when one agent stops loading, which is how this survived. The property is *"discovery logged no failure for this file"*, not *"this file was credited with an agent"* — the loader instantiates every `BasicAgent` subclass visible in a module **including imported ones**, so `ComputerUse` is recorded against `demo_recorder_agent`, which imports it. That misattribution is real and separate; the agent loads either way.

**Verified end to end:** `GoogleVoice` now appears in `--list-agents`, the count is 19, and the warning is gone.

**Mutation-checked:** removing the alias fails 2 of 23.

Python suite: **1488 passed**, 6 skipped (1465 before, plus 23 here).