### PR TITLE
fix(ci): the installer sync check covered one of three duplicated installers

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -53,12 +53,44 @@ jobs:
         run: shellcheck install.sh
 
   docs-sync:
-    name: Verify docs/install.sh is in sync
+    name: Verify the docs/ installer copies are in sync
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Check docs/install.sh matches root install.sh
-        run: diff install.sh docs/install.sh
+      # Three installers are served from docs/ for GitHub Pages and must match
+      # the canonical copies at the repository root. This used to compare
+      # install.sh alone, so editing install.ps1 or install.bat and forgetting
+      # the docs/ copy would have shipped a stale script to every Windows user
+      # piping from Pages, with nothing to catch it.
+      #
+      # Discovered rather than listed, so a fourth pair is covered the day it
+      # appears.
+      - name: Check every docs/ installer matches its canonical copy
+        run: |
+          set -uo pipefail
+          checked=0
+          status=0
+          for canonical in install.*; do
+            [ -f "$canonical" ] || continue
+            served="docs/$canonical"
+            if [ ! -f "$served" ]; then
+              echo "::error::$canonical has no served copy at $served"
+              status=1
+              continue
+            fi
+            if ! diff -u "$canonical" "$served"; then
+              echo "::error::$served has drifted from $canonical"
+              status=1
+            fi
+            checked=$((checked + 1))
+          done
+          # Anti-vacuity: a glob that matched nothing would pass silently.
+          if [ "$checked" -lt 3 ]; then
+            echo "::error::expected at least 3 installer pairs, compared $checked"
+            exit 1
+          fi
+          echo "compared $checked installer pairs"
+          exit $status
 
   docker-smoke:
     name: Docker smoke test (npm method)


### PR DESCRIPTION
## Auditing the rest of install.sh

#275 fixed a checksum check in `install.sh` that could pass having verified
nothing. That was one function; this round read the rest of the file, because
one confirmed defect is a reason to look at its neighbours.

**The rest holds up.** Recording that, since a negative result is the useful
output when it is measured rather than assumed:

- `download_file` — HTTPS enforced with `--proto '=https' --tlsv1.2` for curl
  and `--https-only --secure-protocol=TLSv1_2` for wget
- `run_verified_remote_bash` — refuses non-HTTPS, refuses on download failure,
  refuses when no hashing tool exists, compares an exact hash, and only then
  executes. Fails closed on every path.
- **The third-party pins are correct.** I fetched both and compared:
  Homebrew `609e8f75` → `12479a24…` ✓, nvm `v0.40.1` → `abdb525e…` ✓. The
  comment explaining that "a tag is NOT a pin - tags move", and that nvm is
  hash-verified anyway because tag immutability is "a promise rather than
  something we can check", is exactly right.
- `effective_channel` / `resolve_pkg_spec` — the note about never calling
  `exit` inside `$( )` is a real subshell hazard, correctly handled
- version reporting — three fallbacks, and it omits the version rather than
  inventing one when all three fail
- `run_quiet_step` — every branch returns 0 only on success
- **`gum spin` exit-code propagation**, which `run_quiet_step` depends on: I
  installed the pinned gum 0.17.0 to a temp dir and measured it, including the
  exact `bash -c "cmd > log 2>&1"` shape. Propagates correctly (7 → 7, 0 → 0,
  `false` → 1). The pin is what keeps that true.

`install.ps1` is also sound: it obtains Node through `winget`/`choco`, which
verify their own packages, and — better than checking an exit code — it
re-reads `Get-NodeVersion` and only reports success if the version actually
meets the minimum.

## The finding

CI has a `docs-sync` job. It compares **one** file:

```yaml
- name: Check docs/install.sh matches root install.sh
  run: diff install.sh docs/install.sh
```

Three installers are duplicated into `docs/` for GitHub Pages — `install.sh`,
`install.ps1` and `install.bat`. Editing the PowerShell or batch installer and
forgetting the `docs/` copy would ship a stale script to every Windows user
piping from Pages, and nothing would catch it.

All three are in sync today, so this is latent rather than live. I know the
failure mode is real because **I hit it last round**: I edited `docs/install.sh`
alone and CI stopped me — but only because `install.sh` is the one file the
check happened to cover.

## The fix

The check now discovers `install.*` pairs rather than naming one, so a fourth
is covered the day it appears. It fails on drift, on a canonical file with no
served copy, and on finding fewer than three pairs — the last so that a glob
matching nothing cannot pass silently.

## Evidence

Extracted the step and ran it:

- three pairs in sync → `compared 3 installer pairs`, exit 0
- `docs/install.ps1` drifted → `::error::docs/install.ps1 has drifted…`, exit 1
- only one pair present → `::error::expected at least 3 installer pairs,
  compared 1`, exit 1
- canonical file with no served copy → `::error::install.ps1 has no served copy
  at docs/install.ps1`

YAML parses.
