### PR TITLE
fix(conformance): R2/R3 read TypeScript manifests as code, not text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The conformance gate accepted a manifest that wasn't one** — R2 passed any
+  non-Python agent whose file merely *contained* the substrings `__manifest__`
+  and `rapp-agent/1.0`, and R3 checked required fields for Python agents only.
+  Both were satisfied by `ComputerUseAgent.ts` at a point when it exported no
+  manifest at all, so the gate reported a clean run over a broken contract.
+  Both checks now read the declaration itself, which also surfaced
+  `morning_brief_agent.js` carrying a name that is not `@scope/slug`; it is now
+  `@openrappter/morning-brief`.
 - **`read_screen` never worked, and Computer Use declared no capabilities** — a
   generated manifest block had been inserted at a byte offset that fell inside
   the Python source string `ComputerUseAgent` uses for OCR. The agent therefore

--- a/agents/morning_brief_agent.js
+++ b/agents/morning_brief_agent.js
@@ -15,7 +15,7 @@ import os from 'os';
 
 export const __manifest__ = {
   schema: 'rapp-agent/1.0',
-  name: '@openrappter/morning_brief_agent',
+  name: '@openrappter/morning-brief',
   version: '1.0.0',
   display_name: 'morning_brief_agent',
   description: 'Daily briefing: weather, calendar, priorities from memory, spoken via TTS.',

--- a/conformance.py
+++ b/conformance.py
@@ -200,6 +200,72 @@ def declared_manifest(path):
     return None
 
 
+def _js_balanced_block(text, start):
+    """(start, end) of the `{...}` beginning at or after `start`, nesting-aware."""
+    open_at = text.find("{", start)
+    if open_at == -1:
+        return None
+    depth = 0
+    for i in range(open_at, len(text)):
+        if text[i] == "{":
+            depth += 1
+        elif text[i] == "}":
+            depth -= 1
+            if depth == 0:
+                return open_at, i + 1
+    return None
+
+
+def js_declared_manifest(path):
+    """Read a TypeScript/JavaScript `__manifest__` statically.
+
+    Deliberately does not import the module, for the same reason
+    `declared_manifest` does not: deciding whether to trust a file by running
+    it is the wrong order.
+
+    A declaration only counts if it is code. A generated manifest block was
+    once inserted at an offset that fell inside the Python source string
+    `ComputerUseAgent.ts` passes to `python3`; the file then contained every
+    substring a text check looks for while exporting no manifest at all. A
+    manifest block spans lines, and the only JavaScript string that can span
+    lines is a template literal, so an odd number of backticks before the
+    declaration means it is inside one and is not a declaration."""
+    try:
+        with open(path, encoding="utf-8", errors="replace") as fh:
+            body = fh.read()
+    except OSError:
+        return None
+    for m in re.finditer(r"(?m)^\s*(?:export\s+)?(?:const|let|var)?\s*"
+                         r"__manifest__\s*[:=]", body):
+        if len(re.findall(r"(?<!\\)`", body[:m.start()])) % 2:
+            continue  # inside a template literal, so not a declaration
+        block = _js_balanced_block(body, m.end())
+        if block is None:
+            continue
+        raw = body[block[0]:block[1]]
+        man = {}
+        for key, value in re.findall(
+                r"(?m)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*"
+                r"(\[[^\]]*\]|'[^']*'|\"[^\"]*\"|[^,\n]+)", raw):
+            value = value.strip().rstrip(",")
+            if value.startswith("["):
+                man[key] = [a or b for a, b in
+                            re.findall(r"'([^']*)'|\"([^\"]*)\"", value)]
+            elif value[:1] in "'\"":
+                man[key] = value[1:-1]
+            else:
+                man[key] = value
+        if man:
+            return man
+    return None
+
+
+def any_declared_manifest(path):
+    """The manifest a file declares, whatever language it is written in."""
+    return (declared_manifest(path) if path.endswith(".py")
+            else js_declared_manifest(path))
+
+
 # ── the agent contract ───────────────────────────────────────────────────────
 
 @check("R1", "Every agent is a single file, in every language.")
@@ -223,13 +289,8 @@ def r2_manifest_present():
         return None, "no agents found"
     missing = []
     for path in files:
-        if path.endswith(".py"):
-            man = declared_manifest(path)
-            ok = man is not None and man.get("schema") == AGENT_SCHEMA
-        else:
-            with open(path, encoding="utf-8", errors="replace") as fh:
-                body = fh.read()
-            ok = "__manifest__" in body and AGENT_SCHEMA in body
+        man = any_declared_manifest(path)
+        ok = man is not None and man.get("schema") == AGENT_SCHEMA
         if not ok:
             missing.append(os.path.relpath(path, ROOT))
     if missing:
@@ -243,8 +304,8 @@ def r2_manifest_present():
 def r3_manifest_complete():
     required = ["schema", "name", "version", "description", "capabilities"]
     bad = []
-    for path in agent_files():
-        man = declared_manifest(path) or {}
+    for path in all_agent_files():
+        man = any_declared_manifest(path) or {}
         gaps = [k for k in required if k not in man]
         if gaps:
             bad.append(f"{os.path.basename(path)} lacks {gaps}")

--- a/python/tests/test_conformance_js_manifest.py
+++ b/python/tests/test_conformance_js_manifest.py
@@ -1,0 +1,95 @@
+"""A manifest inside a string is not a manifest.
+
+R2 used to accept any non-Python agent whose file merely *contained* the
+substrings ``__manifest__`` and ``rapp-agent/1.0``, and R3 skipped non-Python
+agents entirely. Both were true of ``ComputerUseAgent.ts`` while it exported no
+manifest at all: a generated block had been inserted at an offset that fell
+inside the Python source string the agent passes to ``python3``. Conformance
+reported "8 passed, 0 failed" over a file whose manifest the runtime could not
+see and whose OCR script was a syntax error.
+
+A manifest block spans lines, and the only JavaScript string that can span
+lines is a template literal, so backtick parity is what separates a declaration
+from text that resembles one.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+import conformance  # noqa: E402
+
+
+REAL = """
+export class Thing {}
+
+export const __manifest__ = {
+  schema: 'rapp-agent/1.0',
+  name: '@openrappter/thing',
+  version: '1.0.0',
+  description: 'A thing.',
+  capabilities: ['network', 'filesystem-write'],
+} as const;
+"""
+
+BURIED = """
+export class Thing {
+  async run() {
+    await exec(`python3 -c "
+import sys
+
+export const __manifest__ = {
+  schema: 'rapp-agent/1.0',
+  name: '@openrappter/thing',
+  version: '1.0.0',
+  description: 'A thing.',
+  capabilities: ['network'],
+} as const;
+print('hi')
+"`);
+  }
+}
+"""
+
+
+def _write(tmp_path, body):
+    p = tmp_path / "Thing.ts"
+    p.write_text(body, encoding="utf-8")
+    return str(p)
+
+
+def test_reads_a_real_declaration(tmp_path):
+    man = conformance.js_declared_manifest(_write(tmp_path, REAL))
+    assert man is not None
+    assert man["schema"] == "rapp-agent/1.0"
+    assert man["name"] == "@openrappter/thing"
+    assert man["capabilities"] == ["network", "filesystem-write"]
+
+
+def test_ignores_a_manifest_buried_in_a_template_literal(tmp_path):
+    # The exact shape that hit ComputerUseAgent.ts. Every substring a text
+    # check looks for is present; none of it is a declaration.
+    path = _write(tmp_path, BURIED)
+    assert "__manifest__" in Path(path).read_text(encoding="utf-8")
+    assert "rapp-agent/1.0" in Path(path).read_text(encoding="utf-8")
+    assert conformance.js_declared_manifest(path) is None
+
+
+def test_finds_a_real_declaration_after_a_template_literal(tmp_path):
+    # Anti-vacuity: backtick parity must not reject everything that follows a
+    # template literal, only what sits inside one.
+    man = conformance.js_declared_manifest(_write(tmp_path, BURIED + REAL))
+    assert man is not None
+    assert man["name"] == "@openrappter/thing"
+
+
+@pytest.mark.parametrize("check", ["r2_manifest_present", "r3_manifest_complete"])
+def test_shipped_agents_satisfy_the_contract(check):
+    ok, detail = getattr(conformance, check).__wrapped__() \
+        if hasattr(getattr(conformance, check), "__wrapped__") \
+        else getattr(conformance, check)()
+    assert ok, detail


### PR DESCRIPTION
## Following #268 to its root

#268 fixed a `__manifest__` block that had been inserted inside a Python source
string, and strengthened the TypeScript-side guard. This round asks the obvious
follow-up: **what else believed that file was fine?**

`conformance.py` did. With the corrupted file in place it reports:

```
8 passed, 0 failed, 1 skipped
```

while the module exports no manifest at all. R2's non-Python branch was:

```python
ok = "__manifest__" in body and AGENT_SCHEMA in body
```

A substring test. The corrupted file contained both strings — inside a Python
script string — so the gate certified it. R3, which checks that a manifest
carries the fields the registry needs, ran over `agent_files()`, which is
"Python agents only". TypeScript manifests were never checked for required
fields at all.

## The fix

`js_declared_manifest` reads the declaration statically. It deliberately does
not import the module, for the reason the existing `declared_manifest`
docstring gives: deciding whether to trust a file by running it is the wrong
order.

A manifest block spans lines, and the only JavaScript string that can span
lines is a template literal, so **backtick parity** is what separates a
declaration from text that resembles one. That is a narrow rule, and I chose it
deliberately — see below.

R2 now reads the declaration in every language; R3 now runs over
`all_agent_files()`.

## What that immediately caught

`morning_brief_agent.js` declared `name: '@openrappter/morning_brief_agent'`,
which is not `@scope/slug`. R3 has enforced that shape for Python agents all
along; this file was simply never checked. Renamed to
`@openrappter/morning-brief`. Nothing referenced the old string — the
references elsewhere are all to the *filename*, which is unchanged.

## A note on how I got here

My first attempt was a proper JavaScript lexer in Python — masking strings,
template literals and comments so offsets still aligned. It was wrong. It
desynchronised partway through `ComputerUseAgent.ts` and blanked the very
declaration it was meant to find, so the checker reported the fixed file as
broken.

I could have debugged it. I threw it away instead: a hand-rolled lexer is a
poor bet for a gate whose whole job is to be trustworthy, and its failure mode
is a confident false result — the exact thing this PR is fixing. Backtick
parity is far less clever and covers the case that can actually occur.

## Evidence

- **Mutation-tested against the real defect:** with the pre-#268 file restored,
  the strengthened gate fails R2 and R3 naming that file. The old gate passed.
- **Mutation-tested the guard:** deleting the parity check makes
  `test_ignores_a_manifest_buried_in_a_template_literal` fail; restoring passes.
- Includes an anti-vacuity test that a real declaration *after* a template
  literal is still found, so parity cannot reject everything downstream.
- `conformance.py`: **8 passed, 0 failed, 1 skipped** (R9 skips — no keyring).
- Python suite: **1558 passed**, 6 skipped, unchanged.

## Negatives worth recording

I checked three other things and found nothing, which is the useful result:

- **No generator is at fault.** The corruption came from one bulk commit,
  `2309be2` ("all 43 agents on the RAPP contract, and a gate that can prove
  it"), whose gate is the substring check this PR replaces. No tool in the repo
  writes agent manifests, so there is no recurrence vector to fix.
- **Python agents are clean.** All 21 export a manifest, and `conformance.py`
  already catches a buried one there — I mutation-tested it by burying
  `pokemon_agent`'s manifest in a string, and three checks failed. The blind
  spot was TypeScript-only.
- **`google_voice_agent` is not broken.** A plain package import of it fails
  with `No module named 'agents'`, which looks alarming. It is deliberate:
  the file is written for grail-brainstem portability and the loader builds a
  synthetic `agents.` namespace for exactly this. `discover_agents()` returns
  20 agents including `GoogleVoice`, with no warning. Changing the agent would
  have broken the portability contract that `test_builtin_agents_load.py`
  documents at length. I nearly did.
