### PR TITLE
fix: a blank maxLineLength made the TypeScript reviewer flag every line

### DIFF
--- a/typescript/src/agents/CodeReviewAgent.ts
+++ b/typescript/src/agents/CodeReviewAgent.ts
@@ -49,6 +49,25 @@ export interface ReviewResult {
 
 // ── CodeReviewAgent ─────────────────────────────────────────────────
 
+/**
+ * A usable number, or the caller's default.
+ *
+ * `??` defaults only on null and undefined, so an empty string passed straight
+ * through and every comparison against it coerced to 0 -- making every line
+ * longer than the limit. Measured: `maxLineLength: ""` reported
+ * `const x = 1;` as exceeding the maximum and dropped a clean file from 100
+ * to 90.
+ *
+ * The Python agent has always been right here: `max_len or self._max_line_length`
+ * treats "" and 0 as unusable and falls back. This matches that, so a review
+ * does not depend on which runtime answered.
+ */
+function usableNumber(value: unknown, fallback: number): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0
+    ? value
+    : fallback;
+}
+
 export class CodeReviewAgent extends BasicAgent {
   private maxLineLength: number;
 
@@ -127,7 +146,7 @@ export class CodeReviewAgent extends BasicAgent {
   private reviewCode(kwargs: Record<string, unknown>): string {
     const content = kwargs.content as string | undefined;
     const file = kwargs.file as string | undefined;
-    const maxLen = (kwargs.maxLineLength as number) ?? this.maxLineLength;
+    const maxLen = usableNumber(kwargs.maxLineLength, this.maxLineLength);
 
     if (!content) {
       return JSON.stringify({
@@ -160,7 +179,7 @@ export class CodeReviewAgent extends BasicAgent {
   private suggestFixes(kwargs: Record<string, unknown>): string {
     const content = kwargs.content as string | undefined;
     const file = kwargs.file as string | undefined;
-    const maxLen = (kwargs.maxLineLength as number) ?? this.maxLineLength;
+    const maxLen = usableNumber(kwargs.maxLineLength, this.maxLineLength);
 
     if (!content) {
       return JSON.stringify({
@@ -197,7 +216,7 @@ export class CodeReviewAgent extends BasicAgent {
 
   private diffReview(kwargs: Record<string, unknown>): string {
     const diff = kwargs.diff as string | undefined;
-    const maxLen = (kwargs.maxLineLength as number) ?? this.maxLineLength;
+    const maxLen = usableNumber(kwargs.maxLineLength, this.maxLineLength);
 
     if (!diff) {
       return JSON.stringify({

--- a/typescript/src/agents/__tests__/CodeReviewAgent.line-length.test.ts
+++ b/typescript/src/agents/__tests__/CodeReviewAgent.line-length.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest';
+import { CodeReviewAgent } from '../CodeReviewAgent.js';
+
+/**
+ * A blank `maxLineLength` must not make every line too long.
+ *
+ * The limit was read with `??`, which defaults only on `null` and `undefined`.
+ * An empty string passed straight through, and `line.length > ""` coerces the
+ * limit to 0 — so every line exceeds it. Measured before the fix, on a file
+ * whose longest line is twelve characters:
+ *
+ *     maxLineLength=120  -> 0 line-length findings, score 100
+ *     maxLineLength=""   -> 2 line-length findings, score  90
+ *
+ * `"abc"` was already safe: it becomes `NaN` and every comparison is false.
+ * The plausible input was the broken one, which is what let it sit.
+ *
+ * The Python agent has always been correct here — `max_len or
+ * self._max_line_length` treats `""` and `0` as unusable and falls back — so
+ * the same review produced different findings depending on which runtime
+ * answered. These tests pin the TypeScript side to Python's behaviour.
+ */
+
+const CLEAN = 'const x = 1;\nconst y = 2;\n';
+
+async function lineLengthFindings(maxLineLength: unknown): Promise<number> {
+  const raw = await new CodeReviewAgent().execute({
+    action: 'review',
+    content: CLEAN,
+    file: 'sample.ts',
+    maxLineLength,
+  });
+  const parsed = JSON.parse(raw) as { review: { findings: { rule: string }[] } };
+  return parsed.review.findings.filter((f) => f.rule === 'line-length').length;
+}
+
+describe('CodeReviewAgent line-length limit', () => {
+  it('reports nothing for short lines under a real limit', async () => {
+    // Anti-vacuity: if the sample ever gained a long line, every assertion
+    // below would pass for the wrong reason.
+    expect(await lineLengthFindings(120)).toBe(0);
+  });
+
+  it('a blank limit does not flag every line', async () => {
+    expect(await lineLengthFindings('')).toBe(0);
+  });
+
+  it('falls back for anything that is not a usable number', async () => {
+    for (const bad of ['', '  ', 'abc', null, undefined, 0, -1, Number.NaN, {}, []]) {
+      expect(await lineLengthFindings(bad), JSON.stringify(bad) ?? 'undefined').toBe(0);
+    }
+  });
+
+  it('still honours a real limit that the content exceeds', async () => {
+    // The behaviour that already worked, pinned so the stricter check did not
+    // quietly disable the rule.
+    expect(await lineLengthFindings(5)).toBe(2);
+  });
+
+  it('matches the Python agent, which treats 0 as unusable', async () => {
+    // `max_len or self._max_line_length` in code_review_agent.py. A limit of
+    // zero is not a request to flag everything; it is an absent limit.
+    expect(await lineLengthFindings(0)).toBe(0);
+  });
+});


### PR DESCRIPTION
A blank `maxLineLength` made the TypeScript reviewer flag **every line** as too long — and the Python reviewer, given the same input, did not.

## Measured, on a file whose longest line is twelve characters

```
maxLineLength=120  -> 0 line-length findings, score 100
maxLineLength=""   -> 2 line-length findings, score  90
```

The limit was read with `??`, which defaults only on `null`/`undefined`. An empty string passes through, and `line.length > ""` coerces the limit to **0**, so every line exceeds it.

`"abc"` was already safe — it becomes `NaN` and every comparison is false. That is why this sat unnoticed: **the obviously-wrong input behaves, and the plausible one produces a review full of false findings.** The same shape as the `DreamAgent` data-loss fix in #260.

## Python was already right, so this is also a parity fix

```python
effective_max_len = max_len or self._max_line_length   # code_review_agent.py
```

`or` treats `""` **and** `0` as unusable and falls back. So the same file, reviewed by the two runtimes, returned different findings and different scores:

```
before:  TS -> 2 findings, score 90     PY -> 0 findings, score 100
after:   TS -> 0 findings, score 100    PY -> 0 findings, score 100
```

This matches TypeScript **to** Python rather than the other way round. A limit of zero is not a request to flag everything; it is an absent limit.

## How it was found, and what I deliberately left

By searching every agent for the exact signature behind #260 — `(kwargs.x as number) ?? default`. Six sites carry it. I fixed the three in `CodeReviewAgent` because I measured their consequence.

**`GitAgent`'s `count` and `SelfHealingCronAgent`'s `maxRetries`/`timeoutMs` are untouched.** They have the same shape, and `timeoutMs: ""` plausibly means every job times out instantly — but I have not measured that, and I would rather report the shape than change code on a hunch.

## Verification

Mutation proof — restoring the original `??`:

```
× a blank limit does not flag every line
× falls back for anything that is not a usable number
× matches the Python agent, which treats 0 as unusable
  Tests  3 failed | 2 passed (5)
```

Full TypeScript suite **4777 passed**. Cross-runtime agreement re-checked against a fresh build, after the first check compared against a stale `dist/`.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
