### PR TITLE
feat: talk to the brainstem and the local runtime from one chat

### DIFF
--- a/typescript/src/gateway/__tests__/brainstem-client.test.ts
+++ b/typescript/src/gateway/__tests__/brainstem-client.test.ts
@@ -1,0 +1,171 @@
+import { describe, it, expect } from 'vitest';
+
+import {
+  askBrainstem,
+  brainstemBaseUrl,
+  BrainstemUnavailableError,
+  DEFAULT_BRAINSTEM_URL,
+} from '../brainstem-client.js';
+import { normalizeChatTarget, CHAT_TARGETS } from '../server.js';
+
+/**
+ * One chat, two brains.
+ *
+ * The brainstem runs as its own process speaking HTTP `POST /chat`, while the
+ * gateway speaks WebSocket `chat.send`. Holding a conversation across both used
+ * to mean two chat windows. They can share one, because both return the same
+ * frozen envelope — `rapp-runtime-parity/1.0` §2.4 — so a reply from either
+ * renders identically.
+ *
+ * What has to be right for that to be safe rather than merely convenient: an
+ * unknown target must not quietly answer from the wrong brain, and a brainstem
+ * that is not running must say so in a way a person can act on. Both replies
+ * look the same on the wire, so neither failure would be visible otherwise.
+ */
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+const envelope = {
+  response: 'Hello from the brainstem.',
+  session_id: 'session-1',
+  agent_logs: '',
+  voice_mode: false,
+  model: 'copilot:auto',
+  requested_model: 'auto',
+};
+
+describe('chat target resolution', () => {
+  it('defaults to the local runtime when nothing is asked for', () => {
+    expect(normalizeChatTarget(undefined)).toBe('openrappter');
+    expect(normalizeChatTarget(null)).toBe('openrappter');
+    expect(normalizeChatTarget('')).toBe('openrappter');
+  });
+
+  it('accepts every target it advertises', () => {
+    // Anti-vacuity: if CHAT_TARGETS were emptied this loop would assert nothing.
+    expect(CHAT_TARGETS.length).toBeGreaterThan(1);
+    for (const target of CHAT_TARGETS) {
+      expect(normalizeChatTarget(target)).toBe(target);
+    }
+  });
+
+  it('refuses an unknown target rather than falling back', () => {
+    // A typo must not silently answer from a different brain: the two replies
+    // are the same shape, so the caller could not tell.
+    expect(() => normalizeChatTarget('brainstm')).toThrow(/Unknown chat target/);
+    expect(() => normalizeChatTarget('BRAINSTEM')).toThrow(/Unknown chat target/);
+    expect(() => normalizeChatTarget(42)).toThrow(/Unknown chat target/);
+  });
+});
+
+describe('brainstemBaseUrl', () => {
+  it('is loopback unless configured', () => {
+    expect(brainstemBaseUrl({} as NodeJS.ProcessEnv)).toBe(DEFAULT_BRAINSTEM_URL);
+    expect(DEFAULT_BRAINSTEM_URL).toMatch(/^http:\/\/127\.0\.0\.1:/);
+  });
+
+  it('honours an override and trims a trailing slash', () => {
+    const env = { OPENRAPPTER_BRAINSTEM_URL: 'http://192.168.1.9:7071/' } as NodeJS.ProcessEnv;
+    expect(brainstemBaseUrl(env)).toBe('http://192.168.1.9:7071');
+  });
+
+  it('ignores a blank override', () => {
+    expect(brainstemBaseUrl({ OPENRAPPTER_BRAINSTEM_URL: '   ' } as NodeJS.ProcessEnv))
+      .toBe(DEFAULT_BRAINSTEM_URL);
+  });
+});
+
+describe('askBrainstem', () => {
+  it('posts the kernel shape and returns the envelope unchanged', async () => {
+    let seen: { url: string; body: unknown } | null = null;
+    const fetchImpl = (async (url: string | URL, init?: RequestInit) => {
+      seen = { url: String(url), body: JSON.parse(String(init?.body)) };
+      return jsonResponse(envelope);
+    }) as unknown as typeof fetch;
+
+    const result = await askBrainstem({
+      message: 'hello',
+      sessionId: 'session-1',
+      baseUrl: 'http://127.0.0.1:7072',
+      fetchImpl,
+    });
+
+    expect(seen!.url).toBe('http://127.0.0.1:7072/chat');
+    expect(seen!.body).toEqual({ message: 'hello', session_id: 'session-1' });
+    // Passed through, not reshaped: rewriting it here would be a second place
+    // for the two runtimes to drift.
+    expect(result).toEqual(envelope);
+  });
+
+  it('omits the session when there is not one, rather than sending null', async () => {
+    let body: Record<string, unknown> = {};
+    const fetchImpl = (async (_url: string | URL, init?: RequestInit) => {
+      body = JSON.parse(String(init?.body));
+      return jsonResponse(envelope);
+    }) as unknown as typeof fetch;
+
+    await askBrainstem({ message: 'hi', fetchImpl, baseUrl: 'http://127.0.0.1:7072' });
+
+    expect('session_id' in body).toBe(false);
+  });
+
+  it('carries a voice seam through when the brainstem split one', async () => {
+    const fetchImpl = (async () =>
+      jsonResponse({ ...envelope, voice_mode: true, voice_response: 'spoken part' })
+    ) as unknown as typeof fetch;
+
+    const result = await askBrainstem({ message: 'hi', fetchImpl });
+
+    expect(result.voice_response).toBe('spoken part');
+    expect(result.voice_mode).toBe(true);
+  });
+
+  it('says the brainstem is not running, and how to start it', async () => {
+    // The overwhelmingly common failure. "fetch failed" would be useless.
+    const fetchImpl = (async () => {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:7072');
+    }) as unknown as typeof fetch;
+
+    await expect(askBrainstem({ message: 'hi', fetchImpl, baseUrl: 'http://127.0.0.1:7072' }))
+      .rejects.toThrow(BrainstemUnavailableError);
+
+    await expect(askBrainstem({ message: 'hi', fetchImpl, baseUrl: 'http://127.0.0.1:7072' }))
+      .rejects.toThrow(/python -m openrappter\.brainstem/);
+  });
+
+  it('reports an HTTP failure with its status and body', async () => {
+    const fetchImpl = (async () =>
+      new Response('no model configured', { status: 503 })
+    ) as unknown as typeof fetch;
+
+    await expect(askBrainstem({ message: 'hi', fetchImpl })).rejects.toThrow(/503/);
+    await expect(askBrainstem({ message: 'hi', fetchImpl })).rejects.toThrow(/no model configured/);
+  });
+
+  it('rejects a body that is not JSON', async () => {
+    const fetchImpl = (async () =>
+      new Response('<html>proxy error</html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html' },
+      })
+    ) as unknown as typeof fetch;
+
+    await expect(askBrainstem({ message: 'hi', fetchImpl })).rejects.toThrow(/not JSON/);
+  });
+
+  it('rejects JSON that is not a chat envelope', async () => {
+    // Something answered on that port. That is not the same as the brainstem
+    // answering, and treating it as a reply would put another service's words
+    // in the assistant's mouth.
+    const fetchImpl = (async () =>
+      jsonResponse({ ok: true, service: 'something-else' })
+    ) as unknown as typeof fetch;
+
+    await expect(askBrainstem({ message: 'hi', fetchImpl })).rejects.toThrow(/not a chat envelope/);
+  });
+});

