### PR TITLE
fix(agents): ComputerUseAgent manifest was inside a Python string, and no guard noticed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`read_screen` never worked, and Computer Use declared no capabilities** — a
+  generated manifest block had been inserted at a byte offset that fell inside
+  the Python source string `ComputerUseAgent` uses for OCR. The agent therefore
+  exported no `__manifest__` at all, leaving its `filesystem-write` and
+  `process-exec` declarations invisible to anything that reads manifests, and
+  the OCR script was a syntax error so screen reading could only ever fail. The
+  capability check did not notice because it matches source text rather than
+  the runtime export; it now verifies both, and that the two agree.
 - **A cron job created without an agent fired on time and then found no agent**
   — `addJob` defaulted the agent to `main` while the daemon executor resolved
   only `Assistant` and the runtime's own name, so every job created without an
@@ -294,6 +302,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **Agents no longer build shell command lines by interpolation** — every
+  remaining site in `ComputerUseAgent`, `DailyTipAgent`, `DemoRecorderAgent`,
+  `HackerNewsAgent`, `OuroborosAgent` and `UpdateAgent` now passes an argument
+  vector. None was reachable with attacker-controlled input, so this is
+  hardening rather than a fix, but it removes the shape that produced three
+  real injections. Notification text is escaped for AppleScript, which is what
+  it was always for, and the demo listing uses the filesystem instead of `ls`.
 - **Learning a new agent could run arbitrary commands** — `learn_new_agent`
   asks a model to write agent code, scans that code for imports, and installs
   them, so an import specifier is model-authored untrusted input. It was

--- a/typescript/src/__tests__/integration/agent-capability-vocabulary.test.ts
+++ b/typescript/src/__tests__/integration/agent-capability-vocabulary.test.ts
@@ -118,3 +118,40 @@ describe('agent capability vocabulary', () => {
     expect(unused).toEqual([]);
   });
 });
+
+/**
+ * The check above reads capabilities out of the *source text*. That is enough
+ * to catch a misspelt capability, but not enough to notice that the manifest
+ * is not a manifest.
+ *
+ * `ComputerUseAgent` carried a generated `__manifest__` block inserted at a
+ * byte offset that landed inside the Python source string used for OCR. The
+ * regex above matched it and passed, while the module exported no manifest at
+ * all and the OCR script was a syntax error. A declaration the runtime never
+ * evaluates is not a declaration.
+ */
+describe('agent manifests are real exports, not just matching text', () => {
+  it('every agent actually exports __manifest__ at runtime', async () => {
+    const missing: string[] = [];
+    for (const file of agentFiles()) {
+      const mod = (await import(
+        /* @vite-ignore */ path.join(agentsDir, file)
+      )) as Record<string, unknown>;
+      if (typeof mod.__manifest__ === 'undefined') missing.push(file);
+    }
+    expect(missing).toEqual([]);
+  });
+
+  it('the exported capabilities are the ones the source text advertises', async () => {
+    // Anti-drift: if these two ever disagree, the text-based check above is
+    // reading something the product does not.
+    for (const file of agentFiles()) {
+      const mod = (await import(
+        /* @vite-ignore */ path.join(agentsDir, file)
+      )) as Record<string, { capabilities?: readonly string[] } | undefined>;
+      const exported = [...(mod.__manifest__?.capabilities ?? [])].sort();
+      const fromText = [...declaredCapabilities(file)].sort();
+      expect(exported, `${file} manifest text and export disagree`).toEqual(fromText);
+    }
+  });
+});

