### PR TITLE
fix(ci): shellcheck covered one shell script of nineteen

### DIFF
--- a/.github/workflows/install-smoke.yml
+++ b/.github/workflows/install-smoke.yml
@@ -49,8 +49,41 @@ jobs:
       - uses: actions/checkout@v4
       - name: Install shellcheck
         run: sudo apt-get install -y shellcheck
-      - name: Run shellcheck on install.sh
-        run: shellcheck install.sh
+      # Every shell script, not just install.sh. Lint that covers one file out
+      # of nineteen says nothing about the other eighteen, and the repository
+      # ships operational scripts — a pinned installer, a deploy script, an
+      # attachment sender — that are exactly where a quoting mistake hurts.
+      #
+      # Discovered rather than listed. A newer shellcheck may introduce checks
+      # that fail here; that is the intended trade, and the fix is a directive
+      # with a reason next to the line, as the existing ones carry.
+      - name: Run shellcheck on every shell script
+        run: |
+          set -uo pipefail
+          scripts=()
+          while IFS= read -r script; do
+            scripts+=("$script")
+          done < <(
+            find . -name '*.sh' \
+              -not -path './.git/*' \
+              -not -path '*/node_modules/*' \
+              -not -path '*/.build/*' \
+              | sort
+          )
+          # Anti-vacuity: a find that matched nothing would pass silently.
+          if [ "${#scripts[@]}" -lt 15 ]; then
+            echo "::error::expected at least 15 shell scripts, found ${#scripts[@]}"
+            exit 1
+          fi
+          status=0
+          for script in "${scripts[@]}"; do
+            if ! shellcheck "$script"; then
+              echo "::error::shellcheck findings in $script"
+              status=1
+            fi
+          done
+          echo "shellchecked ${#scripts[@]} scripts"
+          exit $status
 
   docs-sync:
     name: Verify the docs/ installer copies are in sync

