### PR TITLE
fix: the docs site listed v1.14.0 among shipped releases

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -83,7 +83,6 @@
     <div class="sidebar-title">Releases</div>
     <ul class="sidebar-nav">
       <li><a href="./changelog.html">Changelog</a></li>
-      <li><a href="./release-notes-1.14.0-evolution.html">v1.14.0 Notes</a></li>
       <li><a href="./release-notes-1.13.0-evolution.html">v1.13.0 Notes</a></li>
       <li><a href="./release-notes-1.12.0-evolution.html">v1.12.0 Notes</a></li>
       <li><a href="./release-notes-1.11.0-evolution.html">v1.11.0 Notes</a></li>

--- a/typescript/src/__tests__/docs/site.test.ts
+++ b/typescript/src/__tests__/docs/site.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll } from 'vitest';
-import { readFileSync, existsSync } from 'fs';
+import { readFileSync, existsSync, readdirSync } from 'fs';
 import { resolve } from 'path';
 import { JSDOM } from 'jsdom';
 
@@ -219,6 +219,40 @@ describe('Current release identity', () => {
     for (const link of links) {
       expect(link.getAttribute('href')).toBe(CURRENT_RELEASE_FILE);
     }
+  });
+
+  it('no published page advertises a release that has not shipped', () => {
+    // The existing check above covers index.html only, which is where I was
+    // looking when it was written. docs.html carries a "Releases" archive, and
+    // it listed `v1.14.0 Notes` at the top alongside shipped versions while
+    // 1.14.0 had no tag, nothing on npm, and no released section in
+    // CHANGELOG.md. Anything merged into docs/ is served by Pages immediately,
+    // so it was live and reachable.
+    //
+    // Preparing the page ahead of a release is fine and this does not forbid
+    // it. Linking to it from a list of things that shipped is what misleads.
+    const [major, minor, patch] = CURRENT_VERSION.split('.').map(Number);
+    const offenders: string[] = [];
+
+    for (const file of readdirSync(DOCS_DIR).filter((f) => f.endsWith('.html'))) {
+      const doc = parseHTML(file);
+      for (const link of Array.from(doc.querySelectorAll('a[href*="release-notes-"]'))) {
+        const href = link.getAttribute('href') ?? '';
+        const version = /release-notes-(\d+)\.(\d+)\.(\d+)-/.exec(href);
+        if (!version) continue;
+        const [, hMajor, hMinor, hPatch] = version.map(Number);
+        const ahead =
+          hMajor > major
+          || (hMajor === major && hMinor > minor)
+          || (hMajor === major && hMinor === minor && hPatch > patch);
+        if (ahead) offenders.push(`${file} -> ${href}`);
+      }
+    }
+
+    expect(
+      offenders,
+      `these pages link release notes newer than package.json's ${CURRENT_VERSION}`,
+    ).toEqual([]);
   });
 
   it('current release page identifies the package version and has valid local links', () => {


### PR DESCRIPTION
The published docs site listed **v1.14.0 among shipped releases**. There is no 1.14.0.

## Measured

`docs.html` carries a **Releases** sidebar:

```html
<div class="sidebar-title">Releases</div>
  <li><a href="./changelog.html">Changelog</a></li>
  <li><a href="./release-notes-1.14.0-evolution.html">v1.14.0 Notes</a></li>   <!-- this one -->
  <li><a href="./release-notes-1.13.0-evolution.html">v1.13.0 Notes</a></li>
  <li><a href="./release-notes-1.12.0-evolution.html">v1.12.0 Notes</a></li>
```

Against every measure of what has shipped:

| source | says |
|---|---|
| git tags | no `v1.14.0` |
| npm | latest is 1.9.8 (#255) |
| `CHANGELOG.md` | latest released section is 1.13.0 |
| `package.json` | 1.13.0 |

And it is **live**. `docs/` is served by Pages directly — I fetched the page and it returns `200`, byte-identical to the repo copy. So a visitor could open release notes titled *"OpenRappter 1.14.0 — The doors an agent can open"* describing features as "shipped".

## What changed

**Only the link.** Preparing the page ahead of a release is a reasonable workflow and the file stays exactly where it is. Listing it among things that shipped is the part that misled.

## The guard, and why the old one missed it

`site.test.ts` already asserts *"homepage links only to the current release page"* — and it checks **`index.html` alone**, the page whoever wrote it was looking at. That is the same narrowness that let this sit in `docs.html` untouched.

The new check walks **every** HTML file in `docs/` and fails when any links release notes for a version ahead of `package.json`.

**Mutation proof** — restoring the link exactly as it was:

```
× no published page advertises a release that has not shipped
  → these pages link release notes newer than package.json's 1.13.0
```

162 passed with it removed.

## Also verified while here

The rest of the Pages site is **current**: `index.html`, `docs.html` and `architecture.html` are all byte-identical to the repo, and the architecture page now serves the corrected `34 agents (TypeScript) · 20 agents (Python)` from #232.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