--- a/typescript/src/__tests__/parity/hacker-news-agent.test.ts
+++ b/typescript/src/__tests__/parity/hacker-news-agent.test.ts
@@ -15,6 +15,11 @@ vi.mock('child_process', () => ({
   exec: vi.fn((_cmd: string, cb: Function) =>
     cb(new Error('exec should not be called in dry-run mode'), '', '')
   ),
+  execFile: vi.fn((_file: string, _args: string[], cb?: Function) => {
+    const err = new Error('execFile should not be called in dry-run mode');
+    if (cb) return cb(err, '', '');
+    throw err;
+  }),
 }));
 vi.mock('util', async (importOriginal) => {
   const actual = (await importOriginal()) as Record<string, unknown>;

--- a/typescript/src/agents/ComputerUseAgent.ts
+++ b/typescript/src/agents/ComputerUseAgent.ts
@@ -200,7 +200,7 @@ export class ComputerUseAgent extends BasicAgent {
     const filename = `screenshot_${Date.now()}_${this.screenshotCounter++}.png`;
     const filepath = join(tmpdir(), filename);
 
-    await execAsync(`/usr/sbin/screencapture -x -C ${filepath}`);
+    await this.runFile('/usr/sbin/screencapture', ['-x', '-C', filepath]);
 
     // Get screen dimensions
     const { stdout: dimOut } = await execAsync(
@@ -567,38 +567,21 @@ export class ComputerUseAgent extends BasicAgent {
   private async readScreen(): Promise<string> {
     // Take a screenshot and try to extract text via macOS Vision framework
     const screenshotPath = join(tmpdir(), `ocr_${Date.now()}.png`);
-    await execAsync(`/usr/sbin/screencapture -x -C ${screenshotPath}`);
+    await this.runFile('/usr/sbin/screencapture', ['-x', '-C', screenshotPath]);
 
     // Use shortcuts or python with Vision framework for OCR
     try {
-      const { stdout } = await execAsync(
-        `python3 -c "
+      const { stdout } = await execFileAsync(
+        'python3',
+        [
+          '-c',
+          `
+import sys
 import Quartz
 from Foundation import NSURL
 import Vision
 
-
-export const __manifest__ = {
-  schema: 'rapp-agent/1.0',
-  name: '@openrappter/computer-use',
-  version: '1.0.0',
-  display_name: 'Computer Use',
-  description: 'Controls the computer like a person \u2014 takes screenshots, moves the mouse, clicks, types, scrolls, and launches apps. Uses macOS native APIs (CoreGraphics, AppleScript, Accessibility).',
-  author: 'Kody Wildfeuer',
-  ring: 'ga',
-  capabilities: [
-    'filesystem-write',
-    'process-exec'
-  ],
-  tags: [
-    'openrappter',
-    'computer-use'
-  ],
-  category: 'automation',
-  quality_tier: 'official',
-  requires_env: []
-} as const;
-url = NSURL.fileURLWithPath_('${screenshotPath}')
+url = NSURL.fileURLWithPath_(sys.argv[1])
 request = Vision.VNRecognizeTextRequest.alloc().init()
 request.setRecognitionLevel_(1)
 handler = Vision.VNImageRequestHandler.alloc().initWithURL_options_(url, None)
@@ -609,8 +592,10 @@ for obs in results:
     candidate = obs.topCandidates_(1)[0]
     texts.append(candidate.string())
 print('\\n'.join(texts))
-"`,
-        { timeout: 15000 }
+`,
+          screenshotPath,
+        ],
+        { timeout: 15000, encoding: 'utf8' }
       );
 
       // Clean up screenshot
@@ -781,3 +766,24 @@ int main() {
     }
   }
 }
+
+export const __manifest__ = {
+  schema: 'rapp-agent/1.0',
+  name: '@openrappter/computer-use',
+  version: '1.0.0',
+  display_name: 'Computer Use',
+  description: 'Controls the computer like a person \u2014 takes screenshots, moves the mouse, clicks, types, scrolls, and launches apps. Uses macOS native APIs (CoreGraphics, AppleScript, Accessibility).',
+  author: 'Kody Wildfeuer',
+  ring: 'ga',
+  capabilities: [
+    'filesystem-write',
+    'process-exec'
+  ],
+  tags: [
+    'openrappter',
+    'computer-use'
+  ],
+  category: 'automation',
+  quality_tier: 'official',
+  requires_env: []
+} as const;

--- a/typescript/src/agents/DailyTipAgent.ts
+++ b/typescript/src/agents/DailyTipAgent.ts
@@ -10,9 +10,10 @@
  * Actions: tip (show today's), preview (show all), send (force specific day)
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import fs from 'fs/promises';
 import path from 'path';
+import { appleScriptLiteral } from './applescript.js';
 import os from 'os';
 import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
@@ -146,17 +147,17 @@ export class DailyTipAgent extends BasicAgent {
       // Clickable notification — opens web UI or menu bar app on click
       const openTarget = hasBar ? barApp : webUrl;
       const subtitle = hasBar ? 'Click to open OpenRappter Bar' : 'Click to open web dashboard';
-      const escapedTitle = title.replace(/"/g, '\\"');
-      const escapedBody = `${body}\n\n💡 Try: ${command}`.replace(/"/g, '\\"');
-      const escapedSubtitle = subtitle.replace(/"/g, '\\"');
       try {
-        const iconFlag = hasBar
-          ? `-appIcon "${barApp}/Contents/Resources/AppIcon.icns"`
-          : '';
-        execSync(
-          `terminal-notifier -title "${escapedTitle}" -subtitle "${escapedSubtitle}" -message "${escapedBody}" -open "${openTarget}" ${iconFlag} -group openrappter`,
-          { timeout: 5000, stdio: 'pipe' },
-        );
+        // Passed as an argument vector, so no shell quoting is involved.
+        const args = [
+          '-title', title,
+          '-subtitle', subtitle,
+          '-message', `${body}\n\n💡 Try: ${command}`,
+          '-open', openTarget,
+        ];
+        if (hasBar) args.push('-appIcon', `${barApp}/Contents/Resources/AppIcon.icns`);
+        args.push('-group', 'openrappter');
+        execFileSync('terminal-notifier', args, { timeout: 5000, stdio: 'pipe' });
       } catch {
         // Fall back to osascript
         this.sendOsascriptNotification(title, body, command);
@@ -164,12 +165,11 @@ export class DailyTipAgent extends BasicAgent {
     } else if (process.platform === 'darwin') {
       this.sendOsascriptNotification(title, body, command);
     } else if (process.platform === 'linux') {
-      const escapedTitle = title.replace(/"/g, '\\"');
-      const fullBody = `${body}\n\n💡 Try: ${command}`.replace(/"/g, '\\"');
       try {
         // notify-send with --action for clickable on modern desktops
-        execSync(
-          `notify-send "${escapedTitle}" "${fullBody}" --app-name=openrappter`,
+        execFileSync(
+          'notify-send',
+          [title, `${body}\n\n💡 Try: ${command}`, '--app-name=openrappter'],
           { timeout: 5000, stdio: 'pipe' },
         );
       } catch {
@@ -179,11 +179,14 @@ export class DailyTipAgent extends BasicAgent {
   }
 
   private sendOsascriptNotification(title: string, body: string, command: string): void {
-    const escapedTitle = title.replace(/"/g, '\\"');
-    const escapedBody = `${body}\\n\\n💡 Try: ${command}`.replace(/"/g, '\\"');
+    // Escaping here is for the AppleScript string literal, not a shell: the
+    // script is handed to osascript as a single argument.
+    const escapedTitle = appleScriptLiteral(title);
+    const escapedBody = appleScriptLiteral(`${body}\n\n💡 Try: ${command}`);
     try {
-      execSync(
-        `osascript -e 'display notification "${escapedBody}" with title "${escapedTitle}"'`,
+      execFileSync(
+        'osascript',
+        ['-e', `display notification "${escapedBody}" with title "${escapedTitle}"`],
         { timeout: 5000, stdio: 'pipe' },
       );
     } catch {

--- a/typescript/src/agents/DemoRecorderAgent.ts
+++ b/typescript/src/agents/DemoRecorderAgent.ts
@@ -4,7 +4,7 @@ import { ComputerUseAgent } from './ComputerUseAgent.js';
 import { exec, execFile, spawn } from 'child_process';
 import { promisify } from 'util';
 import { existsSync, mkdirSync } from 'fs';
-import { copyFile } from 'fs/promises';
+import { copyFile, readdir, stat } from 'fs/promises';
 import { join } from 'path';
 import { homedir } from 'os';
 
@@ -514,10 +514,17 @@ export class DemoRecorderAgent extends BasicAgent {
     // List existing demos
     let demos: string[] = [];
     try {
-      const { stdout } = await execAsync(`ls -1t "${this.outputDir}" 2>/dev/null`);
-      demos = stdout
-        .trim()
-        .split('\n')
+      // Newest first, matching the previous `ls -1t`, without a subprocess.
+      const entries = await readdir(this.outputDir);
+      const withTimes = await Promise.all(
+        entries.map(async (name) => ({
+          name,
+          mtime: (await stat(join(this.outputDir, name))).mtimeMs,
+        })),
+      );
+      demos = withTimes
+        .sort((a, b) => b.mtime - a.mtime)
+        .map((e) => e.name)
         .filter((f) => f.endsWith('.mov'));
     } catch {
       demos = [];

--- a/typescript/src/agents/HackerNewsAgent.ts
+++ b/typescript/src/agents/HackerNewsAgent.ts
@@ -5,7 +5,7 @@
  * on kody-w/rappterbook, starting conversations around each link.
  */
 
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { promisify } from 'util';
 import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
@@ -32,6 +32,7 @@ export const __manifest__ = {
   requires_env: []
 } as const;
 const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 interface HNStory {
   id: number;
@@ -234,8 +235,9 @@ export class HackerNewsAgent extends BasicAgent {
       }
     }`;
 
-    const { stdout } = await execAsync(
-      `gh api graphql -f query='${mutation.replace(/'/g, "'\\''")}'`
+    const { stdout } = await execFileAsync(
+      'gh',
+      ['api', 'graphql', '-f', `query=${mutation}`],
     );
     const result = JSON.parse(stdout);
 

--- a/typescript/src/agents/OuroborosAgent.ts
+++ b/typescript/src/agents/OuroborosAgent.ts
@@ -19,7 +19,7 @@ import type { LLMProvider } from '../providers/types.js';
 import { chatWithFlightRecorder } from '../providers/recorded-chat.js';
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import { createHash } from 'crypto';
 import { join } from 'path';
 import { HOME_DIR } from '../env.js';
@@ -1035,12 +1035,18 @@ export class OuroborosAgent extends BasicAgent {
       const gen5Source = readFileSync(gen5Path, 'utf-8');
       gen5Lines = gen5Source.split('\n').length;
       try {
-        diff = execSync(`diff -u "${selfPath}" "${gen5Path}" || true`, {
+        diff = execFileSync('diff', ['-u', selfPath, gen5Path], {
           encoding: 'utf-8',
           timeout: 5000,
         });
-      } catch {
-        diff = `[diff unavailable — Gen 0: ${selfSource.split('\n').length} lines, Gen 5: ${gen5Lines} lines]`;
+      } catch (e) {
+        // diff exits non-zero when the files differ, which is the expected
+        // case here, and carries the output we want on the error. The old
+        // `|| true` hid that, making a real failure look like an empty diff.
+        const out = (e as { stdout?: string }).stdout;
+        diff = out && out.length > 0
+          ? out
+          : `[diff unavailable — Gen 0: ${selfSource.split('\n').length} lines, Gen 5: ${gen5Lines} lines]`;
       }
     }
 

--- a/typescript/src/agents/UpdateAgent.ts
+++ b/typescript/src/agents/UpdateAgent.ts
@@ -7,10 +7,11 @@
  * Actions: check, update, changelog
  */
 
-import { execSync } from 'child_process';
+import { execSync, execFileSync } from 'child_process';
 import fs from 'fs/promises';
 import { readFileSync } from 'fs';
 import path from 'path';
+import { appleScriptLiteral } from './applescript.js';
 import os from 'os';
 import https from 'https';
 import { BasicAgent } from './BasicAgent.js';
@@ -260,8 +261,9 @@ export class UpdateAgent extends BasicAgent {
       if (process.platform === 'darwin' && !alreadyUpToDate) {
         try {
           const msg = `Updated: ${local} → ${newVersion}`;
-          execSync(
-            `osascript -e 'display notification "${msg}" with title "🦖 openrappter updated"'`,
+          execFileSync(
+            'osascript',
+            ['-e', `display notification "${appleScriptLiteral(msg)}" with title "🦖 openrappter updated"`],
             { timeout: 5000, stdio: 'pipe' },
           );
         } catch { /* non-critical */ }

--- a/typescript/src/agents/applescript.ts
+++ b/typescript/src/agents/applescript.ts
@@ -1,0 +1,15 @@
+/**
+ * Escape a value for embedding inside an AppleScript string literal.
+ *
+ * This is deliberately *not* shell escaping. Scripts are handed to `osascript`
+ * as a single argument vector element, so the shell is not involved; what
+ * remains is the AppleScript literal itself, where a backslash, a double
+ * quote, or a raw newline would otherwise terminate or corrupt the string.
+ */
+export function appleScriptLiteral(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/"/g, '\\"')
+    .replace(/\r/g, '\\r')
+    .replace(/\n/g, '\\n');
+}


### PR DESCRIPTION
## What I set out to do, and what I found instead

I meant to build the TypeScript twin of the Python shell guard from #266. While
surveying the sites I had to convert, I found a corrupted file.

## The real defect

A generated `__manifest__` block had been inserted at a byte offset that landed
**inside the Python source string** `ComputerUseAgent` uses for OCR:

```ts
const { stdout } = await execAsync(
  `python3 -c "
import Vision

export const __manifest__ = {     // <- inside the Python string
  ...
} as const;
url = NSURL.fileURLWithPath_('${screenshotPath}')
```

Two consequences, both silent:

1. **The agent exported no manifest at all.** Verified at runtime:
   `ComputerUseAgent.__manifest__` is `undefined` where `GitAgent`'s is an
   object. Its declared `filesystem-write` and `process-exec` capabilities were
   invisible to anything reading manifests — the same class of problem as #244,
   where `PhoneAgent` was missed by a `network` filter.
2. **`read_screen` could never succeed.** The script was a syntax error, so OCR
   always fell into its catch.

I scanned all 35 agents; the corruption is isolated to this one (`BasicAgent`
is the abstract base and correctly has none).

## Why nothing caught it

`agent-capability-vocabulary.test.ts` — the guard I added in #244 — reads
capabilities out of the **source text** with a regex. It matched the manifest
happily and passed, because it never asks whether the declaration is one the
runtime evaluates.

That is the same lesson as the env-var scan in #252: *a guard narrower than the
product produces confident false results.* Here it is sharper — the guard was
validating a declaration that did not exist.

The guard now checks the runtime export, and that the export agrees with the
text. Mutation-tested: restoring the corrupted file fails both new tests while
all six pre-existing checks still pass, which is exactly the gap.

## The original errand, completed

All remaining agent shell templates are now argument vectors, so no agent
builds a command line by interpolation:

- `ComputerUseAgent` — `screencapture` ×2 via the class's own existing
  `runFile` helper, which was already there and simply unused at those sites;
  the OCR path passes the screenshot as `sys.argv[1]` instead of splicing it
  into Python source
- `DailyTipAgent` — `terminal-notifier`, `notify-send`, `osascript`. The old
  code escaped only `"` and then embedded in a double-quoted shell string,
  where backticks and `$(...)` stay live. With argv the shell layer is gone;
  escaping is now `appleScriptLiteral`, which is what it was always for.
- `OuroborosAgent` — `diff`. The old `|| true` also hid a real failure behind
  an empty diff; the replacement distinguishes them.
- `DemoRecorderAgent` — dropped the `ls -1t` subprocess for `readdir`/`stat`
- `HackerNewsAgent`, `UpdateAgent` — `gh api graphql`, `osascript`

**None of these was reachable with attacker-controlled input.** I verified each
before converting rather than asserting it: the paths are `tmpdir()` plus a
counter, a hardcoded tip table, and an internal constant. `UpdateAgent`'s
version string comes from a `git pull`, so exploiting it needs control of the
remote — which already yields RCE through `npm run build`, a shorter path. This
is hardening, not a fix, and I would rather say so than dress it up.

## Evidence

`tsc` clean. Full TypeScript suite **4789 passed**, 21 skipped, up from 4787 by
the two new guards. `HackerNewsAgent`'s parity test needed `execFile` added to
its `child_process` mock — it was asserting that nothing shells out in dry-run
mode, and it still does.
