### PR TITLE
fix: a cron job created without an agent was scheduled, fired, and then found no agent

### DIFF
--- a/typescript/src/cron/__tests__/default-agent-resolvable.test.ts
+++ b/typescript/src/cron/__tests__/default-agent-resolvable.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  CronService,
+  DEFAULT_CRON_AGENT_ID,
+  isAssistantCronAgent,
+} from '../service.js';
+
+/**
+ * A job created without an agent must be runnable.
+ *
+ * `addJob` supplies a default agent id; the daemon executor in `index.ts`
+ * decides which ids mean "the built-in assistant". Those two lived in separate
+ * files with no reason to agree, and they did not: the default was `'main'`
+ * and the executor resolved only `'Assistant'` and `'openrappter'`, so every
+ * job created without `-a` was scheduled, persisted, fired exactly on time and
+ * then failed with `Agent not found: main`.
+ *
+ * Neither file was wrong on its own, which is why nothing caught it. That is
+ * the shape of the invariant below: it is deliberately written against
+ * `DEFAULT_CRON_AGENT_ID` rather than the string `'main'`, so it keeps holding
+ * if the default is ever renamed, and it fails the moment the two sides drift
+ * apart again — whichever side moves.
+ *
+ * It is also decision-independent. #179 asks whether `'main'` should be an
+ * alias, be rejected at creation, or be replaced at creation with the real
+ * name. Any of those keeps this test green; what none of them may do is leave
+ * a default the executor cannot resolve.
+ */
+describe('cron default agent is resolvable', () => {
+  it('the executor accepts whatever addJob defaults to', () => {
+    expect(isAssistantCronAgent(DEFAULT_CRON_AGENT_ID, 'openrappter')).toBe(true);
+  });
+
+  it('holds regardless of what the assistant is called', () => {
+    // The default must not depend on the deployment's assistant name — that is
+    // the coupling that made the two files look independently correct.
+    for (const assistantName of ['openrappter', 'rappter-two', '']) {
+      expect(isAssistantCronAgent(DEFAULT_CRON_AGENT_ID, assistantName)).toBe(true);
+    }
+  });
+
+  it('a job created without an agent gets an id the executor can run', async () => {
+    const service = new CronService();
+    const job = await service.addJob({
+      name: 'nightly',
+      schedule: '0 3 * * *',
+      message: 'summarise yesterday',
+    });
+
+    expect(job.agentId).toBe(DEFAULT_CRON_AGENT_ID);
+    expect(isAssistantCronAgent(job.agentId, 'openrappter')).toBe(true);
+  });
+
+  it('an explicitly named agent is still treated as a registry lookup', () => {
+    // The fix must not swallow real agent names into the assistant branch, or
+    // a job targeting HackerNewsAgent would silently run the assistant instead
+    // — a quieter version of the same bug.
+    expect(isAssistantCronAgent('HackerNewsAgent', 'openrappter')).toBe(false);
+    expect(isAssistantCronAgent('MemoryAgent', 'openrappter')).toBe(false);
+  });
+
+  it('still resolves the two names the executor already accepted', () => {
+    expect(isAssistantCronAgent('Assistant', 'openrappter')).toBe(true);
+    expect(isAssistantCronAgent('openrappter', 'openrappter')).toBe(true);
+  });
+});

--- a/typescript/src/cron/service.ts
+++ b/typescript/src/cron/service.ts
@@ -18,6 +18,34 @@ function generateId(): string {
   return `job_${Date.now()}_${++idCounter}`;
 }
 
+/**
+ * The agent a job gets when its creator names none.
+ *
+ * This is not a free-form label. Whatever it is, the daemon executor has to be
+ * able to resolve it, or every job created without an explicit agent is
+ * scheduled, persisted, fired on time and then fails to find an agent —
+ * the third way a cron job could look healthy and do nothing, after #166 (a
+ * deleted job kept running) and #174 (a job fired with an empty prompt).
+ */
+export const DEFAULT_CRON_AGENT_ID = 'main';
+
+/**
+ * Whether a job's agent id means "the built-in assistant" rather than a named
+ * agent from the registry.
+ *
+ * Exported because the invariant that matters spans two files that had no
+ * reason to agree: `addJob` picks the default here, and the executor in
+ * `index.ts` decides what it accepts. They disagreed, and nothing could see it
+ * because neither file is wrong on its own.
+ */
+export function isAssistantCronAgent(agentId: string, assistantName: string): boolean {
+  return (
+    agentId === 'Assistant' ||
+    agentId === assistantName ||
+    agentId === DEFAULT_CRON_AGENT_ID
+  );
+}
+
 function generateLogId(): string {
   return `log_${Date.now()}_${++idCounter}`;
 }
