### PR TITLE
test: TypeScript never opened the parity corpus it claims to conform to

### DIFF
--- a/typescript/src/gateway/__tests__/parity-corpus-contract.test.ts
+++ b/typescript/src/gateway/__tests__/parity-corpus-contract.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from 'vitest';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { ENVELOPE_REQUIRED_KEYS } from '../chat-envelope.js';
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../../../..');
+const VECTORS_DIR = path.join(repoRoot, 'parity_vectors');
+const VECTORS_TEST = path.resolve(
+  path.dirname(fileURLToPath(import.meta.url)),
+  'parity-vectors.test.ts',
+);
+
+/**
+ * The golden corpus, read by this runtime rather than described by it.
+ *
+ * `parity-vectors.test.ts` implements PARITY §5.2's fourteen cases from the
+ * specification, because when it was written the corpus was marked "PLANNED —
+ * not yet committed" and there was nothing to fetch. The corpus has since been
+ * committed: fourteen vectors and a `CORPUS.json` manifest sit at the repo
+ * root, and `python/tests/test_parity_corpus.py` globs them, recomputes every
+ * digest, and fails if the manifest is stale.
+ *
+ * TypeScript did not open any of them. It opened no file at all — it carried a
+ * hand-written list of the fourteen names and its own expectations. Both sides
+ * happen to agree today, which is the problem: a corpus that only one runtime
+ * reads cannot detect the two runtimes disagreeing, and that is the single
+ * thing a parity corpus exists to do. Edit a vector's expected envelope and
+ * Python fails while TypeScript passes.
+ *
+ * These are the checks that make the corpus binding on this runtime too. They
+ * deliberately stop short of executing the vectors — the multi-round loop cases
+ * need a scripted model harness, which Python has and this package does not,
+ * and claiming to run a vector that is not run would be the same defect again.
+ */
+
+interface Vector {
+  name: string;
+  expect?: { envelope_required_keys?: string[] };
+}
+
+interface Manifest {
+  spec: string;
+  vector_count: number;
+  corpus_sha256: string;
+  vectors: Record<string, string>;
+}
+
+function vectorFiles(): string[] {
+  return fs
+    .readdirSync(VECTORS_DIR)
+    .filter((f) => f.endsWith('.json') && f !== 'CORPUS.json')
+    .sort();
+}
+
+function readVector(file: string): Vector {
+  return JSON.parse(fs.readFileSync(path.join(VECTORS_DIR, file), 'utf8')) as Vector;
+}
+
+function manifest(): Manifest {
+  return JSON.parse(fs.readFileSync(path.join(VECTORS_DIR, 'CORPUS.json'), 'utf8')) as Manifest;
+}
+
+/**
+ * The case names `parity-vectors.test.ts` declares, read from its source.
+ *
+ * Importing the constant would re-register that file's suite inside this one
+ * and run every vector test twice, so the list is parsed instead — the same
+ * derive-from-source approach the dormant-module and event-contract guards use.
+ */
+function declaredCaseNames(): string[] {
+  const source = fs.readFileSync(VECTORS_TEST, 'utf8');
+  const block = /VECTOR_CASES\s*=\s*\[([\s\S]*?)\]\s*as const/.exec(source);
+  if (!block) return [];
+  return [...block[1].matchAll(/name:\s*'([^']+)'/g)].map((m) => m[1]).sort();
+}
+
+/**
+ * The manifest's canonical form: JSON with sorted keys and no separator spaces.
+ *
+ * This mirrors Python's `json.dumps(sort_keys=True, separators=(",", ":"),
+ * ensure_ascii=False)`. `JSON.stringify` cannot sort keys, so the walk is
+ * explicit — and the digests are checked against the manifest, which is what
+ * proves the two implementations agree rather than merely look similar.
+ */
+function canonical(value: unknown): string {
+  if (value === null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map(canonical).join(',')}]`;
+  const record = value as Record<string, unknown>;
+  return `{${Object.keys(record)
+    .sort()
+    .map((key) => `${JSON.stringify(key)}:${canonical(record[key])}`)
+    .join(',')}}`;
+}
+
+function sha256(text: string): string {
+  return createHash('sha256').update(Buffer.from(text, 'utf8')).digest('hex');
+}
+
+describe('the shipped parity corpus binds this runtime', () => {
+  it('finds the corpus on disk', () => {
+    // Anti-vacuity. Every assertion below reads this directory; if the path is
+    // wrong they would all pass over an empty list.
+    expect(fs.existsSync(VECTORS_DIR), `${VECTORS_DIR} should exist`).toBe(true);
+    expect(vectorFiles().length).toBeGreaterThan(10);
+  });
+
+  it('names exactly the vectors that ship, in both directions', () => {
+    const onDisk = vectorFiles().map((f) => f.replace(/\.json$/, '')).sort();
+    const named = declaredCaseNames();
+
+    // Anti-vacuity for the parser: if the regex stopped matching, `named` would
+    // be empty and the second assertion below would pass trivially.
+    expect(named.length, 'VECTOR_CASES should be parseable from the test source').toBeGreaterThan(10);
+
+    // Two assertions rather than one equality, so the failure says which way
+    // the drift went: a vector added and never run, or a case named that no
+    // longer exists.
+    expect(onDisk.filter((n) => !named.includes(n)), 'shipped but not run by TypeScript').toEqual([]);
+    expect(named.filter((n) => !onDisk.includes(n)), 'named by TypeScript but not shipped').toEqual([]);
+  });
+
+  it('agrees with every vector about the envelope contract', () => {
+    // TypeScript keeps its own ENVELOPE_REQUIRED_KEYS constant and the vectors
+    // declare the same list. Nothing tied them together, so they could drift
+    // and both sides would keep passing.
+    const expected = [...ENVELOPE_REQUIRED_KEYS].sort();
+    const disagreements: string[] = [];
+
+    for (const file of vectorFiles()) {
+      const declared = readVector(file).expect?.envelope_required_keys;
+      if (!declared) continue;
+      const sorted = [...declared].sort();
+      if (JSON.stringify(sorted) !== JSON.stringify(expected)) {
+        disagreements.push(`${file}: ${JSON.stringify(declared)}`);
+      }
+    }
+
+    expect(disagreements, disagreements.join('\n')).toEqual([]);
+  });
+
+  it('reproduces every per-vector digest in the manifest', () => {
+    const declared = manifest().vectors;
+    const mismatched: string[] = [];
+    let checked = 0;
+
+    for (const file of vectorFiles()) {
+      const vector = readVector(file);
+      const digest = sha256(canonical(vector));
+      if (declared[vector.name] !== digest) {
+        mismatched.push(`${vector.name}: manifest ${declared[vector.name]} vs computed ${digest}`);
+      }
+      checked++;
+    }
+
+    // Per vector, not on a total: one stale digest is otherwise hidden by the
+    // thirteen that still match.
+    expect(checked).toBe(vectorFiles().length);
+    expect(mismatched, mismatched.join('\n')).toEqual([]);
+  });
+
+  it('reproduces the corpus digest, so a stale manifest cannot pass', () => {
+    const declared = manifest();
+    const lines = Object.keys(declared.vectors)
+      .sort()
+      .map((name) => `${name} ${declared.vectors[name]}`)
+      .join('\n');
+
+    expect(sha256(lines)).toBe(declared.corpus_sha256);
+  });
+
+  it('counts the vectors it claims to', () => {
+    expect(manifest().vector_count).toBe(vectorFiles().length);
+    expect(manifest().spec).toBe('rapp-runtime-parity/1.0');
+  });
+});

--- a/typescript/src/gateway/__tests__/parity-vectors.test.ts
+++ b/typescript/src/gateway/__tests__/parity-vectors.test.ts
@@ -1,18 +1,24 @@
 /**
  * The golden conformance vectors, run against this runtime.
  *
- * PARITY §5 says the corpus **SHOULD** ship at `rapp_brainstem/parity_vectors/`
- * and be mirrored into `rapp-map`. It does not: both locations 404 today, and
- * §5 itself marks the corpus **PLANNED — not yet committed**.
+ * PARITY §5 said the corpus **SHOULD** ship at `rapp_brainstem/parity_vectors/`
+ * and be mirrored into `rapp-map`. When this file was written both locations
+ * 404'd and §5 marked the corpus **PLANNED — not yet committed**, so there was
+ * nothing to fetch and these cases were implemented from §5.2, which names the
+ * fourteen required cases and specifies each one's observable behaviour.
  *
- * So there is nothing to fetch. What *is* normative is §5.2, which names the
- * fourteen required cases and specifies each one's observable behaviour. This
- * file implements those cases against our own runtime, so the tier we declare is
- * measured rather than asserted.
+ * The corpus has since been committed to this repo at `parity_vectors/`. This
+ * file still implements the cases rather than executing the vectors, because
+ * the multi-round loop shapes need a scripted model harness that lives in the
+ * Python suite and not here. What it must not do is drift from the corpus while
+ * claiming to conform to it, so `parity-corpus-contract.test.ts` ties the two
+ * together: it checks the names below against the shipped files in both
+ * directions, checks `ENVELOPE_REQUIRED_KEYS` against what every vector
+ * declares, and recomputes the manifest digests.
  *
- * Where a case cannot be decided without a live model (the multi-round loop
- * shapes), it is reported as `needs-model` rather than quietly passed. A vector
- * that cannot fail is not evidence.
+ * Where a case cannot be decided without a live model, it is reported as
+ * `needs-model` rather than quietly passed. A vector that cannot fail is not
+ * evidence.
  */
 
 import { describe, expect, it } from 'vitest';


### PR DESCRIPTION
`parity_vectors/` ships **fourteen golden vectors** and a `CORPUS.json` manifest. `python/tests/test_parity_corpus.py` globs the directory, recomputes every per-vector digest and the corpus digest, and fails if the manifest is stale.

**TypeScript opened none of them.** `parity-vectors.test.ts` reads no file at all — it carries a hand-written list of the fourteen names and its own expectations, because when it was written the corpus was marked *"PLANNED — not yet committed"* and both published locations 404d.

That was true then. The corpus has since landed in this repo, and the comment saying there is nothing to fetch stayed.

## Why it matters even though both sides agree

Both sides agree today, which is exactly the problem. **A corpus that only one runtime reads cannot detect the two runtimes disagreeing** — and detecting that is the single thing a parity corpus exists for.

Edit a vectors expected envelope and Python fails while TypeScript passes. I did that, and it does.

## What the new file checks

- the fourteen names against the shipped files **in both directions**, so a vector added and never run is as loud as a name that no longer exists
- `ENVELOPE_REQUIRED_KEYS` against what **every vector declares** — TypeScript keeps its own copy of that list and the vectors declare the same six keys; nothing tied them together
- **every per-vector digest and the corpus digest**, so a stale manifest cannot pass here either

Reproducing Pythons canonicalisation in JavaScript was the part worth getting right: sorted keys, `(",",":")` separators, UTF-8, sha256, then sha256 over the sorted `name digest` lines. `JSON.stringify` cannot sort keys, so the walk is explicit. **I proved it against the shipped manifest before writing the test** — all fourteen per-vector digests and the corpus digest reproduce exactly, which is what shows the two implementations agree rather than merely resemble each other.

It deliberately **stops short of executing** the vectors: the multi-round loop cases need a scripted model harness that the Python suite has and this package does not, and claiming to run a vector that is not run would be this same defect wearing a different hat.

## Implementation note

Importing `VECTOR_CASES` from the sibling test file re-registers that suite inside this one and runs every vector test twice — the run reported **15 tests for a file with 6**. The names are parsed from source instead, the way the dormant-module and event-contract guards already do, with an anti-vacuity assertion so a broken parser cannot pass as agreement.

**Mutation-checked:**

| mutation | result |
|---|---|
| a vectors expected envelope is edited | 1 failed |
| `ENVELOPE_REQUIRED_KEYS` drifts | 1 failed |
| a vector ships that TypeScript never names | 2 failed |
| restored | 6 passed |

TypeScript **4822 passed**, Python parity corpus **6 passed**, `tsc` clean.