--- a/typescript/src/gateway/__tests__/brainstem-client.test.ts
+++ b/typescript/src/gateway/__tests__/brainstem-client.test.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, beforeEach } from 'vitest';
 
 import {
   askBrainstem,
   brainstemBaseUrl,
   BrainstemUnavailableError,
   DEFAULT_BRAINSTEM_URL,
+  resolveBrainstemUrl,
+  resetBrainstemDiscovery,
 } from '../brainstem-client.js';
 import { normalizeChatTarget, CHAT_TARGETS } from '../server.js';
 
@@ -96,7 +98,15 @@ describe('askBrainstem', () => {
     });
 
     expect(seen!.url).toBe('http://127.0.0.1:7072/chat');
-    expect(seen!.body).toEqual({ message: 'hello', session_id: 'session-1' });
+    // Both spellings. A live RAPP kernel answered
+    // `400 {"error":"user_input is required"}` to a message-only body, and
+    // every unit test here passed against a fake that accepted `message`, so
+    // only the end-to-end run caught it.
+    expect(seen!.body).toEqual({
+      message: 'hello',
+      user_input: 'hello',
+      session_id: 'session-1',
+    });
     // Passed through, not reshaped: rewriting it here would be a second place
     // for the two runtimes to drift.
     expect(result).toEqual(envelope);
