### PR TITLE
docs: the published agent count described my laptop, not the product

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ openrappter --exec Shell "ls -la"
 | **Local-First Data** | Memory, config, and state live in `~/.openrappter/` on your machine |
 | **Single File Agents** | One file = one agent — metadata defined in native code constructors, deterministic, portable |
 | **Persistent Memory** | Remembers facts, preferences, and context across sessions |
-| **Dual Runtime** | Same agent contract in Python (4 agents) and TypeScript (3 agents) |
+| **Dual Runtime** | Same agent contract in Python (20 agents) and TypeScript (34 agents) |
 | **Data Sloshing** | Automatic context enrichment (temporal, memory, behavioral signals) before every action |
 | **Data Slush** | Agent-to-agent signal pipeline — agents return curated `data_slush` that feeds into the next agent's context |
 | **Auto-Discovery** | Drop a `*_agent.py` or `*Agent.ts` file in `agents/` — no registration needed |

--- a/docs/architecture.html
+++ b/docs/architecture.html
@@ -66,7 +66,7 @@
                                 ▼
     ┌──────────────────────────────────────────────────────────┐
     │                     Agent Registry                        │
-    │        37 agents (TypeScript) · 26 agents (Python)        │
+    │        34 agents (TypeScript) · 20 agents (Python)        │
     │   ┌───────┐ ┌────────┐ ┌───────┐ ┌────────┐ ┌─────────┐  │
     │   │ Shell │ │ Memory │ │  Web  │ │Browser │ │  Media  │  │
     │   └───┬───┘ └───┬────┘ └───┬───┘ └───┬────┘ └────┬────┘  │
@@ -481,7 +481,7 @@ openrappter --instance ada   <span style="color:#525252;"># address one of them<
 
   <pre style="background:var(--bg-card);border:1px solid var(--border);border-radius:12px;padding:2rem;font-family:'JetBrains Mono',monospace;font-size:0.82rem;line-height:1.9;overflow-x:auto;margin-top:2rem;"><span style="color:var(--blue);">openrappter/</span>
 <span style="color:var(--border-light);">├──</span> <span style="color:var(--blue);">typescript/src/</span>
-<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">agents/</span>               <span style="color:#525252;"># 37 agents + router, broadcast, subagent</span>
+<span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">agents/</span>               <span style="color:#525252;"># 34 agents + router, broadcast, subagent</span>
 <span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">channels/</span>             <span style="color:#525252;"># 16 messaging channels</span>
 <span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">gateway/</span>              <span style="color:#525252;"># JSON-RPC over WS + HTTP, /chat, /twin</span>
 <span style="color:var(--border-light);">│   ├──</span> <span style="color:var(--blue);">twin/</span>                 <span style="color:#525252;"># hatching, soul, vault, peer send</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -467,7 +467,7 @@
   <section id="agents" class="py-24 sm:py-32 relative">
     <div class="max-w-6xl mx-auto px-4 sm:px-6">
       <div class="text-center mb-16 fade-in">
-        <h2 class="text-3xl sm:text-4xl font-bold mb-4">22 agents, ready on day one</h2>
+        <h2 class="text-3xl sm:text-4xl font-bold mb-4">34 agents, ready on day one</h2>
         <p class="text-[#a1a1aa] text-lg max-w-xl mx-auto">Every agent is a single file. Read it, fork it, remix it.</p>
       </div>
 
@@ -712,10 +712,10 @@
         <div class="fade-in card-hover rounded-2xl bg-[#111113] p-6 flex flex-col">
           <div class="text-xs font-mono text-[#71717a] tracking-widest uppercase mb-3">Community</div>
           <h3 class="text-xl font-bold mb-1">Free forever</h3>
-          <p class="text-sm text-[#a1a1aa] mb-6 leading-relaxed">Open source. 22 agents, full framework, no limits.</p>
+          <p class="text-sm text-[#a1a1aa] mb-6 leading-relaxed">Open source. 34 agents, full framework, no limits.</p>
           <ul class="text-sm text-[#a1a1aa] space-y-2 mb-8 flex-1">
             <li class="flex items-center gap-2"><span class="text-[#10b981]">✓</span> Full agent framework</li>
-            <li class="flex items-center gap-2"><span class="text-[#10b981]">✓</span> 22 built-in agents</li>
+            <li class="flex items-center gap-2"><span class="text-[#10b981]">✓</span> 34 built-in agents</li>
             <li class="flex items-center gap-2"><span class="text-[#10b981]">✓</span> Community support</li>
             <li class="flex items-center gap-2"><span class="text-[#10b981]">✓</span> MIT License</li>
           </ul>

