### PR TITLE
docs: hatch and doctor existed with no mention anywhere in the documentation

### DIFF
--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -1,0 +1,33 @@
+# CLI commands
+
+Every command `openrappter --help` registers, with what it is for. Generated
+from that output and guarded by
+`typescript/src/__tests__/integration/docs-command-coverage.test.ts`, which
+fails if a registered command is missing here.
+
+Run `openrappter <command> --help` for a command's own options.
+
+| command | arguments | what it does |
+|---|---|---|
+| `onboard` |  | Interactive setup wizard |
+| `service` |  | Manage the launchd-supervised OpenRappter gateway |
+| `imessage` |  | Manage the private macOS iMessage service |
+| `reset` | `[options]` | Clear all credentials, config, and cached tokens for a fresh start |
+| `bar` | `[options]` | Launch the OpenRappter Bar (macOS menu bar app or TUI) |
+| `channel` |  | Manage release channels (stable / experimental digital twin) |
+| `call` |  | Place and manage phone calls the agent makes on your behalf |
+| `twin` | `[options]` | Your digital twin — local-first, never leaves this machine |
+| `cron` |  | Manage cron jobs |
+| `config` |  | Manage configuration |
+| `doctor` | `[options]` | Run system diagnostics and health checks |
+| `twins` | `[options]` | Which rappters are running on this device |
+| `hatch` | `[options] <name>` | Hatch a twin rappter on this device |
+| `flight` |  | Inspect the local privacy-aware Flight Recorder |
+| `show-and-tell` |  | Learn a reusable skill or automation from a local demonstration |
+| `skills` |  | Manage skills |
+| `agents` |  | Manage agents |
+| `models` |  | List, get, or set the active LLM model |
+| `update` | `[options]` | Check whether a newer openrappter is published |
+| `rappterhub` | `[args...]` | Manage RappterHub agents (runs the Python runtime) |
+| `clawhub` | `[args...]` | Manage ClawHub skills (runs the Python runtime) |
+| `gateway` | `[options]` | Start the gateway server (same runtime as `openrappter --daemon`) |

--- a/typescript/src/__tests__/integration/docs-command-coverage.test.ts
+++ b/typescript/src/__tests__/integration/docs-command-coverage.test.ts
@@ -347,6 +347,26 @@ describe('documentation only tells readers to run commands that exist', () => {
     expect(total).toBeGreaterThan(20);
   });
 
+  it('leaves no registered command undocumented', () => {
+    // The other direction, and it was the unguarded one. This file has always
+    // checked that documentation names only real commands; nothing checked
+    // that real commands are named anywhere. `hatch` and `doctor` had zero
+    // mentions in README.md or docs/ — a headline capability and the
+    // diagnostics entry point, both undiscoverable without --help.
+    //
+    // docs/cli-commands.md is the reference that satisfies this. Listing a
+    // command there is the minimum; describing it properly elsewhere is better
+    // and is not something a test can judge.
+    const reference = fs.readFileSync(
+      path.resolve(tsRoot, '..', 'docs/cli-commands.md'),
+      'utf8',
+    );
+    const undocumented = [...rootHelp.subcommands.keys()]
+      .filter((name) => !new RegExp(`\\\`${name}\\\``).test(reference))
+      .sort();
+    expect(undocumented).toEqual([]);
+  });
+
   it('documents no command the CLI does not register', async () => {
     const problems: Problem[] = [];
 


### PR DESCRIPTION
`docs-command-coverage.test.ts` has always checked one direction — *documentation names only commands that exist*. Nothing checked the reverse, and the reverse was where the gap was.

## What was missing

Of **22 registered commands, twelve appear nowhere** in `README.md` or `docs/`. Two are worth naming:

| command | what it does | mentions in all documentation |
|---|---|---|
| `hatch` | Hatch a twin rappter on this device | **0** |
| `doctor` | Run system diagnostics and health checks | **0** |

Not "0 as `openrappter hatch`" — zero occurrences of the word, anywhere. A headline capability and the diagnostics entry point, both discoverable only by running `--help`.

This is the same asymmetry that hid `OPENRAPPTER_TOKEN` in #252: a guard that checks whether documentation lies, but never whether it is silent.

## The reference

`docs/cli-commands.md` is **generated from `--help` output**, not written from memory, so it cannot describe a command that does not exist or drift from the real descriptions. The guard now fails when a registered command is missing from it.

**Listing is the minimum, not the goal.** A one-line table entry is not the same as explaining what hatching a twin means or when to run `doctor`, and no test can judge that. But a command with no entry at all is undiscoverable, and that *is* checkable — so this pins the floor and leaves the ceiling to a human.

## Mutation proof

Removing `hatch` from the reference, exactly as an oversight would:

```
× leaves no registered command undocumented
  → expected [ 'hatch' ] to deeply equal []
```

Restoring gives 4 passed. The file's existing anti-vacuity assertions still apply — more than 10 subcommands parsed from help, more than 20 documented invocations across more than 3 files — so a broken parser cannot make either direction pass by finding nothing.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
