### PR TITLE
docs: the changelog missed the one user-facing fix among my last five rounds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The published agent counts described a developer's laptop, not the product**
+  — `architecture.html`, the README and two other pages advertised 37 TypeScript
+  agents. That number came from running `--list-agents` on a machine that also
+  loads the operator's own agents from `~/.openrappter/agents`, so it counted
+  three that no one else has. A fresh install ships **34 TypeScript and 20
+  Python agents**; the pages now say so, and a guard per runtime re-derives the
+  figure with `HOME` isolated so the published number cannot drift back to
+  whatever the author happens to have installed.
+
 - **Stop did not stop the brainstem** — `chat.abort` marked the run aborted and
   the interface went quiet, while the request carried on, produced a full reply,
   and had it discarded. Stop looked like it worked from every angle a person can


### PR DESCRIPTION
Housekeeping on my own trail, following the same rule I set in #202.

Five PRs have merged since the last changelog pass at #231:

| PR | Kind | Changelog? |
|---|---|---|
| #233 | replaced a vacuous multi-agent suite | no — test-only |
| #234 | deleted three parity suites | no — test-only |
| #236 | deleted two more parity suites | no — test-only |
| #237 | deleted the dormant voice spec | no — test-only |
| #232 | **corrected the published agent count** | **yes — and it was missing** |

#232 changed what the project tells people about itself. `architecture.html`, the README and two other pages advertised 37 TypeScript agents; the real fresh-install figures are 34 TypeScript and 20 Python. The inflated number came from running `--list-agents` on a machine that also loads the operator's own agents from `~/.openrappter/agents`.

That is a user-facing documentation correction, so it gets an entry under Fixed, including the guard that now re-derives the count with `HOME` isolated so it cannot drift back.

Verified: the `documented-agent-count` guard passes (4 tests), confirming 34 and 20 are still the current true figures at the moment of publishing them.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>