### PR TITLE
fix: the Homebrew cask served 1.10.4 while three Bar releases shipped

### DIFF
--- a/macos/homebrew/openrappter-bar.rb
+++ b/macos/homebrew/openrappter-bar.rb
@@ -5,10 +5,25 @@
 # 1. Create a repo: github.com/kody-w/homebrew-tap
 # 2. Copy this file to Casks/openrappter-bar.rb in that repo
 # 3. Update the version and sha256 after each release
+#
+# Step 3 is manual and was missed for three releases: the published tap served
+# 1.10.4 from 18 July while 1.11.0, 1.12.0 and 1.13.0 shipped DMGs, so
+# `brew install --cask openrappter-bar` handed people a build from three
+# versions back. Every Bar release note tells them to install exactly that way.
+#
+# Deliberately not guarded by a test. The Bar's version comes from the release
+# tag, not from any file in this repository, so an offline check would have
+# nothing trustworthy to compare against — and a tag-derived one is unreliable
+# in the shallow clones CI uses. A guard that cannot actually tell whether this
+# file is current would give assurance it has not earned.
+#
+# The check that would work is the one release-bar.yml should do at publish
+# time: it already builds the DMG and computes the sha256, so it is the only
+# place that knows both values without guessing.
 
 cask "openrappter-bar" do
-  version "1.10.4"
-  sha256 "e83acc1e9b90f7f463a137c5a75b2df1d25b79ca1a3450c046999a98a64cfaeb"
+  version "1.13.0"
+  sha256 "5fc4ad868a4b0e2d0b202a9b4a93a3e0bf48111a948c0b8cef0b318e1308bac1"
 
   url "https://github.com/kody-w/openrappter/releases/download/v#{version}-bar/OpenRappter-Bar-#{version}.dmg"
   name "OpenRappter Bar"


### PR DESCRIPTION
`brew install --cask openrappter-bar` installs **1.10.4**. The latest Bar release is **1.13.0**.

## Measured

```
published tap (kody-w/homebrew-tap, Casks/openrappter-bar.rb)  ->  version "1.10.4"
this repo's reference copy                                     ->  version "1.10.4"
latest Bar release                                             ->  v1.13.0-bar, 15 Aug
```

1.11.0, 1.12.0 and 1.13.0 all shipped signed, notarised DMGs — `OpenRappter-Bar-1.13.0.dmg` is on the release right now. And every Bar release note ends with:

```
brew tap kody-w/tap
brew install --cask openrappter-bar
```

so the documented path hands people a build from three versions back, from 18 July.

## Why it drifted

Nothing updates the cask. `release-bar.yml`'s only Homebrew mentions are the instructions inside the release-notes text — there is no step that touches the tap. Step 3 of this file's own header, *"update the version and sha256 after each release"*, is manual, and was missed three times.

## The checksum was verified, not copied

I downloaded the published DMG and hashed it locally rather than trusting the sidecar:

```
computed: 5fc4ad868a4b0e2d0b202a9b4a93a3e0bf48111a948c0b8cef0b318e1308bac1
sidecar : 5fc4ad868a4b0e2d0b202a9b4a93a3e0bf48111a948c0b8cef0b318e1308bac1
MATCH
```

## What this does and does not fix

It fixes **this repository's copy**. Users install from `kody-w/homebrew-tap`, a separate repository I have not touched, so copying this across is still a human step and **nobody's `brew install` improves until that happens**.

## No test, on purpose

The Bar's version comes from the release tag, not from any file here, so an offline guard would have nothing trustworthy to compare against — and a tag-derived one is unreliable in the shallow clones CI uses, which I learned the hard way this session. A guard that cannot actually tell whether this file is current would give assurance it has not earned.

The check that would work belongs in `release-bar.yml`: it already builds the DMG and computes the sha256, so it is the only place that knows both values without guessing.

Related: #255 (the npm lane is four versions behind for a different reason).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
