### PR TITLE
fix: a rappter now presents a credential to a neighbour, so auth no longer severs it

### DIFF
--- a/typescript/src/__tests__/integration/twin-peer-credential.test.ts
+++ b/typescript/src/__tests__/integration/twin-peer-credential.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from 'vitest';
+import { peerHeaders, sendTwin } from '../../twin/send.js';
+
+/**
+ * A rappter presents a credential to a neighbour when it has one.
+ *
+ * Both wires sent only a content type, while `/twin` and `/chat` each call
+ * `resolveHttpAuthenticated` before parsing (#113, #119). Those facts were
+ * compatible only because authentication was off: `isAuthCredentialValid`
+ * returns true immediately when `authMode` is `none`. So the neighborhood
+ * worked *because* the security control was off, and turning it on anywhere
+ * severed it — a peer with a token refused both senders, including one whose
+ * own environment held the credential (#133).
+ *
+ * These assert on the request the sender actually builds, because that is the
+ * half that was wrong. The gateway's acceptance of `Authorization: Bearer` is
+ * already covered by its own auth tests; what nothing checked was whether
+ * anybody ever sent one.
+ */
+
+function capturingFetch(): {
+  calls: { url: string; headers: Record<string, string> }[];
+  impl: typeof fetch;
+} {
+  const calls: { url: string; headers: Record<string, string> }[] = [];
+  const impl = (async (url: unknown, init?: RequestInit) => {
+    calls.push({
+      url: String(url),
+      headers: (init?.headers ?? {}) as Record<string, string>,
+    });
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, reply: 'ack' }),
+    } as unknown as Response;
+  }) as unknown as typeof fetch;
+  return { calls, impl };
+}
+
+describe('presenting a credential to a neighbour', () => {
+  it('sends Bearer when a token is configured', () => {
+    expect(peerHeaders({ OPENRAPPTER_TOKEN: 'sec' })).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer sec',
+    });
+  });
+
+  it('sends no Authorization header when there is no token', () => {
+    // Sending `Bearer undefined` would be worse than sending nothing: the peer
+    // would see a malformed credential rather than an anonymous caller.
+    expect(peerHeaders({})).toEqual({ 'Content-Type': 'application/json' });
+    expect(peerHeaders({ OPENRAPPTER_TOKEN: '' })).toEqual({
+      'Content-Type': 'application/json',
+    });
+    expect(peerHeaders({ OPENRAPPTER_TOKEN: '   ' })).toEqual({
+      'Content-Type': 'application/json',
+    });
+  });
+
+  it('trims a token that arrived with whitespace', () => {
+    expect(peerHeaders({ OPENRAPPTER_TOKEN: '  sec  ' }).Authorization)
+      .toBe('Bearer sec');
+  });
+
+  it('the /twin wire carries the credential', async () => {
+    const previous = process.env.OPENRAPPTER_TOKEN;
+    process.env.OPENRAPPTER_TOKEN = 'wire-token';
+    try {
+      const { calls, impl } = capturingFetch();
+      await sendTwin({
+        to: 'http://127.0.0.1:19167',
+        text: 'hello',
+        fromRappid: 'rappid:@kody-w/alpha:1',
+        toRappid: 'rappid:@kody-w/slate:1',
+        fetchImpl: impl,
+      });
+      const twinCall = calls.find((c) => c.url.endsWith('/twin'));
+      expect(twinCall?.headers.Authorization).toBe('Bearer wire-token');
+    } finally {
+      if (previous === undefined) delete process.env.OPENRAPPTER_TOKEN;
+      else process.env.OPENRAPPTER_TOKEN = previous;
+    }
+  });
+
+  it('an anonymous sender still reaches an unauthenticated peer', async () => {
+    // The neighborhood must keep working on a deployment with auth off, which
+    // is every deployment today. A fix that required a token would trade one
+    // severed configuration for another.
+    const previous = process.env.OPENRAPPTER_TOKEN;
+    delete process.env.OPENRAPPTER_TOKEN;
+    try {
+      const { calls, impl } = capturingFetch();
+      await sendTwin({
+        to: 'http://127.0.0.1:19167',
+        text: 'hello',
+        fromRappid: 'rappid:@kody-w/alpha:1',
+        toRappid: 'rappid:@kody-w/slate:1',
+        fetchImpl: impl,
+      });
+      const twinCall = calls.find((c) => c.url.endsWith('/twin'));
+      expect(twinCall).toBeDefined();
+      expect(twinCall?.headers.Authorization).toBeUndefined();
+    } finally {
+      if (previous !== undefined) process.env.OPENRAPPTER_TOKEN = previous;
+    }
+  });
+});

