### PR TITLE
fix: GitAgent built shell command lines from caller-supplied values

### DIFF
--- a/typescript/src/__tests__/parity/git-agent.test.ts
+++ b/typescript/src/__tests__/parity/git-agent.test.ts
@@ -19,7 +19,11 @@ import { BasicAgent } from '../../agents/BasicAgent.js';
  * for unrecognised commands.
  */
 function createMockExec(responses: Record<string, { stdout: string; stderr: string }>): ExecFn {
-  return (cmd: string, _cwd?: string) => {
+  return (binary: string, args: string[], _cwd?: string) => {
+    // The agent now passes an argv rather than a command line (a shell was
+    // reachable through it). Joining restores the string these expectations
+    // were written against, without restoring the shell.
+    const cmd = [binary, ...args].join(' ');
     for (const [pattern, response] of Object.entries(responses)) {
       if (cmd.includes(pattern)) {
         return response;
@@ -212,8 +216,8 @@ describe('GitAgent', () => {
 
     it('should respect the count parameter in the git log command', async () => {
       const capturedCmds: string[] = [];
-      const capturingExec: ExecFn = (cmd) => {
-        capturedCmds.push(cmd);
+      const capturingExec: ExecFn = (binary, args) => {
+        capturedCmds.push([binary, ...args].join(' '));
         return { stdout: '', stderr: '' };
       };
       const agent = new GitAgent({ execFn: capturingExec });
@@ -270,7 +274,8 @@ describe('GitAgent', () => {
   describe('commit action', () => {
     it('should stage files and commit successfully with files and message', async () => {
       const capturedCmds: string[] = [];
-      const exec: ExecFn = (cmd) => {
+      const exec: ExecFn = (binary, args) => {
+        const cmd = [binary, ...args].join(' ');
         capturedCmds.push(cmd);
         if (cmd.includes('git commit')) {
           return { stdout: '[main abc1234] Add feature', stderr: '' };

--- a/typescript/src/agents/GitAgent.ts
+++ b/typescript/src/agents/GitAgent.ts
@@ -12,7 +12,7 @@
 
 import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 
 
 export const __manifest__ = {
@@ -34,7 +34,23 @@ export const __manifest__ = {
   quality_tier: 'official',
   requires_env: []
 } as const;
-export type ExecFn = (cmd: string, cwd?: string) => { stdout: string; stderr: string };
+/**
+ * Runs a binary with an argument vector, never a command line.
+ *
+ * This took a single string and every caller built it by interpolation, so
+ * caller-controlled values reached a shell. Confirmed: `count` of
+ * `'1 ; touch /tmp/x'` created the file. `name`, `fileList`, `message`, and the
+ * `gh pr create` title, body and base were all interpolated the same way.
+ *
+ * An array cannot be escaped out of -- `execFileSync` hands each element to the
+ * process as one argv entry, so a semicolon is a semicolon rather than a
+ * separator. The binary is explicit because this agent drives `git` and `gh`.
+ */
+export type ExecFn = (
+  binary: string,
+  args: string[],
+  cwd?: string,
+) => { stdout: string; stderr: string };
 
 export class GitAgent extends BasicAgent {
   private cwd: string;
@@ -91,9 +107,13 @@ export class GitAgent extends BasicAgent {
     this.execFn = options?.execFn ?? this.defaultExec;
   }
 
-  private defaultExec(cmd: string, cwd?: string): { stdout: string; stderr: string } {
+  private defaultExec(
+    binary: string,
+    args: string[],
+    cwd?: string,
+  ): { stdout: string; stderr: string } {
     try {
-      const stdout = execSync(cmd, {
+      const stdout = execFileSync(binary, args, {
         cwd: cwd ?? this.cwd,
         encoding: 'utf-8',
         timeout: 30000,
@@ -148,7 +168,7 @@ export class GitAgent extends BasicAgent {
   }
 
   private gitStatus(): string {
-    const { stdout } = this.execFn('git status --porcelain', this.cwd);
+    const { stdout } = this.execFn('git', ['status', '--porcelain'], this.cwd);
     const files: Array<{ status: string; file: string }> = [];
 
     if (stdout) {
@@ -175,8 +195,8 @@ export class GitAgent extends BasicAgent {
   }
 
   private gitDiff(): string {
-    const { stdout: stat } = this.execFn('git diff --stat', this.cwd);
-    const { stdout: diff } = this.execFn('git diff', this.cwd);
+    const { stdout: stat } = this.execFn('git', ['diff', '--stat'], this.cwd);
+    const { stdout: diff } = this.execFn('git', ['diff'], this.cwd);
 
     const truncated = diff.length > 10000;
     const content = diff.slice(0, 10000);
@@ -198,7 +218,7 @@ export class GitAgent extends BasicAgent {
   private gitLog(kwargs: Record<string, unknown>): string {
     const count = (kwargs.count as number) ?? 10;
     const format = '--pretty=format:{"hash":"%H","short":"%h","author":"%an","date":"%ai","subject":"%s"}';
-    const { stdout } = this.execFn(`git log -${count} ${format}`, this.cwd);
+    const { stdout } = this.execFn('git', ['log', `-${count}`, ...format.split(' ').filter(Boolean)], this.cwd);
 
     const commits: Array<Record<string, string>> = [];
     if (stdout) {
@@ -231,10 +251,10 @@ export class GitAgent extends BasicAgent {
 
     if (!name) {
       // List branches
-      const { stdout } = this.execFn('git branch --format="%(refname:short)"', this.cwd);
+      const { stdout } = this.execFn('git', ['branch', '--format="%(refname:short)"'], this.cwd);
       const branches = stdout ? stdout.split('\n').filter(b => b.trim()) : [];
 
-      const { stdout: current } = this.execFn('git branch --show-current', this.cwd);
+      const { stdout: current } = this.execFn('git', ['branch', '--show-current'], this.cwd);
 
       const dataSlush = this.slushOut({
         signals: { branch_count: branches.length, current_branch: current.trim() },
@@ -250,7 +270,7 @@ export class GitAgent extends BasicAgent {
     }
 
     // Create branch
-    const { stdout, stderr } = this.execFn(`git checkout -b ${name}`, this.cwd);
+    const { stdout, stderr } = this.execFn('git', ['checkout', '-b', name], this.cwd);
 
     const dataSlush = this.slushOut({
       signals: { branch_created: name },
@@ -279,11 +299,11 @@ export class GitAgent extends BasicAgent {
     // Stage files
     if (files && files.length > 0) {
       const fileList = files.join(' ');
-      this.execFn(`git add ${fileList}`, this.cwd);
+      this.execFn('git', ['add', ...fileList.split(' ').filter(Boolean)], this.cwd);
     }
 
     // Commit
-    const { stdout, stderr } = this.execFn(`git commit -m "${message}"`, this.cwd);
+    const { stdout, stderr } = this.execFn('git', ['commit', '-m', message], this.cwd);
 
     const dataSlush = this.slushOut({
       signals: { committed: true, message },
@@ -310,9 +330,9 @@ export class GitAgent extends BasicAgent {
       });
     }
 
-    const bodyFlag = body ? ` --body "${body}"` : '';
     const { stdout, stderr } = this.execFn(
-      `gh pr create --title "${title}"${bodyFlag} --base ${base}`,
+      'gh',
+      ['pr', 'create', '--title', title, ...(body ? ['--body', body] : []), '--base', base],
       this.cwd,
     );
 

--- a/typescript/src/agents/__tests__/GitAgent.injection.test.ts
+++ b/typescript/src/agents/__tests__/GitAgent.injection.test.ts
@@ -1,0 +1,101 @@
+import { describe, it, expect } from 'vitest';
+import { GitAgent } from '../GitAgent.js';
+import type { ExecFn } from '../GitAgent.js';
+
+/**
+ * Caller-supplied values reach `git` as arguments, never as shell syntax.
+ *
+ * `GitAgent` built every command by interpolating into a single string and ran
+ * it through `execSync`, which uses a shell. Confirmed against the built agent:
+ *
+ *     execute({ action: 'log', count: '1 ; touch /tmp/openrappter-injection-proof' })
+ *     -> the file was created
+ *
+ * `count` was not special. `name` (branch), `fileList` (add), `message`
+ * (commit), and the `gh pr create` title, body and base were interpolated the
+ * same way — five reachable sites, found only because migrating the first
+ * exposed the rest.
+ *
+ * The fix is structural rather than per-field: `ExecFn` now takes a binary and
+ * an argument vector, and `execFileSync` hands each element to the process as
+ * one argv entry. There is no shell left to escape into, so no escaping rule
+ * has to be got right.
+ *
+ * These tests assert on the argv the agent builds. Nothing here executes git.
+ */
+
+function capture(): { calls: { binary: string; args: string[] }[]; exec: ExecFn } {
+  const calls: { binary: string; args: string[] }[] = [];
+  const exec: ExecFn = (binary, args) => {
+    calls.push({ binary, args });
+    return { stdout: '', stderr: '' };
+  };
+  return { calls, exec };
+}
+
+const PAYLOAD = '1 ; touch /tmp/openrappter-injection-proof';
+
+describe('GitAgent passes arguments, not shell syntax', () => {
+  it('keeps an injected count inside a single argument', async () => {
+    const { calls, exec } = capture();
+    await new GitAgent({ execFn: exec }).perform({ action: 'log', count: PAYLOAD });
+
+    const log = calls.find((c) => c.args[0] === 'log');
+    expect(log, 'the log command should have run').toBeDefined();
+    // The payload may be present -- as one argv element. What must not happen
+    // is it being split into further arguments, which is what a shell did.
+    const suspicious = log!.args.filter((a) => a.includes('touch'));
+    expect(suspicious).toHaveLength(1);
+    expect(suspicious[0]).toBe(`-${PAYLOAD}`);
+  });
+
+  it('keeps an injected branch name inside a single argument', async () => {
+    const { calls, exec } = capture();
+    await new GitAgent({ execFn: exec }).perform({
+      action: 'branch',
+      create: true,
+      name: 'feature; rm -rf /tmp/x',
+    });
+
+    const checkout = calls.find((c) => c.args[0] === 'checkout');
+    expect(checkout?.args).toEqual(['checkout', '-b', 'feature; rm -rf /tmp/x']);
+  });
+
+  it('keeps an injected commit message inside a single argument', async () => {
+    const { calls, exec } = capture();
+    await new GitAgent({ execFn: exec }).perform({
+      action: 'commit',
+      files: ['a.ts'],
+      message: 'msg" ; touch /tmp/x ; echo "',
+    });
+
+    const commit = calls.find((c) => c.args[0] === 'commit');
+    expect(commit?.args).toEqual(['commit', '-m', 'msg" ; touch /tmp/x ; echo "']);
+  });
+
+  it('never hands a whole command line to the exec seam', async () => {
+    // The property that makes the class impossible rather than handled: no
+    // argument may contain a shell metacharacter *because the agent put it
+    // there*. Each element is one argv entry, so the only metacharacters
+    // present are ones the caller supplied inside a single value.
+    const { calls, exec } = capture();
+    const agent = new GitAgent({ execFn: exec });
+    await agent.perform({ action: 'status' });
+    await agent.perform({ action: 'diff' });
+
+    for (const call of calls) {
+      expect(['git', 'gh']).toContain(call.binary);
+      for (const arg of call.args) {
+        expect(arg, `${call.binary} ${call.args.join(' ')}`).not.toMatch(/[;&|]/);
+      }
+    }
+  });
+
+  it('still runs the command it is supposed to', async () => {
+    // Anti-vacuity: assertions about argv prove nothing if the agent stopped
+    // issuing commands.
+    const { calls, exec } = capture();
+    await new GitAgent({ execFn: exec }).perform({ action: 'status' });
+    expect(calls).toEqual([{ binary: 'git', args: ['status', '--porcelain'] }]);
+  });
+});


### PR DESCRIPTION
`GitAgent` executed caller-supplied values as shell syntax. Confirmed against the built agent:

```js
execute({ action: 'log', count: '1 ; touch /tmp/openrappter-injection-proof' })
```

```
INJECTION CONFIRMED: file was created
```

## Not one field — five

Every command was assembled by interpolating into a single string and run through `execSync`, which uses a shell:

```
git log -${count} ${format}
git checkout -b ${name}
git add ${fileList}
git commit -m "${message}"
gh pr create --title "${title}"${bodyFlag} --base ${base}
```

`count`, `name`, `fileList`, `message`, `title`, `body` and `base` all come from `kwargs`.

**I found the fifth site only because migrating the first four made the compiler point at it** — it is a `gh` command inside an agent I had been treating as git-only. Fixing `count` alone, which is what I set out to do, would have left four.

## Structural fix, not per-field escaping

`ExecFn` now takes a binary and an argument vector, and `execFileSync` hands each element to the process as one argv entry. There is no shell left to escape into, so no escaping rule has to be got right — a semicolon inside a value stays inside that value.

## Proof, end to end

Same payload against the rebuilt agent:

```
fatal: '1 ; touch /tmp/openrappter-injection-proof': not an integer
FIXED: no file created
```

`git` now receives the payload as one argument and rejects it, which is exactly what should happen.

## Tests

Five new tests assert on the argv the agent builds — none executes git. They cover an injected `count`, branch name and commit message, plus a property test that no argument the agent constructs contains `;`, `&` or `|`, and an anti-vacuity check that it still issues the command at all.

The existing 23 tests keep their command-string expectations: the mock joins the argv back into a string, restoring what they assert against **without** restoring the shell.

Full TypeScript suite green.

## How it was found

While measuring the two sites I deliberately left unmeasured in #262. The intent was to settle whether a blank `count` mattered. The shape of the line turned out to matter far more than the value — which is an argument for measuring the things you leave, rather than filing them as a hunch.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
