### PR TITLE
fix: config validate called a security policy valid while nothing enforced it

### DIFF
--- a/typescript/src/__tests__/unit/config-unenforced-sections.test.ts
+++ b/typescript/src/__tests__/unit/config-unenforced-sections.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import {
+  UNENFORCED_CONFIG_SECTIONS,
+  unenforcedConfigSections,
+} from '../../cli/config.js';
+import { openRappterConfigSchema } from '../../config/schema.js';
+
+/**
+ * A config section that validates and does nothing must say so.
+ *
+ * `openrappter config validate` prints "Configuration is valid." A user who
+ * writes
+ *
+ *     security:
+ *       approvalPolicy: deny
+ *       allowlists:
+ *         commands: ["git status"]
+ *
+ * is told exactly that, and — because `security` really is in the schema — the
+ * ignored-key report from #211 says nothing either. Every signal the tool gives
+ * says the lockdown is on. Nothing reads `config.security` (#219).
+ *
+ * This is the opposite failure to an ignored key and a worse one: an ignored
+ * key is discarded, which at least means nobody could think it took effect.
+ */
+describe('unenforced config sections', () => {
+  it('reports a section that is set but enforced by nothing', () => {
+    expect(unenforcedConfigSections({ security: { approvalPolicy: 'deny' } }))
+      .toEqual(['security']);
+  });
+
+  it('says nothing about a config that does not set one', () => {
+    expect(unenforcedConfigSections({ agents: { list: [] } })).toEqual([]);
+    expect(unenforcedConfigSections({})).toEqual([]);
+  });
+
+  it('reports every unenforced section a config sets, sorted', () => {
+    expect(
+      unenforcedConfigSections({ network: {}, security: {}, agents: {} }),
+    ).toEqual(['network', 'security']);
+  });
+
+  it('survives input that is not an object', () => {
+    for (const value of [null, undefined, 'security', 42, []]) {
+      expect(unenforcedConfigSections(value)).toEqual([]);
+    }
+  });
+
+  it('every listed section really is in the schema', () => {
+    // A section that is *not* in the schema is already covered by the
+    // ignored-key report, so listing it here would double-report it and hide
+    // that the entry has gone stale.
+    const shape = (openRappterConfigSchema as unknown as {
+      shape: Record<string, unknown>;
+    }).shape;
+    const notInSchema = [...UNENFORCED_CONFIG_SECTIONS.keys()]
+      .filter((section) => !(section in shape))
+      .sort();
+    expect(notInSchema).toEqual([]);
+  });
+
+  it('carries a reason for every entry', () => {
+    // The message is the whole value of the report — "security is not enforced"
+    // without saying what does enforce it sends the reader nowhere.
+    for (const [section, reason] of UNENFORCED_CONFIG_SECTIONS) {
+      expect(reason, `${section} has no reason`).toBeTruthy();
+      expect(reason.length).toBeGreaterThan(20);
+    }
+  });
+
+  it('names the security section, which is the one with consequences', () => {
+    expect(UNENFORCED_CONFIG_SECTIONS.has('security')).toBe(true);
+  });
+});

