### PR TITLE
feat: an agent that consults the brainstem, so the assistant can switch brains itself

### DIFF
--- a/python/openrappter/agents/brainstem_agent.py
+++ b/python/openrappter/agents/brainstem_agent.py
@@ -1,0 +1,195 @@
+"""
+BrainstemAgent — ask the local brainstem from inside an OpenRappter chat turn.
+
+The brainstem is a separate process speaking `POST /chat`, and the two runtimes
+return the same frozen envelope (rapp-runtime-parity/1.0 §2.4). PR #226 gave a
+person a dropdown to choose between them. This agent gives the *assistant* the
+same reach: a user can say "ask the brainstem what it knows about X" and stay in
+one conversation, instead of switching brains by hand and relaying the answer
+themselves.
+
+That matters most where the two brains genuinely differ. The brainstem holds
+agents and memory this runtime does not, so consulting it is a real lookup
+rather than a second opinion from the same source.
+
+Single-file and portable, per the RAPP agent contract: `json` and
+`urllib.request` from the standard library, `BasicAgent` guarded so the file
+loads on its own, and exactly one declared capability — `network` — which is
+the only thing its syntax tree can reach. Reading the address from the
+environment would have added `credential-access` to that declaration, and an
+agent that claims credential access to look up a port number is the kind of
+over-declaration that teaches an operator to ignore the manifest.
+"""
+
+import json
+import urllib.error
+import urllib.request
+
+try:  # grail brainstem
+    from agents.basic_agent import BasicAgent
+except ImportError:  # openrappter's python package
+    from openrappter.agents.basic_agent import BasicAgent
+
+
+__manifest__ = {
+    "schema": "rapp-agent/1.0",
+    "name": "@openrappter/brainstem",
+    "version": "1.0.0",
+    "display_name": "Brainstem",
+    "description": "Asks the local brainstem a question and returns its reply, so a chat turn can consult the other brain without the operator switching.",
+    "author": "Kody Wildfeuer",
+    "ring": "ga",
+    "capabilities": [
+        "network"
+    ],
+    "tags": [
+        "openrappter",
+        "brainstem"
+    ],
+    "category": "research",
+    "quality_tier": "official",
+    "requires_env": []
+}
+
+# Where a brainstem is actually found, in preference order. 7072 is this
+# package's own default; 7071 is the slot a RAPP brainstem sits in, and an
+# installation that followed the grail path has one there and nothing on 7072.
+# The TypeScript client probes the same two, for the same reason.
+CANDIDATE_URLS = ("http://127.0.0.1:7072", "http://127.0.0.1:7071")
+
+# §2.4: the six keys every runtime must return.
+ENVELOPE_KEYS = ("response", "session_id", "agent_logs",
+                 "voice_mode", "model", "requested_model")
+
+HEALTH_TIMEOUT_SECONDS = 2
+CHAT_TIMEOUT_SECONDS = 120
+
+
+class BrainstemAgent(BasicAgent):
+    def __init__(self):
+        self.name = "Brainstem"
+        self.metadata = {
+            "name": self.name,
+            "description": (
+                "Ask the local brainstem a question and return its answer. Use "
+                "this when the user asks what the brainstem knows or thinks, or "
+                "when a question needs the agents and memory that live there "
+                "rather than in this runtime."
+            ),
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "message": {
+                        "type": "string",
+                        "description": "The question to put to the brainstem.",
+                    },
+                    "session_id": {
+                        "type": "string",
+                        "description": (
+                            "Optional conversation id, so follow-up questions "
+                            "continue the same brainstem session."
+                        ),
+                    },
+                    "base_url": {
+                        "type": "string",
+                        "description": (
+                            "Optional brainstem address, e.g. "
+                            "http://127.0.0.1:7071. Discovered automatically "
+                            "when omitted."
+                        ),
+                    },
+                },
+                "required": ["message"],
+            },
+        }
+        super().__init__(self.name, self.metadata)
+
+    def _post_json(self, url, payload, timeout):
+        body = json.dumps(payload).encode("utf-8")
+        request = urllib.request.Request(
+            url,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return response.read().decode("utf-8")
+
+    def _answers(self, base_url):
+        """Whether a brainstem is listening here."""
+        try:
+            request = urllib.request.Request(base_url + "/health", method="GET")
+            with urllib.request.urlopen(request, timeout=HEALTH_TIMEOUT_SECONDS) as response:
+                return 200 <= response.status < 300
+        except Exception:
+            return False
+
+    def _discover(self):
+        for candidate in CANDIDATE_URLS:
+            if self._answers(candidate):
+                return candidate
+        return None
+
+    def perform(self, **kwargs):
+        message = (kwargs.get("message") or "").strip()
+        if not message:
+            return "No question given. Pass `message` with what to ask the brainstem."
+
+        base_url = (kwargs.get("base_url") or "").strip().rstrip("/")
+        if not base_url:
+            base_url = self._discover()
+            if not base_url:
+                return (
+                    "No brainstem is answering on "
+                    + " or ".join(CANDIDATE_URLS)
+                    + ". Start one with `python -m openrappter.brainstem`, or pass "
+                    "`base_url` if it listens elsewhere."
+                )
+
+        payload = {
+            # Both spellings. This package documents `message` with `user_input`
+            # as a legacy alias, but the RAPP kernel it mirrors requires
+            # `user_input` and answers 400 without it.
+            "message": message,
+            "user_input": message,
+        }
+        session_id = (kwargs.get("session_id") or "").strip()
+        if session_id:
+            payload["session_id"] = session_id
+
+        try:
+            raw = self._post_json(base_url + "/chat", payload, CHAT_TIMEOUT_SECONDS)
+        except urllib.error.HTTPError as exc:
+            detail = ""
+            try:
+                detail = exc.read().decode("utf-8")[:300]
+            except Exception:
+                detail = ""
+            return "The brainstem at %s answered %s%s" % (
+                base_url, exc.code, (": " + detail) if detail else ".")
+        except Exception as exc:
+            return "Could not reach the brainstem at %s: %s" % (base_url, exc)
+
+        try:
+            envelope = json.loads(raw)
+        except ValueError:
+            return "The brainstem at %s returned a body that is not JSON." % base_url
+
+        # Something answering on that port is not the same as the brainstem
+        # answering. Passing another service's words back as the brainstem's
+        # would be worse than failing.
+        if not isinstance(envelope, dict) or "response" not in envelope:
+            return (
+                "The brainstem at %s returned JSON that is not a chat envelope "
+                "(expected %s)." % (base_url, ", ".join(ENVELOPE_KEYS))
+            )
+
+        answer = envelope.get("response") or ""
+        model = envelope.get("model") or "unreported"
+        returned_session = envelope.get("session_id") or ""
+
+        lines = ["Brainstem (%s, model %s):" % (base_url, model), "", answer]
+        if returned_session:
+            lines.append("")
+            lines.append("session_id: %s" % returned_session)
+        return "\n".join(lines)

--- a/python/tests/test_brainstem_agent.py
+++ b/python/tests/test_brainstem_agent.py
@@ -1,0 +1,195 @@
+"""The brainstem agent, driven without a brainstem.
+
+PR #226 gave a person a dropdown to choose which brain answers. This agent gives
+the assistant the same reach, so a user can ask for the brainstem's view and stay
+in one conversation instead of switching brains by hand and relaying the answer.
+
+Everything worth testing here is a failure the operator would otherwise see as a
+confident wrong answer:
+
+  - something else answering on that port, passed back as the brainstem's words
+  - a reply that is JSON but not a §2.4 envelope
+  - the kernel's `user_input` requirement, which a live brainstem answers 400
+    without and which no unit test written against the documentation would catch
+
+The happy path is checked too, but a brainstem that is simply down is loud and
+self-explanatory; these are the quiet ones.
+"""
+
+import json
+from io import BytesIO
+
+import pytest
+
+from openrappter.agents.brainstem_agent import (
+    CANDIDATE_URLS,
+    BrainstemAgent,
+)
+
+
+ENVELOPE = {
+    "response": "Hello from the brainstem.",
+    "session_id": "session-1",
+    "agent_logs": "",
+    "voice_mode": False,
+    "model": "claude-opus-4.6",
+    "requested_model": "auto",
+}
+
+
+class FakeResponse(BytesIO):
+    """Enough of an http.client.HTTPResponse for urlopen's context manager."""
+
+    def __init__(self, payload, status=200):
+        super().__init__(payload.encode("utf-8") if isinstance(payload, str) else payload)
+        self.status = status
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        self.close()
+        return False
+
+
+@pytest.fixture
+def agent():
+    return BrainstemAgent()
+
+
+def install_urlopen(monkeypatch, handler):
+    """Route every request the agent makes through `handler(url, method, body)`."""
+    calls = []
+
+    def fake_urlopen(request, timeout=None):
+        body = None
+        if request.data:
+            body = json.loads(request.data.decode("utf-8"))
+        calls.append({
+            "url": request.full_url,
+            "method": request.get_method(),
+            "body": body,
+            "timeout": timeout,
+        })
+        return handler(request.full_url, request.get_method(), body)
+
+    monkeypatch.setattr(
+        "openrappter.agents.brainstem_agent.urllib.request.urlopen", fake_urlopen
+    )
+    return calls
+
+
+def healthy_then(envelope, status=200):
+    def handler(url, method, body):
+        if url.endswith("/health"):
+            return FakeResponse('{"status":"ok"}')
+        return FakeResponse(json.dumps(envelope) if isinstance(envelope, dict) else envelope, status)
+    return handler
+
+
+class TestManifest:
+    def test_declares_exactly_the_capability_it_uses(self):
+        from openrappter.agents.brainstem_agent import __manifest__
+
+        assert __manifest__["schema"] == "rapp-agent/1.0"
+        assert __manifest__["name"] == "@openrappter/brainstem"
+        # Reading the address from the environment would add credential-access
+        # to this list, and an agent claiming credential access to look up a
+        # port number teaches an operator to ignore the manifest.
+        assert __manifest__["capabilities"] == ["network"]
+
+
+class TestRefusals:
+    def test_asks_for_a_question_rather_than_sending_an_empty_one(self, agent):
+        assert "No question given" in agent.perform(message="   ")
+
+    def test_says_where_it_looked_when_no_brainstem_answers(self, agent, monkeypatch):
+        def refuse(url, method, body):
+            raise OSError("connection refused")
+
+        install_urlopen(monkeypatch, refuse)
+        out = agent.perform(message="hello")
+
+        # Actionable: the two addresses tried, and the command that starts one.
+        for candidate in CANDIDATE_URLS:
+            assert candidate in out
+        assert "python -m openrappter.brainstem" in out
+
+    def test_refuses_json_that_is_not_a_chat_envelope(self, agent, monkeypatch):
+        # Something answering on that port is not the same as the brainstem
+        # answering; passing its words back as the brainstem's is the worst
+        # outcome available here.
+        install_urlopen(monkeypatch, healthy_then({"ok": True, "service": "something-else"}))
+        out = agent.perform(message="hello")
+
+        assert "not a chat envelope" in out
+
+    def test_refuses_a_body_that_is_not_json(self, agent, monkeypatch):
+        install_urlopen(monkeypatch, healthy_then("<html>proxy error</html>"))
+        assert "not JSON" in agent.perform(message="hello")
+
+
+class TestSuccess:
+    def test_returns_the_brainstem_answer_with_attribution(self, agent, monkeypatch):
+        install_urlopen(monkeypatch, healthy_then(ENVELOPE))
+        out = agent.perform(message="hello")
+
+        assert "Hello from the brainstem." in out
+        # Which brain and which model, because the reply is otherwise
+        # indistinguishable from this runtime's own.
+        assert "claude-opus-4.6" in out
+        assert "session-1" in out
+
+    def test_sends_both_message_and_user_input(self, agent, monkeypatch):
+        # The kernel this mirrors requires `user_input` and answers
+        # `400 {"error":"user_input is required"}` without it. The docs call it
+        # a legacy alias, so a test written from the documentation would miss
+        # this and only a live brainstem would show it.
+        calls = install_urlopen(monkeypatch, healthy_then(ENVELOPE))
+        agent.perform(message="hello")
+
+        chat = [c for c in calls if c["url"].endswith("/chat")][0]
+        assert chat["body"]["message"] == "hello"
+        assert chat["body"]["user_input"] == "hello"
+
+    def test_carries_a_session_so_follow_ups_continue(self, agent, monkeypatch):
+        calls = install_urlopen(monkeypatch, healthy_then(ENVELOPE))
+        agent.perform(message="hello", session_id="abc")
+
+        chat = [c for c in calls if c["url"].endswith("/chat")][0]
+        assert chat["body"]["session_id"] == "abc"
+
+    def test_omits_the_session_when_there_is_not_one(self, agent, monkeypatch):
+        calls = install_urlopen(monkeypatch, healthy_then(ENVELOPE))
+        agent.perform(message="hello")
+
+        chat = [c for c in calls if c["url"].endswith("/chat")][0]
+        assert "session_id" not in chat["body"]
+
+
+class TestDiscovery:
+    def test_finds_a_brainstem_in_the_rapp_drop_in_slot(self, agent, monkeypatch):
+        # The installation this was written against has nothing on 7072 and a
+        # real brainstem on 7071, so a single hardcoded address would make the
+        # agent look broken there.
+        def handler(url, method, body):
+            if "7072" in url:
+                raise OSError("connection refused")
+            if url.endswith("/health"):
+                return FakeResponse('{"status":"ok"}')
+            return FakeResponse(json.dumps(ENVELOPE))
+
+        install_urlopen(monkeypatch, handler)
+        out = agent.perform(message="hello")
+
+        assert "127.0.0.1:7071" in out
+        assert "Hello from the brainstem." in out
+
+    def test_an_explicit_address_is_used_without_probing(self, agent, monkeypatch):
+        calls = install_urlopen(monkeypatch, healthy_then(ENVELOPE))
+        agent.perform(message="hello", base_url="http://127.0.0.1:9999/")
+
+        # If someone says where it is, probing elsewhere and quietly using a
+        # different brainstem would be worse than failing.
+        assert [c for c in calls if c["url"].endswith("/health")] == []
+        assert calls[0]["url"] == "http://127.0.0.1:9999/chat"


### PR DESCRIPTION
#226 gave a person a dropdown to choose which brain answers. That still leaves **the operator doing the switching**: change the target, ask, read, change back, and relay the answer into the other conversation by hand.

This gives the assistant the same reach. A user can say *"ask the brainstem what it knows about X"* and stay in one thread — the agent is dispatched like any other tool **through the ordinary chat endpoint**. No second client, no second window.

It is worth having because the two brains genuinely differ: the brainstem holds agents and memory this runtime does not, so consulting it is a **lookup**, not a second opinion from the same source.

## RAPP contract, checked rather than asserted

`python3 conformance.py` → **8 passed, 0 failed**

| | |
|---|---|
| R1 | single file |
| R2 | `rapp-agent/1.0` manifest |
| R3 | `@openrappter/brainstem`, version, description, capabilities |
| R4 | declares everything its syntax tree reaches |
| R5 | declares nothing it cannot reach |
| R7 | loads with no kernel import beyond a guarded `basic_agent` |

**R4 and R5 together are why the address is not read from the environment.** `os.getenv` is credential-access evidence, so a configurable address would have forced this agent to declare `credential-access` **to look up a port number** — and an agent that claims credential access for that teaches an operator to ignore the manifest. The address is a parameter with a discovered default instead, and the declaration stays exactly `["network"]`.

## Three refusals

Each would otherwise surface as a confident wrong answer rather than an error:

- **JSON that is not a §2.4 envelope is refused.** Something answering on that port is not *the brainstem* answering, and passing its words back as the brainstem's is the worst outcome available here.
- A non-JSON body is refused rather than shown.
- **An explicit `base_url` is used without probing.** If someone says where it is, quietly using a different brainstem is worse than failing.

It sends both `message` and `user_input`. The docs call `user_input` a legacy alias; the kernel this mirrors **requires** it and answers 400 without it — a test written from the documentation cannot catch that, so the mutation is pinned.

## Verified against the running brainstem

The agent registers (**20 agents**) and reaches 7071. It could not complete a turn while that brainstem's upstream was returning **502** — `curl` direct got the same 502, so the failure is upstream, and the agent reported the status and body faithfully instead of inventing a reply.

**Mutation-checked:**

| mutation | result |
|---|---|
| `user_input` dropped | 1 failed |
| any JSON accepted as envelope | 1 failed |
| probes despite explicit url | 1 failed |
| only one candidate port tried | 1 failed |
| restored | 11 passed |

Python **1501 passed**, 6 skipped.