### PR TITLE
feat: the channels screen updates when a channel connects, instead of going stale

### DIFF
--- a/typescript/src/__tests__/integration/channel-status-event.test.ts
+++ b/typescript/src/__tests__/integration/channel-status-event.test.ts
@@ -1,0 +1,191 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import WebSocket from 'ws';
+import { GatewayServer as RuntimeGatewayServer } from '../../gateway/server.js';
+import type { GatewayConfig } from '../../gateway/types.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * The channels screen updates when a channel connects or disconnects.
+ *
+ * `channels.ts` has always listened for `channel.status` and kept a map of
+ * statuses keyed by type. Nothing ever emitted that event, so the map was
+ * seeded once by `channels.list` and then froze: connecting or disconnecting a
+ * channel left the screen showing the previous state until someone reloaded.
+ * The listener was real, the feature was not.
+ *
+ * These drive a real socket rather than asserting the emit call, because the
+ * failure this fixes lived precisely between two halves that each looked
+ * correct — a listener with no emitter. A test that stubbed either side would
+ * have reproduced the original blind spot rather than closing it.
+ */
+
+let testDataDir = '';
+
+class GatewayServer extends RuntimeGatewayServer {
+  constructor(config: Partial<GatewayConfig>) {
+    super({ ...config, dataDir: testDataDir });
+  }
+}
+
+function rpc(
+  ws: WebSocket,
+  method: string,
+  params?: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve, reject) => {
+    const id = `req_${Date.now()}_${Math.random().toString(36).slice(2)}`;
+    const timeout = setTimeout(() => reject(new Error(`RPC timeout: ${method}`)), 5000);
+    const handler = (data: WebSocket.Data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.id === id) {
+        clearTimeout(timeout);
+        ws.off('message', handler);
+        resolve(msg);
+      }
+    };
+    ws.on('message', handler);
+    ws.send(JSON.stringify({ type: 'req', id, method, params }));
+  });
+}
+
+function connectWs(port: number): Promise<WebSocket> {
+  return new Promise((resolve, reject) => {
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+    ws.on('open', () => resolve(ws));
+    ws.on('error', reject);
+  });
+}
+
+/** Resolve with the first `channel.status` event frame, or null if none arrives. */
+function nextChannelStatus(ws: WebSocket, ms = 1500): Promise<Record<string, unknown> | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      ws.off('message', handler);
+      resolve(null);
+    }, ms);
+    const handler = (data: WebSocket.Data) => {
+      const msg = JSON.parse(data.toString());
+      if (msg.type === 'event' && msg.event === 'channel.status') {
+        clearTimeout(timer);
+        ws.off('message', handler);
+        resolve(msg.payload as Record<string, unknown>);
+      }
+    };
+    ws.on('message', handler);
+  });
+}
+
+/** A registry with one connectable channel, as the server consumes it. */
+function fakeRegistry(): {
+  registry: Record<string, unknown>;
+  connected: () => boolean;
+} {
+  let connected = false;
+  return {
+    connected: () => connected,
+    registry: {
+      getStatusList: () => [
+        { id: 'slack-main', type: 'slack', connected, configured: true },
+        { id: 'discord-main', type: 'discord', connected: false, configured: true },
+      ],
+      connectChannel: async (type: string) => {
+        if (type === 'slack') connected = true;
+      },
+      disconnectChannel: async (type: string) => {
+        if (type === 'slack') connected = false;
+      },
+    },
+  };
+}
+
+describe('channel.status reaches subscribers', () => {
+  let server: GatewayServer | null = null;
+  let socket: WebSocket | null = null;
+
+  beforeEach(() => {
+    testDataDir = fs.mkdtempSync(path.join(process.cwd(), '.channel-status-'));
+  });
+
+  afterEach(async () => {
+    if (socket) { socket.close(); socket = null; }
+    if (server) { await server.stop(); server = null; }
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  });
+
+  async function startWithRegistry(): Promise<{ port: number; connected: () => boolean }> {
+    const { registry, connected } = fakeRegistry();
+    const port = await reserveTestPort();
+    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    (server as unknown as { channelRegistry: unknown }).channelRegistry = registry;
+    await server.start();
+    return { port, connected };
+  }
+
+  async function subscribedSocket(port: number): Promise<WebSocket> {
+    const ws = await connectWs(port);
+    await rpc(ws, 'connect', {
+      client: { id: 'channel-status-test', version: '1.0.0', platform: 'node', mode: 'test' },
+    });
+    await rpc(ws, 'subscribe', { events: ['channel.status'] });
+    return ws;
+  }
+
+  it('connecting a channel notifies a subscriber', async () => {
+    const { port } = await startWithRegistry();
+    socket = await subscribedSocket(port);
+
+    const received = nextChannelStatus(socket);
+    await rpc(socket, 'channels.connect', { type: 'slack' });
+
+    expect(await received).toMatchObject({ type: 'slack', connected: true });
+  });
+
+  it('disconnecting a channel notifies a subscriber', async () => {
+    const { port } = await startWithRegistry();
+    socket = await subscribedSocket(port);
+
+    await rpc(socket, 'channels.connect', { type: 'slack' });
+    const received = nextChannelStatus(socket);
+    await rpc(socket, 'channels.disconnect', { type: 'slack' });
+
+    expect(await received).toMatchObject({ type: 'slack', connected: false });
+  });
+
+  it('sends the same shape channels.list returns, so one type renders both', async () => {
+    const { port } = await startWithRegistry();
+    socket = await subscribedSocket(port);
+
+    const received = nextChannelStatus(socket);
+    await rpc(socket, 'channels.connect', { type: 'slack' });
+    const event = await received;
+
+    const list = (await rpc(socket, 'channels.list')).payload as Record<string, unknown>[];
+    const listed = list.find((entry) => entry.type === 'slack');
+
+    expect(event).toEqual(listed);
+  });
+
+  it('reports only the channel that changed', async () => {
+    // Broadcasting every channel on every change would make the screen redraw
+    // rows nothing happened to, and would hide which one actually moved.
+    const { port } = await startWithRegistry();
+    socket = await subscribedSocket(port);
+
+    const received = nextChannelStatus(socket);
+    await rpc(socket, 'channels.connect', { type: 'slack' });
+
+    expect((await received)?.type).toBe('slack');
+  });
+
+  it('stays silent for a channel the registry does not know', async () => {
+    const { port } = await startWithRegistry();
+    socket = await subscribedSocket(port);
+
+    const received = nextChannelStatus(socket, 600);
+    await rpc(socket, 'channels.connect', { type: 'nonexistent' });
+
+    expect(await received).toBeNull();
+  });
+});

