### PR TITLE
test: the desktop startup handshake was asserted as text, never executed

### DIFF
--- a/typescript/desktop/src/gateway-ready.ts
+++ b/typescript/desktop/src/gateway-ready.ts
@@ -1,0 +1,111 @@
+/**
+ * Waiting for the gateway child to report itself ready.
+ *
+ * This lived inside `ensureGateway` in `main.ts`, which imports `electron` and
+ * therefore cannot be loaded by a plain `node --test` process. That is why the
+ * desktop suite asserts `main.ts` as *text*: the readiness handshake — the one
+ * piece of desktop startup that decides whether the app launches at all — had
+ * no executable coverage.
+ *
+ * Nothing here needs Electron. It needs a child that emits `message`, `exit`
+ * and `error`, which a test can supply.
+ */
+
+export const GATEWAY_READY_SCHEMA = 'openrappter-gateway-ready/1.0';
+
+/**
+ * How long the gateway may take to say it is ready before we give up on it.
+ *
+ * Worth knowing before changing it: `onExit` already rejects immediately when
+ * the gateway genuinely fails to start, so this timer only ever fires while the
+ * process is alive and simply slow — a cold start, a first run resolving
+ * modules, an antivirus scan — which is the case where killing it is least
+ * likely to be the right answer.
+ *
+ * Left at the original 30s. A Windows CI run has failed on it once and passed
+ * on re-run, which is not enough to justify picking a different number; the
+ * question is open in issue #223. Callers can override it, and now that this
+ * handshake is testable a future change can be made against evidence rather
+ * than guessed at.
+ */
+export const GATEWAY_READY_TIMEOUT_MS = 30_000;
+
+/** The part of a child process this handshake uses. */
+export interface ReadyChildProcess {
+  readonly pid?: number;
+  on(event: 'message', listener: (message: unknown) => void): unknown;
+  on(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+  on(event: 'error', listener: (error: Error) => void): unknown;
+  off(event: 'message', listener: (message: unknown) => void): unknown;
+  off(event: 'exit', listener: (code: number | null, signal: NodeJS.Signals | null) => void): unknown;
+  kill(signal?: NodeJS.Signals): unknown;
+}
+
+export interface WaitForGatewayReadyOptions {
+  /** The port the desktop app asked the gateway to listen on. */
+  port: number;
+  timeoutMs?: number;
+}
+
+/**
+ * Resolve when the child reports it is ready, reject on exit, error or timeout.
+ *
+ * The readiness message is accepted only when the schema, pid and port all
+ * match: the desktop app owns this child, and a message that does not describe
+ * it is not evidence that *our* gateway is up.
+ */
+export function waitForGatewayReady(
+  child: ReadyChildProcess,
+  options: WaitForGatewayReadyOptions,
+): Promise<void> {
+  const timeoutMs = options.timeoutMs ?? GATEWAY_READY_TIMEOUT_MS;
+
+  return new Promise<void>((resolve, reject) => {
+    let settled = false;
+    const finish = (error?: Error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      child.off('message', onMessage);
+      child.off('exit', onExit);
+      if (error) reject(error);
+      else resolve();
+    };
+
+    const onMessage = (message: unknown) => {
+      const ready = message as {
+        schema?: unknown;
+        pid?: unknown;
+        port?: unknown;
+      };
+      if (
+        ready?.schema === GATEWAY_READY_SCHEMA &&
+        ready.pid === child.pid &&
+        ready.port === options.port
+      ) {
+        finish();
+      }
+    };
+
+    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
+      finish(
+        new Error(
+          `OpenRappter gateway exited during desktop startup (${code ?? signal ?? 'unknown'}).`,
+        ),
+      );
+    };
+
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM');
+      finish(
+        new Error(
+          `OpenRappter gateway did not become ready in ${Math.round(timeoutMs / 1000)} seconds.`,
+        ),
+      );
+    }, timeoutMs);
+
+    child.on('error', (error: Error) => finish(error));
+    child.on('message', onMessage);
+    child.on('exit', onExit);
+  });
+}

