### PR TITLE
fix: the Python GitAgent had the same command injection as the TypeScript one

### DIFF
--- a/python/openrappter/agents/git_agent.py
+++ b/python/openrappter/agents/git_agent.py
@@ -90,11 +90,20 @@ class GitAgent(BasicAgent):
         self._cwd = cwd or os.getcwd()
         self._exec_fn = exec_fn or self._default_exec
 
-    def _default_exec(self, cmd, cwd=None):
-        """Default exec using subprocess."""
+    def _default_exec(self, binary, args, cwd=None):
+        """Run a binary with an argument vector, never a command line.
+
+        This took a single string with ``shell=True`` and every caller built it
+        with an f-string, so caller-supplied values were shell syntax. Confirmed:
+        ``count='1 ; touch /tmp/x'`` created the file. ``name``, ``file_list``,
+        ``message`` and the ``gh pr create`` title, body and base were the same.
+
+        A list cannot be escaped out of -- each element reaches the process as
+        one argv entry, so a semicolon stays a semicolon.
+        """
         try:
             result = subprocess.run(
-                cmd, shell=True,
+                [binary, *args],
                 capture_output=True, text=True,
                 cwd=cwd or self._cwd,
                 timeout=30
@@ -143,7 +152,7 @@ class GitAgent(BasicAgent):
             })
 
     def _git_status(self):
-        result = self._exec_fn('git status --porcelain', self._cwd)
+        result = self._exec_fn('git', ['status', '--porcelain'], self._cwd)
         stdout = result.get('stdout', '')
         files = []
 
@@ -168,8 +177,8 @@ class GitAgent(BasicAgent):
         })
 
     def _git_diff(self):
-        stat_result = self._exec_fn('git diff --stat', self._cwd)
-        diff_result = self._exec_fn('git diff', self._cwd)
+        stat_result = self._exec_fn('git', ['diff', '--stat'], self._cwd)
+        diff_result = self._exec_fn('git', ['diff'], self._cwd)
 
         diff = diff_result.get('stdout', '')
         truncated = len(diff) > 10000
@@ -191,7 +200,7 @@ class GitAgent(BasicAgent):
     def _git_log(self, kwargs):
         count = kwargs.get('count', 10)
         fmt = '--pretty=format:{"hash":"%H","short":"%h","author":"%an","date":"%ai","subject":"%s"}'
-        result = self._exec_fn(f'git log -{count} {fmt}', self._cwd)
+        result = self._exec_fn('git', ['log', f'-{count}', *fmt.split()], self._cwd)
         stdout = result.get('stdout', '')
 
         commits = []
@@ -220,11 +229,11 @@ class GitAgent(BasicAgent):
         name = kwargs.get('name')
 
         if not name:
-            result = self._exec_fn('git branch --format="%(refname:short)"', self._cwd)
+            result = self._exec_fn('git', ['branch', '--format=%(refname:short)'], self._cwd)
             stdout = result.get('stdout', '')
             branches = [b.strip() for b in stdout.split('\n') if b.strip()]
 
-            current_result = self._exec_fn('git branch --show-current', self._cwd)
+            current_result = self._exec_fn('git', ['branch', '--show-current'], self._cwd)
             current = current_result.get('stdout', '').strip()
 
             data_slush = self.slush_out(
@@ -240,7 +249,7 @@ class GitAgent(BasicAgent):
             })
 
         # Create branch
-        result = self._exec_fn(f'git checkout -b {name}', self._cwd)
+        result = self._exec_fn('git', ['checkout', '-b', name], self._cwd)
 
         data_slush = self.slush_out(
             signals={'branch_created': name}
@@ -266,9 +275,9 @@ class GitAgent(BasicAgent):
 
         if files:
             file_list = ' '.join(files)
-            self._exec_fn(f'git add {file_list}', self._cwd)
+            self._exec_fn('git', ['add', *file_list.split()], self._cwd)
 
-        result = self._exec_fn(f'git commit -m "{message}"', self._cwd)
+        result = self._exec_fn('git', ['commit', '-m', message], self._cwd)
 
         data_slush = self.slush_out(
             signals={'committed': True, 'message': message}
@@ -293,10 +302,12 @@ class GitAgent(BasicAgent):
                 "message": "title is required for pr"
             })
 
