### PR TITLE
test: close the successful /chat key set so a twelfth key cannot appear quietly

### DIFF
--- a/typescript/src/gateway/__tests__/chat-envelope-key-set.test.ts
+++ b/typescript/src/gateway/__tests__/chat-envelope-key-set.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from 'vitest';
+import { buildChatEnvelope } from '../chat-envelope.js';
+
+/**
+ * The set of keys on a successful `/chat` reply is deliberate.
+ *
+ * #116 measures the brainstem answering with 6 keys and this runtime with 11,
+ * and records a real conflict between two written standards: PARITY §3 says
+ * extra axes are free and only absence is drift, while `server.ts` states a
+ * stronger goal in its own words — "a peer must not be able to tell which
+ * runtime answered". Both cannot hold on the 200 path, and which governs is
+ * the owner's call.
+ *
+ * These tests take **no side in that**. Every key asserted here is a key the
+ * runtime emits today. What they add is that the *set* is closed: a twelfth key
+ * cannot appear without this test failing and somebody deciding to change it.
+ *
+ * That gap was real. `chat-envelope-parity.test.ts` checks the required keys
+ * are present and that four named extras are present, and its cross-runtime
+ * comparison uses `arrayContaining`, which passes on any superset. So a new
+ * key widened the fingerprint silently — which is the failure #116 describes
+ * one level up, where an instrument whose twelve cases were all 400s reported
+ * `wire_divergences: 0` on a corpus that could not contain the divergence.
+ */
+
+/** Exactly what a plain successful reply carries. */
+const BASE_KEYS = [
+  'agent_logs',
+  'content',
+  'model',
+  'requested_model',
+  'response',
+  'schema',
+  'sessionId',
+  'session_id',
+  'status',
+  'voice_mode',
+].sort();
+
+function keysOf(value: object): string[] {
+  return Object.keys(value).sort();
+}
+
+describe('the successful /chat key set is closed', () => {
+  it('a plain reply carries exactly the base keys', () => {
+    const envelope = buildChatEnvelope({ content: 'hi', sessionId: 's1' });
+    expect(keysOf(envelope)).toEqual(BASE_KEYS);
+  });
+
+  it('is unchanged by agent logs or an explicit model', () => {
+    // Content varies; the shape must not.
+    const envelope = buildChatEnvelope({
+      content: 'done',
+      sessionId: 's1',
+      agentLogs: ['[A] ran'],
+      model: 'gpt-4o',
+      requestedModel: 'auto',
+    });
+    expect(keysOf(envelope)).toEqual(BASE_KEYS);
+  });
+
+  it('a voice reply adds voice_response and nothing else', () => {
+    const envelope = buildChatEnvelope({
+      content: 'hello|||VOICE|||spoken',
+      sessionId: 's1',
+    });
+    expect(keysOf(envelope)).toEqual([...BASE_KEYS, 'voice_response'].sort());
+  });
+
+  it('an idempotency key puts a twelfth key on the wire', () => {
+    // Not hypothetical: `server.ts:1478` passes exactly this when the client
+    // sent the header. #116 measured 11 keys with a body that carried no
+    // idempotency key, so this one was never in that count — the divergence it
+    // reports is real and slightly larger than stated.
+    const envelope = buildChatEnvelope({
+      content: 'hi',
+      sessionId: 's1',
+      extra: { idempotency_key: 'abc123' },
+    });
+    expect(keysOf(envelope)).toEqual([...BASE_KEYS, 'idempotency_key'].sort());
+  });
+
+  it('extra widens the wire by exactly what it is given', () => {
+    // `extra` is an open spread, so the envelope is not closed by construction
+    // — it is closed by each caller choosing what to put there. Pinning the
+    // base set is what makes those choices visible.
+    const envelope = buildChatEnvelope({
+      content: 'hi',
+      sessionId: 's1',
+      extra: { one: 1, two: 2 },
+    });
+    expect(keysOf(envelope)).toEqual([...BASE_KEYS, 'one', 'two'].sort());
+  });
+
+  it('still refuses the key KERNEL §2.2 forbids', () => {
+    const envelope = buildChatEnvelope({ content: 'hi', sessionId: 's1' });
+    expect(keysOf(envelope)).not.toContain('assistant_response');
+  });
+});


### PR DESCRIPTION
Closes the instrument half of #116. **It decides nothing about the standards conflict** — every key asserted is one the runtime emits today.

## What was open

#116 records a real conflict: PARITY §3 says extra axes are free and only absence is drift; `server.ts` states a stronger goal in its own words — *"a peer must not be able to tell which runtime answered."* Both cannot hold on the 200 path, and which governs is the owner's call.

Underneath that, the key **set** was simply open. `chat-envelope-parity.test.ts` checks that the required keys are present and that four named extras are present, and its cross-runtime comparison uses `arrayContaining` — which passes on any superset. So a new key widened the fingerprint with nothing failing.

That is the same shape #116 describes one level up, where an instrument whose twelve cases were all 400s reported `wire_divergences: 0` on a corpus that could not contain the divergence.

## Mutation proof, and why it is the point

Adding one plausible key to the envelope:

```ts
requested_model: requested,
runtime_fingerprint: 'openrappter',
```

```
× a plain reply carries exactly the base keys
× is unchanged by agent logs or an explicit model
× a voice reply adds voice_response and nothing else
× an idempotency key puts a twelfth key on the wire
× extra widens the wire by exactly what it is given
  Tests  5 failed | 14 passed (19)
```

**The 14 that passed are the existing `chat-envelope-parity` tests.** A key named `runtime_fingerprint` — the most on-the-nose violation of the goal `server.ts` states — was invisible to every test already guarding this wire.

## A correction to #116's count

Writing it turned up that eleven is slightly low. `buildChatEnvelope` ends with `...(input.extra ?? {})`, and `server.ts:1478` passes `{ idempotency_key }` when the client sent the header. That request answers with **twelve** keys. #116's measurement used a body with no idempotency key, so it was never in view.

The envelope is therefore not closed by construction — it is closed by each caller choosing what to put in `extra`. Pinning the base set is what makes those choices visible, so there is a test for that case specifically rather than a blanket ban.

## Scope

No side taken. If the owner rules that indistinguishability wins, these tests change with the envelope and the diff will say exactly which keys left. If PARITY §3 wins, they stay and the set stops drifting. Either way the wire stops changing by accident.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
