### PR TITLE
test: a Swift suite that main.swift forgets to call never runs and never says so

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -112,7 +112,9 @@ jobs:
           swift-version: '6.0'
       - run: swift build -c release --product OpenRappterBar
       # Fails hard on either a Swift build error or any failing test in the
-      # custom RunTests harness (86+ tests; exits non-zero on any failure).
+      # custom RunTests harness, which exits non-zero on any failure. The
+      # harness has no discovery: main.swift calls each suite by hand, and
+      # SuiteRegistrationTests fails the build if one is ever left out.
       - run: swift build --product RunTests && .build/debug/RunTests
 
   python:

--- a/macos/Tests/OpenRappterBarTests/SuiteRegistrationTests.swift
+++ b/macos/Tests/OpenRappterBarTests/SuiteRegistrationTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+
+/// Every suite in this directory must actually run.
+///
+/// The Bar's tests are not XCTest, so nothing discovers them. `main.swift`
+/// calls each `run…Tests()` by hand. A new suite can therefore compile, be
+/// committed, pass review and never execute a single assertion — and nothing
+/// would look wrong, because the only symptom is a total that failed to go up,
+/// and no one reads the total.
+///
+/// That is the failure the TypeScript inert-test guard was built for (#215,
+/// #217): a test that cannot fail is worse than no test, because it is counted
+/// as coverage. TypeScript, the UI and Python are all protected against some
+/// form of it. This runtime was not, which made it the one place where the
+/// oversight could recur silently.
+///
+/// The registration currently matches. This pins it so it keeps matching.
+func runSuiteRegistrationTests() throws {
+    suite("Suite registration") {
+
+        let testsDirectory = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
+
+        func mainBody() throws -> String {
+            try String(
+                contentsOf: testsDirectory.appendingPathComponent("main.swift"),
+                encoding: .utf8
+            )
+        }
+
+        /// Names of `func run…Tests(` declared across every file but main.swift.
+        func definedSuites() throws -> [String] {
+            var names: Set<String> = []
+            let files = try FileManager.default.contentsOfDirectory(
+                at: testsDirectory,
+                includingPropertiesForKeys: nil
+            )
+            for url in files
+            where url.pathExtension == "swift" && url.lastPathComponent != "main.swift" {
+                let body = try String(contentsOf: url, encoding: .utf8)
+                for line in body.split(separator: "\n") {
+                    guard line.hasPrefix("func run"),
+                          line.contains("Tests("),
+                          let open = line.firstIndex(of: "(")
+                    else { continue }
+                    let start = line.index(line.startIndex, offsetBy: "func ".count)
+                    names.insert(String(line[start..<open]))
+                }
+            }
+            return names.sorted()
+        }
+
+        /// A suite is registered when main.swift names it followed by its call
+        /// parenthesis, whatever `try`/`await` prefix that call happens to carry.
+        func unregistered(among names: [String], in main: String) -> [String] {
+            names.filter { !main.contains("\($0)(") }.sorted()
+        }
+
+        test("every suite defined here is called by main.swift") {
+            let missing = try unregistered(among: definedSuites(), in: mainBody())
+            try expect(
+                missing.isEmpty,
+                "defined but never called from main.swift, so it never runs: "
+                    + missing.joined(separator: ", ")
+            )
+        }
+
+        test("finds the suites to check") {
+            // Without this the guard passes just as happily on an empty
+            // directory, which is the exact shape of failure it is meant to
+            // catch.
+            let found = try definedSuites().count
+            try expect(found >= 15, "expected at least 15 suites, found \(found)")
+        }
+
+        test("would notice a suite that main.swift never calls") {
+            // Negative control over the detector itself, not over the tree: a
+            // name that is deliberately absent must be reported as missing.
+            let main = try mainBody()
+            let probe = unregistered(
+                among: ["runAppConstantsTests", "runSuiteNobodyRegisteredTests"],
+                in: main
+            )
+            try expectEqual(probe, ["runSuiteNobodyRegisteredTests"])
+        }
+    }
+}

--- a/macos/Tests/OpenRappterBarTests/main.swift
+++ b/macos/Tests/OpenRappterBarTests/main.swift
@@ -18,6 +18,7 @@ await runOnboardingSpawnTests()
 await runBonesInspectorTests()
 await runBonesWindowTests()
 await runChatTargetTests()
+try runSuiteRegistrationTests()
 
 printResults()
 exitWithCode()


### PR DESCRIPTION
The Bar's tests are not XCTest, so nothing discovers them. `main.swift` calls each `run…Tests()` by hand:

```swift
await runChatTargetTests()
try runSuiteRegistrationTests()
```

A new suite can compile, be committed, pass review and never execute a single assertion. Nothing looks wrong, because the only symptom is a total that failed to go up, and nobody reads the total.

This is the same failure the TypeScript inert-test guard was built for in #215 and #217 — a test counted as coverage that cannot fail. TypeScript, the UI and Python each have some protection against it. **Swift had none**, which made it the one runtime where the oversight could recur in silence. All 15 suites happen to be registered today; this pins that they stay so.

## The mutation test is the interesting part

I added a suite whose only assertion is `expect(false)` — it fails if it runs at all — and deliberately did not register it:

```
FAIL: every suite defined here is called by main.swift
      defined but never called from main.swift, so it never runs: runForgottenTests
Results: 175 passed, 1 failed, 176 total
```

The total stayed at **176**, not 177. The forgotten suite never ran, so its guaranteed failure never surfaced. That is the exact defect, reproduced: an assertion that cannot fail because it is never reached, and the guard is what turns it into a red build.

Removing the file restores 176 passed, 0 failed.

## Guarding the guard

Two of the three tests exist so this one cannot rot the way the thing it watches could:

- **`finds the suites to check`** — asserts at least 15 suites are discovered. Without it the guard passes just as happily against an empty directory, which is the shape of failure it exists to catch.
- **`would notice a suite that main.swift never calls`** — a negative control over the detector itself, not the tree. It feeds in one real name and one deliberately absent name and asserts only the absent one is reported.

## Also here

The CI comment claimed the Swift job runs "86+ tests". It runs 176. I replaced the number with a description of what the job actually guarantees, since a figure like that only gets corrected when someone happens to notice — which is how it drifted by 90 in the first place, and the same class of staleness as the published agent count in #232.

## Verification

- `swift build --product RunTests` clean; **176 passed, 0 failed** (was 173).
- Mutation-proven above, in both directions.
- `ci.yml` still parses as YAML.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
