### PR TITLE
fix: Stop now stops the brainstem, instead of only stopping the listening

### DIFF
--- a/typescript/src/__tests__/integration/brainstem-abort.test.ts
+++ b/typescript/src/__tests__/integration/brainstem-abort.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import WebSocket from 'ws';
+
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * Stop has to stop the brainstem, not just stop the gateway listening.
+ *
+ * `chat.abort` marks the run aborted and broadcasts `state: 'aborted'`, so the
+ * UI goes quiet immediately. That was the whole of it: the HTTP request to the
+ * brainstem carried on, produced a full reply, and the result was discarded
+ * after the fact. From every angle a person can see, Stop worked — while a
+ * hosted model kept generating billed output nobody would read.
+ *
+ * The client-side tests prove `askBrainstem` honours a signal. They cannot
+ * prove the gateway ever fires one, and when I removed `run.controller.abort()`
+ * from `abortActiveRun` all of them still passed. This test is the half that
+ * was missing: it drives the real server over a real socket and asserts the
+ * in-flight request was actually cancelled.
+ */
+
+let server: GatewayServer | null = null;
+let sockets: WebSocket[] = [];
+
+async function connect(port: number): Promise<WebSocket> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  sockets.push(ws);
+  await new Promise<void>((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', reject);
+  });
+  return ws;
+}
+
+/** Send a request and wait for the matching response frame. */
+function rpc(ws: WebSocket, id: string, method: string, params?: Record<string, unknown>): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`${method} timed out`)), 5000);
+    const onMessage = (raw: WebSocket.RawData) => {
+      const frame = JSON.parse(String(raw)) as Record<string, unknown>;
+      if (frame.id !== id) return;
+      clearTimeout(timer);
+      ws.off('message', onMessage);
+      resolve(frame);
+    };
+    ws.on('message', onMessage);
+    ws.send(JSON.stringify({ id, method, params }));
+  });
+}
+
+afterEach(async () => {
+  vi.unstubAllGlobals();
+  for (const ws of sockets) {
+    try { ws.close(); } catch { /* already closed */ }
+  }
+  sockets = [];
+  if (server) {
+    await server.stop();
+    server = null;
+  }
+});
+
+describe('aborting a brainstem turn', () => {
+  it('cancels the in-flight request rather than discarding its answer', async () => {
+    let requestSignal: AbortSignal | null = null;
+    let resolvedNormally = false;
+
+    // A brainstem that never answers on its own. The only way this request
+    // finishes is if somebody cancels it — which is exactly the claim.
+    vi.stubGlobal('fetch', (async (url: string | URL, init?: RequestInit) => {
+      if (String(url).endsWith('/health')) {
+        return new Response('{"status":"ok"}', { status: 200 });
+      }
+      requestSignal = init?.signal ?? null;
+      await new Promise<void>((_resolve, reject) => {
+        init?.signal?.addEventListener('abort', () => {
+          const error = new Error('This operation was aborted');
+          error.name = 'AbortError';
+          reject(error);
+        });
+      });
+      resolvedNormally = true;
+      return new Response('{}');
+    }) as unknown as typeof fetch);
+
+    const port = await reserveTestPort();
+    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    await server.start();
+
+    const ws = await connect(port);
+    await rpc(ws, 'c-1', 'connect', {
+      client: { id: 'abort-test', version: '1.0.0', platform: 'node', mode: 'control' },
+    });
+
+    const sent = await rpc(ws, 's-1', 'chat.send', {
+      message: 'take your time',
+      sessionKey: 'abort-session',
+      target: 'brainstem',
+    });
+    const accepted = sent.payload as { runId: string };
+    expect(accepted.runId, 'chat.send should accept the brainstem run').toBeTruthy();
+
+    // Give the deferred dispatch a moment to actually issue the request.
+    await vi.waitFor(() => expect(requestSignal).not.toBeNull(), { timeout: 3000 });
+    expect(requestSignal!.aborted, 'not cancelled before Stop').toBe(false);
+
+    const aborted = await rpc(ws, 'a-1', 'chat.abort', { runId: accepted.runId });
+    expect((aborted.payload as { aborted: boolean }).aborted).toBe(true);
+
+    // The point of the whole change: the request itself is cancelled, so the
+    // brainstem stops generating instead of finishing an unread reply.
+    await vi.waitFor(() => expect(requestSignal!.aborted).toBe(true), { timeout: 3000 });
+    expect(resolvedNormally, 'the request must not have run to completion').toBe(false);
+  }, 30_000);
+});