--- a/typescript/src/cli/config.ts
+++ b/typescript/src/cli/config.ts
@@ -90,6 +90,43 @@ function formatValidationErrors(error: string): string[] {
 }
 
 /**
+ * Sections the schema accepts and no runtime enforces.
+ *
+ * `ignoredConfigKeys` above catches keys the schema will *discard*. These are
+ * the opposite problem and a worse one: they are in the schema, so they parse,
+ * they survive into the loaded config, and `config validate` has every reason
+ * to call them valid. Nothing then reads them.
+ *
+ * For `security` that is not a cosmetic difference. A user can write
+ * `approvalPolicy: deny` with an allowlist, be told the configuration is valid,
+ * and reasonably conclude the policy is in force. It is not — `ExecSafety` and
+ * `ApprovalManager` are configured programmatically and never consult this file
+ * (#219). Every signal the tool gives says the lockdown is on.
+ *
+ * Listing a section here is a statement about the runtime, not about the
+ * section's worth. When one of these is wired up its entry comes out, and the
+ * test alongside this fails until it does.
+ */
+export const UNENFORCED_CONFIG_SECTIONS: ReadonlyMap<string, string> = new Map([
+  [
+    'security',
+    'nothing reads it — ExecSafety and ApprovalManager are configured in code, not from this file (#219)',
+  ],
+  [
+    'network',
+    'nothing reads it — TailscaleClient is constructed by no production code (#235)',
+  ],
+]);
+
+/** Which unenforced sections a given config actually sets. */
+export function unenforcedConfigSections(value: unknown): string[] {
+  if (!isPlainObject(value)) return [];
+  return [...UNENFORCED_CONFIG_SECTIONS.keys()]
+    .filter((section) => section in value)
+    .sort();
+}
+
+/**
  * Config keys the schema will silently discard.
  *
  * Zod strips unknown keys rather than rejecting them, so a config file can be
@@ -295,6 +332,20 @@ export function registerConfigCommand(program: Command): void {
           console.log('');
           console.log(`${ignored.length} key(s) are not part of the schema and will be ignored:`);
           for (const key of ignored) console.log(`  - ${key}`);
+        }
+
+        // Worse than an ignored key: in the schema, parsed, kept, and read by
+        // nobody. A security policy that validates and does nothing looks
+        // exactly like one that works.
+        const unenforced = unenforcedConfigSections(cfg);
+        if (unenforced.length > 0) {
+          console.log('');
+          console.log(
+            `${unenforced.length} section(s) are valid but not enforced by any runtime:`,
+          );
+          for (const section of unenforced) {
+            console.log(`  - ${section}: ${UNENFORCED_CONFIG_SECTIONS.get(section)}`);
+          }
         }
       } catch (error) {
         console.log('Configuration validation failed:');


### PR DESCRIPTION
Addresses the active danger in #219 without settling the question that issue asks.

## The problem

A user writes this and runs `openrappter config validate`:

```json5
{ security: { approvalPolicy: 'deny', allowlists: { commands: ['git status'] } } }
```

```
Configuration is valid.
```

The ignored-key report from #211 stays silent too, because `security` **really is** in the schema. So every signal the tool gives says the lockdown is on. Nothing reads `config.security` — `ExecSafety` and `ApprovalManager` are configured in code and never consult the file.

This is the opposite failure to an ignored key, and a worse one. An ignored key is *discarded*, so nobody could believe it took effect. A section that parses, validates and survives into the loaded config looks exactly like one that works.

## After

```
Configuration is valid.

2 section(s) are valid but not enforced by any runtime:
  - network: nothing reads it — TailscaleClient is constructed by no production code (#235)
  - security: nothing reads it — ExecSafety and ApprovalManager are configured in code, not from this file (#219)
```

Each entry names what *does* the enforcing, so the reader has somewhere to go rather than just being told no.

Verified end to end through the built CLI against an isolated `HOME`, not only as a unit.

## Design notes

- Seeded with the two sections I verified by tracing every importer of `config/`, rather than everything that looked suspicious.
- **Listing a section is a statement about the runtime, not about the section's worth.** When one is wired up, its entry comes out.
- A test fails if an entry names something absent from the schema — that case is already covered by the ignored-key report, and double-reporting it would hide that the entry had gone stale.
- Every entry must carry a reason of real length: "security is not enforced" without saying what *is* enforcing sends the reader nowhere.

## Mutation proof

Making the reporter return nothing:

```
× reports a section that is set but enforced by nothing
× reports every unenforced section a config sets, sorted
  Tests  2 failed | 5 passed (7)
```

Restoring gives 7 passed.

## Scope

This does not settle #219, which asks whether to wire the section up or drop it from the schema. It stops the tool agreeing with a lockdown that is not in force while that is decided.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