--- a/typescript/src/__tests__/integration/event-contract-coverage.test.ts
+++ b/typescript/src/__tests__/integration/event-contract-coverage.test.ts
@@ -80,7 +80,8 @@ function invokedMethodModules(): Set<string> {
  * emitted while still listed.
  */
 const LISTENED_BUT_NEVER_EMITTED = new Set([
-  'channel.status',
+  // `channel.status` came off this list when the gateway started emitting it
+  // on channels.connect/disconnect — see channel-status-event.test.ts.
   'agent.tool',
 ]);
 
@@ -89,7 +90,6 @@ const DECLARED_BUT_NEVER_EMITTED = new Set([
   'agent.tool',
   'channel',
   'channel.message',
-  'channel.status',
   'chat.message',
   'cron',
   'cron.complete',

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -913,6 +913,28 @@ export class GatewayServer {
     };
   }
 
+  /**
+   * Tell subscribers a channel's connection state changed.
+   *
+   * The channels screen keeps a map of statuses and listens for
+   * `channel.status` to update it. Nothing ever emitted that event, so the map
+   * was populated once by `channels.list` and then went stale: connecting or
+   * disconnecting a channel left the screen showing the old state until reload.
+   *
+   * The payload is deliberately one entry of exactly what `channels.list`
+   * returns, because the screen renders both through the same `ChannelStatus`
+   * type. An event shaped differently from the list that seeds it would be a
+   * second contract for the same thing.
+   */
+  private broadcastChannelStatus(type: string): void {
+    if (!this.channelRegistry) return;
+    const status = this.channelRegistry
+      .getStatusList()
+      .find((entry) => entry.type === type);
+    if (!status) return;
+    this.broadcastEvent(GatewayEvents.CHANNEL_STATUS, status);
+  }
+
   /** Broadcast an event to all authenticated connections (type: "event" frame) */
   broadcastEvent(event: string, payload: unknown, filter?: (conn: ConnectionInfo) => boolean): void {
     if (this.stopping || !this.wss) return;
@@ -2528,11 +2550,13 @@ export class GatewayServer {
     this.registerMethod('channels.connect', async (params: { type: string }) => {
       if (!this.channelRegistry) throw new Error('Channel registry not configured');
       await this.channelRegistry.connectChannel(params.type);
+      this.broadcastChannelStatus(params.type);
       return { connected: true };
     }, { requiresAuth: true });
     this.registerMethod('channels.disconnect', async (params: { type: string }) => {
       if (!this.channelRegistry) throw new Error('Channel registry not configured');
       await this.channelRegistry.disconnectChannel(params.type);
+      this.broadcastChannelStatus(params.type);
       return { disconnected: true };
     }, { requiresAuth: true });
     this.registerMethod('channels.probe', async (params: { type: string }) => {


### PR DESCRIPTION
Implements the `channel.status` half of #195. `agent.tool` is untouched and stays on the list.

## A listener with no emitter

`ui/src/components/channels.ts` has always subscribed to `channel.status` and kept a map of statuses keyed by type. **Nothing ever emitted it.** The map was seeded once by `channels.list` and then froze — connecting or disconnecting a channel left the screen showing the previous state until the page was reloaded.

Each half reads as correct on its own, which is exactly why this survived: only comparing the two sides reveals that one of them is talking to nobody. That comparison is what #194 added, and it is what recorded this in `LISTENED_BUT_NEVER_EMITTED`.

## The payload was not actually an open question

#195 asked what the payload should be. The consumer had already answered — `channels.list` returns `ChannelStatus[]` and the screen renders both the list and the event through that same type. So the event is **one entry of exactly what `channels.list` returns**, and a test asserts that equality directly:

```ts
const list = (await rpc(socket, 'channels.list')).payload;
expect(event).toEqual(list.find((entry) => entry.type === 'slack'));
```

An event shaped differently from the list that seeds it would be a second contract for the same thing.

Only the changed channel is sent. Broadcasting all of them would redraw rows nothing happened to and hide which one actually moved.

## Tested over a real socket

The tests connect a real WebSocket, subscribe, call the RPC and wait for the frame. That is deliberate: the bug lived precisely *between* two halves that each looked right, so stubbing either side would have reproduced the original blind spot rather than closing it. This is the lesson from #228, where my client tests could not prove the gateway ever fired the signal.

Five tests, including a channel the registry does not know staying silent.

**Mutation proof** — removing the emit from `channels.connect`:

```
× connecting a channel notifies a subscriber
× sends the same shape channels.list returns, so one type renders both
× reports only the channel that changed
  Tests  3 failed | 2 passed (5)
```

## The ratchet worked on the way in

Implementing the event turned `event-contract-coverage` red until `channel.status` came off both lists:

```
× the never-emitted list contains nothing that is now emitted
  → expected [ 'channel.status' ] to deeply equal []
```

So the catalogue cannot keep claiming an event is unimplemented after someone implements it. Both entries removed; that guard is back to 6 passed.

## Verification

Full TypeScript suite **4723 passed**, 21 skipped. `tsc --noEmit` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
