### PR TITLE
feat: the TypeScript assistant can consult the brainstem too

### DIFF
--- a/typescript/src/agents/BrainstemAgent.ts
+++ b/typescript/src/agents/BrainstemAgent.ts
@@ -1,0 +1,109 @@
+/**
+ * BrainstemAgent — ask the local brainstem from inside a chat turn.
+ *
+ * The brainstem is a separate process speaking `POST /chat`, and both runtimes
+ * return the same frozen envelope (rapp-runtime-parity/1.0 §2.4). PR #226 gave a
+ * person a dropdown to choose between them, and #229 gave the Python assistant
+ * an agent so it could consult the brainstem itself.
+ *
+ * This is the TypeScript half. Without it the gap is not academic: the web UI
+ * and the Bar both talk to this runtime, so the human could switch brains while
+ * the assistant they were talking to could not — the useful case, "ask the
+ * brainstem and tell me what it said", was the one that did not work.
+ *
+ * The transport is `gateway/brainstem-client.ts`, already used by `chat.send`
+ * when a caller selects the brainstem. Reusing it means discovery, the
+ * `user_input` spelling the RAPP kernel requires, envelope validation and
+ * cancellation behave identically whether a person or the assistant is asking.
+ */
+
+import { BasicAgent } from './BasicAgent.js';
+import type { AgentMetadata } from './types.js';
+import { askBrainstem, BRAINSTEM_CANDIDATE_URLS } from '../gateway/brainstem-client.js';
+
+export const __manifest__ = {
+  schema: 'rapp-agent/1.0',
+  name: '@openrappter/brainstem',
+  version: '1.0.0',
+  display_name: 'Brainstem',
+  description: 'Asks the local brainstem a question and returns its reply, so a chat turn can consult the other brain without the operator switching.',
+  author: 'Kody Wildfeuer',
+  ring: 'ga',
+  capabilities: [
+    'network'
+  ],
+  tags: [
+    'openrappter',
+    'brainstem'
+  ],
+  category: 'research',
+  quality_tier: 'official',
+  requires_env: []
+} as const;
+
+export class BrainstemAgent extends BasicAgent {
+  constructor() {
+    const metadata: AgentMetadata = {
+      name: 'Brainstem',
+      description:
+        'Ask the local brainstem a question and return its answer. Use this when the user asks what the brainstem knows or thinks, or when a question needs the agents and memory that live there rather than in this runtime.',
+      parameters: {
+        type: 'object',
+        properties: {
+          message: {
+            type: 'string',
+            description: 'The question to put to the brainstem.',
+          },
+          session_id: {
+            type: 'string',
+            description:
+              'Optional conversation id, so follow-up questions continue the same brainstem session.',
+          },
+          base_url: {
+            type: 'string',
+            description:
+              'Optional brainstem address, e.g. http://127.0.0.1:7071. Discovered automatically when omitted.',
+          },
+        },
+        required: ['message'],
+      },
+    };
+    super('Brainstem', metadata);
+  }
+
+  async perform(kwargs: Record<string, unknown>): Promise<string> {
+    const message = String(kwargs.message ?? '').trim();
+    if (!message) {
+      return 'No question given. Pass `message` with what to ask the brainstem.';
+    }
+
+    const sessionId = String(kwargs.session_id ?? '').trim() || undefined;
+    const baseUrl = String(kwargs.base_url ?? '').trim() || undefined;
+
+    let envelope;
+    try {
+      envelope = await askBrainstem({ message, sessionId, baseUrl });
+    } catch (error) {
+      // The client already distinguishes "not running" from "answered badly"
+      // and says which address it tried, so the message is returned as-is
+      // rather than being rewritten into something vaguer.
+      const detail = error instanceof Error ? error.message : String(error);
+      return baseUrl
+        ? detail
+        : `${detail}\n\nAddresses tried: ${BRAINSTEM_CANDIDATE_URLS.join(', ')}.`;
+    }
+
+    const answer = envelope.response ?? '';
+    const model = envelope.model || 'unreported';
+    const source = baseUrl ?? 'the local brainstem';
+
+    // Attribute the reply. A brainstem answer and this runtime's own answer are
+    // the same shape, so an unlabelled one is indistinguishable from something
+    // this assistant worked out itself.
+    const lines = [`Brainstem (${source}, model ${model}):`, '', answer];
+    if (envelope.session_id) {
+      lines.push('', `session_id: ${envelope.session_id}`);
+    }
+    return lines.join('\n');
+  }
+}

