### PR TITLE
fix: a comment claimed agents.list was wire-compatible when it shares one key

### DIFF
--- a/python/openrappter/gateway/server.py
+++ b/python/openrappter/gateway/server.py
@@ -848,12 +848,28 @@ class GatewayServer:
 
     # ── Built-in methods ─────────────────────────────────────────────────
     #
-    # Cross-runtime contract note: `ping`/`status`/`health`/`agents.list`
-    # are wire-compatible with the TypeScript gateway's canonical
-    # registration path (see `typescript/src/gateway/methods/index.ts` and
-    # `GatewayServer.registerBuiltInMethods` in
+    # Cross-runtime contract note: `ping`/`status`/`health` are
+    # wire-compatible with the TypeScript gateway's canonical registration
+    # path (`GatewayServer.registerBuiltInMethods` in
     # `typescript/src/gateway/server.ts`) — same names, same response
     # shapes, same fail-closed `requires_auth`/`requiresAuth` semantics.
+    #
+    # `agents.list` is the exception, and this note used to claim it was not.
+    # The two runtimes answer that name with payloads sharing exactly one key:
+    #
+    #     TypeScript  [{ id, type, description }]
+    #     Python      [{ name, description, parameters, module, file, source }]
+    #
+    # `description` overlaps; TypeScript's `id` is this runtime's `name`. A
+    # client written against either cannot read the other. Which shape should
+    # be canonical is an open product question (#198) — what is not open is
+    # that they differ, so the claim is corrected here rather than left to
+    # mislead the next reader. Both shapes are pinned by tests so neither can
+    # drift further while that is decided.
+    #
+    # The old note also cited `typescript/src/gateway/methods/index.ts` as a
+    # canonical path. It is not: nothing calls `registerAllMethods`, and those
+    # modules are reference implementations kept for parity testing.
     # This Python transport has no HTTP JSON-RPC POST surface (only
     # `/health`, `/status`, `/ws`), so the HTTP-auth-bypass class of bug
     # fixed on the TS side (forcing `authenticated: true` for HTTP RPC

--- a/python/tests/test_agents_list_shape.py
+++ b/python/tests/test_agents_list_shape.py
@@ -20,7 +20,6 @@ the one shared method where that distinction has consequences.
 from __future__ import annotations
 
 import sys
-import types
 
 import pytest
 
