### PR TITLE
fix(ci): eleven telephony integration tests had never run anywhere

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,47 @@ jobs:
           cache: npm
           cache-dependency-path: typescript/package-lock.json
       - run: npm ci
+      # `src/telephony/integration.test.ts` skips itself unless it finds the
+      # RAPP Second Brain binary. It looks at RSB_BIN, then ~/rapp-secondbrain,
+      # then ~/.local/bin — which is exactly where the installers in
+      # release.yml and flight-recorder.yml put it. Nothing installed it in the
+      # job that runs the suite, so eleven integration tests covering call
+      # negotiation, approval, the audit chain and concurrent writers had never
+      # executed in CI. They pass; they were simply never asked to.
+      #
+      # Pinned and checksummed, matching release.yml.
+      - name: Install RAPP Second Brain so the telephony integration tests run
+        working-directory: ${{ github.workspace }}
+        run: |
+          set -euo pipefail
+          RSB_SHA=7846dfdd5e2c74ea2201e1b141269df359b4ce5a
+          curl -fsSL \
+            "https://raw.githubusercontent.com/kody-w/rapp-secondbrain/$RSB_SHA/install.sh" \
+            -o "$RUNNER_TEMP/rsb-install.sh"
+          echo "6fbe9cf84a2b911384957743250e09bacb2c03a5be917974589255e89334d848  $RUNNER_TEMP/rsb-install.sh" \
+            | sha256sum -c -
+          RSB_REF="$RSB_SHA" bash "$RUNNER_TEMP/rsb-install.sh"
+          test -x "$HOME/.local/bin/rsb"
       - run: npm run lint
       # vitest (esbuild) does not type-check — tsc is the only gate for type errors
       - run: npm run build
       - run: npm test
+      # A skip here is indistinguishable from a pass in the summary line, and
+      # this suite has already shipped tests that never ran anywhere.
+      - name: Assert the telephony integration tests were not skipped
+        run: |
+          set -euo pipefail
+          npx vitest run src/telephony/integration.test.ts --reporter=json \
+            --outputFile="$RUNNER_TEMP/telephony.json" >/dev/null
+          node -e '
+            const r = require(process.env.RUNNER_TEMP + "/telephony.json");
+            const total = r.numTotalTests, passed = r.numPassedTests;
+            if (total === 0 || passed !== total) {
+              console.error(`::error::telephony integration tests did not all run: ${passed}/${total}`);
+              process.exit(1);
+            }
+            console.log(`telephony integration tests executed: ${passed}/${total}`);
+          '
 
   # Dedicated gate for the dashboard UI surface (typescript/ui) — a separate
   # npm project (own lockfile/deps) that the generic `typescript` job above


### PR DESCRIPTION
## Three test files skip on every local run

```
↓ src/telephony/integration.test.ts            (11 tests | 11 skipped)
↓ src/flight-recorder/windows-storage.test.ts   (2 tests |  2 skipped)
↓ src/telephony/providers/google-voice-live.test.ts (3 tests | 3 skipped)
```

A skip is not a failure, so this is invisible in a green run. The question is
whether any environment *does* run them.

- **`windows-storage.test.ts` — yes.** `flight-recorder.yml` and `release.yml`
  both run it explicitly on `windows-latest`. Correctly gated, no action.
- **`google-voice-live.test.ts` — no**, and reasonably so: it needs a real
  Chrome on a CDP port. Genuinely manual. Left alone.
- **`integration.test.ts` — no, and it should have.**

## The eleven

The file resolves its dependency like this:

```ts
const RSB_CANDIDATES = [
  process.env.RSB_BIN,
  join(homedir(), 'rapp-secondbrain', 'rsb'),
  join(homedir(), '.local', 'bin', 'rsb'),
].filter(Boolean);
```

`~/.local/bin` is **exactly** where `release.yml` and `flight-recorder.yml`
install `rsb`. But those jobs run specific test files — `windows-storage`,
show-and-tell — not the suite. The job that runs the suite never installed it.

So the tests were one missing install step away from running, and nobody could
tell, because a skipped file and a passing file look the same in:

```
Test Files  284 passed | 3 skipped (287)
```

## They pass

I installed `rsb` from the same pinned, checksummed source `release.yml` uses,
into a temporary prefix, and ran them:

```
✓ the JARVIS call > negotiates, refuses to book, calls back, and only then commits
✓ the JARVIS call > books on its own authority when the offer is what was asked for
✓ the JARVIS call > cancels the hold when the owner says no
✓ the JARVIS call > leaves the approval pending when the owner does not answer
✓ the JARVIS call > records a failed negotiation without inventing a booking
✓ keeps one unbroken chain across everything openrappter wrote
✓ survives concurrent writers without corrupting the log

Tests  11 passed (11)
```

That is not a thin surface. Negotiation refusal, approval timeout, an unbroken
audit chain, concurrent writers — the behaviours you would most want a gate on,
and the gate was never armed.

## The change

Install `rsb` in the job that runs the suite, pinned and checksummed exactly as
`release.yml` does it, then **assert afterwards that all eleven executed**.

The assertion is the part that matters. Adding the install alone would fix it
today and fail silently the next time the path or the installer moves — which
is the identical failure mode, one layer along. If the count is not 11/11 the
job fails and says so.

## Evidence

- with `rsb` present: `telephony integration tests executed: 11/11`, exit 0
- with it absent: `::error::telephony integration tests did not all run: 0/11`,
  exit 1
- workflow YAML parses; the job has 8 steps in the expected order

I have not verified the `rsb` installer on Ubuntu — I ran it on macOS. It is
the same pinned script two other workflows already run on Ubuntu runners, so
CI on this PR is the check.
