### PR TITLE
fix(ci): the PR gate installed its credential broker unpinned, and R9's contract tests skipped where R9 ran

### DIFF
--- a/.github/workflows/rapp-conformance.yml
+++ b/.github/workflows/rapp-conformance.yml
@@ -21,7 +21,24 @@ jobs:
       # credential scan could stop running entirely behind a green build. A
       # security check that can quietly disappear is not a security check.
       - name: Install RAPP Keyring
-        run: curl -fsSL https://kody-w.github.io/rapp-keyring/install.sh | bash
+        # Pinned and checksummed, matching release.yml and flight-recorder.yml.
+        # This step runs on every pull request, so an unpinned `curl | bash`
+        # would let whoever controls the Pages site run code in CI on every
+        # proposed change — including the run that decides whether the change
+        # is compliant. The two workflows that install the same broker already
+        # do it this way.
+        run: |
+          set -euo pipefail
+          KEYRING_SHA=89386724e9bf8b365ce3bd2847fbcc06365953d5
+          curl -fsSL \
+            "https://raw.githubusercontent.com/kody-w/rapp-keyring/$KEYRING_SHA/install.sh" \
+            -o "$RUNNER_TEMP/keyring-install.sh"
+          echo "a41a8e50f7a1a29212a402024bb65b8e9060e2b6f3bc4594b16d066ff666542c  $RUNNER_TEMP/keyring-install.sh" \
+            | sha256sum -c -
+          sed -i \
+            "s|https://raw.githubusercontent.com/\${REPO}/main|https://raw.githubusercontent.com/\${REPO}/$KEYRING_SHA|" \
+            "$RUNNER_TEMP/keyring-install.sh"
+          bash "$RUNNER_TEMP/keyring-install.sh"
 
       # Fail here, legibly, rather than as an unexplained SKIP three steps
       # later. R9 looks on PATH and then at ~/.local/bin, which is where the

--- a/conformance.py
+++ b/conformance.py
@@ -439,11 +439,26 @@ def r8_attribution():
     return False, "no file attributes RAPP as the underlying substrate"
 
 
-@check("R9", "The repository contains no credential of its own.")
-def r9_no_secrets():
+def keyring_broker():
+    """The credential broker R9 will use, or None.
+
+    Both R9 and the tests that verify the broker's JSON contract must look in
+    the same place. When the tests looked only in ~/.local/bin while R9 also
+    honoured PATH, a machine with the broker on PATH alone ran R9 while
+    skipping every contract test — so the check executed against a contract
+    nothing had checked. CI installs to ~/.local/bin, which is why the two
+    agreed there and the drift went unnoticed."""
     broker = shutil.which("rapp-keyring") or \
         os.path.expanduser("~/.local/bin/rapp-keyring")
-    if not (os.path.isfile(broker) and os.access(broker, os.X_OK)):
+    if os.path.isfile(broker) and os.access(broker, os.X_OK):
+        return broker
+    return None
+
+
+@check("R9", "The repository contains no credential of its own.")
+def r9_no_secrets():
+    broker = keyring_broker()
+    if broker is None:
         return None, ("rapp-keyring not installed; cannot run the credential scan "
                       "(curl -fsSL https://kody-w.github.io/rapp-keyring/install.sh | bash)")
     tracked = subprocess.run(["git", "ls-files"], cwd=ROOT,

--- a/python/tests/test_conformance_r9.py
+++ b/python/tests/test_conformance_r9.py
@@ -182,9 +182,9 @@ def test_pragma_suppressions_are_surfaced_rather_than_silently_dropped(tmp_path,
 
 # ── the contract we are relying on, checked against the real tool ────────────
 
-REAL_BROKER = os.path.expanduser("~/.local/bin/rapp-keyring")
+REAL_BROKER = conformance.keyring_broker()
 needs_broker = pytest.mark.skipif(
-    not (os.path.isfile(REAL_BROKER) and os.access(REAL_BROKER, os.X_OK)),
+    REAL_BROKER is None,
     reason="rapp-keyring not installed; CI installs it and runs these")
 
 


### PR DESCRIPTION
## R9 was the one check I had never been able to run

Across #269, #270 and #271 I mutation-tested every conformance check against
the failure it claims to prevent — except R9, which skips without
`rapp-keyring`. This round runs it.

Two findings, and one thing that turned out to be already excellent.

## R9 itself is the best-reasoned check in the file

I want to record this rather than bury it. R9 already distinguishes a scanner
that ran and found nothing from a scanner that could not run:

> a broker that failed outright printed nothing at all, so nothing matched, the
> count stayed zero, and the check reported a clean bill of health over files it
> had never opened.

It checks exit codes, refuses to treat a broker failure as an absence of
findings, and skips honestly when the tool is missing. Its test file has ten
tests including an end-to-end detection against a real broker. Nothing to fix.

**Verified:** installed the broker to a temp prefix and ran it. Conformance is
`9 passed, 0 failed, 0 skipped`, 1350 tracked files scanned.

## Finding 1 — the PR gate installed its broker unpinned

`release.yml` and `flight-recorder.yml` install `rapp-keyring` by pinned SHA,
verify the installer with `sha256sum -c -`, and rewrite its internal `main`
reference to the pinned commit. `rapp-conformance.yml`, which runs on **every
pull request**, did this:

```yaml
run: curl -fsSL https://kody-w.github.io/rapp-keyring/install.sh | bash
```

So whoever controls that Pages site could run code in CI on every proposed
change — including the run that decides whether the change is compliant. The
hardened pattern already existed in the same repository, for the same
dependency.

Now pinned, using the same SHA and checksum the other two workflows already
carry. **Verified end to end**, not just copied: I downloaded the pinned
installer, confirmed the checksum matches (it does), confirmed the `sed`
substitution target actually exists in the script — it occurs exactly once, at
`RAW="https://raw.githubusercontent.com/${REPO}/main"`, so the pinning is real
and not a silent no-op — then ran the whole sequence into a temp prefix and
confirmed a working `rapp-keyring 0.1.0`.

The Pages script is currently byte-identical to the pinned commit, so nothing
was wrong; there was simply no protection against it changing.

## Finding 2 — the contract tests skipped where R9 ran

R9 resolves the broker as `shutil.which("rapp-keyring")` **or**
`~/.local/bin/rapp-keyring`. The tests that verify the broker's JSON contract
resolved it as `~/.local/bin/rapp-keyring` only.

On a machine with the broker on PATH but not in `~/.local/bin` — which is
exactly what I had — **R9 runs while all four contract tests skip**. The check
executes against a contract nothing verified. Among the four is
`test_r9_end_to_end_catches_a_credential_committed_to_a_repo`, the only test
that proves R9 can detect anything at all.

CI installs to `~/.local/bin`, so the two agreed there and the drift never
surfaced. It would have surfaced as a *failure* eventually: the workflow fails
the build if any R9 test skips, so a runner with a differently-placed broker
would have failed CI for a reason that had nothing to do with the change.

Both now call one `keyring_broker()` helper, so they cannot disagree again.

## Evidence

- Broker on PATH only: **10 passed** (was 6 passed, 4 skipped).
- No broker at all: **6 passed, 4 skipped** — still honest.
- `conformance.py`: **9 passed, 0 failed, 0 skipped**.
- Python suite: **1576 passed, 2 skipped** — skips fell from 6 because the four
  R9 contract tests now run.
- Workflow YAML parses; the install step is asserted to carry the pinned SHA
  and checksum and to contain no `| bash`.