--- a/docs/rappter-com.html
+++ b/docs/rappter-com.html
@@ -196,7 +196,7 @@
         <p class="text-gray-500 text-sm mb-6">Free forever</p>
         <ul class="space-y-3 text-sm flex-1 mb-8 text-gray-400">
           <li class="flex items-start gap-2"><span class="text-accent font-bold">✓</span> Full openrappter framework</li>
-          <li class="flex items-start gap-2"><span class="text-accent font-bold">✓</span> 22 agents, soul templates</li>
+          <li class="flex items-start gap-2"><span class="text-accent font-bold">✓</span> 34 agents, soul templates</li>
           <li class="flex items-start gap-2"><span class="text-accent font-bold">✓</span> Dream mode, self-updating</li>
           <li class="flex items-start gap-2"><span class="text-accent font-bold">✓</span> Community support</li>
         </ul>

--- a/python/tests/test_documented_agent_count.py
+++ b/python/tests/test_documented_agent_count.py
@@ -1,0 +1,104 @@
+"""The documented Python agent count, checked against a fresh install.
+
+`architecture.html` said 26 Python agents. That is the number of `.py` files in
+the agents directory, not the number the runtime registers — six of those files
+are not standalone agents. The TypeScript figure beside it was taken from
+`--list-agents`, so the page compared a file count against a registration count
+and made the two runtimes look further apart than they are.
+
+Counting the way a person experiences it means asking the registry, with `HOME`
+pointed somewhere empty: `--list-agents` also loads the operator's own agents,
+and a published figure that includes those describes a laptop rather than the
+product. That is exactly how the TypeScript number came to say 37.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+from openrappter.cli import AgentRegistry
+
+ROOT = Path(__file__).resolve().parents[2]
+DOC_FILES = [
+    ROOT / "docs" / "architecture.html",
+    ROOT / "README.md",
+]
+
+
+@pytest.fixture
+def built_in_count():
+    """Agents a fresh install registers.
+
+    Several suites install a *stub* `agents` / `agents.basic_agent` into
+    `sys.modules` at import time to simulate the grail brainstem, and those
+    stubs persist for the rest of the run. With them present the portable
+    agents subclass a different BasicAgent than the registry checks against,
+    and the count drops from 20 to 16 — so this test passed alone and failed in
+    the full suite.
+
+    Nothing installs those stubs in production. They are removed for the
+    duration and put back, so the suites that rely on them are unaffected.
+    """
+    saved = {
+        name: sys.modules.pop(name)
+        for name in ("agents", "agents.basic_agent")
+        if name in sys.modules
+    }
+    try:
+        yield len(AgentRegistry().discover_agents())
+    finally:
+        sys.modules.update(saved)
+
+
+def _nearest_language(text, index, window=60):
+    """The language mentioned closest to a position, either side of it."""
+    start = max(0, index - window)
+    best, best_distance = None, None
+    for match in re.finditer(r"python|typescript", text[start:index + window], re.I):
+        position = start + match.start()
+        distance = abs(position - index)
+        if best_distance is None or distance < best_distance:
+            best, best_distance = match.group(0).lower(), distance
+    return best
+
+
+def documented_python_counts():
+    """Every "<n> agents" claim that names Python, with its file."""
+    found = []
+    for path in DOC_FILES:
+        if not path.exists():
+            continue
+        text = path.read_text(encoding="utf-8")
+        for match in re.finditer(r"(\d+)\s+(?:built-in\s+)?agents", text, re.I):
+            # The language can sit either side of the number: the README writes
+            # "Python (20 agents)", architecture.html writes "20 agents (Python)".
+            # It must be the NEAREST mention, not any within the window — the
+            # README puts both languages on one line, and a plain search found
+            # "Python" before the TypeScript figure and mislabelled it.
+            if _nearest_language(text, match.start()) == "python":
+                found.append((path.name, match.group(0), int(match.group(1))))
+    return found
+
+
+def test_registers_a_realistic_number_of_agents(built_in_count):
+    # Anti-vacuity: a registry that loaded nothing would make the comparison
+    # below pass against zero.
+    assert built_in_count > 10
+
+
+def test_finds_a_python_count_to_check():
+    # Anti-vacuity for the extractor: if the pattern or the context window
+    # stopped matching, the assertion below would check an empty list.
+    assert documented_python_counts(), "no documented Python agent count found"
+
+
+def test_published_python_counts_match_the_runtime(built_in_count):
+    wrong = [c for c in documented_python_counts() if c[2] != built_in_count]
+    assert not wrong, (
+        "A fresh install registers %d Python agents. These say otherwise: %s. "
+        "Count with the registry, not by listing *.py — several files in that "
+        "directory are not standalone agents."
+        % (built_in_count, ", ".join("%s: %r" % (f, claim) for f, claim, _ in wrong))
+    )

--- a/typescript/src/__tests__/integration/documented-agent-count.test.ts
+++ b/typescript/src/__tests__/integration/documented-agent-count.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execFile } from 'child_process';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { promisify } from 'util';
+import { fileURLToPath } from 'url';
+
+const execFileAsync = promisify(execFile);
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const tsRoot = path.resolve(__dirname, '../../..');
+const repoRoot = path.resolve(tsRoot, '..');
+
+/**
+ * The agent count the documentation advertises, checked against a fresh install.
+ *
+ * These numbers had drifted three different ways at once: `architecture.html`
+ * said 37 TypeScript agents, `index.html` said 22, and the README said 3. None
+ * matched, and none matched the runtime.
+ *
+ * The 37 is the instructive one. I put it there myself, taken from
+ * `--list-agents` on the machine I was working on — which is the right source
+ * and the wrong reading, because that command also loads the operator's own
+ * agents from `~/.openrappter/agents`. I had three of my own at the time, so
+ * the published figure described my laptop rather than the product, and it
+ * looked more authoritative than a guess precisely because it came from the
+ * runtime.
+ *
+ * So this counts with `HOME` pointed at an empty directory. That is the number
+ * a person gets when they install it, which is the only number worth printing.
+ */
+
+/** Agents a fresh install registers, with no user agents present. */
+async function builtInAgentCount(): Promise<number> {
+  const emptyHome = fs.mkdtempSync(path.join(os.tmpdir(), 'openrappter-fresh-'));
+  try {
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [path.join(tsRoot, 'bin', 'openrappter.mjs'), '--list-agents'],
+      {
+        cwd: tsRoot,
+        timeout: 120_000,
+        env: { ...process.env, HOME: emptyHome, USERPROFILE: emptyHome, NO_COLOR: '1' },
+      },
+    );
+    return stdout.split('\n').filter((line) => /^\s{2}• /.test(line)).length;
+  } finally {
+    fs.rmSync(emptyHome, { recursive: true, force: true });
+  }
+}
+
+/** The language mentioned closest to a position, either side of it. */
+function nearestLanguage(text: string, index: number, window = 60): string | null {
+  const start = Math.max(0, index - window);
+  let best: string | null = null;
+  let bestDistance = Number.POSITIVE_INFINITY;
+  for (const match of text.slice(start, index + window).matchAll(/python|typescript/gi)) {
+    const position = start + (match.index ?? 0);
+    const distance = Math.abs(position - index);
+    if (distance < bestDistance) {
+      bestDistance = distance;
+      best = /python/i.test(match[0]) ? 'Python' : 'TypeScript';
+    }
+  }
+  return best;
+}
+
+/** Every "<n> agents" claim in the published pages, with where it was found. */
+function documentedCounts(): { file: string; claim: string; count: number; language: string | null }[] {
+  const files = [
+    path.join(repoRoot, 'docs', 'architecture.html'),
+    path.join(repoRoot, 'docs', 'index.html'),
+    path.join(repoRoot, 'docs', 'rappter-com.html'),
+    path.join(repoRoot, 'README.md'),
+  ].filter((f) => fs.existsSync(f));
+
+  const found: { file: string; claim: string; count: number; language: string | null }[] = [];
+  for (const file of files) {
+    const text = fs.readFileSync(file, 'utf8');
+    for (const match of text.matchAll(/(\d+)\s+(?:built-in\s+)?agents/gi)) {
+      // Which runtime a count belongs to is not always after the number. The
+      // README writes "Python (20 agents) and TypeScript (34 agents)", so the
+      // language sits before it — reading only forwards attributed the Python
+      // figure to TypeScript and rejected a correct line.
+      //
+      // It has to be the NEAREST mention rather than any within the window,
+      // because that same line puts both languages within a few characters of
+      // each other: a plain search finds "Python" before the TypeScript figure
+      // and quietly drops it from this check.
+      const language = nearestLanguage(text, match.index);
+      found.push({
+        file: path.relative(repoRoot, file),
+        claim: match[0].trim(),
+        count: Number(match[1]),
+        language,
+      });
+    }
+  }
+  return found;
+}
+
+describe('the documented agent count matches a fresh install', () => {
+  let builtIns = 0;
+
+  beforeAll(async () => {
+    builtIns = await builtInAgentCount();
+  }, 180_000);
+
+  it('registers a realistic number of built-in agents', () => {
+    // Anti-vacuity: a broken spawn or a changed bullet character would report
+    // zero, and every comparison below would then be against nothing.
+    expect(builtIns).toBeGreaterThan(20);
+  });
+
+  it('counts fewer agents than a machine with user agents present', async () => {
+    // Detector control. If the isolated HOME were ignored, this count would
+    // include whatever the developer happens to have installed, which is the
+    // exact mistake being guarded against — so prove the isolation does
+    // something by comparing against the unisolated count on this machine.
+    const { stdout } = await execFileAsync(
+      process.execPath,
+      [path.join(tsRoot, 'bin', 'openrappter.mjs'), '--list-agents'],
+      { cwd: tsRoot, timeout: 120_000, env: { ...process.env, NO_COLOR: '1' } },
+    );
+    const here = stdout.split('\n').filter((line) => /^\s{2}• /.test(line)).length;
+
+    expect(here).toBeGreaterThanOrEqual(builtIns);
+  }, 180_000);
+
+  it('finds agent counts to check in more than one page', () => {
+    const counts = documentedCounts();
+    expect(counts.length).toBeGreaterThan(3);
+    expect(new Set(counts.map((c) => c.file)).size).toBeGreaterThan(2);
+    // Anti-vacuity for the attribution: if every count came back unattributed
+    // the Python filter below would silently check nothing.
+    expect(counts.some((c) => c.language === 'Python')).toBe(true);
+  });
+
+  it('publishes no TypeScript agent count that is not the real one', () => {
+    // Python counts are checked by the Python suite, which is where a Python
+    // runtime is guaranteed to exist.
+    const wrong = documentedCounts()
+      .filter((c) => c.language !== 'Python')
+      .filter((c) => c.count !== builtIns);
+
+    expect(
+      wrong,
+      wrong.length
+        ? `A fresh install registers ${builtIns} agents. These say otherwise:\n` +
+          wrong.map((c) => `  ${c.file}: "${c.claim}"`).join('\n') +
+          `\n\nCount with HOME pointed at an empty directory; --list-agents on a\n` +
+          `developer machine also loads that person's own agents.\n`
+        : '',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
Four pages, three different numbers, none of them right:

| page | claimed |
|---|---|
| `architecture.html` | 37 TypeScript · 26 Python |
| `index.html` | 22 agents (three places) |
| `rappter-com.html` | 22 agents |
| `README.md` | Python 4 · TypeScript 3 |

**A fresh install registers 34 and 20.**

## The 37 is mine, and it is the instructive one

I put it there in #163, taken from `--list-agents` on this machine — and wrote in that commit that the counts came from the runtime rather than from `ls`. Right instinct, wrong reading: **that command also loads the operator's own agents** from `~/.openrappter/agents`, and I had three of my own.

The number described my laptop. And it looked more trustworthy than a guess *precisely because* it came from the runtime.

The 26 is the opposite error — a count of `.py` files, six of which are not standalone agents. So the page compared a **file count against a registration count** and made the two runtimes look further apart than they are.

Both are now taken with `HOME` pointed at an empty directory: what a person actually gets when they install it.

## Two guards, one per runtime

Each lives in the suite where that runtime is guaranteed to exist, and each **derives** the number rather than storing it — so the next agent to land updates the expectation by existing.

## Getting the attribution right took two passes

The README writes `Python (20 agents) and TypeScript (34 agents)`: the language sits **before** the number there and **after** it in `architecture.html`. Once that was handled, a plain search for "python" near the TypeScript figure still matched the other half of the same line. The rule is the **nearest** language mention on either side — and the TypeScript guard carried the same latent fault until the Python one exposed it.

The Python guard also had to remove the stub `agents` modules other suites install at import time; with them present the portable agents subclass a different `BasicAgent` than the registry checks against and the count reads **16**, so it passed alone and failed in the full run.

**Mutation-checked, per page and per runtime:**

| mutation | result |
|---|---|
| `architecture.html` back to 37 (TypeScript) | 1 failed |
| `architecture.html` back to 26 (Python) | 1 failed |
| `index.html` marketing count back to 22 | 1 failed |
| README TypeScript figure back to 3 | 1 failed |

TypeScript **4857 passed**, Python **1504 passed**, conformance **8 passed**.