### PR TITLE
fix(agents): three agents declared capabilities they cannot reach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Three agents held capabilities they cannot reach** — `DocScannerAgent`,
+  `NotesIntakeAgent` and `WebAgent` declared `process-exec` while importing no
+  `child_process` at all; what they contain is regular-expression `.exec()`
+  calls. The two scanners additionally declared `filesystem-write` while
+  importing only `readdir`, `stat` and `readFile`. Read-only scanners therefore
+  held the two most dangerous capabilities in the vocabulary, so a policy
+  denying either would have refused agents that only match text. `conformance.py`
+  enforces this as R5, but R5 reads Python agents only; TypeScript now has an
+  equivalent check, and R4, R5 and R7 say which runtime they cover.
 - **The conformance gate accepted a manifest that wasn't one** — R2 passed any
   non-Python agent whose file merely *contained* the substrings `__manifest__`
   and `rapp-agent/1.0`, and R3 checked required fields for Python agents only.

--- a/conformance.py
+++ b/conformance.py
@@ -335,8 +335,9 @@ def r4_capabilities_honest():
                        f"{undeclared} ({hint})")
     if bad:
         return False, "; ".join(bad[:3])
-    return True, ("all %d agents declare every capability their syntax tree "
-                  "can reach" % len(agent_files()))
+    return True, ("all %d Python agents declare every capability their syntax "
+                  "tree can reach; TypeScript is covered by "
+                  "capability-reachability.test.ts" % len(agent_files()))
 
 
 @check("R5", "No agent over-declares a capability it cannot reach.")
@@ -355,7 +356,8 @@ def r5_no_over_declaration():
             noisy.append(f"{os.path.basename(path)} claims unused {extra}")
     if noisy:
         return False, "; ".join(noisy[:3])
-    return True, "no agent claims a capability its code does not use"
+    return True, ("no Python agent claims a capability its code does not use; "
+                  "TypeScript is covered by capability-reachability.test.ts")
 
 
 # ── kernel parity ────────────────────────────────────────────────────────────
@@ -404,7 +406,8 @@ def r7_agents_are_portable():
                 offenders.append(f"{os.path.basename(path)} hard-imports {module}")
     if offenders:
         return False, "; ".join(sorted(set(offenders))[:3])
-    return True, "agents import nothing from the kernel beyond basic_agent"
+    return True, ("Python agents import nothing from the kernel beyond "
+                  "basic_agent")
 
 
 # ── licence and provenance ───────────────────────────────────────────────────

