### PR TITLE
fix: a fractional or non-numeric day crashed DailyTipAgent instead of reporting

### DIFF
--- a/typescript/src/agents/DailyTipAgent.ts
+++ b/typescript/src/agents/DailyTipAgent.ts
@@ -284,11 +284,23 @@ export class DailyTipAgent extends BasicAgent {
   }
 
   private async sendSpecificDay(day: number): Promise<string> {
-    if (day < 1 || day > 30) {
+    // `kwargs.day` arrives as an unchecked cast, so a caller can hand this a
+    // float or a string. Both slip past a bare range check -- 1.5 is within
+    // 1..30, and comparing "abc" to a number is false either way -- and then
+    // index TIPS with a fraction or NaN, yielding undefined. Reading .title off
+    // that threw a TypeError instead of the structured error this function is
+    // written to return.
+    if (!Number.isInteger(day) || day < 1 || day > 30) {
       return JSON.stringify({ status: 'error', message: 'Day must be 1-30' });
     }
 
     const tip = TIPS[day - 1];
+    if (!tip) {
+      // Unreachable while TIPS covers 1..30, which a test pins. Kept because
+      // sendTodaysTip already checks the same thing, and the asymmetry is what
+      // made this the crashing path rather than the reporting one.
+      return JSON.stringify({ status: 'error', message: `No tip for day ${day}` });
+    }
     this.sendNotification(tip.title, tip.body, tip.command);
 
     return JSON.stringify({

--- a/typescript/src/agents/__tests__/DailyTipAgent.test.ts
+++ b/typescript/src/agents/__tests__/DailyTipAgent.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { DailyTipAgent } from '../DailyTipAgent.js';
+
+/**
+ * `day` arrives as an unchecked cast and must not be able to crash the agent.
+ *
+ * `perform` reads `kwargs.day as number | undefined`, so a caller can hand
+ * `sendSpecificDay` a float or a string. Both slip past a bare range check —
+ * `1.5` is inside 1..30, and comparing `"abc"` to a number is false in either
+ * direction — and then index `TIPS` with a fraction or `NaN`. That yields
+ * `undefined`, and reading `.title` off it threw:
+ *
+ *     TypeError: Cannot read properties of undefined (reading 'title')
+ *
+ * Reproduced against the built agent before the fix, for `1.5` and `"abc"`.
+ * The function already had an error path for a bad day; the cast meant some bad
+ * days reached the crash instead of the report.
+ *
+ * These are the agent's first behavioural tests. It was constructed by
+ * `builtin-agents-load.test.ts` like every other built-in, which proves it
+ * loads and says nothing about what it does.
+ *
+ * Every case here returns before any notification is sent, deliberately: this
+ * agent's success path shells out to `terminal-notifier` or `osascript`, and a
+ * test suite should not put desktop notifications on the machine running it.
+ */
+describe('DailyTipAgent day validation', () => {
+  const agent = new DailyTipAgent();
+
+  async function send(day: unknown): Promise<Record<string, unknown>> {
+    const raw = await agent.perform({ action: 'send', day });
+    return JSON.parse(raw) as Record<string, unknown>;
+  }
+
+  it('reports a fractional day instead of crashing', async () => {
+    expect(await send(1.5)).toEqual({ status: 'error', message: 'Day must be 1-30' });
+  });
+
+  it('reports a non-numeric day instead of crashing', async () => {
+    expect(await send('abc')).toEqual({ status: 'error', message: 'Day must be 1-30' });
+    expect(await send({})).toEqual({ status: 'error', message: 'Day must be 1-30' });
+  });
+
+  it('still reports days outside the range', async () => {
+    // The behaviour that already worked, pinned so the stricter check did not
+    // quietly replace it.
+    for (const day of [0, -1, 31, 999]) {
+      expect(await send(day), `day ${day}`).toEqual({
+        status: 'error',
+        message: 'Day must be 1-30',
+      });
+    }
+  });
+
+  it('rejects NaN and Infinity', async () => {
+    for (const day of [Number.NaN, Number.POSITIVE_INFINITY, Number.NEGATIVE_INFINITY]) {
+      expect(await send(day), String(day)).toEqual({
+        status: 'error',
+        message: 'Day must be 1-30',
+      });
+    }
+  });
+
+  it('covers every day the range admits', async () => {
+    // The range check and the table have to agree. If TIPS ever stops covering
+    // 1..30, the null check added alongside this reports it rather than
+    // throwing — but this is what would catch the mismatch first.
+    const preview = JSON.parse(await agent.perform({ action: 'preview' })) as {
+      tips?: { title: string }[];
+    };
+    expect(preview.tips?.length).toBe(30);
+  });
+});


### PR DESCRIPTION
A fractional or non-numeric `day` crashed `DailyTipAgent` instead of returning the error it is written to return.

## Reproduced first

Against the built agent, before changing anything:

```
1.5    -> THREW: TypeError Cannot read properties of undefined (reading 'title')
"abc"  -> THREW: TypeError Cannot read properties of undefined (reading 'title')
```

## Why the range check missed them

`perform` reads `kwargs.day as number | undefined` — an unchecked cast — and hands it to:

```ts
if (day < 1 || day > 30) { ...error... }
const tip = TIPS[day - 1];
this.sendNotification(tip.title, ...);   // <- undefined.title
```

`1.5` is genuinely inside 1..30. And comparing `"abc"` against a number is false in **both** directions, so a string passes a range check that looks total. Each then indexed `TIPS` with a fraction or `NaN`, got `undefined`, and threw.

The function already had an error path for a bad day. The cast meant some bad days reached the crash instead of the report.

`sendTodaysTip` null-checks its tip; `sendSpecificDay` did not. That asymmetry is what made this the crashing path, so the check is now on both.

## First behavioural tests for this agent

It was constructed by `builtin-agents-load.test.ts` like every built-in — which proves it *loads* and says nothing about what it *does*. Seven built-ins are in that position; this is one of them.

Every case returns **before any notification is sent**, deliberately: the success path shells out to `terminal-notifier` or `osascript`, and a test suite should not put desktop notifications on the machine running it.

**Mutation proof** — reverting to the range-only check:

```
Tests  3 failed | 2 passed (5)
```

The two that survive are the ones that already worked (out-of-range integers), pinned so the stricter check did not quietly replace existing behaviour.

## Noted while here, not changed

`sendNotification` interpolates the tip's title, body and command into a shell string for `terminal-notifier`, escaping only `"`. The `osascript` fallback wraps that in single quotes and still escapes only `"`. **Not exploitable**: both call sites index the static `TIPS` table with a bounds-checked integer, so nothing external reaches them. I am flagging rather than rewriting it because it becomes reachable the moment a tip is made dynamic — personalised, or drawn from memory — and the escaping looks adequate at a glance.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