--- a/install-pinned.sh
+++ b/install-pinned.sh
@@ -138,6 +138,9 @@ install_node_runtime() {
     tar -xzf "$WORK_DIR/$archive" -C "$WORK_DIR/x"
     [ -d "$WORK_DIR/x/$base" ] || die "Node.js archive did not contain $base."
     mv "$WORK_DIR/x/$base" "$RUNTIME_DIR"
+    # Both tests are pure predicates, so `die` runs exactly when either is
+    # false. Not the A && B || C hazard SC2015 warns about.
+    # shellcheck disable=SC2015
     [ -x "$NODE" ] && [ -x "$NPM" ] || die "Extracted Node.js runtime is incomplete."
     printf '%s\n' "$expected" > "$RUNTIME_DIR/.archive-sha256"
     sha256_file "$NODE" > "$RUNTIME_DIR/.node-sha256"

--- a/scripts/deploy-runtime.sh
+++ b/scripts/deploy-runtime.sh
@@ -90,6 +90,10 @@ ln -sfn "$TARGET" "$CURRENT"
 printf '  current  -> %s\n' "$(readlink "$CURRENT")"
 
 # Keep the last five releases so a rollback target always exists.
+# `find` cannot order by mtime, which is the whole point here: keep the five
+# newest releases. Release directories are created by this script with
+# timestamp names, so they contain no whitespace.
+# shellcheck disable=SC2012
 ls -1dt "$RELEASES"/* 2>/dev/null | tail -n +6 | while read -r old; do
   [ "$old" = "$TARGET" ] || rm -rf "$old"
 done

--- a/scripts/send-attachment.sh
+++ b/scripts/send-attachment.sh
@@ -63,6 +63,8 @@ STAGE_DIR="$HOME/Pictures/.openrappter-outbox"
 mkdir -p "$STAGE_DIR"
 STAGED="$STAGE_DIR/$(date +%s)-$$-$(basename "$SOURCE")"
 
+# Invoked by the trap below, which shellcheck does not trace.
+# shellcheck disable=SC2317
 cleanup() { rm -f "$STAGED"; }
 trap cleanup EXIT
 

--- a/tests/install/progress_test.sh
+++ b/tests/install/progress_test.sh
@@ -75,9 +75,13 @@ if missing:
     print(f"WARNING: not extracted: {sorted(missing)}", file=sys.stderr)
 EXTRACT
 
-# The helpers expect these; the installer sets them later.
+# The helpers expect these; the installer sets them later. Read by the sourced
+# helpers rather than by this file, which is what SC2034 sees.
+# shellcheck disable=SC2034
 VERBOSE=0
+# shellcheck disable=SC2034
 GUM=""
+# shellcheck disable=SC2034
 TMPFILES=()
 # shellcheck disable=SC1090
 source "$HELPERS"

--- a/tests/test_install.sh
+++ b/tests/test_install.sh
@@ -64,6 +64,7 @@ assert_executable() {
 
 # ── Source the script for function access ───────────────────
 export OPENRAPPTER_INSTALL_SH_NO_RUN=1
+# shellcheck disable=SC1090
 source "$INSTALL_SCRIPT"
 
 # Pre-load script content for content assertion tests

--- a/tests/test_install_progress.sh
+++ b/tests/test_install_progress.sh
@@ -95,7 +95,6 @@ fi
 
 # ── failures stay diagnosable ────────────────────────────────────────────
 output="$(bash -c "source '$HARNESS'; run_quiet_step 'Broken step' bash -c 'echo \"pip: no matching distribution\" >&2; exit 1'" 2>&1)"
-status=$?
 assert_contains "$output" "pip: no matching distribution" "surfaces the real error from the log"
 assert_contains "$output" "--verbose" "points at --verbose for more detail"
 
@@ -150,8 +149,8 @@ copy_at() {
     bash -c "source '$HARNESS'; spinner_reassurance $1 'Installing Python packages'"
 }
 
-[[ -z "$(copy_at 5)" ]] && ok "stays quiet for the first few seconds" || bad "stays quiet for the first few seconds"
-[[ -n "$(copy_at 25)" ]] && ok "says something by 25s" || bad "says something by 25s"
+if [[ -z "$(copy_at 5)" ]]; then ok "stays quiet for the first few seconds"; else bad "stays quiet for the first few seconds"; fi
+if [[ -n "$(copy_at 25)" ]]; then ok "says something by 25s"; else bad "says something by 25s"; fi
 assert_contains "$(copy_at 65)" "slow by nature" "explains that pip is slow by nature"
 assert_contains "$(copy_at 200)" "several minutes" "sets expectations past three minutes"
 


### PR DESCRIPTION
## The shape, a fourth time

#272: R9's contract tests looked in one of the two places R9 looks for its
broker. #274: one workflow pinned an action another referenced by tag. #277:
the sync check compared one of three duplicated installers.

Same shape here. CI lints shell:

```yaml
- name: Run shellcheck on install.sh
  run: shellcheck install.sh
```

One file. The repository has **nineteen**, including a pinned installer, a
deploy script that deletes old releases, and an attachment sender — exactly
where a quoting mistake hurts.

## What was actually in the other eighteen

I fetched a standalone shellcheck 0.10.0 rather than guess. **Ten findings, no
errors**, and I read every one:

**Two are correct code that shellcheck cannot see through**

- `install-pinned.sh:141` — a two-predicate guard followed by `|| die` trips
  SC2015. Both operands are pure tests, so `die` runs exactly when either is
  false. I chose not to rewrite a pinned installer's verification line to
  satisfy a style note; the directive says why instead.
- `send-attachment.sh:66` — SC2317 "unreachable" on a function invoked by
  `trap`.

**Four are variables consumed by sourced code**

`progress_test.sh` sets `VERBOSE`, `GUM`, `TMPFILES` under its own comment
*"The helpers expect these; the installer sets them later"*, then sources the
helpers. Plus two dynamic `source` paths (SC1090). That file already carried a
`disable=SC1090`, so the directive style is the repository's own.

**Three were worth fixing rather than silencing**

- `tests/test_install_progress.sh` had a dead assignment capturing an exit
  status nothing read. Removed.
- Two lines of the form *test, then `ok` on success or `bad` otherwise*, joined
  with `&&` and `||`. Here SC2015 is *right*: if `ok` ever returned non-zero,
  `bad` would also run and the test would report both a pass and a failure for
  a single assertion. Rewritten as `if`/`else`.

**One is a deliberate `ls`**

`deploy-runtime.sh` uses `ls -1dt` to keep the five newest releases. `find`
cannot order by mtime, which is the entire point.

Net: zero findings across all nineteen, no behaviour changed except the two
assertion lines that were genuinely hazardous.

## The check

Discovered rather than listed, so a twentieth script is covered the day it
lands. It fails on any finding, and fails if it sees fewer than fifteen scripts
— a `find` that matched nothing must not pass silently.

I wrote it with a `while read` loop rather than `mapfile` so it runs on bash
3.2 as well as the runner's bash 5. That is not portability for its own sake:
it meant I could execute the step locally instead of pushing and hoping.

## Evidence

Extracted the step from the YAML and ran it:

- clean tree gives `shellchecked 19 scripts`, exit 0
- a deliberate finding in `quickstart.sh` gives
  `::error::shellcheck findings in ./quickstart.sh`, exit 1
- run where one script exists gives
  `::error::expected at least 15 shell scripts, found 1`, exit 1

`tests/test_install.sh` **127 passed**, `tests/test_install_progress.sh`
**28 passed** — the latter matters because I changed its control flow.