--- a/typescript/src/agents/DocScannerAgent.ts
+++ b/typescript/src/agents/DocScannerAgent.ts
@@ -12,10 +12,7 @@ export const __manifest__ = {
   description: 'Scans a directory for documents and notes, reporting file count, types, recent changes, and TODOs found.',
   author: 'Kody Wildfeuer',
   ring: 'ga',
-  capabilities: [
-    'filesystem-write',
-    'process-exec'
-  ],
+  capabilities: [],
   tags: [
     'openrappter',
     'doc-scanner'

--- a/typescript/src/agents/NotesIntakeAgent.ts
+++ b/typescript/src/agents/NotesIntakeAgent.ts
@@ -12,10 +12,7 @@ export const __manifest__ = {
   description: 'Scans an Obsidian vault or notes directory, extracts action items, tags, and identifies smart reminders by urgency.',
   author: 'Kody Wildfeuer',
   ring: 'ga',
-  capabilities: [
-    'filesystem-write',
-    'process-exec'
-  ],
+  capabilities: [],
   tags: [
     'openrappter',
     'notes-intake'

--- a/typescript/src/agents/WebAgent.ts
+++ b/typescript/src/agents/WebAgent.ts
@@ -27,8 +27,7 @@ export const __manifest__ = {
   author: 'Kody Wildfeuer',
   ring: 'ga',
   capabilities: [
-    'network',
-    'process-exec'
+    'network'
   ],
   tags: [
     'openrappter',

--- a/typescript/src/agents/__tests__/capability-reachability.test.ts
+++ b/typescript/src/agents/__tests__/capability-reachability.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * An agent must not declare a capability it cannot reach.
+ *
+ * `conformance.py` enforces this as R5 — "No agent over-declares a capability
+ * it cannot reach" — but R5 walks `agent_files()`, which its own docstring
+ * describes as "Python agents only". No TypeScript agent had ever been checked.
+ *
+ * Three were wrong, all the same way. `DocScannerAgent`, `NotesIntakeAgent`
+ * and `WebAgent` declared `process-exec` while importing no `child_process` at
+ * all; what they contain is regular-expression `.exec()` calls. The two
+ * scanners additionally declared `filesystem-write` while importing only
+ * `readdir`, `stat` and `readFile`. Read-only scanners held the two most
+ * dangerous capabilities in the vocabulary.
+ *
+ * Over-declaration is the mirror of the under-declaration in #244, and it
+ * costs the same thing: a capability that does not mean what it says cannot be
+ * used to make a decision. A policy denying `process-exec` would refuse three
+ * agents that only match text.
+ *
+ * SCOPE, deliberately narrow. Evidence is read from the agent's own file, so
+ * this can only speak for agents whose imports are all Node builtins — an
+ * agent that delegates through a local module may reach a capability this file
+ * cannot see. Those are excluded from the assertion rather than guessed at,
+ * and counted below so the exclusion cannot quietly grow to cover everything.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const agentsDir = path.resolve(here, '..');
+
+/** Evidence that a capability is reachable, mirroring CAPABILITY_EVIDENCE. */
+const EVIDENCE: Record<string, RegExp> = {
+  'process-exec': /from\s+['"](?:node:)?child_process['"]/,
+  'network':
+    /from\s+['"](?:node:)?(?:http|https|net|dns|dns\/promises|tls)['"]|from\s+['"](?:axios|node-fetch|undici|ws)['"]|\bfetch\s*\(/,
+  'filesystem-write':
+    /\b(writeFile|writeFileSync|mkdir|mkdirSync|rmSync|unlink|unlinkSync|appendFile|appendFileSync|copyFile|rename|createWriteStream)\b/,
+};
+
+function agentFiles(): string[] {
+  return readdirSync(agentsDir)
+    .filter((f) => f.endsWith('Agent.ts') && f !== 'BasicAgent.ts');
+}
+
+/**
+ * An agent whose every import is a Node builtin, `./BasicAgent.js` or a type.
+ * `BasicAgent` itself performs no disk or process I/O, so for these files the
+ * source is the whole story.
+ */
+function isSelfContained(source: string): boolean {
+  const imports = [...source.matchAll(/^import\s[^;]*?from\s+['"]([^'"]+)['"]/gm)]
+    .map((m) => m[1]);
+  return imports.every(
+    (spec) => !spec.startsWith('../') && !/^\.\/(?!BasicAgent|types)/.test(spec),
+  );
+}
+
+describe('agents do not declare capabilities they cannot reach', () => {
+  it('checks a meaningful number of agents', () => {
+    // Anti-vacuity: if the self-contained set shrank to nothing, every
+    // assertion below would pass without examining anything.
+    const selfContained = agentFiles().filter((f) =>
+      isSelfContained(readFileSync(path.join(agentsDir, f), 'utf8')),
+    );
+    expect(selfContained.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('no self-contained agent declares an unreachable capability', async () => {
+    const over: string[] = [];
+    for (const file of agentFiles()) {
+      const source = readFileSync(path.join(agentsDir, file), 'utf8');
+      if (!isSelfContained(source)) continue;
+      const mod = (await import(path.join(agentsDir, file))) as Record<
+        string,
+        { capabilities?: readonly string[] } | undefined
+      >;
+      for (const cap of mod.__manifest__?.capabilities ?? []) {
+        const evidence = EVIDENCE[cap];
+        if (evidence && !evidence.test(source)) {
+          over.push(`${file} declares ${cap} with nothing in the file that reaches it`);
+        }
+      }
+    }
+    expect(over).toEqual([]);
+  });
+
+  it('no self-contained agent reaches a capability it did not declare', async () => {
+    const under: string[] = [];
+    for (const file of agentFiles()) {
+      const source = readFileSync(path.join(agentsDir, file), 'utf8');
+      if (!isSelfContained(source)) continue;
+      const mod = (await import(path.join(agentsDir, file))) as Record<
+        string,
+        { capabilities?: readonly string[] } | undefined
+      >;
+      const declared = new Set(mod.__manifest__?.capabilities ?? []);
+      for (const [cap, evidence] of Object.entries(EVIDENCE)) {
+        if (!declared.has(cap) && evidence.test(source)) {
+          under.push(`${file} reaches ${cap} without declaring it`);
+        }
+      }
+    }
+    expect(under).toEqual([]);
+  });
+});


### PR DESCRIPTION
## The audit

#269 fixed R2 and R3, which claimed to cover every agent and covered only text.
This round asks the same question of the rest: **does each check verify as much
as its title says?**

R1, R2 and R3 walk `all_agent_files()`. **R4, R5 and R7 walk `agent_files()`**,
which its own docstring describes as *"Python agents only — the checks that
parse a syntax tree"*. So R5 — "No agent over-declares a capability it cannot
reach" — had never examined a TypeScript agent.

## What that was hiding

Applying R5's own rule to TypeScript found three agents declaring capabilities
they provably cannot reach:

| agent | declared | actually imports |
|---|---|---|
| `DocScannerAgent` | `filesystem-write`, `process-exec` | `readdir`, `stat`, `readFile`, `path` |
| `NotesIntakeAgent` | `filesystem-write`, `process-exec` | `readdir`, `readFile`, `path` |
| `WebAgent` | `network`, `process-exec` | `dns/promises`, `../net/url-guard.js` |

The cause is visible in the source: each contains regular-expression `.exec()`
calls — one, three and two respectively. Something matched the substring
`exec` and concluded process execution. `PhoneAgent` shows the same shape with
`brain.exec('approval', 'list')`, an RPC method that happens to share the name;
I left its declarations alone because it genuinely reaches those capabilities
through nine local imports.

`BasicAgent` performs no disk or process I/O, so for the two scanners the
source really is the whole story: they are read-only, and they were holding the
two most dangerous capabilities in the vocabulary. There is no
`filesystem-read` capability to move to — reading is not declarable — and six
agents already ship `capabilities: []`, so that is the honest value.

This is the mirror of #244, where `PhoneAgent` under-declared and became
invisible to a `network` filter. Over-declaration costs the same thing from the
other side: a policy denying `process-exec` would refuse three agents that only
match text.

## The guard, and its limits

`capability-reachability.test.ts` applies the evidence rule in both directions.

It asserts only over agents whose every import is a Node builtin, `BasicAgent`
or a type — 15 of 34. An agent that delegates through a local module may reach
a capability its own file cannot show, and I would rather exclude those than
guess. The excluded ones are excluded by a rule, not a list, and a third test
fails if the self-contained set ever shrinks below eight, so the exclusion
cannot quietly grow to cover everything.

**`WebAgent` is one of the excluded ones** — it imports `../net/url-guard.js`.
I found that out because my first mutation test used `WebAgent`, reintroduced
`process-exec`, and the suite stayed green. The fix to `WebAgent` is still
right (verified by hand: zero exec references), but the guard cannot defend it,
and a mutation test that proves nothing is worse than none. I redid it against
`DocScannerAgent`, which is genuinely self-contained.

## On the check titles

I did not touch them. R4, R5 and R7 are the RAPP spec, reproduced in
`docs/RAPP.md`, and the spec is right — the contract *is* language-independent.
The implementation is partial. So the titles stand and the **detail lines** now
say which runtime was examined:

```
PASS  R5   No agent over-declares a capability it cannot reach.
      no Python agent claims a capability its code does not use;
      TypeScript is covered by capability-reachability.test.ts
```

A gate should not imply coverage it does not have, but it also should not
rewrite the contract to match its own limits.

## Evidence

- Mutation-tested in both directions on a genuinely self-contained agent:
  adding `process-exec` to `DocScannerAgent` fails the over-declaration test;
  removing `network` from `HackerNewsAgent` fails the under-declaration test.
- TypeScript: **4792 passed**, 21 skipped, `tsc` clean.
- Python: **1563 passed**. `conformance.py`: **8 passed, 0 failed**.