@@ -167,5 +177,59 @@ describe('askBrainstem', () => {
     ) as unknown as typeof fetch;
 
     await expect(askBrainstem({ message: 'hi', fetchImpl })).rejects.toThrow(/not a chat envelope/);
+  });
+});
+
+describe('resolveBrainstemUrl', () => {
+  beforeEach(() => resetBrainstemDiscovery());
+
+  it('uses an explicit setting without probing anything', async () => {
+    let probes = 0;
+    const fetchImpl = (async () => { probes++; return new Response('{}'); }) as unknown as typeof fetch;
+
+    const url = await resolveBrainstemUrl({
+      env: { OPENRAPPTER_BRAINSTEM_URL: 'http://127.0.0.1:9999/' } as NodeJS.ProcessEnv,
+      fetchImpl,
+    });
+
+    expect(url).toBe('http://127.0.0.1:9999');
+    // If someone has said where it is, quietly using a different one would be
+    // worse than failing.
+    expect(probes).toBe(0);
+  });
+
+  it('finds a brainstem sitting in the RAPP drop-in slot', async () => {
+    // The installation this was written against has nothing on 7072 and a real
+    // brainstem on 7071. A single hardcoded default would look broken there.
+    const fetchImpl = (async (url: string | URL) =>
+      String(url).includes('7071')
+        ? new Response('{"status":"ok"}', { status: 200 })
+        : Promise.reject(new Error('ECONNREFUSED'))
+    ) as unknown as typeof fetch;
+
+    expect(await resolveBrainstemUrl({ env: {} as NodeJS.ProcessEnv, fetchImpl }))
+      .toBe('http://127.0.0.1:7071');
+  });
+
+  it('prefers this package own port when both answer', async () => {
+    const fetchImpl = (async () => new Response('{"status":"ok"}', { status: 200 })) as unknown as typeof fetch;
+    expect(await resolveBrainstemUrl({ env: {} as NodeJS.ProcessEnv, fetchImpl }))
+      .toBe('http://127.0.0.1:7072');
+  });
+
+  it('names a concrete address when nothing answers', async () => {
+    const fetchImpl = (async () => { throw new Error('ECONNREFUSED'); }) as unknown as typeof fetch;
+    expect(await resolveBrainstemUrl({ env: {} as NodeJS.ProcessEnv, fetchImpl }))
+      .toBe(DEFAULT_BRAINSTEM_URL);
+  });
+
+  it('does not re-probe once it has found one', async () => {
+    let probes = 0;
+    const fetchImpl = (async () => { probes++; return new Response('{"status":"ok"}', { status: 200 }); }) as unknown as typeof fetch;
+
+    await resolveBrainstemUrl({ env: {} as NodeJS.ProcessEnv, fetchImpl });
+    await resolveBrainstemUrl({ env: {} as NodeJS.ProcessEnv, fetchImpl });
+
+    expect(probes).toBe(1);
   });
 });

--- a/typescript/src/gateway/brainstem-client.ts
+++ b/typescript/src/gateway/brainstem-client.ts
@@ -1,0 +1,146 @@
+/**
+ * Talking to the local brainstem from the OpenRappter gateway.
+ *
+ * The brainstem (`python -m openrappter.brainstem`) is a separate process
+ * speaking HTTP `POST /chat`, while the gateway speaks WebSocket `chat.send`.
+ * Historically that meant two chat windows to hold one conversation across two
+ * brains. It does not have to: both runtimes return the *same* frozen envelope
+ * — `rapp-runtime-parity/1.0` §2.4 — so a reply from either can be rendered by
+ * the same client without translation.
+ *
+ * This module is the client half. It is deliberately free of gateway state so
+ * it can be tested by handing it a fetch, which is the only way to prove what
+ * it does when the brainstem is missing, slow, or answering something that is
+ * not an envelope.
+ */
+
+/** §2.4: the six keys every runtime must return. */
+export const BRAINSTEM_ENVELOPE_KEYS = [
+  'response',
+  'session_id',
+  'agent_logs',
+  'voice_mode',
+  'model',
+  'requested_model',
+] as const;
+
+/** Where the brainstem listens when nothing says otherwise. */
+export const DEFAULT_BRAINSTEM_URL = 'http://127.0.0.1:7072';
+
+const DEFAULT_TIMEOUT_MS = 120_000;
+
+export interface BrainstemEnvelope {
+  response: string;
+  session_id: string;
+  agent_logs: string;
+  voice_mode: boolean;
+  model: string;
+  requested_model: string;
+  /** Present only when the reply carried a voice seam. */
+  voice_response?: string;
+}
+
+export interface BrainstemAskOptions {
+  message: string;
+  sessionId?: string;
+  conversationHistory?: unknown[];
+  baseUrl?: string;
+  timeoutMs?: number;
+  /** Injected for tests; defaults to global fetch. */
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * The configured brainstem address.
+ *
+ * Loopback by default and overridable, because a brainstem on another host is a
+ * legitimate setup — but the default must not be a network address that someone
+ * else could occupy.
+ */
+export function brainstemBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
+  const configured = env.OPENRAPPTER_BRAINSTEM_URL?.trim();
+  return configured && configured.length > 0 ? configured.replace(/\/+$/, '') : DEFAULT_BRAINSTEM_URL;
+}
+
+/**
+ * A refusal a person can act on.
+ *
+ * "fetch failed" tells a user nothing. The common case by far is that the
+ * brainstem simply is not running, and the fix is one command, so the error
+ * says which address was tried and what to do about it.
+ */
+export class BrainstemUnavailableError extends Error {
+  constructor(baseUrl: string, cause: unknown) {
+    const reason = cause instanceof Error ? cause.message : String(cause);
+    super(
+      `The brainstem is not answering at ${baseUrl} (${reason}). ` +
+        `Start it with \`python -m openrappter.brainstem\`, or set ` +
+        `OPENRAPPTER_BRAINSTEM_URL if it listens elsewhere.`,
+    );
+    this.name = 'BrainstemUnavailableError';
+  }
+}
+
+function isEnvelope(value: unknown): value is BrainstemEnvelope {
+  if (!value || typeof value !== 'object') return false;
+  const record = value as Record<string, unknown>;
+  return typeof record.response === 'string' && typeof record.session_id === 'string';
+}
+
+/**
+ * Ask the brainstem, and return its envelope unchanged.
+ *
+ * The envelope is passed through rather than reshaped: it is already the format
+ * every OpenRappter client understands, and rewriting it here would be a second
+ * place for the two runtimes to drift apart.
+ */
+export async function askBrainstem(options: BrainstemAskOptions): Promise<BrainstemEnvelope> {
+  const baseUrl = (options.baseUrl ?? brainstemBaseUrl()).replace(/\/+$/, '');
+  const doFetch = options.fetchImpl ?? fetch;
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  const body: Record<string, unknown> = { message: options.message };
+  if (options.sessionId) body.session_id = options.sessionId;
+  if (options.conversationHistory) body.conversation_history = options.conversationHistory;
+
+  let response: Response;
+  try {
+    response = await doFetch(`${baseUrl}/chat`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify(body),
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+  } catch (error) {
+    // Not running, refused, DNS, or timed out — all of them mean "no brainstem
+    // answered", and all of them are actionable in the same way.
+    throw new BrainstemUnavailableError(baseUrl, error);
+  }
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => '');
+    throw new Error(
+      `The brainstem answered ${response.status} at ${baseUrl}/chat${detail ? `: ${detail.slice(0, 300)}` : '.'}`,
+    );
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = await response.json();
+  } catch (error) {
+    throw new Error(
+      `The brainstem returned a body that is not JSON (${(error as Error).message}).`,
+    );
+  }
+
+  if (!isEnvelope(parsed)) {
+    throw new Error(
+      'The brainstem returned JSON that is not a chat envelope: ' +
+        `expected ${BRAINSTEM_ENVELOPE_KEYS.join(', ')}, got ${
+          parsed && typeof parsed === 'object' ? Object.keys(parsed).join(', ') || '{}' : typeof parsed
+        }.`,
+    );
+  }
+
+  return parsed;
+}

