### PR TITLE
fix(ci): one workflow referenced a third-party action by mutable tag while another pinned it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,7 +107,9 @@ jobs:
         working-directory: macos
     steps:
       - uses: actions/checkout@v4
-      - uses: swift-actions/setup-swift@v2
+      # Pinned by commit, matching release-bar.yml. A mutable tag on a
+      # third-party action lets its maintainer change what runs here.
+      - uses: swift-actions/setup-swift@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a # v2
         with:
           swift-version: '6.0'
       - run: swift build -c release --product OpenRappterBar

--- a/typescript/src/__tests__/integration/workflow-action-pinning.test.ts
+++ b/typescript/src/__tests__/integration/workflow-action-pinning.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A third-party action must be pinned to a commit.
+ *
+ * A tag is mutable. `uses: someone/action@v2` runs whatever that maintainer
+ * decides `v2` means at the moment the job starts, which for a workflow with
+ * repository credentials is a standing invitation.
+ *
+ * This repository already knew that: `pypa/gh-action-pypi-publish` and
+ * `softprops/action-gh-release` are pinned by SHA, and `release-bar.yml` pins
+ * `swift-actions/setup-swift`. But `ci.yml` referenced that same action as
+ * `@v2` — the identical inconsistency as the credential broker in #272, where
+ * two workflows pinned an installer and the one running on every pull request
+ * did not.
+ *
+ * SCOPE. `actions/*` and `github/*` are exempt. They are published by GitHub
+ * itself from the same trust boundary the runner already lives in, they
+ * receive security fixes within a major tag, and this repository has no
+ * Dependabot to refresh a frozen SHA. Pinning those 49 references is a
+ * maintenance policy for the owner to choose, not a rule to smuggle in through
+ * a test — see the issue this test's PR links. The rule here is only the one
+ * the repository already follows everywhere else.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const workflowsDir = path.resolve(here, '../../../..', '.github/workflows');
+
+const FIRST_PARTY = /^(actions|github)\//;
+const COMMIT_SHA = /^[0-9a-f]{40}$/;
+
+interface Ref {
+  workflow: string;
+  action: string;
+  ref: string;
+}
+
+function actionReferences(): Ref[] {
+  const refs: Ref[] = [];
+  for (const file of readdirSync(workflowsDir).filter((f) => /\.ya?ml$/.test(f))) {
+    const source = readFileSync(path.join(workflowsDir, file), 'utf8');
+    for (const line of source.split('\n')) {
+      // Skip comments so a commented-out example cannot fail the build.
+      if (/^\s*#/.test(line)) continue;
+      const m = /^\s*-?\s*uses:\s*["']?([^"'\s@]+)@([^"'\s#]+)/.exec(line);
+      if (!m) continue;
+      const [, action, ref] = m;
+      if (action.startsWith('./') || action.startsWith('docker://')) continue;
+      refs.push({ workflow: file, action, ref });
+    }
+  }
+  return refs;
+}
+
+describe('third-party actions are pinned to a commit', () => {
+  it('finds the actions this repository uses', () => {
+    // Anti-vacuity: a parse that matched nothing would make the rule below
+    // hold over an empty set.
+    const refs = actionReferences();
+    expect(refs.length).toBeGreaterThan(20);
+    expect(refs.some((r) => FIRST_PARTY.test(r.action))).toBe(true);
+    expect(refs.some((r) => !FIRST_PARTY.test(r.action))).toBe(true);
+  });
+
+  it('every third-party action is referenced by commit, never a tag', () => {
+    const mutable = actionReferences()
+      .filter((r) => !FIRST_PARTY.test(r.action))
+      .filter((r) => !COMMIT_SHA.test(r.ref))
+      .map((r) => `${r.workflow}: ${r.action}@${r.ref} is a mutable reference`);
+    expect(mutable).toEqual([]);
+  });
+
+  it('the same action is not pinned two different ways', () => {
+    // The failure in #272 and here was not an unpinned dependency in the
+    // abstract — it was one workflow disagreeing with another about the same
+    // dependency, which is how a hardened pattern grows a hole.
+    const byAction = new Map<string, Set<string>>();
+    for (const r of actionReferences()) {
+      if (FIRST_PARTY.test(r.action)) continue;
+      if (!byAction.has(r.action)) byAction.set(r.action, new Set());
+      byAction.get(r.action)!.add(r.ref);
+    }
+    const divergent = [...byAction.entries()]
+      .filter(([, refs]) => refs.size > 1)
+      .map(([action, refs]) => `${action} is referenced as ${[...refs].join(' and ')}`);
+    expect(divergent).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Sweeping for the pattern #272 found

#272 fixed a workflow that installed its credential broker with an unpinned
`curl | bash` while two sibling workflows pinned the same installer by SHA.
This checks whether that shape appears anywhere else.

**No `curl | bash` remains** in any workflow. But the same *inconsistency*
does, one layer up.

## The finding

`swift-actions/setup-swift` is referenced two ways:

| workflow | reference |
|---|---|
| `release-bar.yml` | `@7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a` |
| `ci.yml` | `@v2` |

A tag is mutable: `@v2` runs whatever that maintainer decides `v2` means when
the job starts. It is the only third-party action in the repository referenced
by tag — `pypa/gh-action-pypi-publish` and `softprops/action-gh-release` are
both pinned. So this is not a missing convention, it is one workflow that
missed it.

**The tag currently resolves to exactly the commit `release-bar.yml` pins.** I
checked, dereferencing the annotated tag object rather than trusting the ref:

```
v2 tag -> commit 7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a
release-bar pin:  7ca6abe6b3b0e8b5421b88be48feee39cbf52c6a
```

So this changes nothing about what runs today. It only removes the ability for
it to change without a commit here.

## The guard

`workflow-action-pinning.test.ts` enforces three things:

1. every third-party action is referenced by commit
2. no action is referenced two different ways in different workflows
3. the parse actually found both first- and third-party actions

The second is the one that matters. Neither this nor #272 was an unpinned
dependency in the abstract — both were **one workflow disagreeing with another
about the same dependency**, which is how a hardened pattern grows a hole while
looking fine in review.

Mutation-tested: restoring `@v2` fails tests 1 and 2 with
`ci.yml: swift-actions/setup-swift@v2 is a mutable reference` and
`swift-actions/setup-swift is referenced as v2 and 7ca6abe...`.

## What I deliberately did not do

**49 references remain on mutable tags, all `actions/*`.** I did not pin them,
and the test exempts them explicitly rather than silently.

This repository has **no Dependabot or Renovate configuration**. A tag gets
security fixes within its major version for free; a pinned SHA does not.
Pinning 49 references with no update mechanism trades a small supply-chain risk
for a guaranteed, invisible drift into unpatched actions. That is a maintenance
policy with a real recurring cost — a stream of update PRs — and it is not mine
to impose through a test.

Filed as #273 with the three options I can see and no recommendation between
the two reasonable ones.

I will note that `actions/checkout` is *also* referenced both ways today
(`@v4` and `@11d5960...`), as are `setup-node`, `setup-python`,
`upload-artifact` and `download-artifact`. So rule 2 above is currently
enforced only for third-party actions; extending it to first-party would fail
today, which is precisely the decision #273 asks for.

## Evidence

- TypeScript suite: **4795 passed**, 21 skipped (up 3 from the new guard).
- Tag dereferenced through the GitHub API to confirm no behavioural change.
- Guard mutation-tested in the failing direction.
