### PR TITLE
test(ci): every skipped test must say where it does run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,23 +64,15 @@ jobs:
       - run: npm run lint
       # vitest (esbuild) does not type-check — tsc is the only gate for type errors
       - run: npm run build
-      - run: npm test
-      # A skip here is indistinguishable from a pass in the summary line, and
-      # this suite has already shipped tests that never ran anywhere.
-      - name: Assert the telephony integration tests were not skipped
-        run: |
-          set -euo pipefail
-          npx vitest run src/telephony/integration.test.ts --reporter=json \
-            --outputFile="$RUNNER_TEMP/telephony.json" >/dev/null
-          node -e '
-            const r = require(process.env.RUNNER_TEMP + "/telephony.json");
-            const total = r.numTotalTests, passed = r.numPassedTests;
-            if (total === 0 || passed !== total) {
-              console.error(`::error::telephony integration tests did not all run: ${passed}/${total}`);
-              process.exit(1);
-            }
-            console.log(`telephony integration tests executed: ${passed}/${total}`);
-          '
+      # One run, two reporters: the readable one for a human scanning the log,
+      # and JSON so the skip budget below has something to check.
+      - name: Run the suite
+        run: npm test -- --reporter=default --reporter=json --outputFile.json="$RUNNER_TEMP/vitest.json"
+      # `284 passed | 3 skipped` reads like success. It was how eleven
+      # telephony integration tests went unexecuted in every environment
+      # (#280). Every skip must now be named, with where it does run.
+      - name: Skip budget
+        run: node ../tools/skip-budget.mjs "$RUNNER_TEMP/vitest.json"
 
   # Dedicated gate for the dashboard UI surface (typescript/ui) — a separate
   # npm project (own lockfile/deps) that the generic `typescript` job above