--- a/typescript/src/gateway/brainstem-client.ts
+++ b/typescript/src/gateway/brainstem-client.ts
@@ -27,7 +27,22 @@ export const BRAINSTEM_ENVELOPE_KEYS = [
 /** Where the brainstem listens when nothing says otherwise. */
 export const DEFAULT_BRAINSTEM_URL = 'http://127.0.0.1:7072';
 
+/**
+ * The addresses a brainstem is actually found at, in preference order.
+ *
+ * 7072 is this package's own default. 7071 is the slot a RAPP brainstem sits in
+ * — `brainstem.py` documents it as the full drop-in port — and an installation
+ * that followed the grail path has one there and nothing on 7072. Probing both
+ * is the difference between the selector working on a stock machine and
+ * appearing broken until someone finds an environment variable.
+ */
+export const BRAINSTEM_CANDIDATE_URLS = [
+  'http://127.0.0.1:7072',
+  'http://127.0.0.1:7071',
+] as const;
+
 const DEFAULT_TIMEOUT_MS = 120_000;
+const HEALTH_PROBE_TIMEOUT_MS = 1_500;
 
 export interface BrainstemEnvelope {
   response: string;
@@ -63,6 +78,57 @@ export function brainstemBaseUrl(env: NodeJS.ProcessEnv = process.env): string {
 }
 
 /**
+ * Find the brainstem, preferring an explicit setting over a guess.
+ *
+ * An explicit `OPENRAPPTER_BRAINSTEM_URL` is returned without probing: if
+ * someone has said where it is, silently using a different one would be worse
+ * than failing. Otherwise each candidate is asked `/health`, and the first that
+ * answers wins.
+ *
+ * The result is remembered, because this runs on every brainstem turn and the
+ * answer does not change while the gateway is up. `resetBrainstemDiscovery`
+ * exists so tests are not order-dependent on that cache.
+ */
+let discovered: string | null = null;
+
+export function resetBrainstemDiscovery(): void {
+  discovered = null;
+}
+
+export async function resolveBrainstemUrl(options: {
+  env?: NodeJS.ProcessEnv;
+  fetchImpl?: typeof fetch;
+  candidates?: readonly string[];
+} = {}): Promise<string> {
+  const env = options.env ?? process.env;
+  const configured = env.OPENRAPPTER_BRAINSTEM_URL?.trim();
+  if (configured && configured.length > 0) return configured.replace(/\/+$/, '');
+
+  if (discovered) return discovered;
+
+  const doFetch = options.fetchImpl ?? fetch;
+  const candidates = options.candidates ?? BRAINSTEM_CANDIDATE_URLS;
+
+  for (const candidate of candidates) {
+    try {
+      const response = await doFetch(`${candidate}/health`, {
+        signal: AbortSignal.timeout(HEALTH_PROBE_TIMEOUT_MS),
+      });
+      if (response.ok) {
+        discovered = candidate;
+        return candidate;
+      }
+    } catch {
+      // Nothing there; try the next.
+    }
+  }
+
+  // Nothing answered. Return the documented default so the failure names a
+  // concrete address rather than reporting that no address was tried.
+  return DEFAULT_BRAINSTEM_URL;
+}
+
+/**
  * A refusal a person can act on.
  *
  * "fetch failed" tells a user nothing. The common case by far is that the
@@ -95,11 +161,21 @@ function isEnvelope(value: unknown): value is BrainstemEnvelope {
  * place for the two runtimes to drift apart.
  */
 export async function askBrainstem(options: BrainstemAskOptions): Promise<BrainstemEnvelope> {
-  const baseUrl = (options.baseUrl ?? brainstemBaseUrl()).replace(/\/+$/, '');
   const doFetch = options.fetchImpl ?? fetch;
+  const baseUrl = (
+    options.baseUrl ?? (await resolveBrainstemUrl({ fetchImpl: doFetch }))
+  ).replace(/\/+$/, '');
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
 
-  const body: Record<string, unknown> = { message: options.message };
+  const body: Record<string, unknown> = {
+    // Both spellings, deliberately. `brainstem.py` documents `message` with
+    // `user_input` as a legacy alias, but the RAPP kernel this mirrors is
+    // older and rejects a body without `user_input` — a live one answered
+    // `400 {"error":"user_input is required"}` to a `message`-only request.
+    // Sending both is what makes one client work against both kernels.
+    message: options.message,
+    user_input: options.message,
+  };
   if (options.sessionId) body.session_id = options.sessionId;
   if (options.conversationHistory) body.conversation_history = options.conversationHistory;
 

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -25,6 +25,7 @@ import type {
   SendMessageRequest,
 } from './types.js';
 import { RPC_ERROR, GatewayEvents } from './types.js';
+import { askBrainstem } from './brainstem-client.js';
 import { registerShowcaseMethods } from './methods/showcase-methods.js';
 import { registerRappterMethods } from './methods/rappter-methods.js';
 import { registerAuthMethods } from './methods/auth-methods.js';
@@ -96,6 +97,27 @@ import {
 } from './observability.js';
 
 const DEFAULT_PORT = 18790;
+
+/** The brains a chat turn can be addressed to. */
+export const CHAT_TARGETS = ['openrappter', 'brainstem'] as const;
+export type ChatTarget = (typeof CHAT_TARGETS)[number];
+
+/**
+ * Resolve the requested brain, refusing anything unrecognised.
+ *
+ * Defaulting an unknown target to the local runtime would be the wrong kind of
+ * forgiving: a typo would silently answer from a different brain than the one
+ * the caller asked for, and the reply looks identical either way.
+ */
+export function normalizeChatTarget(value: unknown): ChatTarget {
+  if (value === undefined || value === null || value === '') return 'openrappter';
+  if (typeof value !== 'string' || !CHAT_TARGETS.includes(value as ChatTarget)) {
+    throw new Error(
+      `Unknown chat target ${JSON.stringify(value)}. Expected one of: ${CHAT_TARGETS.join(', ')}.`,
+    );
+  }
+  return value as ChatTarget;
+}
 const DEFAULT_HEARTBEAT_INTERVAL = 30000;
 const DEFAULT_CONNECTION_TIMEOUT = 120000;
 const DEFAULT_SHUTDOWN_TIMEOUT = 250;
@@ -2292,10 +2314,17 @@ export class GatewayServer {
     // chat.send — primary chat entry point (openclaw-compatible)
     this.registerMethod(
       'chat.send',
-      async (params: { sessionKey?: string; sessionId?: string; message?: string; idempotencyKey?: string }, conn) => {
+      async (params: { sessionKey?: string; sessionId?: string; message?: string; idempotencyKey?: string; target?: string }, conn) => {
         const message = params.message?.trim();
         if (!message) throw new Error('message required');
-        if (!this.agentHandler) throw new Error('Agent handler not configured');
+
+        // Which brain answers. The brainstem is a separate process speaking
+        // HTTP, but it returns the same §2.4 envelope, so a caller can switch
+        // between them on one connection instead of keeping two chats open.
+        const target = normalizeChatTarget(params.target);
+        if (target === 'openrappter' && !this.agentHandler) {
+          throw new Error('Agent handler not configured');
+        }
 
         const sessionKey = resolveSessionId(params) || `session_${randomUUID().slice(0, 8)}`;
         const runId = `run_${randomUUID().slice(0, 8)}`;
@@ -2327,12 +2356,16 @@ export class GatewayServer {
         this.activeRunsById.set(runId, run);
         this.activeRunBySession.set(sessionKey, runId);
 
-        const accepted = { runId, sessionKey, sessionId: sessionKey, status: 'accepted' as const, acceptedAt: Date.now() };
+        const accepted = { runId, sessionKey, sessionId: sessionKey, status: 'accepted' as const, acceptedAt: Date.now(), target };
 
-        // Execute agent asynchronously — defer to ensure response is sent first
+        // Execute asynchronously — defer to ensure response is sent first
         setTimeout(() => {
           if (run.aborted || !this.isGenerationActive(run.generation)) {
             this.cleanupActiveRun(run);
+            return;
+          }
+          if (target === 'brainstem') {
+            void this.askBrainstemWithEvents(run, message);
             return;
           }
           void this.executeAgentWithEvents(run, message, conn.id);
@@ -3124,6 +3157,69 @@ export class GatewayServer {
         sessionId: run.sessionId,
         state: 'aborted',
       });
+    }
+  }
+
+  /**
+   * Run a turn against the brainstem instead of the local agent runtime.
+   *
+   * Emits exactly the events the agent path emits, because the point of the
+   * selector is that a client does not have to care which brain answered — the
+   * §2.4 envelope is shared, so the rendering is too.
+   */
+  private async askBrainstemWithEvents(run: ActiveRun, message: string): Promise<void> {
+    try {
+      const envelope = await this.runAgentOperation(
+        run.generation,
+        () => askBrainstem({ message, sessionId: run.sessionId }),
+      );
+
+      if (run.aborted || !this.isGenerationActive(run.generation)) return;
+
+      const text = envelope.response ?? '';
+      this.broadcastEvent(GatewayEvents.CHAT, {
+        runId: run.runId,
+        sessionKey: run.sessionId,
+        sessionId: run.sessionId,
+        state: 'final',
+        target: 'brainstem',
+        message: text
+          ? { role: 'assistant', content: [{ type: 'text', text }], timestamp: Date.now() }
+          : undefined,
+        voiceText: envelope.voice_response || undefined,
+        agentLogs: envelope.agent_logs || undefined,
+        model: envelope.model,
+      });
+
+      const session = this.sessionStore.get(run.sessionId);
+      if (session) {
+        session.messages.push({
+          id: `msg_${randomUUID().slice(0, 8)}`,
+          role: 'assistant',
+          content: text,
+          timestamp: new Date().toISOString(),
+        });
+        session.updatedAt = new Date().toISOString();
+        this.saveSessions();
+      }
+    } catch (error) {
+      if (
+        run.aborted
+        || error instanceof GatewayStoppedError
+        || !this.isGenerationActive(run.generation)
+      ) {
+        return;
+      }
+      this.broadcastEvent(GatewayEvents.CHAT, {
+        runId: run.runId,
+        sessionKey: run.sessionId,
+        sessionId: run.sessionId,
+        state: 'error',
+        target: 'brainstem',
+        errorMessage: (error as Error).message,
+      });
+    } finally {
+      this.cleanupActiveRun(run);
     }
   }
 

--- a/typescript/ui/src/__tests__/chat-brain-selector.test.ts
+++ b/typescript/ui/src/__tests__/chat-brain-selector.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import '../components/chat.js';
+import { gateway } from '../services/gateway.js';
+
+/**
+ * Choosing which brain answers.
+ *
+ * The brainstem runs as its own process speaking HTTP, and the OpenRappter
+ * runtime answers over the gateway. Holding one conversation across both used
+ * to mean two chat windows side by side. They can share this one, because both
+ * return the same §2.4 envelope.
+ *
+ * The risk that makes these tests worth writing: the two brains know different
+ * things, and their replies are the same shape. An answer from the wrong brain
+ * does not look wrong. So the selected target has to actually reach the wire,
+ * and it has to survive a reload rather than silently reverting to the default.
+ */
+
+interface TestChatElement extends HTMLElement {
+  chatTarget: 'openrappter' | 'brainstem';
+  sessionKey: string | null;
+  inputValue: string;
+  sending: boolean;
+  handleSend(): Promise<void>;
+  handleTargetChange(event: Event): void;
+  restoreChatTarget(): void;
+}
+
+function makeChat(): TestChatElement {
+  return document.createElement('openrappter-chat') as TestChatElement;
+}
+
+/** A change event from a <select>, as the component receives it. */
+function selectEvent(value: string): Event {
+  const select = document.createElement('select');
+  for (const option of ['openrappter', 'brainstem']) {
+    const element = document.createElement('option');
+    element.value = option;
+    select.append(element);
+  }
+  select.value = value;
+  const event = new Event('change');
+  Object.defineProperty(event, 'target', { value: select });
+  return event;
+}
+
+describe('chat brain selector', () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    localStorage.clear();
+  });
+
+  it('talks to the local runtime unless told otherwise', () => {
+    expect(makeChat().chatTarget).toBe('openrappter');
+  });
+
+  it('sends the selected target on the wire', async () => {
+    const chat = makeChat();
+    chat.chatTarget = 'brainstem';
+    chat.sessionKey = 'session-1';
+    chat.inputValue = 'who are you?';
+
+    const request = vi
+      .spyOn(gateway, 'request')
+      .mockResolvedValue({ runId: 'run-1', sessionKey: 'session-1', status: 'accepted' } as never);
+
+    await chat.handleSend();
+
+    const [method, params] = request.mock.calls[0] as [string, Record<string, unknown>];
+    expect(method).toBe('chat.send');
+    // The whole feature is this parameter arriving; without it the brainstem
+    // selection is decorative and the local runtime answers instead.
+    expect(params.target).toBe('brainstem');
+    expect(params.message).toBe('who are you?');
+  });
+
+  it('sends the local runtime as the target when that is selected', async () => {
+    const chat = makeChat();
+    chat.sessionKey = 'session-1';
+    chat.inputValue = 'hello';
+
+    const request = vi
+      .spyOn(gateway, 'request')
+      .mockResolvedValue({ runId: 'run-1', sessionKey: 'session-1', status: 'accepted' } as never);
+
+    await chat.handleSend();
+
+    const [, params] = request.mock.calls[0] as [string, Record<string, unknown>];
+    expect(params.target).toBe('openrappter');
+  });
+
+  it('remembers the choice across a reload', () => {
+    const chat = makeChat();
+    chat.handleTargetChange(selectEvent('brainstem'));
+    expect(chat.chatTarget).toBe('brainstem');
+
+    // A fresh element is what a reload produces.
+    const reopened = makeChat();
+    reopened.restoreChatTarget();
+    expect(reopened.chatTarget).toBe('brainstem');
+  });
+
+  it('ignores a stored value that is not a brain', () => {
+    localStorage.setItem('openrappter.chat.target', 'something-else');
+    const chat = makeChat();
+    chat.restoreChatTarget();
+    expect(chat.chatTarget).toBe('openrappter');
+  });
+
+  it('ignores a change to an unknown target', () => {
+    const chat = makeChat();
+    chat.chatTarget = 'brainstem';
+    chat.handleTargetChange(selectEvent('not-a-brain'));
+    // Unchanged rather than reset: a bad event must not silently move the
+    // conversation to the other brain.
+    expect(chat.chatTarget).toBe('brainstem');
+  });
+
+  it('still switches when localStorage refuses to store', () => {
+    const chat = makeChat();
+    vi.spyOn(Storage.prototype, 'setItem').mockImplementation(() => {
+      throw new Error('QuotaExceededError');
+    });
+
+    chat.handleTargetChange(selectEvent('brainstem'));
+
+    // Private browsing or a full quota is not a reason to ignore the operator.
+    expect(chat.chatTarget).toBe('brainstem');
+  });
+});

--- a/typescript/ui/src/components/chat.ts
+++ b/typescript/ui/src/components/chat.ts
@@ -15,6 +15,8 @@ import type { ChatSessionSummary, Attachment } from '../types.js';
 
 const AGENT_RUN_OVERALL_TIMEOUT_MS = 30 * 60_000;
 const RUN_ABORT_TIMEOUT_MS = 5_000;
+/** Remembers which brain the operator last chose to talk to. */
+const CHAT_TARGET_STORAGE_KEY = 'openrappter.chat.target';
 
 interface Message {
   id: string;
@@ -622,6 +624,30 @@ export class OpenRappterChat extends LitElement {
       align-items: flex-end;
     }
 
+    .brain-select {
+      height: 44px;
+      padding: 0 0.5rem;
+      background: var(--bg-tertiary);
+      border: 1px solid var(--border);
+      border-radius: 0.5rem;
+      color: var(--text-secondary);
+      font-size: 0.8125rem;
+      font-family: inherit;
+      cursor: pointer;
+      transition: all 0.15s ease;
+      flex-shrink: 0;
+    }
+
+    .brain-select:hover:not(:disabled) {
+      border-color: var(--accent);
+      color: var(--text-primary);
+    }
+
+    .brain-select:disabled {
+      opacity: 0.5;
+      cursor: not-allowed;
+    }
+
     .attach-btn {
       display: flex;
       align-items: center;
@@ -846,6 +872,14 @@ export class OpenRappterChat extends LitElement {
 
   @state() private messages: Message[] = [];
   @state() private inputValue = '';
+  /**
+   * Which brain answers the next turn.
+   *
+   * The brainstem is a separate process, but it returns the same §2.4 envelope,
+   * so both replies render through this one component instead of needing a
+   * second chat window open beside it.
+   */
+  @state() private chatTarget: 'openrappter' | 'brainstem' = 'openrappter';
   @state() private sending = false;
   @state() private speechEnabled = false;
   @state() private speechStatus = 'idle';
@@ -900,6 +934,7 @@ export class OpenRappterChat extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
+    this.restoreChatTarget();
     this.loadSessions();
 
     // Listen for chat events (streaming deltas + finals)
@@ -1444,6 +1479,7 @@ export class OpenRappterChat extends LitElement {
       const params: Record<string, unknown> = {
         message: content,
         sessionKey,
+        target: this.chatTarget,
       };
       if (attachmentPayload.length > 0) {
         params.attachments = attachmentPayload;
@@ -1718,6 +1754,34 @@ export class OpenRappterChat extends LitElement {
     target.style.height = `${Math.min(target.scrollHeight, 200)}px`;
   }
 
+  /**
+   * Switch which brain answers, and remember it.
+   *
+   * The choice persists because the two brains know different things — an
+   * answer from the wrong one is not obviously wrong, it is just wrong — and
+   * silently reverting to the default on reload is how someone ends up
+   * believing the brainstem said something it never said.
+   */
+  private handleTargetChange(e: Event) {
+    const value = (e.target as HTMLSelectElement).value;
+    if (value !== 'openrappter' && value !== 'brainstem') return;
+    this.chatTarget = value;
+    try {
+      localStorage.setItem(CHAT_TARGET_STORAGE_KEY, value);
+    } catch {
+      // A blocked or full localStorage must not stop the switch itself.
+    }
+  }
+
+  private restoreChatTarget() {
+    try {
+      const stored = localStorage.getItem(CHAT_TARGET_STORAGE_KEY);
+      if (stored === 'openrappter' || stored === 'brainstem') this.chatTarget = stored;
+    } catch {
+      // Unreadable storage just means the default.
+    }
+  }
+
   private formatTime(ts: number): string {
     return new Date(ts).toLocaleTimeString([], {
       hour: '2-digit',
@@ -1977,6 +2041,16 @@ export class OpenRappterChat extends LitElement {
           <div class="input-area">
             ${this.renderAttachmentStrip()}
             <div class="input-container">
+              <select
+                class="brain-select"
+                title="Which brain answers"
+                .value=${this.chatTarget}
+                @change=${this.handleTargetChange}
+                ?disabled=${this.sessionTransitioning}
+              >
+                <option value="openrappter">🦖 OpenRappter</option>
+                <option value="brainstem">🧠 Brainstem</option>
+              </select>
               <button
                 class="attach-btn"
                 @click=${this.handleAttachClick}


### PR DESCRIPTION
Holding a conversation across both brains meant two chat windows: the brainstem is its own process speaking HTTP `POST /chat`, and the OpenRappter runtime answers `chat.send` over the gateway. Nothing joined them, so you switched browser tabs to switch brains.

**They can share one chat — and the reason was already in the codebase.** Both runtimes return the same frozen envelope (`rapp-runtime-parity/1.0` §2.4: `response, session_id, agent_logs, voice_mode, model, requested_model`). A reply from either renders identically. The only missing piece was a way to say which one to ask.

`chat.send` now takes an optional `target`. Default is `openrappter`, so every existing caller is unaffected. With `brainstem` the gateway proxies the turn and emits **exactly the same `chat` event** the agent path emits — voice seam, agent logs and model carried through unchanged. The UI gets a dropdown beside the composer, and the choice persists.

## Three things this had to get right

- **An unknown target is refused, never defaulted.** The two brains know different things and their replies are the same shape, so a typo that quietly answered from the local runtime would be indistinguishable from the brainstem answering.
- **The choice persists.** Silently reverting to the default on reload is how someone ends up believing the brainstem said something it never said.
- **JSON that is not an envelope is refused.** Something answering on that port is not the same as *the brainstem* answering, and treating it as a reply would put another service's words in the assistant's mouth.

## Two bugs only the live brainstem could reveal

Every unit test passed while both of these were broken, because they were written against a fake that agreed with the documentation.

**The address was wrong.** `brainstem.py` defaults to 7072, so the client did too — but the same file documents **7071** as the "full drop-in where a RAPP brainstem would sit", and an install that followed the grail path has one there and nothing on 7072. This machine is that install. A single hardcoded default would have shipped a selector that looks broken until someone finds an env var. It now probes both, prefers this package's own port, and uses an explicit `OPENRAPPTER_BRAINSTEM_URL` without probing.

**The request was wrong.** The docs say `{message, ...}` with `user_input` as a legacy alias. The live kernel answered:

```
400 {"error":"user_input is required"}
```

The documentation is ahead of the kernel it mirrors. Both spellings are now sent.

## End-to-end, against the running brainstem

```
discovered: http://127.0.0.1:7071
envelope complete: yes
model: claude-opus-4.6 | session: e2e-brain-selector
response: "PONG"
```

**Mutation-checked:**

| mutation | result |
|---|---|
| UI stops sending `target` | 2 failed |
| UI stops persisting the choice | 1 failed |
| gateway defaults an unknown target instead of refusing | 1 failed |

Gateway **18** tests, UI **7** new. TypeScript **4840 passed**, UI **130 passed**, both packages `tsc` clean.