### PR TITLE
fix: scanning a directory that does not exist reported success with zero results

### DIFF
--- a/typescript/src/agents/DocScannerAgent.ts
+++ b/typescript/src/agents/DocScannerAgent.ts
@@ -54,7 +54,18 @@ export class DocScannerAgent extends BasicAgent {
   private async scanDirectory(dirPath: string, depth = 0): Promise<FileInfo[]> {
     if (depth > 5) return [];
     const results: FileInfo[] = [];
-    let entries; try { entries = await readdir(dirPath, { withFileTypes: true }); } catch { return []; }
+    // Swallowing this at any depth reported `status: success` with zero files
+    // for a path that does not exist, which a caller cannot tell apart from an
+    // empty directory -- a typo'd path looked like a clean scan. Below the root
+    // it is still right to skip: one unreadable subdirectory should not abort a
+    // scan of everything else.
+    let entries;
+    try {
+      entries = await readdir(dirPath, { withFileTypes: true });
+    } catch (err) {
+      if (depth === 0) throw err;
+      return [];
+    }
     for (const entry of entries) {
       if (results.length >= MAX_FILES) break;
       if (entry.isDirectory() && !SKIP_DIRS.has(entry.name) && !entry.name.startsWith('.')) { results.push(...await this.scanDirectory(join(dirPath, entry.name), depth + 1)); }

--- a/typescript/src/agents/NotesIntakeAgent.ts
+++ b/typescript/src/agents/NotesIntakeAgent.ts
@@ -69,7 +69,17 @@ export class NotesIntakeAgent extends BasicAgent {
   }
 
   private async findMarkdownFiles(dirPath: string, depth = 0): Promise<string[]> {
-    if (depth > 4) return []; const results: string[] = []; let entries; try { entries = await readdir(dirPath, { withFileTypes: true }); } catch { return []; }
+    if (depth > 4) return [];
+    const results: string[] = [];
+    // See DocScannerAgent: swallowing this at the root reported success over a
+    // directory that does not exist. Deeper down, skipping is still correct.
+    let entries;
+    try {
+      entries = await readdir(dirPath, { withFileTypes: true });
+    } catch (err) {
+      if (depth === 0) throw err;
+      return [];
+    }
     for (const entry of entries) { if (results.length >= 200) break; const fullPath = join(dirPath, entry.name); if (entry.isDirectory() && !entry.name.startsWith('.') && entry.name !== 'node_modules') results.push(...await this.findMarkdownFiles(fullPath, depth + 1)); else if (entry.isFile() && extname(entry.name).toLowerCase() === '.md') results.push(fullPath); }
     return results;
   }

--- a/typescript/src/agents/__tests__/scan-agents-missing-directory.test.ts
+++ b/typescript/src/agents/__tests__/scan-agents-missing-directory.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { DocScannerAgent } from '../DocScannerAgent.js';
+import { NotesIntakeAgent } from '../NotesIntakeAgent.js';
+
+/**
+ * A directory that does not exist must not look like an empty one.
+ *
+ * Both agents walk a tree with `readdir(...)` wrapped in `catch { return []; }`.
+ * That is right *below* the root — one unreadable subdirectory should not abort
+ * a scan of everything else — and wrong *at* it. Given a path that does not
+ * exist, both answered:
+ *
+ *     {"status":"success","summary":{"total_files":0,...}}
+ *
+ * which a caller cannot tell apart from a real, empty directory. Someone who
+ * mistypes a path is told the scan worked and found nothing.
+ *
+ * Reproduced against the built agents before the change, for
+ * `/tmp/definitely-not-a-real-directory-xyz`.
+ *
+ * These are the first behavioural tests for either agent. Both were constructed
+ * by `builtin-agents-load.test.ts`, which proves they load and nothing more.
+ */
+
+const MISSING = path.join(os.tmpdir(), 'openrappter-no-such-dir-9f3a2b');
+
+async function parsed(result: string): Promise<Record<string, unknown>> {
+  return JSON.parse(result) as Record<string, unknown>;
+}
+
+describe('scanning a directory that is not there', () => {
+  it('DocScanner reports the failure instead of an empty success', async () => {
+    const out = await parsed(await new DocScannerAgent().perform({ path: MISSING }));
+    expect(out.status).toBe('error');
+    expect(String(out.message)).toContain('Failed to scan');
+  });
+
+  it('NotesIntake reports the failure instead of an empty success', async () => {
+    const out = await parsed(await new NotesIntakeAgent().perform({ path: MISSING }));
+    expect(out.status).toBe('error');
+    expect(String(out.message)).toContain('Failed to scan');
+  });
+
+  it('an empty directory is still a success, and still distinguishable', async () => {
+    // The point is the distinction. If the fix had turned every quiet scan into
+    // an error it would have traded one indistinguishable pair for another.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'openrappter-empty-'));
+    try {
+      const doc = await parsed(await new DocScannerAgent().perform({ path: dir }));
+      expect(doc.status).toBe('success');
+      expect((doc.summary as { total_files: number }).total_files).toBe(0);
+
+      const notes = await parsed(await new NotesIntakeAgent().perform({ path: dir }));
+      expect(notes.status).toBe('success');
+      expect(notes.notes_scanned).toBe(0);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('a directory with content still scans', async () => {
+    // Anti-vacuity: without this, returning an error for everything would pass
+    // the two assertions above that matter most.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'openrappter-docs-'));
+    try {
+      await fs.writeFile(path.join(dir, 'note.md'), '# Title\n\n- [ ] TODO: something\n');
+      const doc = await parsed(await new DocScannerAgent().perform({ path: dir }));
+      expect(doc.status).toBe('success');
+      expect((doc.summary as { total_files: number }).total_files).toBe(1);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('an unreadable subdirectory does not abort the scan', async () => {
+    // The behaviour the swallow was there for, kept: only the root propagates.
+    const dir = await fs.mkdtemp(path.join(os.tmpdir(), 'openrappter-partial-'));
+    try {
+      await fs.writeFile(path.join(dir, 'readable.md'), 'content\n');
+      const locked = path.join(dir, 'locked');
+      await fs.mkdir(locked);
+      await fs.chmod(locked, 0o000);
+
+      const doc = await parsed(await new DocScannerAgent().perform({ path: dir }));
+      expect(doc.status).toBe('success');
+      expect((doc.summary as { total_files: number }).total_files).toBe(1);
+
+      await fs.chmod(locked, 0o755);
+    } finally {
+      await fs.rm(dir, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
`DocScannerAgent` and `NotesIntakeAgent` reported **success** when asked to scan a directory that does not exist.

## Reproduced first

Against the built agents, before changing anything:

```
DocScannerAgent  -> {"status":"success","summary":{"total_files":0,...}}
NotesIntakeAgent -> {"status":"success","notes_scanned":0,...}
```

for `/tmp/definitely-not-a-real-directory-xyz`.

A caller cannot tell that apart from a real, empty directory. Someone who mistypes a path is told the scan worked and found nothing — the same "looks like it worked and did nothing" shape as the cron job that fired with no agent (#240) and the security policy that validated and was never read (#245).

## Cause, and why the fix is narrow

Both walk the tree with:

```ts
let entries; try { entries = await readdir(dirPath, { withFileTypes: true }); } catch { return []; }
```

That swallow is **right below the root** — one unreadable subdirectory should not abort a scan of everything else — and **wrong at it**. Only `depth === 0` now propagates, where `perform`'s existing try/catch turns it into a structured error carrying the underlying message.

## Tests pin the distinction in both directions

First behavioural tests for either agent; both were constructed by `builtin-agents-load.test.ts`, which proves they load and nothing more.

- a missing directory **errors**
- an empty directory still **succeeds with zero** — otherwise the fix would have traded one indistinguishable pair for another
- a populated directory still scans (anti-vacuity: without it, erroring on everything would satisfy the assertions that matter most)
- an unreadable subdirectory still does not abort its parent — the behaviour the swallow existed for, kept and pinned with a `chmod 000` directory

**Mutation proof** — restoring the root swallow:

```
× DocScanner reports the failure instead of an empty success
  Tests  1 failed | 4 passed (5)
```

The four survivors are exactly the ones that should be unaffected.

Full TypeScript suite green.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
