### PR TITLE
fix(lint): the lint gate reported 17 problems and exited 0

### DIFF
--- a/typescript/eslint.config.js
+++ b/typescript/eslint.config.js
@@ -8,7 +8,15 @@ export default tseslint.config(
   {
     rules: {
       '@typescript-eslint/no-explicit-any': 'off',
-      '@typescript-eslint/no-unused-vars': ['warn', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-vars': ['warn', {
+        // The codebase marks a deliberately-unused binding with a leading
+        // underscore. That was honoured for arguments only, so the same
+        // convention on a variable or a caught error still warned.
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+      }],
       '@typescript-eslint/no-require-imports': 'off',
       '@typescript-eslint/no-unsafe-function-type': 'off',
       '@typescript-eslint/no-unused-expressions': 'off',

--- a/typescript/package.json
+++ b/typescript/package.json
@@ -17,7 +17,7 @@
     "test": "vitest run",
     "test:package": "node scripts/package-smoke.mjs",
     "test:watch": "vitest",
-    "lint": "eslint src/",
+    "lint": "eslint src/ --max-warnings 0",
     "demo": "tsx examples/quickstart.ts",
     "demo:ouroboros": "tsx examples/ouroboros.ts",
     "demo:learn": "tsx examples/learn-new.ts",

--- a/typescript/src/__tests__/integration/approval-event-contract.test.ts
+++ b/typescript/src/__tests__/integration/approval-event-contract.test.ts
@@ -137,7 +137,7 @@ describe('an approval entering the queue reaches the screen watching for it', ()
   });
 
   it('a throwing listener does not break the command it announces', async () => {
-    const port = await startServer();
+    await startServer();
     const safety = server!.getExecSafety();
     safety.onApprovalRequested(() => {
       throw new Error('a watcher blew up');

--- a/typescript/src/__tests__/integration/skills-connections-contract.test.ts
+++ b/typescript/src/__tests__/integration/skills-connections-contract.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { describe, it, expect, afterEach } from 'vitest';
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { mkdtempSync, rmSync, mkdirSync } from 'fs';
 import { join } from 'path';
 import WebSocket from 'ws';
 import { GatewayServer, type SkillsRegistryLike } from '../../gateway/server.js';

--- a/typescript/src/__tests__/unit/rappter-roster.test.ts
+++ b/typescript/src/__tests__/unit/rappter-roster.test.ts
@@ -31,7 +31,6 @@ import {
   listRappters,
   plannedPortFor,
   portForInstance,
-  recordedPortFor,
   urlForInstance,
 } from '../../infra/roster.js';
 import {

--- a/typescript/src/agents/Assistant.ts
+++ b/typescript/src/agents/Assistant.ts
@@ -1291,6 +1291,3 @@ Revenue's up 12 percent and customers are happier - looking good this quarter.
   }
 }
 
-function truncate(s: string, max: number): string {
-  return s.length <= max ? s : s.slice(0, max - 3) + "...";
-}

--- a/typescript/src/agents/HackerNewsAgent.ts
+++ b/typescript/src/agents/HackerNewsAgent.ts
@@ -5,7 +5,7 @@
  * on kody-w/rappterbook, starting conversations around each link.
  */
 
-import { exec, execFile } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import { BasicAgent } from './BasicAgent.js';
 import type { AgentMetadata } from './types.js';
@@ -31,7 +31,6 @@ export const __manifest__ = {
   quality_tier: 'official',
   requires_env: []
 } as const;
-const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
 
 interface HNStory {

--- a/typescript/src/agents/LearnNewAgent.ts
+++ b/typescript/src/agents/LearnNewAgent.ts
@@ -97,7 +97,6 @@ export function docCommentSafe(value: string): string {
   return value
     .replace(/\*\//g, '*\\/')
     .replace(/\r?\n/g, ' ')
-    // eslint-disable-next-line no-control-regex
     .replace(/[\u0000-\u001F\u007F]/g, ' ');
 }
 

--- a/typescript/src/agents/OuroborosAgent.ts
+++ b/typescript/src/agents/OuroborosAgent.ts
@@ -19,7 +19,7 @@ import type { LLMProvider } from '../providers/types.js';
 import { chatWithFlightRecorder } from '../providers/recorded-chat.js';
 import { readFileSync, writeFileSync, mkdirSync, existsSync } from 'fs';
 import { fileURLToPath, pathToFileURL } from 'url';
-import { execSync, execFileSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { createHash } from 'crypto';
 import { join } from 'path';
 import { HOME_DIR } from '../env.js';

--- a/typescript/src/agents/PythonAgent.ts
+++ b/typescript/src/agents/PythonAgent.ts
@@ -42,7 +42,7 @@ export interface PythonAgentDescriptor {
   parameters: AgentMetadata['parameters'];
 }
 
-interface RunnerOk<T> { status: 'ok'; }
+interface RunnerOk { status: 'ok'; }
 interface RunnerErr { status: 'error'; error: string; }
 
 /** Default ceiling for one agent call. Long enough for real work, short enough to not wedge a chat turn. */
@@ -137,7 +137,7 @@ export async function introspectPythonAgents(
     python,
   );
 
-  let parsed: (RunnerOk<unknown> & { agents?: PythonAgentDescriptor[] }) | RunnerErr;
+  let parsed: (RunnerOk & { agents?: PythonAgentDescriptor[] }) | RunnerErr;
   try {
     parsed = JSON.parse(stdout.trim());
   } catch {

--- a/typescript/src/cli/rappters.ts
+++ b/typescript/src/cli/rappters.ts
@@ -25,7 +25,7 @@ import {
   recordedPortFor,
   type RappterStatus,
 } from '../infra/roster.js';
-import { canonicalInstanceKey, gatewayPortFor } from '../infra/gateway-lock.js';
+import { canonicalInstanceKey } from '../infra/gateway-lock.js';
 import { portTypedOnCommandLine } from '../infra/cli-port.js';
 
 const EMOJI = '🦖';

--- a/typescript/src/flight-recorder/process-owner.ts
+++ b/typescript/src/flight-recorder/process-owner.ts
@@ -1,6 +1,5 @@
 import {
   closeSync,
-  existsSync,
   fsyncSync,
   linkSync,
   lstatSync,

--- a/typescript/src/providers/__tests__/copilot-stream.test.ts
+++ b/typescript/src/providers/__tests__/copilot-stream.test.ts
@@ -228,7 +228,6 @@ describe('CopilotProvider.chatStream', () => {
     const provider = await createProvider();
 
     await expect(async () => {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       for await (const _ of provider.chatStream([{ role: 'user', content: 'hi' }])) {
         // should not reach here
       }

--- a/typescript/src/providers/copilot-cli-direct.ts
+++ b/typescript/src/providers/copilot-cli-direct.ts
@@ -294,7 +294,6 @@ export class CopilotCliDirectProvider implements LLMProvider {
   }
 
   private cleanOutput(raw: string): string {
-    // eslint-disable-next-line no-control-regex
     const noAnsi = raw.replace(/\x1b\[[0-9;]*m/g, '');
     const lines = noAnsi.split('\n');
     const footer = /^(Changes|AI Credits|Tokens|Resume|Total|Session|Model|Usage)\b/;

--- a/typescript/src/telephony/providers/google-voice-browser.test.ts
+++ b/typescript/src/telephony/providers/google-voice-browser.test.ts
@@ -10,7 +10,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import { GoogleVoiceBrowserDriver, GoogleVoiceSurfaceError } from './google-voice-browser.js';
+import { GoogleVoiceBrowserDriver } from './google-voice-browser.js';
 import type { PageSurface } from './chrome-cdp.js';
 
 /**

--- a/typescript/src/voice/local-speech.js
+++ b/typescript/src/voice/local-speech.js
@@ -185,6 +185,8 @@ export function createLocalSpeech(options = {}) {
   let state = SPEECH_STATES.IDLE;
   let lastDetail = {};
   /** Chrome garbage-collects a live utterance mid-speech; holding it prevents that. */
+  // The assignment is the whole purpose, so this is written and never read.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   let held = null;
   let gestureSeen = false;
   let watchingLate = false;


### PR DESCRIPTION
## The gate that could not fail

`npm run lint` ran `eslint src/`. ESLint exits 0 on warnings, so the job passed
while reporting:

```
✖ 17 problems (0 errors, 17 warnings)
```

Seventeen problems, green build, every run. That is the same shape as #271's
R6 and R8 — a check that reports and cannot fail — except here the report was
printed in full and scrolled past.

**Two of the seventeen were mine.** `execAsync` in `HackerNewsAgent` and
`execSync` in `OuroborosAgent`, both orphaned when #268 moved those agents to
argument vectors. The linter caught them at the time and said so; nothing was
listening.

## What the other fifteen were

**Four were a config gap, not dead code.** The rule was
`['warn', { argsIgnorePattern: '^_' }]`. This codebase marks a deliberately
unused binding with a leading underscore — `_privateIdentityKey`,
`_generation`, `_ignored` — but that pattern was honoured for *arguments*
only, so the identical convention on a variable still warned. Added
`varsIgnorePattern`, `caughtErrorsIgnorePattern` and
`destructuredArrayIgnorePattern`.

**Two were suppressions suppressing nothing** — `eslint-disable-next-line
no-control-regex` on lines that no longer contain a control-character class.

**One was a deliberate write.** `local-speech.js` holds a reference to a live
utterance because, in its own words, *"Chrome garbage-collects a live utterance
mid-speech; holding it prevents that."* Written and never read is the entire
point, so the rule is wrong there and the code is right. It now carries a
disable with that reason rather than being "cleaned up".

**One was a deliberate `ls`-style false positive** in the same spirit: a type
parameter on `RunnerOk<T>` that no caller needed. Both sites are in one file,
so the parameter is simply gone.

The rest were genuinely unused imports and one dead `truncate` helper —
distinct from the live `truncateHistory` it sits near, which is why it survived
this long.

## Enforcement

`--max-warnings 0`, so the next one fails the build rather than joining a
tally. Verified by reintroducing two variables: it fails on `reallyUnused` and
stays silent on `_unusedButNamed`, which also demonstrates the convention now
works.

## Two mistakes I made getting here, both caught

1. I replaced **all four** `const port = await startServer()` bindings when
   only the fourth was unused. `tsc` failed with `Cannot find name 'port'` in
   three other blocks. Reverted and changed exactly the flagged line. The
   lesson is that a warning names one occurrence, not a pattern.
2. I mutation-tested the new gate before committing, and the `git checkout`
   that restored the mutation also reverted an uncommitted fix. I have hit this
   before; the tell is that the "restored" run still fails. Redone and
   committed first.

## Evidence

- `npm run lint`: **0 warnings**, exit 0.
- Reintroduced warning: `ESLint found too many warnings (maximum: 0)`, exit 1.
- `tsc --noEmit` clean.
- Suite: **4795 passed**, 21 skipped — unchanged, which matters because I
  touched four test files.

## Not done here

`typescript/ui` (45 files, ~17k lines) and `typescript/desktop` (5 files,
~2.7k lines) have no lint script at all. That is a missing tool rather than a
lying gate, and adding one is a larger change with its own findings to triage,
so I have left it out of a PR that is about making the existing gate honest.