--- a/typescript/src/gateway/__tests__/brainstem-client.test.ts
+++ b/typescript/src/gateway/__tests__/brainstem-client.test.ts
@@ -4,6 +4,7 @@ import {
   askBrainstem,
   brainstemBaseUrl,
   BrainstemUnavailableError,
+  BrainstemAbortedError,
   DEFAULT_BRAINSTEM_URL,
   resolveBrainstemUrl,
   resetBrainstemDiscovery,
@@ -231,5 +232,67 @@ describe('resolveBrainstemUrl', () => {
     await resolveBrainstemUrl({ env: {} as NodeJS.ProcessEnv, fetchImpl });
 
     expect(probes).toBe(1);
+  });
+});
+
+describe('cancelling a brainstem request', () => {
+  it('passes the caller signal to fetch, so the model stops generating', async () => {
+    let seenSignal: AbortSignal | undefined;
+    const fetchImpl = (async (_url: string | URL, init?: RequestInit) => {
+      seenSignal = init?.signal ?? undefined;
+      return jsonResponse(envelope);
+    }) as unknown as typeof fetch;
+
+    const controller = new AbortController();
+    await askBrainstem({ message: 'hi', fetchImpl, signal: controller.signal, baseUrl: 'http://127.0.0.1:7072' });
+
+    // Marking a run aborted only stops the gateway listening. Without a signal
+    // on the request the brainstem keeps generating a reply nobody reads,
+    // which on a hosted model is billed work.
+    expect(seenSignal).toBeDefined();
+    expect(seenSignal!.aborted).toBe(false);
+
+    controller.abort();
+    expect(seenSignal!.aborted).toBe(true);
+  });
+
+  it('reports cancellation as cancellation, not as an unreachable brainstem', async () => {
+    const controller = new AbortController();
+    const fetchImpl = (async (_url: string | URL, init?: RequestInit) => {
+      controller.abort();
+      const error = new Error('This operation was aborted');
+      error.name = 'AbortError';
+      void init;
+      throw error;
+    }) as unknown as typeof fetch;
+
+    // Telling someone who pressed Stop that the brainstem is down, and offering
+    // the command to start it, would be a confusing lie: it was reachable.
+    await expect(
+      askBrainstem({ message: 'hi', fetchImpl, signal: controller.signal }),
+    ).rejects.toThrow(BrainstemAbortedError);
+  });
+
+  it('still reports an unreachable brainstem when nobody cancelled', async () => {
+    const controller = new AbortController();
+    const fetchImpl = (async () => {
+      throw new Error('connect ECONNREFUSED 127.0.0.1:7072');
+    }) as unknown as typeof fetch;
+
+    await expect(
+      askBrainstem({ message: 'hi', fetchImpl, signal: controller.signal }),
+    ).rejects.toThrow(BrainstemUnavailableError);
+  });
+
+  it('still applies the timeout when no caller signal is given', async () => {
+    let seenSignal: AbortSignal | undefined;
+    const fetchImpl = (async (_url: string | URL, init?: RequestInit) => {
+      seenSignal = init?.signal ?? undefined;
+      return jsonResponse(envelope);
+    }) as unknown as typeof fetch;
+
+    await askBrainstem({ message: 'hi', fetchImpl, timeoutMs: 5_000 });
+
+    expect(seenSignal).toBeDefined();
   });
 });

--- a/typescript/src/gateway/brainstem-client.ts
+++ b/typescript/src/gateway/brainstem-client.ts
@@ -61,6 +61,14 @@ export interface BrainstemAskOptions {
   conversationHistory?: unknown[];
   baseUrl?: string;
   timeoutMs?: number;
+  /**
+   * Cancels the request when the caller stops caring about the answer.
+   *
+   * Without this, pressing Stop only stops the *client* listening: the
+   * brainstem carries on generating a reply nobody will read, which on a hosted
+   * model is billed work.
+   */
+  signal?: AbortSignal;
   /** Injected for tests; defaults to global fetch. */
   fetchImpl?: typeof fetch;
 }
