### PR TITLE
docs: the switch that turns gateway authentication on was documented nowhere

### DIFF
--- a/docs/gateway-authentication.md
+++ b/docs/gateway-authentication.md
@@ -1,0 +1,99 @@
+# Gateway authentication
+
+The gateway is unauthenticated by default. This page says how to turn
+authentication on, what it protects, and — as precisely as possible — what it
+does not.
+
+## The switch
+
+There is exactly one:
+
+```bash
+export OPENRAPPTER_TOKEN="$(openssl rand -hex 32)"
+```
+
+`index.ts` reads it once when the daemon starts:
+
+```ts
+auth: token ? { mode: 'token', tokens: [token] } : { mode: 'none' },
+```
+
+Set, the gateway requires a credential. Unset or empty, `mode` is `none` and
+`isAuthCredentialValid` returns `true` for every caller, including one that
+presents nothing.
+
+There is no config-file equivalent. `config.security` exists in the schema and
+is read by nothing (#219), so setting `approvalPolicy` there does not turn
+anything on — `openrappter config validate` will now tell you so.
+
+## Presenting the credential
+
+Three forms are accepted, in this order:
+
+```http
+Authorization: Bearer <token>
+X-Gateway-Token: <token>
+```
+
+or in the request body:
+
+```json
+{ "auth": { "token": "<token>" } }
+```
+
+The CLI reads `OPENRAPPTER_TOKEN` from the environment and presents it for you,
+as do rappters contacting each other over `/twin` and `/chat`. A rappter with no
+token sends no authorization header at all rather than a malformed one, so an
+unauthenticated neighbourhood keeps working.
+
+## What it protects
+
+`/chat`, `/twin` and `/agents/import` each check the credential **before**
+parsing the body, so an unauthenticated caller learns nothing about envelope
+validity — otherwise the 400s become an oracle for probing the wire format
+without a credential.
+
+That matters more than it sounds. `/chat` runs agents. On a gateway with `mode:
+none`, any local caller can execute the shell tool as the user running the
+daemon.
+
+## What it does not protect
+
+**The default bind is loopback.** The daemon starts with `bind: 'loopback'`, so
+without a token the exposure is to local processes rather than the network. A
+token is what raises that boundary from "anything on this machine" to "anything
+holding the secret".
+
+**Turning it on has consequences for the neighborhood.** Every peer must hold
+the credential. Peers present `OPENRAPPTER_TOKEN` when they have one, so a
+device-wide token works today; a peer configured with a different token, or
+none, is refused. Where credentials should come from when peers are not meant to
+share one is still open (#133).
+
+**Only token mode is reachable from the environment.** The server also supports
+a password mode, but nothing sets it from `OPENRAPPTER_TOKEN`, so `mode:
+'password'` requires constructing the server directly.
+
+## Checking it works
+
+With the daemon running and a token exported:
+
+```bash
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://127.0.0.1:18790/chat \
+  -H 'Content-Type: application/json' \
+  -d '{"user_input":"hello"}'
+# 401
+
+curl -s -o /dev/null -w '%{http_code}\n' \
+  -X POST http://127.0.0.1:18790/chat \
+  -H "Authorization: Bearer $OPENRAPPTER_TOKEN" \
+  -H 'Content-Type: application/json' \
+  -d '{"user_input":"hello"}'
+# 200
+```
+
+A `401` from the first and a `200` from the second is the whole test. If the
+first returns `200`, the daemon was started without the variable in its
+environment — it is read at startup, not per request, so exporting it in your
+shell after the daemon is already running changes nothing.

--- a/typescript/src/__tests__/integration/documented-env-vars.test.ts
+++ b/typescript/src/__tests__/integration/documented-env-vars.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Every environment variable the documentation promises must be read somewhere.
+ *
+ * Documentation that names a setting nothing reads is the same defect as a
+ * config section nothing enforces (#219) or an RPC method nothing registers
+ * (#206): the reader has every reason to believe it works, and no way to find
+ * out that it does not.
+ *
+ * The scan deliberately covers shell scripts and workflows as well as source.
+ * Writing this guard, my first pass looked only at TypeScript, Python and Swift
+ * and reported `OPENRAPPTER_COMMIT` and `OPENRAPPTER_INSTALL_ROOT` as
+ * undocumented fiction. Both are real — they are read by `install-pinned.sh`
+ * and `pinned-install.yml`. A guard narrower than the product it checks
+ * produces confident false findings, which is worse than no guard.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '../../../..');
+
+const DOC_SOURCES = ['README.md', 'docs'];
+const CODE_ROOTS = [
+  'typescript/src',
+  'typescript/ui/src',
+  'typescript/desktop/src',
+  'typescript/desktop/test',
+  'python/openrappter',
+  'macos/Sources',
+  'scripts',
+  '.github/workflows',
+  'install-pinned.sh',
+  'install.sh',
+  'conformance.py',
+];
+
+const ENV_PATTERN = /OPENRAPPTER_[A-Z0-9_]+/g;
+
+function walk(target: string, accept: (file: string) => boolean): string[] {
+  const full = path.join(repoRoot, target);
+  if (!fs.existsSync(full)) return [];
+  if (fs.statSync(full).isFile()) return accept(full) ? [full] : [];
+
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(full, { withFileTypes: true })) {
+    if (entry.name === 'node_modules' || entry.name === '__pycache__') continue;
+    const child = path.join(target, entry.name);
+    out.push(...walk(child, accept));
+  }
+  return out;
+}
+
+/** Every OPENRAPPTER_* name mentioned across a set of roots. */
+function namesIn(roots: string[], accept: (file: string) => boolean): Set<string> {
+  const found = new Set<string>();
+  for (const root of roots) {
+    for (const file of walk(root, accept)) {
+      const body = fs.readFileSync(file, 'utf8');
+      for (const match of body.match(ENV_PATTERN) ?? []) found.add(match);
+    }
+  }
+  return found;
+}
+
+const isMarkdown = (f: string) => f.endsWith('.md');
+/**
+ * Production and tooling code, never tests.
+ *
+ * The exclusion is load-bearing, and the control test below is what found that
+ * out: this file lives under `typescript/src`, so without it the scan read its
+ * own source and reported the deliberately-fake name as used. A variable
+ * mentioned only in a test is not a variable the product reads.
+ */
+const isCode = (f: string) =>
+  /\.(ts|tsx|js|mjs|py|swift|sh|yml|yaml)$/.test(f)
+  && !f.endsWith('.d.ts')
+  && !/(^|[\\/])(__tests__|tests|test)[\\/]/.test(f)
+  && !/\.test\.[a-z]+$/.test(f)
+  && !/(^|[\\/])test_[^\\/]+\.py$/.test(f);
+
+describe('documented environment variables are real', () => {
+  it('finds documentation and code to compare', () => {
+    // Without this the comparison passes by reading nothing.
+    expect(namesIn(DOC_SOURCES, isMarkdown).size).toBeGreaterThan(5);
+    expect(namesIn(CODE_ROOTS, isCode).size).toBeGreaterThan(30);
+  });
+
+  it('every variable the docs name is read somewhere', () => {
+    const documented = namesIn(DOC_SOURCES, isMarkdown);
+    const used = namesIn(CODE_ROOTS, isCode);
+    const fiction = [...documented].filter((name) => !used.has(name)).sort();
+    expect(fiction).toEqual([]);
+  });
+
+  it('the switch that turns gateway authentication on is documented', () => {
+    // OPENRAPPTER_TOKEN is read in ten places and was documented in none.
+    // It is the only thing that moves the gateway off `auth: { mode: 'none' }`,
+    // so a reader who cannot find it cannot secure the gateway at all.
+    const documented = namesIn(DOC_SOURCES, isMarkdown);
+    expect(documented.has('OPENRAPPTER_TOKEN')).toBe(true);
+  });
+
+  it('would notice a documented variable that nothing reads (control)', () => {
+    // Proves the comparison discriminates rather than accepting any input.
+    const used = namesIn(CODE_ROOTS, isCode);
+    expect(used.has('OPENRAPPTER_TOKEN')).toBe(true);
+    expect(used.has('OPENRAPPTER_NOT_A_REAL_SETTING')).toBe(false);
+  });
+});


### PR DESCRIPTION
`OPENRAPPTER_TOKEN` is read in ten places and appeared in **no documentation**. It is the only thing that moves the gateway off unauthenticated:

```ts
// index.ts:149
auth: token ? { mode: 'token', tokens: [token] } : { mode: 'none' },
```

Unset, `isAuthCredentialValid` returns `true` for every caller — including one presenting nothing. And `/chat` runs agents, so on a default install any local caller can execute the shell tool as the user running the daemon. Someone who wants to prevent that had no way to learn how short of reading `index.ts`.

**This is the missing half of #133**, which observes that the neighborhood only works because authentication is off. Part of why nobody turns it on is that nothing tells them it exists.

## The page

States what the token protects, and is careful about what it does not:

- the daemon binds **loopback** by default, so the token raises the boundary from "anything on this machine" to "anything holding the secret" rather than creating it
- peers present the credential (#247), so an unauthenticated neighborhood keeps working, but every peer must hold it once it is on
- `config.security` is **not** an alternative — nothing reads it (#219)
- only token mode is reachable from the environment; password mode requires constructing the server directly

It ends with a two-command check, including the trap that the variable is read **at startup**, so exporting it after the daemon is already running changes nothing.

## The guard, and two mistakes it caught in itself

Asserts every `OPENRAPPTER_*` name the docs promise is read somewhere.

**It scans shell scripts and workflows, not just source.** My first pass looked only at TypeScript, Python and Swift and confidently reported `OPENRAPPTER_COMMIT` and `OPENRAPPTER_INSTALL_ROOT` as documented fiction. Both are real — `install-pinned.sh` and `pinned-install.yml` read them. **A guard narrower than the product it checks produces confident false findings, which is worse than no guard**, so that scope is now load-bearing and commented as such.

**It excludes tests from the "is read" side**, which its own control test found: this file lives under `typescript/src`, so the first version read its own source and reported its deliberately-fake name as used. A variable mentioned only in a test is not one the product reads.

## Mutation proof

Adding a name to the docs that nothing reads:

```
× every variable the docs name is read somewhere
  → expected [ 'OPENRAPPTER_DOES_NOT_EXIST' ] to deeply equal []
```

Restoring gives 4 passed. Anti-vacuity assertions require more than 5 documented and more than 30 used names, so a broken scan cannot pass by reading nothing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
