### PR TITLE
fix: the device-code URL from GitHub was opened through a shell

### DIFF
--- a/typescript/src/auth/oauth.ts
+++ b/typescript/src/auth/oauth.ts
@@ -353,9 +353,18 @@ export async function initiateOAuthFlow(
   const { url, state } = client.getAuthorizationUrl();
 
   // Open browser
-  const open = process.platform === 'darwin' ? 'open' : process.platform === 'win32' ? 'start' : 'xdg-open';
-  const { exec } = await import('child_process');
-  exec(`${open} "${url}"`);
+  // `start` is a cmd.exe builtin and cannot be spawned; rundll32 is the
+  // shell-free way to hand a URL to the Windows default handler.
+  const [open, leading] = process.platform === 'darwin'
+    ? ['open', [] as string[]]
+    : process.platform === 'win32'
+      ? ['rundll32', ['url.dll,FileProtocolHandler']]
+      : ['xdg-open', [] as string[]];
+  const { execFile } = await import('child_process');
+  // Server-supplied verification URI: quoting it into a shell string leaves a
+  // crafted `"` able to close the quote. One argv entry cannot be escaped out
+  // of at all.
+  execFile(open, [...leading, url], () => {});
 
   console.log(`\nOpen this URL if the browser did not open:\n${url}\n`);
 

--- a/typescript/src/chat.ts
+++ b/typescript/src/chat.ts
@@ -52,13 +52,21 @@ async function inlineAuth(): Promise<string | null> {
       // Try to open browser
       import("child_process")
         .then((cp) => {
-          const cmd =
+          // `start` is a cmd.exe builtin rather than an executable, so it
+          // cannot be spawned directly. `rundll32 url.dll,FileProtocolHandler`
+          // is the documented way to open a URL on Windows without a shell.
+          const [cmd, leading] =
             process.platform === "darwin"
-              ? "open"
+              ? ["open", [] as string[]]
               : process.platform === "win32"
-                ? "start"
-                : "xdg-open";
-          cp.exec(`${cmd} ${url}`);
+                ? ["rundll32", ["url.dll,FileProtocolHandler"]]
+                : ["xdg-open", [] as string[]];
+          // `url` is the verification URI from the device-code response, so
+          // it is server-supplied. Through a shell -- unquoted, as this was --
+          // a crafted value would be command syntax. execFile passes it as one
+          // argument, the way telephony/providers/macos.ts already opens `tel:`
+          // links.
+          cp.execFile(cmd, [...leading, url], () => {});
         })
         .catch(() => {});
     });


### PR DESCRIPTION
Both browser-open paths passed a **server-supplied** value through a shell:

```ts
cp.exec(`${cmd} ${url}`)      // chat.ts  — unquoted
exec(`${open} "${url}"`)      // oauth.ts — quoted
```

`url` is the verification URI from the device-code response, so it comes from the auth server, not from this program. Unquoted it is command syntax outright; quoted, a crafted `"` closes the quote.

## Severity, honestly

**Narrower than #263.** Exploiting either needs control of the auth server's response — a redirected endpoint or a successful MITM — whereas `GitAgent`'s `count` came from agent kwargs a model can choose under prompt injection. I am not presenting this as equivalent.

It is the same shape, the fix is small, and server data should not reach a shell at all.

## Windows needed care, not the obvious change

`start` is a **cmd.exe builtin, not an executable**, so `execFile('start', [url])` would have failed — trading a narrow vulnerability for a broken platform. Both sites now use `rundll32 url.dll,FileProtocolHandler`, which hands the URL to the default handler without a shell.

That was the part worth slowing down for: the security fix and the correct fix were not the same edit.

## Scope of the audit

Found by checking every agent and module for the shape behind #263. Everything else that matched passes program constants (`/Applications/OpenRappter Bar.app` and similar), and `telephony/providers/macos.ts` was **already** correct — it opens `tel:` links with `this.exec('open', [...])`, which is the pattern both of these now follow.

Full TypeScript suite **4782 passed**, `tsc` clean.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