@@ -135,6 +143,14 @@ export async function resolveBrainstemUrl(options: {
  * brainstem simply is not running, and the fix is one command, so the error
  * says which address was tried and what to do about it.
  */
+/** The caller cancelled; not a failure of the brainstem. */
+export class BrainstemAbortedError extends Error {
+  constructor() {
+    super('The brainstem request was cancelled.');
+    this.name = 'BrainstemAbortedError';
+  }
+}
+
 export class BrainstemUnavailableError extends Error {
   constructor(baseUrl: string, cause: unknown) {
     const reason = cause instanceof Error ? cause.message : String(cause);
@@ -181,13 +197,25 @@ export async function askBrainstem(options: BrainstemAskOptions): Promise<Brains
 
   let response: Response;
   try {
+    // The caller's cancellation and the timeout are both reasons to stop
+    // waiting, so the request answers to either.
+    const timeoutSignal = AbortSignal.timeout(timeoutMs);
+    const signal = options.signal
+      ? AbortSignal.any([options.signal, timeoutSignal])
+      : timeoutSignal;
+
     response = await doFetch(`${baseUrl}/chat`, {
       method: 'POST',
       headers: { 'content-type': 'application/json' },
       body: JSON.stringify(body),
-      signal: AbortSignal.timeout(timeoutMs),
+      signal,
     });
   } catch (error) {
+    // A caller who cancelled already knows why, and does not need to be told
+    // the brainstem is unreachable — it was reachable, they changed their mind.
+    if (options.signal?.aborted) {
+      throw new BrainstemAbortedError();
+    }
     // Not running, refused, DNS, or timed out — all of them mean "no brainstem
     // answered", and all of them are actionable in the same way.
     throw new BrainstemUnavailableError(baseUrl, error);

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -190,6 +190,12 @@ interface ActiveRun {
   sessionId: string;
   aborted: boolean;
   generation: number;
+  /**
+   * Cancels work that is genuinely cancellable, such as an in-flight brainstem
+   * request. Marking a run aborted stops the gateway listening; it does not
+   * stop a remote model generating a reply nobody will read.
+   */
+  controller?: AbortController;
 }
 
 interface ActiveOperation {
@@ -2333,6 +2339,7 @@ export class GatewayServer {
           sessionId: sessionKey,
           aborted: false,
           generation: this.generation,
+          controller: new AbortController(),
         };
 
         // Store user message in session
@@ -3149,6 +3156,7 @@ export class GatewayServer {
   private abortActiveRun(run: ActiveRun, broadcast = true): void {
     if (run.aborted) return;
     run.aborted = true;
+    run.controller?.abort();
     this.cleanupActiveRun(run);
     if (broadcast && this.isGenerationActive(run.generation)) {
       this.broadcastEvent(GatewayEvents.CHAT, {
@@ -3171,7 +3179,11 @@ export class GatewayServer {
     try {
       const envelope = await this.runAgentOperation(
         run.generation,
-        () => askBrainstem({ message, sessionId: run.sessionId }),
+        () => askBrainstem({
+          message,
+          sessionId: run.sessionId,
+          signal: run.controller?.signal,
+        }),
       );
 
       if (run.aborted || !this.isGenerationActive(run.generation)) return;


### PR DESCRIPTION
`chat.abort` marked the run aborted, broadcast `state: 'aborted'`, and the UI went quiet. **The request to the brainstem carried on.** It ran to completion, produced a full reply, and `askBrainstemWithEvents` then noticed the run was aborted and threw the answer away.

So Stop looked like it worked from every angle a person can see, while the model kept generating — **billed work on a hosted backend**, and a local machine kept busy on an answer nobody would read.

This is the shape of defect this session keeps finding, arriving in code I wrote two rounds ago: the guard was there, it just did not reach the thing it was guarding.

## The fix

A run now carries an `AbortController`. `abortActiveRun` fires it, and the signal reaches `fetch` — combined with the existing timeout via `AbortSignal.any`, so the request answers to either reason to stop waiting.

**Cancellation is reported as cancellation.** Telling someone who pressed Stop that the brainstem is unreachable, and offering the command to start it, would be a confusing lie: it *was* reachable, they changed their mind. An unreachable brainstem still reports as unreachable when nobody cancelled — that distinction is what the tests pin.

The agent path is unchanged: it has no equivalent remote call to cancel, so noticing `run.aborted` after the fact is all there is to do there.

## The test I was missing

The client tests prove `askBrainstem` honours a signal. They cannot prove the gateway ever fires one — and removing `run.controller?.abort()` left **all 22 of them green**.

That is the same defect one layer up, in the tests written to close it: two halves each covered, the wire between them covered by neither.

So there is now an integration test driving the real server over a real socket — `chat.send` with `target: brainstem` against a stubbed brainstem that never answers on its own, then `chat.abort`. The request can only finish if something cancels it, so the assertion is not about timing. It also asserts the request did **not** run to completion, because *"the signal fired"* and *"the work stopped"* are different claims and only the second is the point.

**Mutation-checked:**

| mutation | result |
|---|---|
| signal never reaches `fetch` | 1 failed |
| cancellation reported as unreachable | 1 failed |
| `abortActiveRun` does not fire the controller | 1 failed *(green before this test existed)* |
| restored | 23 passed |

TypeScript **4845 passed**, `tsc` clean.