### PR TITLE
feat: let an operator widen the gateway startup budget without editing source

### DIFF
--- a/docs/electron-desktop.md
+++ b/docs/electron-desktop.md
@@ -142,6 +142,35 @@ login, and optional OpenRappter Bar launch. It publishes
 validates the file, process, host, port, and token, then authenticates to that
 gateway instead of creating another daemon.
 
+## Slow gateway startup
+
+The desktop app will not open a window until the gateway it spawned reports
+itself ready. That budget is **30 seconds**, and when it runs out the gateway is
+killed and startup fails with:
+
+```
+OpenRappter gateway did not become ready in 30 seconds.
+```
+
+A gateway that genuinely fails to start is reported immediately by its exit,
+so this particular message only appears when the process is alive and merely
+slow — a cold first run resolving modules, an antivirus scan, or a heavily
+loaded machine.
+
+If that is your machine, raise the budget:
+
+```bash
+export OPENRAPPTER_GATEWAY_READY_TIMEOUT_MS=90000
+```
+
+Values must be a plain positive integer of milliseconds. Anything else is
+ignored in favour of the 30s default rather than being treated as fatal, and
+the accepted maximum is ten minutes so that a mistyped value cannot hang
+startup indefinitely.
+
+Whether 30 seconds is the right default is still open (issue #223); this
+variable exists so that nobody has to wait for that answer to start the app.
+
 ## Deterministic smoke
 
 `OPENRAPPTER_DESKTOP_SMOKE=1` launches the real Electron app, verifies the

--- a/typescript/desktop/src/gateway-ready.ts
+++ b/typescript/desktop/src/gateway-ready.ts
@@ -30,6 +30,48 @@ export const GATEWAY_READY_SCHEMA = 'openrappter-gateway-ready/1.0';
  */
 export const GATEWAY_READY_TIMEOUT_MS = 30_000;
 
+/**
+ * The environment variable an operator can use to widen that budget.
+ *
+ * The 30s default stays where it is, because a single Windows CI flake is not
+ * evidence for a different universal number and #223 leaves that question open.
+ * But the person who actually hits it — a cold first run, an antivirus scan, a
+ * loaded machine — could not do anything about it: `waitForGatewayReady` has
+ * always accepted a `timeoutMs`, and no caller passed one and nothing read an
+ * environment variable, so the documented escape hatch could only be reached by
+ * editing source.
+ *
+ * This does not decide what the budget should be. It lets someone who knows
+ * their machine raise it without waiting for that decision.
+ */
+export const GATEWAY_READY_TIMEOUT_ENV = 'OPENRAPPTER_GATEWAY_READY_TIMEOUT_MS';
+
+/** Upper bound, so a typo cannot hang desktop startup indefinitely. */
+const MAX_GATEWAY_READY_TIMEOUT_MS = 10 * 60_000;
+
+/**
+ * Resolve the readiness budget from the environment, falling back to the
+ * default for anything that is not a plain positive integer within bounds.
+ *
+ * A bad value is ignored rather than fatal: refusing to launch the app because
+ * someone exported a malformed number would be a worse failure than the one
+ * this setting exists to relieve.
+ */
+export function resolveGatewayReadyTimeout(
+  env: Record<string, string | undefined> = process.env,
+): number {
+  const raw = env[GATEWAY_READY_TIMEOUT_ENV];
+  if (raw === undefined) return GATEWAY_READY_TIMEOUT_MS;
+
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return GATEWAY_READY_TIMEOUT_MS;
+
+  const parsed = Number(trimmed);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) return GATEWAY_READY_TIMEOUT_MS;
+  if (parsed > MAX_GATEWAY_READY_TIMEOUT_MS) return MAX_GATEWAY_READY_TIMEOUT_MS;
+  return parsed;
+}
+
 /** The part of a child process this handshake uses. */
 export interface ReadyChildProcess {
   readonly pid?: number;
@@ -58,7 +100,7 @@ export function waitForGatewayReady(
   child: ReadyChildProcess,
   options: WaitForGatewayReadyOptions,
 ): Promise<void> {
-  const timeoutMs = options.timeoutMs ?? GATEWAY_READY_TIMEOUT_MS;
+  const timeoutMs = options.timeoutMs ?? resolveGatewayReadyTimeout();
 
   return new Promise<void>((resolve, reject) => {
     let settled = false;

--- a/typescript/desktop/test/gateway-ready.test.mjs
+++ b/typescript/desktop/test/gateway-ready.test.mjs
@@ -4,7 +4,9 @@ import { test } from 'node:test';
 
 import {
   GATEWAY_READY_SCHEMA,
+  GATEWAY_READY_TIMEOUT_ENV,
   GATEWAY_READY_TIMEOUT_MS,
+  resolveGatewayReadyTimeout,
   waitForGatewayReady,
 } from '../dist/gateway-ready.js';
 
@@ -148,4 +150,60 @@ test('the default budget is the one the error message promises', () => {
   // The message states a number of seconds; if the constant and the text ever
   // disagree the error would misreport how long the app actually waited.
   assert.equal(GATEWAY_READY_TIMEOUT_MS, 30_000);
+});
+
+/**
+ * The readiness budget is reachable without editing source.
+ *
+ * `waitForGatewayReady` has always accepted a `timeoutMs`, and until now no
+ * caller passed one and nothing read an environment variable — so the escape
+ * hatch the module documents existed only for its own tests. The person who
+ * actually hits a 30s cold start had no remedy at all.
+ *
+ * These drive `resolveGatewayReadyTimeout` against an injected environment
+ * rather than mutating `process.env`, so they cannot leak into another test.
+ */
+test('readiness budget falls back to the default when unset', () => {
+  assert.equal(resolveGatewayReadyTimeout({}), GATEWAY_READY_TIMEOUT_MS);
+});
+
+test('readiness budget honours a valid override', () => {
+  assert.equal(
+    resolveGatewayReadyTimeout({ [GATEWAY_READY_TIMEOUT_ENV]: '90000' }),
+    90_000,
+  );
+  assert.equal(
+    resolveGatewayReadyTimeout({ [GATEWAY_READY_TIMEOUT_ENV]: '  45000  ' }),
+    45_000,
+  );
+});
+
+test('readiness budget ignores anything that is not a positive integer', () => {
+  // Refusing to launch because someone exported a malformed number would be a
+  // worse failure than the slow start this setting exists to relieve.
+  for (const bad of ['', 'soon', '30s', '-1', '0', '1.5', '1e5', '0x30', 'NaN']) {
+    assert.equal(
+      resolveGatewayReadyTimeout({ [GATEWAY_READY_TIMEOUT_ENV]: bad }),
+      GATEWAY_READY_TIMEOUT_MS,
+      `expected ${JSON.stringify(bad)} to be ignored`,
+    );
+  }
+});
+
+test('readiness budget is capped so a typo cannot hang startup forever', () => {
+  assert.equal(
+    resolveGatewayReadyTimeout({ [GATEWAY_READY_TIMEOUT_ENV]: '999999999' }),
+    10 * 60_000,
+  );
+});
+
+test('an explicit caller option still wins over the environment', async () => {
+  // The option is the mechanism; the variable is only the default for it.
+  const child = new FakeChild();
+  const started = Date.now();
+  await assert.rejects(
+    waitForGatewayReady(child, { port: 18790, timeoutMs: 20 }),
+    /did not become ready in 0 seconds\./,
+  );
+  assert.ok(Date.now() - started < 5_000);
 });


### PR DESCRIPTION
Addresses the live half of #223 without pre-empting the question that issue leaves open.

## What was unreachable

The desktop app will not open a window until the gateway it spawned reports ready. That budget is 30s, after which the gateway is killed and startup fails.

`gateway-ready.ts` documents, in its own comments, that this timer only fires when the process is **alive and merely slow** — `onExit` already reports a genuine startup failure immediately. So it lands on cold first runs, antivirus scans and loaded machines, which is exactly the case where killing the gateway is least likely to help.

It also documents an escape hatch: *"Callers can override it."* They could not:

```ts
// main.ts:384 — the only caller
await waitForGatewayReady(child, { port: gatewayPort });
```

No caller passed `timeoutMs`, and nothing read an environment variable. The override existed for the module's own tests. A user hitting a 35-second cold start had to edit source and rebuild.

That is the same shape as #219, #222 and #235 — a capability that is built, documented, and reachable by nobody.

## What this does and deliberately does not do

`OPENRAPPTER_GATEWAY_READY_TIMEOUT_MS` now supplies the default for that option:

```bash
export OPENRAPPTER_GATEWAY_READY_TIMEOUT_MS=90000
```

**The 30s default is unchanged.** One Windows CI flake that passed on re-run is not evidence for a different universal number, and #223 asks what the budget should be. This does not answer that — it means nobody has to wait for the answer to start the app. `main.ts` needed no change: passing no override, it now picks up the environment default.

Two deliberate choices in the validation:

- **A malformed value is ignored, not fatal.** Refusing to launch because someone exported `30s` would be a worse failure than the slow start this relieves.
- **Ten-minute cap.** A mistyped `999999999` should not hang startup indefinitely.

## Verification

Desktop suite **25 pass, 0 fail** (was 20). Mutation-tested — removing the integer validation and the cap:

```
not ok 23 - readiness budget ignores anything that is not a positive integer
not ok 24 - readiness budget is capped so a typo cannot hang startup forever
# pass 23
# fail 2
```

Restoring gives 25/25. The new tests inject an environment object rather than mutating `process.env`, so they cannot leak into another test.

Documented under a new "Slow gateway startup" section in `docs/electron-desktop.md`, including why the message appears only for a live-but-slow gateway.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
