### PR TITLE
feat: the Bar can choose its brain too

### DIFF
--- a/macos/Sources/OpenRappterBar/Core/DependencyContainer.swift
+++ b/macos/Sources/OpenRappterBar/Core/DependencyContainer.swift
@@ -16,7 +16,7 @@ public protocol RpcClientProtocol: Sendable {
     func getStatus() async throws -> GatewayStatusResponse
     func getHealth() async throws -> HealthResponse
     func ping() async throws -> PingResponse
-    func sendChat(message: String, sessionKey: String?) async throws -> ChatAccepted
+    func sendChat(message: String, sessionKey: String?, target: ChatTarget) async throws -> ChatAccepted
     func listMethods() async throws -> [String]
 }
 

--- a/macos/Sources/OpenRappterBar/Models/ChatTarget.swift
+++ b/macos/Sources/OpenRappterBar/Models/ChatTarget.swift
@@ -1,0 +1,42 @@
+import Foundation
+
+/// Which brain answers a chat turn.
+///
+/// The brainstem runs as its own process speaking HTTP, and the OpenRappter
+/// runtime answers over the gateway. Both return the same `rapp-runtime-parity/1.0`
+/// §2.4 envelope, so the Bar renders either reply identically — the only thing
+/// that differs is which one was asked.
+///
+/// That sameness is exactly why the choice has to be explicit and remembered.
+/// The two brains know different things, and an answer from the wrong one does
+/// not look wrong.
+public enum ChatTarget: String, CaseIterable, Codable, Sendable {
+    case openrappter
+    case brainstem
+
+    /// What the operator sees in the picker.
+    public var label: String {
+        switch self {
+        case .openrappter: return "🦖 OpenRappter"
+        case .brainstem: return "🧠 Brainstem"
+        }
+    }
+
+    /// Where the choice is remembered between launches.
+    public static let defaultsKey = "openrappter.chat.target"
+
+    /// Read a stored choice, falling back to the local runtime.
+    ///
+    /// An unrecognised stored value is treated as absent rather than as an
+    /// error: a defaults file edited by hand should not stop the Bar from
+    /// chatting, and the local runtime is the safe brain to fall back to.
+    public static func restored(from defaults: UserDefaults = .standard) -> ChatTarget {
+        guard let raw = defaults.string(forKey: defaultsKey) else { return .openrappter }
+        return ChatTarget(rawValue: raw) ?? .openrappter
+    }
+
+    /// Remember this choice for the next launch.
+    public func remember(in defaults: UserDefaults = .standard) {
+        defaults.set(rawValue, forKey: Self.defaultsKey)
+    }
+}

--- a/macos/Sources/OpenRappterBar/Services/RpcClient.swift
+++ b/macos/Sources/OpenRappterBar/Services/RpcClient.swift
@@ -155,9 +155,17 @@ public struct RpcClient: RpcClientProtocol, Sendable {
         }
     }
 