--- a/typescript/src/agents/__tests__/brainstem-agent.test.ts
+++ b/typescript/src/agents/__tests__/brainstem-agent.test.ts
@@ -1,0 +1,139 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+
+import { BrainstemAgent, __manifest__ } from '../BrainstemAgent.js';
+import { resetBrainstemDiscovery } from '../../gateway/brainstem-client.js';
+
+/**
+ * The assistant consulting the brainstem, without a brainstem.
+ *
+ * #226 let a person choose which brain answers; #229 gave the Python assistant
+ * an agent so it could ask on its own. Without this one the gap was not
+ * academic — the web UI and the Bar both talk to this runtime, so the human
+ * could switch brains while the assistant they were talking to could not, and
+ * "ask the brainstem and tell me what it said" was exactly the case that failed.
+ *
+ * The transport is shared with `chat.send`, so discovery, the `user_input`
+ * spelling and envelope validation are covered by the client's own tests. What
+ * is specific here is what the assistant hands back: an answer that is
+ * attributed, and a failure that stays actionable instead of being flattened
+ * into "something went wrong".
+ */
+
+const ENVELOPE = {
+  response: 'The brainstem knows about Nicolas.',
+  session_id: 'session-1',
+  agent_logs: '',
+  voice_mode: false,
+  model: 'claude-opus-4.6',
+  requested_model: 'auto',
+};
+
+function stubFetch(handler: (url: string, init?: RequestInit) => Response | Promise<Response>) {
+  vi.stubGlobal('fetch', ((url: string | URL, init?: RequestInit) =>
+    Promise.resolve(handler(String(url), init))) as unknown as typeof fetch);
+}
+
+function healthyThen(body: unknown, status = 200) {
+  return (url: string) => {
+    if (url.endsWith('/health')) return new Response('{"status":"ok"}', { status: 200 });
+    return new Response(typeof body === 'string' ? body : JSON.stringify(body), {
+      status,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+}
+
+describe('BrainstemAgent', () => {
+  beforeEach(() => resetBrainstemDiscovery());
+  afterEach(() => vi.unstubAllGlobals());
+
+  it('declares exactly the capability it uses', () => {
+    // R4/R5: the conformance gate reads capabilities out of the syntax tree and
+    // fails both under- and over-declaration.
+    expect(__manifest__.schema).toBe('rapp-agent/1.0');
+    expect(__manifest__.name).toBe('@openrappter/brainstem');
+    expect(__manifest__.capabilities).toEqual(['network']);
+  });
+
+  it('constructs with no arguments, so discovery can register it', () => {
+    // The built-in loader calls `new` with no arguments; a constructor that
+    // needed one would be skipped with a logged warning and the agent would
+    // silently not exist.
+    expect(new BrainstemAgent().name).toBe('Brainstem');
+  });
+
+  it('asks for a question rather than sending an empty one', async () => {
+    const result = await new BrainstemAgent().perform({ message: '   ' });
+    expect(result).toMatch(/No question given/);
+  });
+
+  it('attributes the answer to the brainstem and names the model', async () => {
+    stubFetch(healthyThen(ENVELOPE));
+
+    const result = await new BrainstemAgent().perform({ message: 'what do you know?' });
+
+    expect(result).toContain('The brainstem knows about Nicolas.');
+    // A brainstem reply and this runtime's own reply are the same shape, so an
+    // unlabelled one is indistinguishable from something the assistant worked
+    // out itself.
+    expect(result).toMatch(/^Brainstem \(/);
+    expect(result).toContain('claude-opus-4.6');
+    expect(result).toContain('session-1');
+  });
+
+  it('passes the session through so follow-ups continue the same thread', async () => {
+    let sent: Record<string, unknown> = {};
+    stubFetch((url, init) => {
+      if (url.endsWith('/health')) return new Response('{"status":"ok"}');
+      sent = JSON.parse(String(init?.body));
+      return new Response(JSON.stringify(ENVELOPE), {
+        headers: { 'content-type': 'application/json' },
+      });
+    });
+
+    await new BrainstemAgent().perform({ message: 'and then?', session_id: 'abc' });
+
+    expect(sent.session_id).toBe('abc');
+    // Both spellings, because the kernel this mirrors requires `user_input`.
+    expect(sent.message).toBe('and then?');
+    expect(sent.user_input).toBe('and then?');
+  });
+
+  it('keeps a failure actionable and says where it looked', async () => {
+    stubFetch(() => {
+      throw new Error('connect ECONNREFUSED');
+    });
+
+    const result = await new BrainstemAgent().perform({ message: 'hello' });
+
+    // Flattening this into "something went wrong" would strip the one thing
+    // that makes it fixable: which addresses were tried, and the command.
+    expect(result).toMatch(/python -m openrappter\.brainstem/);
+    expect(result).toContain('127.0.0.1:7072');
+    expect(result).toContain('127.0.0.1:7071');
+  });
+
+  it('does not list candidate addresses when one was given', async () => {
+    stubFetch(() => {
+      throw new Error('connect ECONNREFUSED');
+    });
+
+    const result = await new BrainstemAgent().perform({
+      message: 'hello',
+      base_url: 'http://127.0.0.1:9999',
+    });
+
+    expect(result).toContain('9999');
+    expect(result).not.toContain('Addresses tried');
+  });
+
+  it('refuses JSON that is not a chat envelope', async () => {
+    // Something answering on that port is not the brainstem answering, and
+    // passing its words back as the brainstem's is the worst outcome here.
+    stubFetch(healthyThen({ ok: true, service: 'something-else' }));
+
+    const result = await new BrainstemAgent().perform({ message: 'hello' });
+
+    expect(result).toMatch(/not a chat envelope/);
+  });
+});


### PR DESCRIPTION
#229 gave the **Python** assistant a Brainstem agent. The TypeScript runtime had none — and it is the one the web UI and the Bar actually talk to.

So the human could switch brains with the dropdown while **the assistant they were talking to could not**. *"Ask the brainstem and tell me what it said"* was precisely the case that did not work.

Python agents do not fill the gap: the TypeScript registry loads `.py` files from the **user's own** agents directory, not from the Python package, so `brainstem_agent.py` is invisible here.

## Shared transport, not a second implementation

The agent uses `gateway/brainstem-client.ts` — already used by `chat.send` when a caller selects the brainstem. Reusing it means discovery, the `user_input` spelling the RAPP kernel requires, envelope validation and cancellation behave **identically whether a person or the assistant is asking**, rather than a parallel implementation that agrees until it doesn't.

## Two things it does deliberately

- **The reply is attributed.** A brainstem answer and this runtime's own answer are the same §2.4 shape, so an unlabelled one is indistinguishable from something the assistant worked out itself.
- **A failure is returned as the client phrased it**, with candidate addresses appended only when none was given. Flattening it into "something went wrong" would strip the one thing that makes it fixable.

## RAPP conformance

`python3 conformance.py` → **8 passed, 0 failed**. The manifest declares exactly `["network"]`, which is what R4 and R5 read out of the file.

## Verified

The agent registers (**38 agents**, was 37) and reaches the brainstem at 7071. It could not complete a turn while that brainstem's upstream was returning **502** — `curl` direct got the same 502 — and reported the status rather than inventing a reply.

TypeScript **4853 passed**. One unrelated flake appeared in the first full run and did not reproduce across two more; it is not in this file.