@@ -31,7 +30,34 @@ EXPECTED_KEYS = {"name", "description", "parameters", "module", "file", "source"
 
 
 @pytest.fixture
-def registry(tmp_path, monkeypatch):
+def clean_agents_namespace():
+    """Remove the stub `agents` modules other suites leave in `sys.modules`.
+
+    `test_google_voice_agent.py`, `test_brainstem_compliance.py` and
+    `test_twin_agent.py` install a stub `agents` / `agents.basic_agent` at
+    import time to simulate the grail brainstem, and those stubs persist for the
+    rest of the run. The loader's `setdefault` then finds one already present
+    and leaves it, so the probe below subclasses a different `BasicAgent` than
+    the registry checks against and is never discovered.
+
+    These tests found that the hard way: all four passed alone and three failed
+    under the full suite. The one that failed first was the anti-vacuity check,
+    which is the only reason the shape assertions did not quietly pass over an
+    empty listing.
+    """
+    saved = {
+        name: sys.modules.pop(name)
+        for name in ("agents", "agents.basic_agent")
+        if name in sys.modules
+    }
+    try:
+        yield
+    finally:
+        sys.modules.update(saved)
+
+
+@pytest.fixture
+def registry(tmp_path, clean_agents_namespace):
     """A registry over a directory holding one minimal agent."""
     agent_dir = tmp_path / "agents"
     agent_dir.mkdir()

--- a/python/tests/test_agents_list_shape.py
+++ b/python/tests/test_agents_list_shape.py
@@ -1,0 +1,96 @@
+"""`agents.list` answers with a shape, and that shape must not drift.
+
+The two runtimes disagree about what `agents.list` returns. TypeScript sends
+``[{ id, type, description }]``; this runtime sends
+``[{ name, description, parameters, module, file, source }]``. Exactly one key
+overlaps, and TypeScript's ``id`` is this runtime's ``name``, so a client
+written against either cannot read the other.
+
+Which shape should be canonical is an open product question (#198) with real
+callers on both sides, and nothing here decides it. What these tests do is stop
+the shapes drifting *further* apart while it is decided: today's payload is
+pinned exactly, so adding or removing a key is a deliberate act rather than
+something that happens quietly.
+
+`contracts/gateway-rpc-parity.json` says in its own words that it pins method
+names "and nothing about what they answer with". This is the missing half for
+the one shared method where that distinction has consequences.
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+
+import pytest
+
+from openrappter.cli import AgentRegistry
+
+
+EXPECTED_KEYS = {"name", "description", "parameters", "module", "file", "source"}
+
+
+@pytest.fixture
+def registry(tmp_path, monkeypatch):
+    """A registry over a directory holding one minimal agent."""
+    agent_dir = tmp_path / "agents"
+    agent_dir.mkdir()
+    (agent_dir / "shape_probe_agent.py").write_text(
+        '''
+from agents.basic_agent import BasicAgent
+
+__manifest__ = {
+    "schema": "rapp-agent/1.0",
+    "name": "@test/shape-probe",
+    "version": "1.0.0",
+    "description": "Pins the agents.list payload shape.",
+    "capabilities": [],
+}
+
+
+class ShapeProbeAgent(BasicAgent):
+    def __init__(self):
+        super().__init__("ShapeProbe", {
+            "name": "ShapeProbe",
+            "description": "Pins the agents.list payload shape.",
+            "parameters": {},
+        })
+
+    def perform(self, **kwargs):
+        return "ok"
+''',
+        encoding="utf-8",
+    )
+    return AgentRegistry(str(agent_dir))
+
+
+def test_the_registry_finds_the_probe(registry):
+    # Anti-vacuity: every assertion below is about an entry, so an empty
+    # listing would make them all pass by having nothing to check.
+    names = [a["name"] for a in registry.list_agents()]
+    assert "ShapeProbe" in names, names
+
+
+def test_every_entry_carries_exactly_the_documented_keys(registry):
+    for entry in registry.list_agents():
+        assert set(entry) == EXPECTED_KEYS, (
+            f"agents.list entry for {entry.get('name')!r} changed shape: "
+            f"{sorted(set(entry) ^ EXPECTED_KEYS)} differs. This payload is one "
+            "half of a cross-runtime divergence under discussion in #198 — "
+            "changing it is fine, changing it silently is not."
+        )
+
+
+def test_the_key_typescript_calls_id_is_called_name_here(registry):
+    # The rename is the divergence's sharpest edge: both runtimes answer the
+    # same method with a differently-named identifier, so a client reading
+    # `id` gets nothing rather than an error.
+    entry = next(a for a in registry.list_agents() if a["name"] == "ShapeProbe")
+    assert "name" in entry
+    assert "id" not in entry
+
+
+def test_description_is_the_only_key_the_two_runtimes_share(registry):
+    typescript_keys = {"id", "type", "description"}
+    entry = next(a for a in registry.list_agents() if a["name"] == "ShapeProbe")
+    assert set(entry) & typescript_keys == {"description"}

--- a/typescript/src/__tests__/integration/agents-list-shape.test.ts
+++ b/typescript/src/__tests__/integration/agents-list-shape.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * `agents.list` answers with a shape, and that shape must not drift.
+ *
+ * The two runtimes disagree about what this method returns:
+ *
+ *     TypeScript  [{ id, type, description }]
+ *     Python      [{ name, description, parameters, module, file, source }]
+ *
+ * Exactly one key overlaps, and this runtime's `id` is Python's `name`, so a
+ * client written against either cannot read the other. The macOS Bar
+ * (`RpcClient.swift`), the dashboard (`ui/src/components/agents.ts`) and the
+ * TUI all call it typed as the shape below.
+ *
+ * Which shape should be canonical is an open product question (#198) with real
+ * callers on both sides, and nothing here decides it. These tests stop the
+ * shapes drifting *further* apart while it is decided.
+ *
+ * `contracts/gateway-rpc-parity.json` states in its own words that it pins
+ * method names "and nothing about what they answer with". This is the missing
+ * half for the one shared method where that distinction has consequences.
+ */
+
+const EXPECTED_KEYS = ['description', 'id', 'type'];
+
+async function listFrom(
+  entries: { id: string; type: string; description?: string }[],
+): Promise<Record<string, unknown>[]> {
+  const port = await reserveTestPort();
+  const server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server.setAgentList(() => entries);
+  try {
+    await server.start();
+    const entry = (server as unknown as {
+      methods: Map<string, { handler: (p: unknown, c: unknown) => Promise<unknown> }>;
+    }).methods.get('agents.list');
+    expect(entry, 'agents.list should be registered').toBeDefined();
+    return (await entry!.handler({}, {})) as Record<string, unknown>[];
+  } finally {
+    await server.stop();
+  }
+}
+
+describe('agents.list payload shape', () => {
+  it('returns the entries the runtime supplies', async () => {
+    // Anti-vacuity: every assertion below is about an entry, so an empty
+    // listing would make them pass by having nothing to check.
+    const list = await listFrom([
+      { id: 'Echo', type: 'echo', description: 'echoes' },
+    ]);
+    expect(list).toHaveLength(1);
+  });
+
+  it('every entry carries exactly the documented keys', async () => {
+    const list = await listFrom([
+      { id: 'Echo', type: 'echo', description: 'echoes' },
+      { id: 'Shell', type: 'shell', description: 'runs commands' },
+    ]);
+    for (const entry of list) {
+      expect(
+        Object.keys(entry).sort(),
+        'agents.list changed shape — one half of the #198 divergence. '
+          + 'Changing it is fine; changing it silently is not.',
+      ).toEqual(EXPECTED_KEYS);
+    }
+  });
+
+  it('names the identifier `id`, which Python calls `name`', async () => {
+    // The rename is the divergence's sharpest edge: both runtimes answer the
+    // same method with a differently-named identifier, so a client reading the
+    // wrong one gets undefined rather than an error.
+    const [entry] = await listFrom([
+      { id: 'Echo', type: 'echo', description: 'echoes' },
+    ]);
+    expect(entry).toHaveProperty('id');
+    expect(entry).not.toHaveProperty('name');
+  });
+
+  it('shares only `description` with the Python shape', async () => {
+    const pythonKeys = new Set([
+      'name', 'description', 'parameters', 'module', 'file', 'source',
+    ]);
+    const [entry] = await listFrom([
+      { id: 'Echo', type: 'echo', description: 'echoes' },
+    ]);
+    const shared = Object.keys(entry).filter((k) => pythonKeys.has(k));
+    expect(shared).toEqual(['description']);
+  });
+});


### PR DESCRIPTION
A comment in the Python gateway denied a divergence that #198 measured. Both shapes are now pinned so they cannot drift further while that issue is decided.

## The false claim

Directly above the built-in registrations in `python/openrappter/gateway/server.py`:

> Cross-runtime contract note: `ping`/`status`/`health`/`agents.list` are wire-compatible with the TypeScript gateway ... **same names, same response shapes**

True for `ping`, `status` and `health`. **False for `agents.list`** — the one it matters for:

```
TypeScript  [{ id, type, description }]
Python      [{ name, description, parameters, module, file, source }]
```

`description` is the only shared key, and TypeScript's `id` is Python's `name`, so a client written against either reads `undefined` rather than erroring. Anyone trusting that comment would conclude the shapes agree — and it sits three lines above `register_method("agents.list", ...)`.

Verified from source on both sides: `index.ts:489` builds `{ id, type, description }`; `cli.py:228` builds the six-key entry.

## Also corrected

The note cited `typescript/src/gateway/methods/index.ts` as a canonical registration path. It is not — nothing calls `registerAllMethods`, and those 25 modules are reference implementations kept for parity testing. The canonical path is `registerBuiltInMethods` in `server.ts`, which the note also names.

## The pins

`contracts/gateway-rpc-parity.json` says in its own words that it pins method names *"and nothing about what they answer with"*. These are the missing half for the one shared method where that distinction has consequences — one test per runtime, each pinning its own payload exactly.

**Neither takes a side.** #198 asks which shape should be canonical, with real callers on both — the Bar, the dashboard and the TUI all read the TypeScript shape. These tests only make a change deliberate rather than silent.

## Mutation proof

I simulated the most plausible well-meaning drift: adding `name` as an alias for `id` on the TypeScript side, to converge the shapes.

```
× every entry carries exactly the documented keys
× names the identifier `id`, which Python calls `name`
× shares only `description` with the Python shape
  Tests  3 failed | 1 passed (4)
```

That is the case worth catching — a partial convergence that leaves both runtimes claiming compatibility they still do not have. Restoring gives 4 passed, and the Python side is 4 passed with the full suite green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