--- a/typescript/desktop/src/main.ts
+++ b/typescript/desktop/src/main.ts
@@ -41,6 +41,7 @@ import {
   VibeVoiceService,
 } from './vibevoice.js';
 import { SECURE_RENDERER_PREFERENCES } from './window-security.js';
+import { waitForGatewayReady } from './gateway-ready.js';
 
 const packageRoot = path.join(
   import.meta.dirname,
@@ -380,46 +381,7 @@ async function ensureGateway(): Promise<void> {
     },
   );
   gatewayProcess = child;
-  await new Promise<void>((resolve, reject) => {
-    let settled = false;
-    const finish = (error?: Error) => {
-      if (settled) return;
-      settled = true;
-      clearTimeout(timeout);
-      child.off('message', onMessage);
-      child.off('exit', onExit);
-      if (error) reject(error);
-      else resolve();
-    };
-    const onMessage = (message: unknown) => {
-      const ready = message as {
-        schema?: unknown;
-        pid?: unknown;
-        port?: unknown;
-      };
-      if (
-        ready?.schema === 'openrappter-gateway-ready/1.0' &&
-        ready.pid === child.pid &&
-        ready.port === gatewayPort
-      ) {
-        finish();
-      }
-    };
-    const onExit = (code: number | null, signal: NodeJS.Signals | null) => {
-      finish(new Error(
-        `OpenRappter gateway exited during desktop startup (${
-          code ?? signal ?? 'unknown'
-        }).`,
-      ));
-    };
-    const timeout = setTimeout(() => {
-      child.kill('SIGTERM');
-      finish(new Error('OpenRappter gateway did not become ready in 30 seconds.'));
-    }, 30_000);
-    child.on('error', (error) => finish(error));
-    child.on('message', onMessage);
-    child.on('exit', onExit);
-  });
+  await waitForGatewayReady(child, { port: gatewayPort });
 }
 
 async function loadShowRuntime() {

--- a/typescript/desktop/test/desktop-contract.test.mjs
+++ b/typescript/desktop/test/desktop-contract.test.mjs
@@ -3,6 +3,13 @@ import { readFileSync } from 'node:fs';
 import { test } from 'node:test';
 
 const main = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8');
+// The readiness handshake was lifted out of main.ts so it could be driven by a
+// test — main.ts imports electron and cannot be loaded here. These text
+// assertions follow it to the module that now owns it.
+const gatewayReady = readFileSync(
+  new URL('../src/gateway-ready.ts', import.meta.url),
+  'utf8',
+);
 const runtimeEntry = readFileSync(
   new URL('../../src/index.ts', import.meta.url),
   'utf8',
@@ -92,7 +99,7 @@ test('desktop publishes one authenticated endpoint for tray and Swift Bar', () =
 
 test('desktop accepts gateway readiness only from its owned child IPC channel', () => {
   assert.match(main, /stdio: \['ignore', 'ignore', 'ignore', 'ipc'\]/);
-  assert.match(main, /openrappter-gateway-ready\/1\.0/);
+  assert.match(gatewayReady, /openrappter-gateway-ready\/1\.0/);
   assert.doesNotMatch(main, /desktop_probe_/);
   assert.match(runtimeEntry, /process\.send\?\.\(\{/);
   assert.match(runtimeEntry, /openrappter-gateway-ready\/1\.0/);
@@ -118,7 +125,7 @@ test('desktop reuses the packaged OpenRappter gateway and core', () => {
   assert.match(main, /runtime[\s\S]*node_modules[\s\S]*openrappter/);
   assert.match(main, /ShowAndTellAgent\.js/);
   assert.match(main, /--daemon/);
-  assert.match(main, /openrappter-gateway-ready\/1\.0/);
+  assert.match(gatewayReady, /openrappter-gateway-ready\/1\.0/);
   assert.match(main, /window\.loadFile\(uiIndex\)/);
   assert.match(preload, /gatewayUrl:/);
   assert.match(main, /onBeforeSendHeaders/);

--- a/typescript/desktop/test/gateway-ready.test.mjs
+++ b/typescript/desktop/test/gateway-ready.test.mjs
@@ -1,0 +1,151 @@
+import { strict as assert } from 'node:assert';
+import { EventEmitter } from 'node:events';
+import { test } from 'node:test';
+
+import {
+  GATEWAY_READY_SCHEMA,
+  GATEWAY_READY_TIMEOUT_MS,
+  waitForGatewayReady,
+} from '../dist/gateway-ready.js';
+
+/**
+ * The gateway readiness handshake, driven rather than described.
+ *
+ * Desktop startup hangs on this one promise: the app either sees its gateway
+ * report ready, or it does not launch. Until now it lived inside
+ * `ensureGateway` in `main.ts`, which imports `electron` and so cannot be
+ * loaded by `node --test` — which is why the desktop suite asserts that file as
+ * text. The security property ("accept readiness only from our own child") was
+ * pinned by a regex over the source and never once executed.
+ *
+ * These tests supply a fake child and check what the handshake actually does.
+ */
+
+/** A child process as this handshake sees it: an emitter with a pid and kill. */
+class FakeChild extends EventEmitter {
+  constructor(pid = 4242) {
+    super();
+    this.pid = pid;
+    this.killed = [];
+  }
+
+  kill(signal) {
+    this.killed.push(signal);
+  }
+}
+
+const ready = (child, port) => ({
+  schema: GATEWAY_READY_SCHEMA,
+  pid: child.pid,
+  port,
+});
+
+test('resolves when the child reports the expected schema, pid and port', async () => {
+  const child = new FakeChild();
+  const waiting = waitForGatewayReady(child, { port: 18790, timeoutMs: 1000 });
+
+  child.emit('message', ready(child, 18790));
+
+  await waiting; // rejects the test if it does not resolve
+  assert.deepEqual(child.killed, [], 'a ready gateway must not be killed');
+});
+
+test('ignores a readiness message describing a different process', async () => {
+  // Another gateway on this machine announcing itself is not evidence that
+  // *ours* is up. This is the property the source-text test asserted by regex.
+  const child = new FakeChild(4242);
+  const waiting = waitForGatewayReady(child, { port: 18790, timeoutMs: 120 });
+
+  child.emit('message', { ...ready(child, 18790), pid: 9999 });
+
+  await assert.rejects(waiting, /did not become ready/);
+});
+
+test('ignores a readiness message for a different port', async () => {
+  const child = new FakeChild();
+  const waiting = waitForGatewayReady(child, { port: 18790, timeoutMs: 120 });
+
+  child.emit('message', { ...ready(child, 18790), port: 9999 });
+
+  await assert.rejects(waiting, /did not become ready/);
+});
+
+test('ignores a message with the wrong schema', async () => {
+  const child = new FakeChild();
+  const waiting = waitForGatewayReady(child, { port: 18790, timeoutMs: 120 });
+
+  child.emit('message', { ...ready(child, 18790), schema: 'something-else/1.0' });
+
+  await assert.rejects(waiting, /did not become ready/);
+});
+
+test('ignores malformed messages without throwing', async () => {
+  const child = new FakeChild();
+  const waiting = waitForGatewayReady(child, { port: 18790, timeoutMs: 120 });
+
+  for (const message of [null, undefined, 'ready', 42, {}, { schema: null }]) {
+    child.emit('message', message);
+  }
+
+  await assert.rejects(waiting, /did not become ready/);
+});
+
+test('rejects immediately when the gateway exits, naming the code', async () => {
+  const child = new FakeChild();
+  const waiting = waitForGatewayReady(child, { port: 18790, timeoutMs: 60_000 });
+
+  child.emit('exit', 3, null);
+
+  // The timeout is a minute; if exit were not handled this would hang the suite.
+  await assert.rejects(waiting, /exited during desktop startup \(3\)/);
+  assert.deepEqual(child.killed, [], 'an already-exited child must not be killed');
+});
+
+test('rejects when the child emits an error', async () => {
+  const child = new FakeChild();
+  const waiting = waitForGatewayReady(child, { port: 18790, timeoutMs: 60_000 });
+
+  child.emit('error', new Error('spawn ENOENT'));
+
+  await assert.rejects(waiting, /spawn ENOENT/);
+});
+
+test('kills the child and reports the budget when it never reports ready', async () => {
+  const child = new FakeChild();
+
+  await assert.rejects(
+    waitForGatewayReady(child, { port: 18790, timeoutMs: 50 }),
+    /did not become ready in 0 seconds/,
+  );
+  assert.deepEqual(child.killed, ['SIGTERM']);
+});
+
+test('a late ready message cannot resolve a already-rejected wait', async () => {
+  const child = new FakeChild();
+  const waiting = waitForGatewayReady(child, { port: 18790, timeoutMs: 40 });
+  await assert.rejects(waiting, /did not become ready/);
+
+  // Settling twice would resolve a promise that already rejected, or throw an
+  // unhandled error inside a listener that should have been removed.
+  child.emit('message', ready(child, 18790));
+  child.emit('exit', 0, null);
+  assert.deepEqual(child.killed, ['SIGTERM'], 'the child is killed once, not per event');
+});
+
+test('stops listening once settled', async () => {
+  const child = new FakeChild();
+  const waiting = waitForGatewayReady(child, { port: 18790, timeoutMs: 1000 });
+  child.emit('message', ready(child, 18790));
+  await waiting;
+
+  // A retained listener on a long-lived child process is a leak, and this
+  // handshake runs on every desktop start.
+  assert.equal(child.listenerCount('message'), 0);
+  assert.equal(child.listenerCount('exit'), 0);
+});
+
+test('the default budget is the one the error message promises', () => {
+  // The message states a number of seconds; if the constant and the text ever
+  // disagree the error would misreport how long the app actually waited.
+  assert.equal(GATEWAY_READY_TIMEOUT_MS, 30_000);
+});


### PR DESCRIPTION
Desktop startup hangs on one promise: the app either sees its gateway child report ready, or it does not launch. That promise lived inside `ensureGateway` in `main.ts`, which imports `electron` and so cannot be loaded by `node --test` — which is why the desktop suite reads that file with `readFileSync` and asserts on the **source text**.

So the security property the suite names — *"desktop accepts gateway readiness only from its owned child IPC channel"* — was pinned by a regex looking for the schema string, and the code implementing it **had never run under test**. A regex can tell you the string is present. It cannot tell you the pid comparison is there and correct.

## Nothing in that handshake needs Electron

It needs a child that emits `message`, `exit` and `error`. Lifted into `gateway-ready.ts` **unchanged**, and driven by a fake child:

- resolves only when schema, pid **and** port all match
- a message describing a different pid or port is ignored — another gateway on the machine announcing itself is not evidence that *ours* is up
- malformed messages (`null`, a bare string, `{}`) do not throw
- `exit` rejects immediately and names the code, rather than waiting out the timeout
- a spawn error rejects
- a timeout kills the child **once** and reports the budget
- a late message after settling cannot resolve an already-rejected wait
- listeners are removed once settled, since this runs on every start

**Mutation-checked, one behaviour at a time:**

| mutation | result |
|---|---|
| accept any pid | 1 failed |
| never kill on timeout | 2 failed |
| leak the listeners | 1 failed |
| ignore the port | 1 failed |
| restored | 20 passed |

Two existing text assertions matched the schema string in `main.ts` and now match it in the module that owns the handshake, so the contract they encode is unchanged rather than dropped.

## The 30s budget is deliberately untouched

`onExit` already covers a gateway that genuinely fails to start, so the timer only fires while the process is **alive and slow**, and killing it then is doubtful. But one Windows CI run failing and passing on re-run is not enough to justify a different number. The question is open in #223 — the point of this change is that a future answer can be **measured instead of guessed**.

## Correction

I claimed in #223 that this package has no tests. **It has nine**, run by `node --test` in `desktop.yml`. I searched for `*.test.ts` under `src/` and reported that narrow answer as the broad one. [The issue is corrected](https://github.com/kody-w/openrappter/issues/223#issuecomment-5316120551).

Desktop **20 passed**. Root TypeScript **4822 passed**, `tsc` clean.