--- a/tools/skip-budget.mjs
+++ b/tools/skip-budget.mjs
@@ -1,0 +1,108 @@
+#!/usr/bin/env node
+/**
+ * A skipped test is indistinguishable from a passing one in the summary line.
+ *
+ *     Test Files  284 passed | 3 skipped (287)
+ *     Tests       4795 passed | 21 skipped (4816)
+ *
+ * Nothing in a green run tells you that eleven telephony integration tests
+ * covering call negotiation, approval timeouts, the audit chain and concurrent
+ * writers had never executed in any environment — they resolved a binary CI
+ * installed in two other workflows but not in the job that runs the suite
+ * (#280). The install fixed it; only this stops it recurring silently, and
+ * catches the next file that starts skipping for its own reason.
+ *
+ * Every skip must be named here with a reason. Anything else fails the build.
+ *
+ * Usage: node tools/skip-budget.mjs <vitest-json-report>
+ */
+
+import { readFileSync } from 'node:fs';
+
+/**
+ * Files permitted to skip, and how many.
+ *
+ * A budget is a claim that the tests run *somewhere*. If that somewhere stops
+ * being true, the entry is wrong and should be deleted along with the tests.
+ */
+const ALLOWED = {
+  'src/flight-recorder/windows-storage.test.ts': {
+    max: 2,
+    why: 'Windows-only storage paths. flight-recorder.yml and release.yml run '
+      + 'this file explicitly on windows-latest, so it is exercised — just not '
+      + 'on this runner.',
+  },
+  'src/telephony/providers/google-voice-live.test.ts': {
+    max: 3,
+    why: 'Drives a real Chrome over a CDP port set by OPENRAPPTER_CDP_PORT. '
+      + 'No CI job provides one, so these are manual by design.',
+  },
+};
+
+const reportPath = process.argv[2];
+if (!reportPath) {
+  console.error('usage: node tools/skip-budget.mjs <vitest-json-report>');
+  process.exit(2);
+}
+
+const report = JSON.parse(readFileSync(reportPath, 'utf8'));
+
+const skippedByFile = new Map();
+for (const suite of report.testResults ?? []) {
+  const file = String(suite.name ?? '').replace(/.*\/typescript\//, '');
+  for (const assertion of suite.assertionResults ?? []) {
+    if (assertion.status === 'pending' || assertion.status === 'skipped') {
+      if (!skippedByFile.has(file)) skippedByFile.set(file, []);
+      skippedByFile.get(file).push(assertion.fullName ?? assertion.title ?? '?');
+    }
+  }
+}
+
+// Anti-vacuity: a report this script cannot read would produce an empty map
+// and pass, which is the exact failure it exists to prevent.
+const total = report.numTotalTests ?? 0;
+if (total < 1000) {
+  console.error(
+    `::error::skip budget read only ${total} tests from ${reportPath}; `
+    + 'that is not the full suite, so its verdict means nothing',
+  );
+  process.exit(1);
+}
+
+let failed = false;
+
+for (const [file, names] of [...skippedByFile].sort()) {
+  const entry = ALLOWED[file];
+  if (!entry) {
+    console.error(`::error::${file} skipped ${names.length} test(s) with no budget entry.`);
+    console.error('  A skip is not a pass. Either make them run, or add an entry to');
+    console.error('  tools/skip-budget.mjs saying where they do run and why.');
+    for (const n of names.slice(0, 5)) console.error(`    - ${n}`);
+    failed = true;
+    continue;
+  }
+  if (names.length > entry.max) {
+    console.error(
+      `::error::${file} skipped ${names.length} test(s), budget is ${entry.max}.`,
+    );
+    console.error(`  Budget reason: ${entry.why}`);
+    failed = true;
+  }
+}
+
+// A budget for a file that no longer skips is stale. Report it rather than let
+// the list rot into a set of claims nobody checks.
+for (const [file, entry] of Object.entries(ALLOWED)) {
+  if (!skippedByFile.has(file)) {
+    console.log(`note: ${file} no longer skips anything; its budget entry can go.`);
+    void entry;
+  }
+}
+
+if (failed) process.exit(1);
+
+const skippedTotal = [...skippedByFile.values()].reduce((n, l) => n + l.length, 0);
+console.log(
+  `skip budget satisfied: ${skippedTotal} skipped, all accounted for, `
+  + `${report.numPassedTests}/${total} passed`,
+);


### PR DESCRIPTION
## Finishing what #280 started

#280 found eleven telephony integration tests that had never executed anywhere
and installed the binary they needed. It asserted that *one file* ran.

`PhoneAgent.test.ts` resolves the same binary through the identical chain:

```ts
process.env.RSB_BIN,
join(homedir(), 'rapp-secondbrain', 'rsb'),
join(homedir(), '.local', 'bin', 'rsb'),
```

So five more tests — *"records the call and leaves the approval for the
owner"*, *"cannot decide the same approval twice"*, *"reads back a
transcript"* — were un-skipped as a **side effect**, with nothing checking
them. Sixteen tests now run because of a step whose stated purpose covers
eleven of them.

That is the same shape as the thing it fixed, one layer along: correct today,
silent tomorrow.

## The budget

`tools/skip-budget.mjs` reads the suite's JSON report and fails on any skip
that is not named, with where those tests do run:

- `windows-storage.test.ts` — 2, Windows-only; `flight-recorder.yml` and
  `release.yml` run this file explicitly on `windows-latest`
- `google-voice-live.test.ts` — 3, drives a real Chrome over a CDP port no CI
  job provides. Manual by design.

Anything else fails, including the rsb-gated files, which must run.

A budget entry is a **claim that the tests run somewhere**. When a file stops
skipping, the script says the entry can be deleted, so the list cannot rot into
assertions nobody rechecks.

## Measured

With the binary present the suite goes from

```
Tests  4795 passed | 21 skipped (4816)
```

to

```
Tests  4811 passed | 5 skipped (4816)
skip budget satisfied: 5 skipped, all accounted for, 4811/4816 passed
```

Sixteen more tests executing, and the remaining five are the two documented
files.

## Failure modes, both exercised

- **A new unbudgeted skip:** `::error::src/chat-flight.test.ts skipped 1
  test(s) with no budget entry.`
- **A report that is not the full suite:** `::error::skip budget read only 12
  tests …; that is not the full suite, so its verdict means nothing`. Without
  that, a malformed or truncated report yields an empty skip map and passes —
  which is precisely the failure this script exists to catch, and I would
  rather not ship the bug in the guard against the bug.

## One run, not two

`npm test` now passes `--reporter=default --reporter=json`, so the human-
readable output and the JSON come from a single execution. Running the suite
twice to check it would have doubled the longest job in CI.

## Replaces, not adds

The bespoke telephony assertion from #280 is gone — the budget subsumes it, and
two guards for one property is how they drift apart.