@@ -189,7 +217,7 @@ export class CronService {
       id: generateId(),
       name: input.name,
       schedule: input.schedule,
-      agentId: input.agentId ?? 'main',
+      agentId: input.agentId ?? DEFAULT_CRON_AGENT_ID,
       message: input.message,
       enabled: input.enabled ?? true,
       createdAt: now,

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -726,7 +726,7 @@ async function startGatewayInProcess(opts?: {
   if (isTwin) {
     log(`${EMOJI} Twin "${opts?.instance}" — cron and outbound channels stay with the alpha.`);
   } else try {
-    const { CronService } = await import('./cron/service.js');
+    const { CronService, isAssistantCronAgent } = await import('./cron/service.js');
     const { createCronGatewayAdapter } = await import('./cron/gateway-adapter.js');
     const cronService = new CronService();
     const cronFile = path.join(HOME_DIR, 'cron.json');
@@ -741,7 +741,7 @@ async function startGatewayInProcess(opts?: {
         console.log(`${EMOJI} Cron executing: agent=${agentId} message="${message.slice(0, 60)}"`);
         try {
           // Use the main assistant for 'Assistant' agentId
-          if (agentId === 'Assistant' || agentId === NAME) {
+          if (isAssistantCronAgent(agentId, NAME)) {
             // Each cron job gets its own conversation key to prevent
             // poisoned history from one job breaking others
             const cronKey = `cron_${agentId}_${Date.now()}`;


### PR DESCRIPTION
Fixes the bug in #179. Deliberately does **not** settle the naming question that issue also raises.

## The bug

`CronService.addJob` defaults `agentId` to `'main'`. The daemon executor in `index.ts` resolved only `'Assistant'` and the assistant's own name:

```ts
if (agentId === 'Assistant' || agentId === NAME) { ...assistant... }
const agent = agents.get(agentId);   // agents.get('main') -> undefined
if (!agent) return `Agent not found: ${agentId}`;
```

So every job created without an explicit agent — from the Bar and from `openrappter cron add` without `-a` alike — was accepted, persisted, scheduled, fired exactly on time, and only then failed. It looked healthy at every point a user would check.

That is the **third** way a cron job could look healthy and do nothing, after #166 (a deleted job kept running) and #174 (a job fired with an empty prompt).

## Why nothing caught it

Neither file was wrong on its own. `addJob` is entitled to pick a default; the executor is entitled to decide which ids mean "the built-in assistant". The bug lived in the gap between two locally reasonable decisions, in two files with no reason to reference each other — so no test that examined either one in isolation could have seen it.

That is why the fix is not just the alias:

- `DEFAULT_CRON_AGENT_ID` is now a named export, referenced by both sides instead of `'main'` being written twice.
- The resolver is a shared `isAssistantCronAgent()` rather than a comparison open-coded in the executor.
- The test asserts against `DEFAULT_CRON_AGENT_ID`, never the literal `'main'`, so it survives a rename and fails the moment the two sides drift apart again — **whichever one moves**.

## Mutation proof

Reverting only the resolver to its pre-fix two-name form:

```
× the executor accepts whatever addJob defaults to
× holds regardless of what the assistant is called
× a job created without an agent gets an id the executor can run
  Tests  3 failed | 2 passed (5)
```

The two that stay green are exactly the two the mutation should not affect — that a named agent is still a registry lookup, and that the two original names still resolve. Restoring gives 5 passed.

## What this leaves to the owner

#179 asks whether `'main'` should be an alias, be rejected at creation, or be replaced with the real name at creation. **All three keep this invariant green.** What none of them may do is leave a default the executor cannot resolve, and that is now the thing under test rather than the spelling. I have left #179 open for the naming decision.

I also checked whether Python had the same defect — it has no cron scheduler at all, so this is TypeScript-only.

## Verification

- Full TypeScript suite **4717 passed**, 21 skipped (up 5 — all new and all capable of failing, as shown above).
- `tsc --noEmit` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
