### PR TITLE
fix(agents): stop shell injection via generated-code imports in LearnNewAgent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -294,6 +294,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Learning a new agent could run arbitrary commands** — `learn_new_agent`
+  asks a model to write agent code, scans that code for imports, and installs
+  them, so an import specifier is model-authored untrusted input. It was
+  interpolated into a shell command line, and the import pattern permits both
+  spaces and semicolons, so generated code containing
+  `import x from 'lodash; touch pwned'` executed the second command. Installs
+  now use an argument vector, and package names are checked against npm's own
+  grammar before use.
 - **Turning authentication on no longer severs the neighborhood** — a rappter
   contacting a peer sent no credential at all, while `/twin` and `/chat` both
   authenticate before parsing. Those were compatible only because

--- a/typescript/src/agents/LearnNewAgent.ts
+++ b/typescript/src/agents/LearnNewAgent.ts
@@ -13,7 +13,7 @@
  * This avoids import resolution issues — the host passes BasicAgent in.
  */
 
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import fs from 'fs/promises';
 import path from 'path';
@@ -47,7 +47,16 @@ export const __manifest__ = {
   quality_tier: 'official',
   requires_env: []
 } as const;
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+// npm's own package-name grammar. Generated code is model-authored, so an
+// import specifier is untrusted input: reject anything that is not a package
+// name rather than letting it reach an install command.
+const NPM_PACKAGE_NAME = /^(?:@[a-z0-9-~][a-z0-9-._~]*\/)?[a-z0-9-~][a-z0-9-._~]*$/;
+
+export function isValidNpmPackageName(name: string): boolean {
+  return name.length > 0 && name.length <= 214 && NPM_PACKAGE_NAME.test(name);
+}
 
 /**
  * Truncate by code point, then encode as a JavaScript string literal.
@@ -635,7 +644,10 @@ ${performBody}
 
     try {
       for (const pkg of packages) {
-        const { stderr } = await execAsync(`npm install --save ${pkg}`, {
+        if (!isValidNpmPackageName(pkg)) {
+          return { success: false, error: `refusing to install invalid package name: ${JSON.stringify(pkg)}` };
+        }
+        const { stderr } = await execFileAsync('npm', ['install', '--save', pkg], {
           timeout: 60000,
           cwd: process.cwd(),
         });

--- a/typescript/src/agents/__tests__/learn-new-npm-injection.test.ts
+++ b/typescript/src/agents/__tests__/learn-new-npm-injection.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { isValidNpmPackageName } from '../LearnNewAgent.js';
+
+const SOURCE = readFileSync(
+  path.join(path.dirname(fileURLToPath(import.meta.url)), '..', 'LearnNewAgent.ts'),
+  'utf-8',
+);
+
+/**
+ * LearnNewAgent asks a model to write agent code, scans that code for imports,
+ * then installs them. The import specifier is therefore model-authored,
+ * untrusted input on a path to a command line.
+ *
+ * Before the fix, `npm install --save ${pkg}` ran through a shell, so
+ * `import x from 'lodash; touch pwned'` executed an arbitrary command.
+ */
+describe('LearnNewAgent dependency install is not shell-injectable', () => {
+  // The extraction in detectMissingImports, replicated so the test states the
+  // threat in terms of what the product actually parses.
+  function extractPackages(code: string): string[] {
+    const pattern = /import\s+(?:.*?\s+from\s+)?['"]([^'"./][^'"]*)['"]/g;
+    const found: string[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = pattern.exec(code)) !== null) {
+      const pkg = m[1];
+      found.push(pkg.startsWith('@') ? pkg.split('/').slice(0, 2).join('/') : pkg.split('/')[0]);
+    }
+    return found;
+  }
+
+  it('extracts a package name carrying shell metacharacters from generated code', () => {
+    // Documents that the taint is real: the regex permits spaces and `;`, and
+    // split('/') does not remove them. This is the input the fix must survive.
+    const [pkg] = extractPackages(`import x from 'lodash; touch pwned-marker'`);
+    expect(pkg).toBe('lodash; touch pwned-marker');
+  });
+
+  it('rejects every extracted name that is not a valid npm package name', () => {
+    const payloads = [
+      "lodash; touch pwned-marker",
+      "lodash && curl evil.example",
+      "lodash | sh",
+      "lodash`whoami`",
+      "lodash$(whoami)",
+      "lodash\nrm -rf .",
+      "../../etc/passwd",
+      "lodash ; :",
+    ];
+    for (const payload of payloads) {
+      const [extracted] = extractPackages(`import x from '${payload}'`);
+      const candidate = extracted ?? payload;
+      expect(isValidNpmPackageName(candidate), `should reject ${JSON.stringify(candidate)}`).toBe(false);
+    }
+  });
+
+  it('still accepts the package names real generated code imports', () => {
+    for (const good of ['lodash', 'axios', 'node-fetch', '@scope/pkg', 'left-pad', 'p-queue', 'rxjs']) {
+      expect(isValidNpmPackageName(good), `should accept ${good}`).toBe(true);
+    }
+  });
+
+  it('installs through an argument vector, never a shell command string', () => {
+    // The structural half: even a valid name must not be interpolated into a
+    // command line, so that a future validator change cannot reopen the hole.
+    expect(SOURCE).not.toMatch(/exec(?:Async|Sync)?\(\s*`npm install/);
+    expect(SOURCE).toMatch(/execFileAsync\(\s*'npm',\s*\['install',\s*'--save',\s*pkg\]/);
+  });
+
+  it('does not retain a shell-capable exec helper in this module', () => {
+    expect(SOURCE).not.toMatch(/promisify\(exec\)/);
+  });
+});


### PR DESCRIPTION
## The defect

`learn_new_agent` takes a natural-language description, asks a model to write
agent code, scans that code for imports, and installs them. The import
specifier is therefore **model-authored untrusted input on a path to a command
line**, with no review step between generation and install.

`installDependencies` interpolated it into a shell:

```ts
await execAsync(`npm install --save ${pkg}`)
```

The extraction does not sanitize. Its regex captures `[^'"./][^'"]*` — spaces,
semicolons, backticks and `$()` are all permitted — and `split('/')[0]` removes
only slashes.

## Proof

Generated code containing:

```js
import x from 'lodash; touch pwned-marker'
```

yields the package name `lodash; touch pwned-marker`, and running the same
template created the marker file. Arbitrary command execution, confirmed.

`split('/')` is an accidental partial mitigation — it truncates a payload at
the first slash, so my first attempt lost its argument and `touch` errored on
no operand. It still ran. Any slash-free payload defeats it entirely.

## Why this one matters more than the previous two

The `GitAgent` injections (#263, #265) needed a model to be steered into an odd
argument. Here, running model-authored content through this path **is the
feature**. A poisoned description reaches `npm install` by design.

## The fix

- install through `execFile` with an argument vector — no shell
- validate names against npm's own grammar first, so a malformed import fails
  loudly instead of reaching a command line
- drop the now-unused shell-capable `promisify(exec)` helper from the module

## Evidence

Mutation-tested: reintroducing the interpolation fails the two structural
tests; restoring passes all 5. The validator tests are deliberately independent
of the call site, so they keep passing under mutation — they cover a different
claim.

Full TypeScript suite: **4787 passed**, 21 skipped (was 4782 + 5 new), `tsc`
clean.

## Scope note

I set out to build a TypeScript equivalent of the Python shell guard from #266
and found this instead. A blanket guard would need to rule on 48 sites across
18 files, several of which are SQLite `db.exec` rather than shell — a guard
with a 20-entry allowlist is not much of a guard. The agent-scoped equivalent,
matching the Python guard's scope, is worth doing separately; the remaining
agent sites (`ComputerUseAgent`, `OuroborosAgent`, `DemoRecorderAgent`) take
internally-generated paths rather than model output, so they are latent shape
rather than reachable defects.
