### PR TITLE
fix(conformance): R6 and R8 could not detect the violations they exist to catch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Two conformance checks could not fail** — R8 asserts the RAPP substrate is
+  attributed, which its own docstring calls the licence condition, but it
+  tested for `rapp` as a plain substring, and open**rapp**ter contains it; the
+  check passed on a README with every mention of the substrate deleted (`mit`
+  was the same shape, satisfied by "commit"). R6 asserts the brainstem keeps
+  wire parity, but tested for the bare word `response`, which survives in
+  `send_response`; renaming every `"response":` key in the `/chat` envelope —
+  the exact breakage R6 exists to prevent — left it reporting parity. Both now
+  match the token rather than the substring.
 - **Three agents held capabilities they cannot reach** — `DocScannerAgent`,
   `NotesIntakeAgent` and `WebAgent` declared `process-exec` while importing no
   `child_process` at all; what they contain is regular-expression `.exec()`

--- a/conformance.py
+++ b/conformance.py
@@ -415,13 +415,22 @@ def r7_agents_are_portable():
 @check("R8", "The RAPP substrate is attributed.")
 def r8_attribution():
     """RAPP is open and MIT-licensed; this organism stands on it. Saying so is
-    both the licence condition and the point of the architecture."""
+    both the licence condition and the point of the architecture.
+
+    The token has to stand alone. `rapp` as a plain substring is satisfied by
+    the project's own name — openRAPPter contains it — so the check used to
+    pass on a README with every mention of the substrate deleted. A licence
+    condition that cannot fail is worse than none: it reports compliance
+    without ever having looked."""
+    substrate = re.compile(r"(?<![a-z0-9])rapp(?![a-z])")
+    licence = re.compile(r"(?<![a-z0-9])mit(?![a-z])")
     for name in ("README.md", "LICENSE", "NOTICE"):
         path = os.path.join(ROOT, name)
         if os.path.isfile(path):
             with open(path, encoding="utf-8", errors="replace") as fh:
                 body = fh.read().lower()
-            if "rapp" in body and ("mit" in body or "rapp-1" in body):
+            if substrate.search(body) and (licence.search(body)
+                                           or "rapp-1" in body):
                 return True, f"{name} attributes the RAPP substrate"
     return False, "no file attributes RAPP as the underlying substrate"
 

--- a/conformance.py
+++ b/conformance.py
@@ -375,7 +375,11 @@ def r6_kernel_parity():
     missing = [r for r in required if f'"{r}"' not in body and f"'{r}'" not in body]
     if missing:
         return False, "routes absent from the brainstem: %s" % ", ".join(missing)
-    if "response" not in body:
+    if '"response":' not in body and "'response':" not in body:
+        # The bare word is not evidence: `send_response` is a standard
+        # BaseHTTPRequestHandler method, so "response" appears in any server
+        # whatever its reply envelope looks like. Renaming every `"response":`
+        # key in the brainstem left this check passing.
         return False, "the /chat reply field `response` is not present"
     return True, "routes %s present; /chat replies in `response`" % ", ".join(required)
 

--- a/python/tests/test_conformance_r6_wire_parity.py
+++ b/python/tests/test_conformance_r6_wire_parity.py
@@ -1,0 +1,79 @@
+"""R6 has to be able to notice the wire changing.
+
+R6 asserts the brainstem keeps wire parity with the RAPP kernel — the point
+being that a client trained against a RAPP brainstem keeps working here. It
+checked ``"response" not in body`` for the reply envelope, and ``response`` is
+a substring of ``send_response``, a standard ``BaseHTTPRequestHandler`` method.
+Renaming every ``"response":`` key in the brainstem left R6 reporting parity.
+
+Renaming the reply field is the exact breakage R6 exists to prevent.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+import conformance  # noqa: E402
+
+
+ROUTES = '''
+class Handler(BaseHTTPRequestHandler):
+    def do_GET(self):
+        if self.path == "/health":
+            pass
+        elif self.path == "/version":
+            pass
+        elif self.path == "/agents":
+            pass
+        elif self.path == "/models":
+            pass
+
+    def do_POST(self):
+        if self.path == "/chat":
+            self.send_response(200)
+            self.wfile.write(json.dumps({%s}).encode())
+'''
+
+
+@pytest.fixture
+def brainstem(tmp_path, monkeypatch):
+    def write(body):
+        path = tmp_path / "brainstem.py"
+        path.write_text(body, encoding="utf-8")
+        monkeypatch.setattr(conformance, "BRAINSTEM", str(path))
+        return path
+    return write
+
+
+def test_a_faithful_brainstem_passes(brainstem):
+    brainstem(ROUTES % '"response": reply')
+    ok, detail = conformance.r6_kernel_parity()
+    assert ok, detail
+
+
+def test_send_response_alone_is_not_the_envelope(brainstem):
+    # Every route present, `send_response` present, and no reply field at all.
+    # This is what R6 used to accept.
+    brainstem(ROUTES % '"reply": reply')
+    ok, detail = conformance.r6_kernel_parity()
+    assert not ok, detail
+    assert "response" in detail
+
+
+def test_a_missing_route_is_caught(brainstem):
+    body = ROUTES % '"response": reply'
+    brainstem(body.replace('"/models"', '"/model-list"'))
+    ok, detail = conformance.r6_kernel_parity()
+    assert not ok, detail
+    assert "/models" in detail
+
+
+def test_the_shipped_brainstem_keeps_parity():
+    # Anti-vacuity: the rule must not be so strict that the brainstem it ships
+    # alongside fails it.
+    ok, detail = conformance.r6_kernel_parity()
+    assert ok, detail