-        body_flag = f' --body "{body}"' if body else ''
         result = self._exec_fn(
-            f'gh pr create --title "{title}"{body_flag} --base {base}',
-            self._cwd
+            'gh',
+            ['pr', 'create', '--title', title,
+             *(['--body', body] if body else []),
+             '--base', base],
+            self._cwd,
         )
 
         data_slush = self.slush_out(

--- a/python/tests/test_git_agent.py
+++ b/python/tests/test_git_agent.py
@@ -12,7 +12,11 @@ from openrappter.agents.git_agent import GitAgent
 
 def make_exec(responses):
     """Build a deterministic exec function from a dict of command-prefix -> result."""
-    def exec_fn(cmd, cwd=None):
+    def exec_fn(binary, args, cwd=None):
+        # The agent now passes an argv rather than a command line -- a shell was
+        # reachable through the old string. Joining restores what these
+        # expectations were written against, without restoring the shell.
+        cmd = " ".join([binary, *args])
         for prefix, response in responses.items():
             if prefix in cmd:
                 return response
@@ -53,7 +57,7 @@ class TestGitAgentInit:
         assert agent._cwd == "/tmp"
 
     def test_accepts_custom_exec_fn(self):
-        fn = lambda cmd, cwd=None: {"stdout": "", "stderr": ""}
+        fn = lambda binary, args, cwd=None: {"stdout": "", "stderr": ""}
         agent = GitAgent(exec_fn=fn)
         assert agent._exec_fn is fn
 
@@ -228,7 +232,8 @@ class TestLogAction:
     def test_log_respects_count_parameter(self):
         captured = []
 
-        def exec_fn(cmd, cwd=None):
+        def exec_fn(binary, args, cwd=None):
+            cmd = " ".join([binary, *args])
             captured.append(cmd)
             return {"stdout": "", "stderr": ""}
 
@@ -305,7 +310,8 @@ class TestCommitAction:
     def test_commit_with_files_stages_them(self):
         staged = []
 
-        def exec_fn(cmd, cwd=None):
+        def exec_fn(binary, args, cwd=None):
+            cmd = " ".join([binary, *args])
             if "git add" in cmd:
                 staged.append(cmd)
                 return {"stdout": "", "stderr": ""}

--- a/python/tests/test_git_agent_injection.py
+++ b/python/tests/test_git_agent_injection.py
@@ -1,0 +1,104 @@
+"""Caller-supplied values reach ``git`` as arguments, never as shell syntax.
+
+``GitAgent._default_exec`` ran ``subprocess.run(cmd, shell=True)`` and every
+caller built ``cmd`` with an f-string. Confirmed against the agent::
+
+    perform(action='log', count='1 ; touch /tmp/openrappter-py-injection-proof')
+    -> the file was created
+
+``count`` was not special. ``name`` (branch), ``file_list`` (add), ``message``
+(commit) and the ``gh pr create`` title, body and base were interpolated the
+same way -- five reachable sites.
+
+This is the Python half of the same defect fixed in the TypeScript agent in
+#263. The two are transliterations, so the flaw came across with the code, and
+finding it in one runtime meant it was worth looking in the other.
+
+The fix is structural rather than per-field: the exec seam takes a binary and a
+list, and ``subprocess.run`` is called without ``shell=True``. There is no shell
+left to escape into, so no escaping rule has to be got right.
+
+These tests assert on the argv the agent builds. Nothing here runs git.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from openrappter.agents.git_agent import GitAgent
+
+PAYLOAD = "1 ; touch /tmp/openrappter-py-injection-proof"
+
+
+@pytest.fixture
+def calls():
+    return []
+
+
+@pytest.fixture
+def agent(calls):
+    def exec_fn(binary, args, cwd=None):
+        calls.append((binary, list(args)))
+        return {"stdout": "", "stderr": ""}
+
+    return GitAgent(cwd=".", exec_fn=exec_fn)
+
+
+def test_an_injected_count_stays_one_argument(agent, calls):
+    agent.perform(action="log", count=PAYLOAD)
+    log = next(c for c in calls if c[1][0] == "log")
+    # The payload may appear -- as a single argv entry. What must not happen is
+    # it being split into further arguments, which is what a shell did.
+    suspicious = [a for a in log[1] if "touch" in a]
+    assert suspicious == [f"-{PAYLOAD}"]
+
+
+def test_an_injected_branch_name_stays_one_argument(agent, calls):
+    agent.perform(action="branch", create=True, name="feature; rm -rf /tmp/x")
+    checkout = next(c for c in calls if c[1][0] == "checkout")
+    assert checkout == ("git", ["checkout", "-b", "feature; rm -rf /tmp/x"])
+
+
+def test_an_injected_commit_message_stays_one_argument(agent, calls):
+    agent.perform(action="commit", files=["a.py"], message='msg" ; touch /tmp/x ; echo "')
+    commit = next(c for c in calls if c[1][0] == "commit")
+    assert commit == ("git", ["commit", "-m", 'msg" ; touch /tmp/x ; echo "'])
+
+
+def test_the_agent_never_builds_shell_metacharacters(agent, calls):
+    # The property that makes the class impossible rather than handled: any
+    # metacharacter present is one the caller put inside a single value.
+    agent.perform(action="status")
+    agent.perform(action="diff")
+    for binary, args in calls:
+        assert binary in {"git", "gh"}
+        for arg in args:
+            assert not any(ch in arg for ch in ";&|"), f"{binary} {args}"
+
+
+def test_it_still_issues_the_command(agent, calls):
+    # Anti-vacuity: assertions about argv prove nothing if the agent stopped
+    # running commands at all.
+    agent.perform(action="status")
+    assert calls == [("git", ["status", "--porcelain"])]
+
+
+def test_the_default_exec_does_not_use_a_shell():
+    # The seam is what made every call site dangerous, so it is pinned directly
+    # rather than only through the call sites above.
+    import ast
+    import inspect
+    import textwrap
+
+    # Parse rather than grep: the docstring explaining this fix mentions
+    # `shell=True`, so a substring check on the source fails on the very
+    # sentence describing the repair.
+    tree = ast.parse(textwrap.dedent(inspect.getsource(GitAgent._default_exec)))
+    shell_kwargs = [
+        keyword
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Call)
+        for keyword in node.keywords
+        if keyword.arg == "shell"
+    ]
+    assert shell_kwargs == [], "subprocess must not be given shell="


### PR DESCRIPTION
The Python `GitAgent` had the same command injection as the TypeScript one fixed in #263.

```python
perform(action='log', count='1 ; touch /tmp/openrappter-py-injection-proof')
```
```
PYTHON INJECTION CONFIRMED
```

## The same five sites, in the same order

`_default_exec` ran `subprocess.run(cmd, shell=True)` and every caller built `cmd` with an f-string interpolating `count`, `name`, `file_list`, `message`, and the `gh pr create` title, body and base.

**The two agents are transliterations, so the flaw came across with the code.** Finding it in one runtime is the only reason it was worth looking in the other — and I would not have looked if #263 had been treated as a one-off fix rather than a class.

## Fix and proof

The seam takes a binary and a list, and `subprocess.run` is called without `shell=True`. Same payload after the change:

```
FIXED: no file created
```

The existing 36 tests keep their command-string expectations — the mocks join the argv back into a string, restoring what they assert against **without** restoring the shell.

## A test that defeated itself

`test_the_default_exec_does_not_use_a_shell` first asserted that `shell=True` was absent from `inspect.getsource(...)`. It failed — because the docstring I had just written to *explain the fix* mentions `shell=True`. A substring check on source tripped on the sentence describing the repair.

It now parses the AST and asserts no `subprocess` call carries a `shell` keyword, which is what the property actually is.

## Verification

Python suite **1526 passed**, `conformance.py` 8 passed / 0 failed.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