-    public func sendChat(message: String, sessionKey: String? = nil) async throws -> ChatAccepted {
+    public func sendChat(
+        message: String,
+        sessionKey: String? = nil,
+        target: ChatTarget = .openrappter
+    ) async throws -> ChatAccepted {
         var params: [String: AnyCodable] = [
-            "message": AnyCodable(message)
+            "message": AnyCodable(message),
+            // Which brain answers. Always sent, including the default, so a
+            // gateway that ever changes its own default cannot silently move
+            // the conversation to the other brain.
+            "target": AnyCodable(target.rawValue)
         ]
         if let sessionKey {
             params["sessionKey"] = AnyCodable(sessionKey)

--- a/macos/Sources/OpenRappterBar/ViewModels/ChatViewModel.swift
+++ b/macos/Sources/OpenRappterBar/ViewModels/ChatViewModel.swift
@@ -13,6 +13,16 @@ public final class ChatViewModel {
     public var chatInput: String = ""
     public var currentSessionKey: String?
 
+    /// Which brain answers the next turn, restored from the last launch.
+    ///
+    /// Persisted because the two brains know different things and their replies
+    /// are the same shape: silently reverting to the local runtime on relaunch
+    /// is how someone ends up believing the brainstem said something it never
+    /// said.
+    public var chatTarget: ChatTarget = .restored() {
+        didSet { chatTarget.remember() }
+    }
+
     // Services
     private var rpcClient: RpcClient?
     private var sessionStore: SessionStore?
@@ -84,7 +94,11 @@ public final class ChatViewModel {
             await sessionStore?.addMessage(userMsg)
 
             do {
-                let accepted = try await rpc.sendChat(message: text, sessionKey: currentSessionKey)
+                let accepted = try await rpc.sendChat(
+                    message: text,
+                    sessionKey: currentSessionKey,
+                    target: chatTarget
+                )
                 currentSessionKey = accepted.sessionKey
 
                 // Update the user message with correct sessionKey if it changed

--- a/macos/Sources/OpenRappterBar/Views/ChatInputView.swift
+++ b/macos/Sources/OpenRappterBar/Views/ChatInputView.swift
@@ -87,6 +87,26 @@ public struct ChatInputView: View {
                     .help("Send (Return)")
                 }
             }
+
+            // Which brain answers. Below the input rather than beside it, so it
+            // is visible while typing without competing with Send for the eye.
+            HStack(spacing: 6) {
+                Picker("Brain", selection: Binding(
+                    get: { viewModel.chatViewModel.chatTarget },
+                    set: { viewModel.chatViewModel.chatTarget = $0 }
+                )) {
+                    ForEach(ChatTarget.allCases, id: \.self) { target in
+                        Text(target.label).tag(target)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .controlSize(.small)
+                .fixedSize()
+                .help("Which brain answers: the local runtime, or the brainstem")
+
+                Spacer()
+            }
         }
     }
 }

--- a/macos/Tests/OpenRappterBarTests/ChatTargetTests.swift
+++ b/macos/Tests/OpenRappterBarTests/ChatTargetTests.swift
@@ -1,0 +1,78 @@
+import Foundation
+@testable import OpenRappterBarLib
+
+/// Choosing which brain the Bar talks to.
+///
+/// The web dashboard got this selector first. The Bar calls the same
+/// `chat.send` and had no way to choose, so the same feature was present in one
+/// client of two — the narrowness #199, #200, #201 and #217 each had to correct
+/// in an earlier guard.
+///
+/// What has to hold: the target reaches the wire on every send, an unrecognised
+/// stored value cannot strand the Bar, and the choice survives a relaunch. The
+/// two brains return the same §2.4 envelope, so an answer from the wrong one
+/// does not look wrong — none of these failures would be visible.
+func runChatTargetTests() async {
+    await suite("Chat target") {
+
+        func scratchDefaults() throws -> UserDefaults {
+            let name = "chat-target-\(UUID().uuidString)"
+            guard let defaults = UserDefaults(suiteName: name) else {
+                throw AssertionError(description: "could not open a scratch defaults suite")
+            }
+            return defaults
+        }
+
+        await test("defaults to the local runtime") {
+            let defaults = try scratchDefaults()
+            try expectEqual(ChatTarget.restored(from: defaults), .openrappter)
+        }
+
+        await test("offers both brains, each with a label") {
+            // Anti-vacuity: an empty case list would make the picker render
+            // nothing and every assertion about it pass.
+            try expectEqual(ChatTarget.allCases.count, 2)
+            for target in ChatTarget.allCases {
+                try expect(!target.label.isEmpty, "\(target) needs a label for the picker")
+            }
+        }
+
+        await test("round-trips through defaults") {
+            let defaults = try scratchDefaults()
+            ChatTarget.brainstem.remember(in: defaults)
+            try expectEqual(ChatTarget.restored(from: defaults), .brainstem)
+        }
+
+        await test("a stored value that is not a brain falls back rather than throwing") {
+            // A hand-edited defaults file must not stop the Bar chatting, and
+            // the local runtime is the safe brain to land on.
+            let defaults = try scratchDefaults()
+            defaults.set("something-else", forKey: ChatTarget.defaultsKey)
+            try expectEqual(ChatTarget.restored(from: defaults), .openrappter)
+        }
+
+        await test("the wire value is the gateway's spelling, not the label") {
+            // The gateway refuses an unknown target outright, so a renamed case
+            // would fail every brainstem turn.
+            try expectEqual(ChatTarget.openrappter.rawValue, "openrappter")
+            try expectEqual(ChatTarget.brainstem.rawValue, "brainstem")
+        }
+
+        await test("sendChat puts the target on the wire, including the default") {
+            // Always sent, even for the default: a gateway that ever changes its
+            // own default must not be able to move the conversation silently.
+            let source = try String(
+                contentsOf: URL(fileURLWithPath: #filePath)
+                    .deletingLastPathComponent()
+                    .deletingLastPathComponent()
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("Sources/OpenRappterBar/Services/RpcClient.swift"),
+                encoding: .utf8
+            )
+            try expect(
+                source.contains("\"target\": AnyCodable(target.rawValue)"),
+                "sendChat must send the selected target"
+            )
+        }
+    }
+}

--- a/macos/Tests/OpenRappterBarTests/main.swift
+++ b/macos/Tests/OpenRappterBarTests/main.swift
@@ -17,6 +17,7 @@ await runSessionStoreTests()
 await runOnboardingSpawnTests()
 await runBonesInspectorTests()
 await runBonesWindowTests()
+await runChatTargetTests()
 
 printResults()
 exitWithCode()


### PR DESCRIPTION
#226 gave the web dashboard a brain selector. **The Bar calls the same `chat.send` and had no way to choose** — so the feature existed in one client of two.

That is the same narrowness #199, #200, #201 and #217 each had to correct in a guard of mine. Shipping it for one surface and calling it done would have been the exact defect this session keeps finding, introduced deliberately.

`sendChat` takes a `ChatTarget`, the view model remembers it across launches, and the picker sits under the composer.

## Two judgement calls

- **The target is sent on every turn, including the default.** Omitting it when it is `openrappter` would mean relying on the gateway's default — and a change there would silently move the conversation to the other brain. Both return the same §2.4 envelope, so the operator could not tell.
- **An unrecognised stored value falls back to the local runtime** rather than throwing. A hand-edited defaults file should not stop the Bar chatting, and the local runtime is the safe brain to land on.

## Worth recording: the "unused" protocol did work

`RpcClientProtocol` caught the signature change at compile time:

```
error: type 'RpcClient' does not conform to protocol 'RpcClientProtocol'
```

That is the protocol I reported in #222 as *declared and used by nothing*. It is still true that nothing holds a value of that type — but the conformance is not inert, and this is the first evidence of it doing work. [#222 is corrected accordingly.](https://github.com/kody-w/openrappter/issues/222#issuecomment-5316786847)

**Mutation-checked:**

| mutation | result |
|---|---|
| target dropped from the request | 1 failed |
| bad stored value falls back to brainstem | 1 failed |
| choice not persisted | 1 failed |
| restored | 173 passed |

Swift **173 passed** (167 before, plus 6).