### PR TITLE
fix: the Bones window told a fresh install it had no agents

### DIFF
--- a/macos/Sources/OpenRappterBar/Core/BonesInspector.swift
+++ b/macos/Sources/OpenRappterBar/Core/BonesInspector.swift
@@ -56,16 +56,21 @@ public enum BonesInspector {
     ) -> Bones {
         var sections: [Bones.Section] = []
 
-        // ── Agents: what it can DO ──────────────────────────────────────────
+        // ── Agents: what YOU have added ─────────────────────────────────────
+        // Only the user's own directory. The built-in agents — 37 in the
+        // TypeScript runtime, 19 in Python — live inside the installed package
+        // and never appear here, so this section must not claim to show
+        // everything the AI can do. It said "No agents installed yet" on a
+        // fresh machine that ships 37 working agents.
         let agentsDir = home + "/agents"
         sections.append(
             Bones.Section(
                 id: "agents",
-                title: "Agents",
-                blurb: "Single-file capabilities. Each one is a thing this AI can do.",
+                title: "Your Agents",
+                blurb: "Single-file capabilities you have added. The built-in agents ship with the runtime and are not listed here.",
                 root: agentsDir,
                 items: files(in: agentsDir, matching: [".js", ".py", ".ts"], fileManager: fileManager),
-                emptyNote: "No agents installed yet. Build one with the Brain Surgeon."
+                emptyNote: "You haven't added any agents of your own yet. The built-in ones are already working; build another with the Brain Surgeon."
             ))
 
         // ── Skills ──────────────────────────────────────────────────────────

--- a/macos/Tests/OpenRappterBarTests/BonesInspectorTests.swift
+++ b/macos/Tests/OpenRappterBarTests/BonesInspectorTests.swift
@@ -104,5 +104,29 @@ func runBonesInspectorTests() async {
                            "\(section.title) should say what that part of the organism does")
             }
         }
+
+        await test("an empty agents directory does not claim the AI has no agents") {
+            // This section reads only the user's own directory. The built-in
+            // agents — 37 in the TypeScript runtime, 19 in Python — live inside
+            // the installed package and never appear here.
+            //
+            // It used to be titled "Agents", blurbed "Each one is a thing this
+            // AI can do", and said "No agents installed yet" when empty. On a
+            // fresh machine that is three false statements at once: the user
+            // sees nothing while 37 agents are working.
+            let bones = BonesInspector.inspect(home: try makeHome())
+            let section = bones.sections.first { $0.id == "agents" }
+            try expectNotNil(section)
+            try expect(section!.items.isEmpty, "a fresh home has no user agents")
+
+            let claim = (section!.title + " " + section!.blurb + " " + (section!.emptyNote ?? ""))
+                .lowercased()
+            try expect(!claim.contains("no agents installed"),
+                       "the empty note must not deny agents that are installed and working")
+            try expect(claim.contains("your") || claim.contains("you"),
+                       "the section must say these are the user's own agents")
+            try expect(claim.contains("built-in"),
+                       "the section must account for the agents that ship with the runtime")
+        }
     }
 }


### PR DESCRIPTION
The agents section of the Bones window reads one directory: the user's own `~/.openrappter/agents`. The built-in agents live inside the installed package and never appear there — **37 in the TypeScript runtime, 19 in Python**.

The section did not say so. It was titled `Agents`, blurbed *"Single-file capabilities. Each one is a thing this AI can do"*, and when the directory was empty:

```
No agents installed yet. Build one with the Brain Surgeon.
```

On a fresh machine that is **three false statements at once**, in the one window whose stated purpose is to *"read the organism as it exists right now"*. The user is told the assistant can do nothing while 37 agents are working.

**Measured on this machine:** the window counts **5**, the runtime reports **37**.

## The fix

The section now says these are the agents *you* added, and that the built-in ones ship with the runtime — which is what it has always actually shown.

This is a **wording fix, not the whole answer**. Whether the window should list the built-ins too — the natural source is the gateway's `agents.list`, which the Bar already has a client wrapper for and **never calls** — is a design question, filed separately rather than decided here.

**Mutation-checked:** restoring the old copy fails with

```
FAIL: an empty agents directory does not claim the AI has no agents
      — the empty note must not deny agents that are installed and working
```

Swift: **167 passed**, 0 failed.