### PR TITLE
fix: the agent that phones real people declared a capability that does not exist

### DIFF
--- a/typescript/src/__tests__/integration/agent-capability-vocabulary.test.ts
+++ b/typescript/src/__tests__/integration/agent-capability-vocabulary.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Every capability a TypeScript agent declares must be a real capability.
+ *
+ * `conformance.py` defines the vocabulary and enforces it for Python agents:
+ * R4 and R5 read capabilities out of the AST and fail both under- and
+ * over-declaration. TypeScript has no equivalent — no schema, no validation,
+ * nothing — so an agent could declare anything at all and no check would care.
+ *
+ * It did. `PhoneAgent` declared `network-access`, which is not a capability;
+ * the vocabulary word is `network`, used by eight other agents. The agent that
+ * places real phone calls on the owner's behalf was therefore invisible to any
+ * filter selecting on `network`, and under-declared the one capability that
+ * matters most about it. That is precisely the hazard #122 describes: a rule
+ * that can only be applied through a vocabulary nobody validates.
+ *
+ * The canonical list is read from `conformance.py` rather than copied, so the
+ * two runtimes cannot drift apart the way the two halves of every other defect
+ * this session did.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../..');
+const agentsDir = path.resolve(here, '../../agents');
+
+/**
+ * Capabilities that exist only in the TypeScript runtime.
+ *
+ * Listing one here is a deliberate statement that it has no Python counterpart,
+ * not a way to silence this test. `ui-control` is real: `DesktopControlAgent`
+ * drives the desktop, and Python ships no agent that does.
+ */
+const TYPESCRIPT_ONLY_CAPABILITIES = new Set(['ui-control']);
+
+/** The vocabulary as `conformance.py` defines it. */
+function canonicalCapabilities(): Set<string> {
+  const source = fs.readFileSync(path.join(repoRoot, 'conformance.py'), 'utf8');
+  const block = /CAPABILITY_EVIDENCE = \{([\s\S]*?)\n\}/.exec(source);
+  if (!block) throw new Error('CAPABILITY_EVIDENCE not found in conformance.py');
+  return new Set(
+    [...block[1].matchAll(/^ {4}"([a-z-]+)":/gm)].map((m) => m[1]),
+  );
+}
+
+function agentFiles(): string[] {
+  return fs
+    .readdirSync(agentsDir)
+    .filter((f) => f.endsWith('Agent.ts'))
+    .filter((f) => !f.endsWith('.test.ts'))
+    .filter((f) => f !== 'BasicAgent.ts');
+}
+
+/** Capabilities declared in a file's `__manifest__`. */
+function declaredCapabilities(file: string): string[] {
+  const source = fs.readFileSync(path.join(agentsDir, file), 'utf8');
+  const match = /capabilities:\s*\[([\s\S]*?)\]/.exec(source);
+  if (!match) return [];
+  return [...match[1].matchAll(/'([^']+)'/g)].map((m) => m[1]);
+}
+
+describe('agent capability vocabulary', () => {
+  it('reads a non-empty vocabulary from conformance.py', () => {
+    // Anti-vacuity: a parse that silently returned nothing would make every
+    // declaration below valid by comparing against an empty set.
+    const canonical = canonicalCapabilities();
+    expect(canonical.size).toBeGreaterThanOrEqual(5);
+    expect(canonical).toContain('network');
+  });
+
+  it('finds a non-trivial number of agents to check', () => {
+    expect(agentFiles().length).toBeGreaterThan(25);
+  });
+
+  it('every declared capability is a real one', () => {
+    const allowed = new Set([
+      ...canonicalCapabilities(),
+      ...TYPESCRIPT_ONLY_CAPABILITIES,
+    ]);
+
+    const offenders: string[] = [];
+    for (const file of agentFiles()) {
+      for (const capability of declaredCapabilities(file)) {
+        if (!allowed.has(capability)) {
+          offenders.push(`${file}: ${capability}`);
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('the agent that can phone a person declares that it reaches the network', () => {
+    // Named explicitly rather than left to the sweep above, because this is
+    // the declaration whose absence had consequences: a twin filter selecting
+    // on `network` skipped the agent that dials real people (#122).
+    expect(declaredCapabilities('PhoneAgent.ts')).toContain('network');
+  });
+
+  it('would notice an invented capability (control)', () => {
+    // Proves the sweep discriminates rather than accepting whatever it reads.
+    const allowed = new Set([
+      ...canonicalCapabilities(),
+      ...TYPESCRIPT_ONLY_CAPABILITIES,
+    ]);
+    expect(allowed.has('network-access')).toBe(false);
+    expect(allowed.has('network')).toBe(true);
+  });
+
+  it('every TypeScript-only capability is actually in use', () => {
+    // Stops the escape hatch becoming a dumping ground: a term listed here and
+    // used by nobody is a stale exception, not a runtime difference.
+    const declared = new Set(agentFiles().flatMap(declaredCapabilities));
+    const unused = [...TYPESCRIPT_ONLY_CAPABILITIES].filter((c) => !declared.has(c));
+    expect(unused).toEqual([]);
+  });
+});

--- a/typescript/src/agents/PhoneAgent.ts
+++ b/typescript/src/agents/PhoneAgent.ts
@@ -38,7 +38,7 @@ export const __manifest__ = {
     'Place real phone calls on the owner\'s behalf with a goal and hard limits, negotiate, and stop for approval rather than committing outside them.',
   author: 'Kody Wildfeuer',
   ring: 'ga',
-  capabilities: ['network-access', 'credential-access', 'process-exec'],
+  capabilities: ['network', 'credential-access', 'process-exec'],
   tags: ['openrappter', 'phone', 'telephony', 'second-brain'],
   category: 'communication',
   quality_tier: 'official',


### PR DESCRIPTION
Groundwork for #122, and a real defect found on the way.

## `PhoneAgent` declared a capability that does not exist

```ts
capabilities: ['network-access', 'credential-access', 'process-exec'],
```

`network-access` is not a capability. The vocabulary word is **`network`**, and eight other agents use it. Surveying all 34:

| term | agents |
|---|---|
| `process-exec` | 17 |
| `filesystem-write` | 15 |
| `network` | 9 |
| `dynamic-code` | 9 |
| `credential-access` | 4 |
| **`network-access`** | **1 — PhoneAgent** |
| `ui-control` | 1 — DesktopControlAgent |

## Why it survived, and why it matters

`conformance.py` defines the vocabulary and enforces it for Python agents — R4 and R5 read capabilities out of the AST and fail both under- and over-declaration. **TypeScript has no equivalent.** No schema, no validation, nothing. So a misspelling on the most consequential agent in the roster went unnoticed.

The consequence is exactly what #122 is about. That issue names its blocker as *"there is no capability vocabulary to gate on"*, and any answer to it is a filter over declared capabilities. **A filter selecting on `network` would have skipped `PhoneAgent`** — the agent that dials real people on the owner's single phone line, which is the precise hazard the twin rules exist to contain.

So the vocabulary was not merely unenforced. It was already wrong at the one point where being wrong had consequences, and the fix for #122 would have inherited that hole silently.

## The guard

- **Reads the canonical list out of `conformance.py`** rather than copying it, so the two runtimes cannot drift — the failure mode behind nearly every defect I have found this session.
- **`ui-control` is an explicit TypeScript-only term**, not an oversight: `DesktopControlAgent` drives the desktop and Python ships no counterpart. Listing one there is a deliberate statement, not a way to silence the test.
- **A further test fails if a TypeScript-only term falls out of use**, so that escape hatch cannot become a dumping ground.
- Two anti-vacuity tests: the parsed vocabulary must be non-empty and contain `network`, and the sweep must find more than 25 agents. Without them a broken parse would make every declaration valid by comparing against an empty set.

## Mutation proof

Reintroducing the original typo:

```
× every declared capability is a real one
  → expected [ 'PhoneAgent.ts: network-access' ] to deeply equal []
× the agent that can phone a person declares that it reaches the network
  → expected [ 'network-access', …(2) ] to include 'network'
```

Restoring gives 6 passed.

## Verification

Full TypeScript suite **4729 passed**, 21 skipped. `conformance.py` 8 passed, 0 failed. `tsc --noEmit` clean.

This does **not** settle #122's design question — whether a twin should be able to place a call at all. It makes the vocabulary that question depends on trustworthy.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
