### PR TITLE
fix: a docs test made every future release impossible to pass

### DIFF
--- a/typescript/src/__tests__/docs/site.test.ts
+++ b/typescript/src/__tests__/docs/site.test.ts
@@ -237,8 +237,13 @@ describe('Current release identity', () => {
     }
   });
 
-  it('presents Show-and-Tell as consent-bound reusable learning', () => {
-    const doc = parseHTML(CURRENT_RELEASE_FILE);
+  it("pins 1.13.0's own copy to 1.13.0's page", () => {
+    // These are one release's headline and marketing copy. Asserted against
+    // CURRENT_RELEASE_FILE they failed on every future release, because no
+    // release note about anything other than Show-and-Tell could satisfy them
+    // however good it was. Pinned to the file they were actually written about,
+    // they keep protecting that page and stop expiring.
+    const doc = parseHTML('release-notes-1.13.0-evolution.html');
     expect(doc.title).toContain('Show-and-Tell');
     const text = doc.body.textContent || '';
     expect(text).toContain('Show it once.');
@@ -246,6 +251,21 @@ describe('Current release identity', () => {
     expect(text).toContain('Screenshots are explicit-only');
     expect(text).toContain('one-use local token');
     expect(text).toContain('Native tools over pixel replay');
+  });
+
+  it('every release page states what it is and what it changed', () => {
+    // The generic half of what the pinned test above was doing: a release note
+    // has a subject in its title and a body substantial enough to describe the
+    // release. This is the part that should follow CURRENT_RELEASE_FILE, and it
+    // is satisfiable by any honest release note rather than by one subject.
+    const doc = parseHTML(CURRENT_RELEASE_FILE);
+    const title = doc.title || '';
+    expect(title).toMatch(/openrappter/i);
+    expect(title).toMatch(new RegExp(CURRENT_VERSION.replace(/\./g, '\\.')));
+
+    const text = doc.body.textContent || '';
+    expect(text.length).toBeGreaterThan(2000);
+    expect(doc.querySelectorAll('h2, h3').length).toBeGreaterThan(2);
   });
 
   it('uses durable Bar release links instead of versioned DMG URLs', () => {


### PR DESCRIPTION
Fixes #164.

## The landmine

`site.test.ts` asserted 1.13.0's headline and marketing copy against `CURRENT_RELEASE_FILE`, which is derived from `package.json`:

```ts
const CURRENT_RELEASE_FILE = `release-notes-${CURRENT_VERSION}-evolution.html`;
...
expect(doc.title).toContain('Show-and-Tell');
expect(text).toContain('Show it once.');
expect(text).toContain('Context, not surveillance');
```

Any release whose subject was not Show-and-Tell failed, however good its notes were. It was already armed: `release-notes-1.14.0-evolution.html` exists in `docs/` while `package.json` still says 1.13.0, so the failure was waiting for the version bump.

## Reproduced before fixing

Bumping to 1.14.0 locally:

```
× publishes the 1.13.0 Pages release
× homepage badge derives from package metadata
× homepage links only to the current release page
× presents Show-and-Tell as consent-bound reusable learning
  Tests  4 failed | 156 passed (160)
```

Three of those are **legitimate release-time steps** — update the test's hardcoded version, the homepage badge, the homepage link. A release engineer does them and moves on. The fourth was unsatisfiable: no correct 1.14.0 release note could ever contain 1.13.0's headline.

## The split

Deleting the assertions would have thrown away real protection, so both halves were kept and pointed at the right targets:

- **The copy is pinned to `release-notes-1.13.0-evolution.html`** — the page it was actually written about. It still guards that page's consent language, and it can no longer expire.
- **The generic half follows `CURRENT_RELEASE_FILE`** — a release page names the product and its version in the title and carries enough structure to describe the release. Any honest release note satisfies that; only one subject satisfied the old assertion.

After this, bumping to 1.14.0 leaves **exactly the three real release steps** failing.

## Mutation proof

Both halves were checked to make sure the split did not produce two tests that pass regardless:

- altering one pinned string (`'Context, not surveillance'`) fails the pinned test
- aiming the shape test at `index.html`, a page that is not a release note, fails the shape test

```
Tests  2 failed | 159 passed (161)
```

Restoring gives 161 passed at 1.13.0.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