--- a/python/tests/test_conformance_r8_attribution.py
+++ b/python/tests/test_conformance_r8_attribution.py
@@ -1,0 +1,74 @@
+"""R8 has to be able to fail.
+
+R8 asserts that the RAPP substrate is attributed, and its own docstring calls
+that "the licence condition". It tested ``"rapp" in body``, which the project's
+own name satisfies — open**rapp**ter contains it — so the check passed on a
+README with every mention of the substrate deleted. It reported compliance with
+a licence obligation without ever having looked.
+
+``"mit"`` was the same shape: satisfied by "commit", "submit" or "permit".
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+import conformance  # noqa: E402
+
+
+@pytest.fixture
+def repo(tmp_path, monkeypatch):
+    """A throwaway repo root whose README this test controls."""
+    monkeypatch.setattr(conformance, "ROOT", str(tmp_path))
+    return tmp_path
+
+
+def test_the_project_name_alone_is_not_attribution(repo):
+    # Every token R8 used to look for, and no attribution whatsoever:
+    # "openrappter" contains "rapp", and "commit" contains "mit".
+    (repo / "README.md").write_text(
+        "# openrappter\n\nRun openrappter, then commit your changes.\n",
+        encoding="utf-8",
+    )
+    ok, detail = conformance.r8_attribution()
+    assert not ok, detail
+
+
+def test_a_real_attribution_passes(repo):
+    (repo / "README.md").write_text(
+        "# openrappter\n\nBuilt on RAPP, which is MIT-licensed.\n",
+        encoding="utf-8",
+    )
+    ok, detail = conformance.r8_attribution()
+    assert ok, detail
+
+
+def test_attribution_may_live_in_notice_instead(repo):
+    # R8 accepts any of README, LICENSE or NOTICE; a README that does not
+    # attribute must not stop a NOTICE that does from counting.
+    (repo / "README.md").write_text("# openrappter\n\nJust commit.\n",
+                                    encoding="utf-8")
+    (repo / "NOTICE").write_text("This product includes RAPP (MIT).\n",
+                                 encoding="utf-8")
+    ok, detail = conformance.r8_attribution()
+    assert ok, detail
+
+
+def test_mit_must_be_a_word_not_a_fragment(repo):
+    # "permit" is not a licence.
+    (repo / "README.md").write_text(
+        "# openrappter\n\nBuilt on RAPP. We permit anything.\n", encoding="utf-8"
+    )
+    ok, _ = conformance.r8_attribution()
+    assert not ok
+
+
+def test_the_shipped_repository_really_is_attributed():
+    # Anti-vacuity in the other direction: the rule above must not be so strict
+    # that the repository it ships in fails it.
+    ok, detail = conformance.r8_attribution()
+    assert ok, detail


### PR DESCRIPTION
## Finishing the conformance audit

#269 and #270 covered R2/R3 and R4/R5/R7. This is R6 and R8, the two left.

Both could pass over a repository that violated them.

## R8 — a licence condition that never looked

R8's docstring says attribution is "both the licence condition and the point of
the architecture". The test was:

```python
if "rapp" in body and ("mit" in body or "rapp-1" in body):
```

`rapp` as a plain substring is satisfied by the project's own name —
open**rapp**ter contains it. `mit` is satisfied by "commit", "submit",
"permit".

**Proof:** I replaced every standalone `RAPP` token in `README.md` with
`SUBSTRATE`, leaving the project name and the word "commit" alone. R8 reported:

```
PASS  R8   The RAPP substrate is attributed.
      README.md attributes the RAPP substrate
```

A check that reports compliance with a licence obligation without having looked
is worse than no check: it is the basis on which someone stops worrying.

## R6 — parity that survives the wire changing

R6 verifies the brainstem keeps wire parity with the RAPP kernel, so that a
client trained against a RAPP brainstem keeps working here. The route check is
sound — it looks for the *quoted* `"/chat"`, which appears only in the dispatch,
and I confirmed by mutation that renaming the handler fails it. I had assumed
the module docstring listing the routes would satisfy it; it does not, and I
was wrong about that.

The envelope check was not sound:

```python
if "response" not in body:
```

`response` is a substring of `send_response`, a standard
`BaseHTTPRequestHandler` method.

**Proof:** renaming all three `"response":` keys in the `/chat` envelope to
`"reply":` left R6 reporting:

```
PASS  R6   The brainstem keeps wire parity with the RAPP kernel.
      routes ... present; /chat replies in `response`
```

Renaming the reply field is the precise breakage R6 exists to prevent.

## The fix

Both now match a token rather than a substring: a standalone `rapp` and `mit`
for R8, the quoted key `"response":` for R6. Neither rule is clever, and both
are mutation-tested in the failing direction, which is the direction that had
never been exercised.

## Evidence

- R8: passes on the real README; **fails** when attribution is stripped.
- R6: passes on the real brainstem; **fails** when the envelope key is renamed,
  and separately when a route is renamed.
- Both new test files assert the shipped repository still satisfies the rule,
  so a stricter check cannot pass by rejecting everything.
- Reverting either implementation fails the new tests; restoring passes.
- `conformance.py`: **8 passed, 0 failed, 1 skipped**. Python: **1572 passed**.

## Where the gate stands now

Across #269, #270 and this PR, every check I could reach has been mutation-
tested against the failure it claims to prevent. R9 is the exception — it needs
`rapp-keyring`, which is not installed here, so it skips and I could not
exercise it. I have not verified R9 and am not claiming to.