--- a/typescript/src/twin/send.ts
+++ b/typescript/src/twin/send.ts
@@ -106,6 +106,34 @@ export function buildTwinSay(options: {
 }
 
 /**
+ * Headers for a peer request, carrying a credential when this rappter has one.
+ *
+ * Both wires used to send only a content type. `/twin` and `/chat` each call
+ * `resolveHttpAuthenticated` before parsing (#113, #119), so those two facts
+ * were compatible only because authentication was off — `isAuthCredentialValid`
+ * returns true immediately when `authMode` is `none`. Turning the control on
+ * anywhere severed the neighborhood: a peer with a token refused both senders,
+ * including one whose own environment held the credential.
+ *
+ * `OPENRAPPTER_TOKEN` is the credential that actually exists on this
+ * deployment — the CLI and the daemon both read it. Presenting it when set is
+ * what "a rappter presents a credential when it has one" means today.
+ *
+ * This deliberately does not answer where a credential should come from in
+ * general. A device-wide token, a per-instance token exchanged at hatch, and
+ * the sealed identity in `rapp-sealed/1.0` are all still open (#133), and all
+ * three are compatible with sending what we hold now. Sending nothing is not.
+ */
+export function peerHeaders(
+  env: NodeJS.ProcessEnv = process.env,
+): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' };
+  const token = env.OPENRAPPTER_TOKEN?.trim();
+  if (token) headers.Authorization = `Bearer ${token}`;
+  return headers;
+}
+
+/**
  * The other wire. Plain `/chat`, the one every participant already answers.
  *
  * Deliberately carries no rappid and no envelope: `/chat` has no place to put
@@ -123,7 +151,7 @@ async function sendChat(
   try {
     const res = await doFetch(`${options.to.replace(/\/$/, '')}/chat`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: peerHeaders(),
       body: JSON.stringify({
         user_input: options.text,
         conversation_history: [],
@@ -170,7 +198,7 @@ export async function sendTwin(options: TwinSendOptions): Promise<TwinSendResult
   try {
     const res = await doFetch(`${options.to.replace(/\/$/, '')}/twin`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: peerHeaders(),
       body: JSON.stringify(envelope),
       signal: controller.signal,
     });


### PR DESCRIPTION
Fixes the sender half of #133. The design question that issue raises is untouched.

## The neighborhood worked because the security control was off

`sendTwin` posted both wires with only a content type:

```ts
headers: { 'Content-Type': 'application/json' },   // src/twin/send.ts, twice
```

Meanwhile `/twin` and `/chat` each call `resolveHttpAuthenticated` **before parsing** (#113, #119). Those two facts were compatible only because `isAuthCredentialValid` returns true immediately when `authMode` is `none`, and no `OPENRAPPTER_TOKEN` is set on this device.

So turning authentication on anywhere severed the neighborhood. The measurement in #133 shows a peer with a token refusing both senders — including one whose own environment held the credential:

```
$ openrappter twin say --to-instance independent-review ...
peer answered 401: {"error":"Authentication required"}
```

**A system where the security control and the core feature cannot both be on is a control nobody will keep on.** That is the part worth fixing without waiting for a design.

## What changed

Both wires now send `Authorization: Bearer` when `OPENRAPPTER_TOKEN` is set. That is the credential that actually exists here — `cli/cron.ts`, `cli/channels.ts` and `index.ts` already read it, and `server.ts` names it as *"the credential that DOES exist... which is the boundary this actually protects."*

Two deliberate details:

- **No token means no header at all**, not `Bearer undefined`. A peer should see an anonymous caller, not a malformed credential. Blank and whitespace-only are treated the same way.
- **A test pins that an anonymous sender still reaches an unauthenticated peer.** That is every deployment today, and a fix that required a token would have traded one severed configuration for another.

## What this does not decide

Where a credential should come from in general. A device-wide token, a per-instance token exchanged at hatch, and the sealed identity in `rapp-sealed/1.0` are all still open. **All three are compatible with sending what we already hold. Sending nothing is not.**

Also untouched: #133's separate observation that `authMode: none` makes #113 and #119 inert on this deployment, so any local caller can drive the alpha's agents. That is a deployment configuration question for the owner.

## Verification

Tests assert on the request the sender actually builds, because that is the half that was wrong — the gateway's acceptance of `Bearer` already has its own tests; what nothing checked was whether anybody ever sent one.

Mutation proof — never attaching the credential:

```
× sends Bearer when a token is configured
× trims a token that arrived with whitespace
× the /twin wire carries the credential
  Tests  3 failed | 2 passed (5)
```

The two that survive are exactly the no-token cases, which the mutation should not affect. Restoring gives 5 passed.

Full suite **4741 passed**, 21 skipped. `tsc --noEmit` clean — it caught a missing required field in my own fixture on the first run.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
