### PR TITLE
fix(agents): a non-numeric Pokemon setting crashed the agent instead of being refused

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A non-numeric Pokemon setting crashed the agent instead of being refused** —
+  `port`, `max_clips`, `max_states`, `max_storage_gb` and `min_free_gb` are
+  chosen by a model, so they arrive as whatever it produced, and each was
+  passed straight to `int()` or `float()` while building the supervisor command
+  line. `int("abc")` raises `ValueError`, nothing above it caught `ValueError`,
+  and one odd argument took the agent down rather than coming back as an error.
+  They are now coerced before the command is built, and a bad one names the
+  setting that was wrong.
 - **Two conformance checks could not fail** — R8 asserts the RAPP substrate is
   attributed, which its own docstring calls the licence condition, but it
   tested for `rapp` as a plain substring, and open**rapp**ter contains it; the

--- a/python/openrappter/agents/pokemon_agent.py
+++ b/python/openrappter/agents/pokemon_agent.py
@@ -770,6 +770,23 @@ def public_runtime_status(runtime_dir: Path = DEFAULT_RUNTIME_DIR) -> dict[str, 
     return public
 
 
+class SettingError(ValueError):
+    """A caller-supplied setting is not the number it has to be."""
+
+
+def numeric_setting(kwargs: Any, field: str, default: Any, cast: Any) -> Any:
+    """Coerce a caller-supplied setting, or say which one was wrong.
+
+    These arrive from a model, so they can be any string at all. `int("abc")`
+    raises ValueError, nothing above catches ValueError, and one odd argument
+    took the whole agent down rather than coming back as a refusal."""
+    raw = kwargs.get(field, default)
+    try:
+        return cast(raw)
+    except (TypeError, ValueError):
+        raise SettingError(f"{field} must be a number, got {raw!r}") from None
+
+
 def positive_finite_float(value: Any) -> float:
     try:
         parsed = float(value)
@@ -1052,6 +1069,23 @@ class PokemonAgent(BasicAgent):
         )
         log_handle = os.fdopen(log_descriptor, "a", encoding="utf-8")
         instance_id = uuid.uuid4().hex
+        try:
+            port_setting = numeric_setting(kwargs, "port", DEFAULT_PORT, int)
+            max_clips_setting = numeric_setting(
+                kwargs, "max_clips", DEFAULT_MAX_CLIPS, int
+            )
+            max_states_setting = numeric_setting(
+                kwargs, "max_states", DEFAULT_MAX_STATES, int
+            )
+            max_storage_setting = numeric_setting(
+                kwargs, "max_storage_gb", DEFAULT_MAX_STORAGE_GB, float
+            )
+            min_free_setting = numeric_setting(
+                kwargs, "min_free_gb", DEFAULT_MIN_FREE_GB, float
+            )
+        except SettingError as error:
+            log_handle.close()
+            return json.dumps({"status": "error", "message": str(error)})
         command = [
             sys.executable,
             "-m",
@@ -1062,19 +1096,19 @@ class PokemonAgent(BasicAgent):
             "--runtime-dir",
             str(runtime_dir),
             "--port",
-            str(int(kwargs.get("port", DEFAULT_PORT))),
+            str(port_setting),
             "--clip-minutes",
             str(clip_minutes),
             "--instance-id",
             instance_id,
             "--max-clips",
-            str(int(kwargs.get("max_clips", DEFAULT_MAX_CLIPS))),
+            str(max_clips_setting),
             "--max-states",
-            str(int(kwargs.get("max_states", DEFAULT_MAX_STATES))),
+            str(max_states_setting),
             "--max-storage-gb",
-            str(float(kwargs.get("max_storage_gb", DEFAULT_MAX_STORAGE_GB))),
+            str(max_storage_setting),
             "--min-free-gb",
-            str(float(kwargs.get("min_free_gb", DEFAULT_MIN_FREE_GB))),
+            str(min_free_setting),
             "--open-viewer",
         ]
         if kwargs.get("visible", True):
@@ -1098,7 +1132,7 @@ class PokemonAgent(BasicAgent):
             minimum_startup_timeout,
         )
         deadline = time.monotonic() + startup_timeout
-        viewer_url = f"http://127.0.0.1:{int(kwargs.get('port', DEFAULT_PORT))}"
+        viewer_url = f"http://127.0.0.1:{port_setting}"
         while time.monotonic() < deadline:
             child_status = read_json(runtime_dir / "status.json")
             child_instance = child_status.get("instance_id")

--- a/python/tests/test_pokemon_agent.py
+++ b/python/tests/test_pokemon_agent.py
@@ -1972,3 +1972,57 @@ def test_clip_indices_continue_beyond_four_digits(tmp_path):
     recorder.clips_dir = clips_dir
 
     assert recorder._next_index() == 10001
+
+
+@pytest.mark.skipif(
+    sys.version_info < (3, 11),
+    reason="The Copilot SDK-backed Pokemon runtime requires Python 3.11+",
+)
+@pytest.mark.parametrize(
+    "field, value",
+    [
+        ("port", "abc"),
+        ("port", ""),
+        ("max_clips", "lots"),
+        ("max_storage_gb", "big"),
+    ],
+)
+def test_a_non_numeric_setting_is_an_error_not_a_crash(monkeypatch, tmp_path, field, value):
+    """A model chooses these kwargs, so they arrive as whatever it produced.
+
+    `int(kwargs.get("port", DEFAULT_PORT))` raises ValueError on anything
+    non-numeric, and nothing above it catches ValueError, so a single odd
+    argument took the agent down instead of coming back as a refusal.
+    """
+    rom = make_rom(tmp_path / "Pokemon Red.gb")
+    runtime_dir = tmp_path / "runtime"
+    runtime_dir.mkdir()
+
+    class Process:
+        pid = 4321
+
+        def poll(self):
+            return None
+
+    def fake_popen(*args, **kwargs):
+        del args, kwargs
+        raise AssertionError("must not spawn a supervisor with an invalid setting")
+
+    monkeypatch.setattr(
+        pokemon_module.importlib.util, "find_spec", lambda name: object()
+    )
+    monkeypatch.setattr(pokemon_module.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+    monkeypatch.setattr(pokemon_module, "ensure_copilot_runtime", lambda: None)
+    monkeypatch.setattr(pokemon_module.subprocess, "Popen", fake_popen)
+
+    result = json.loads(
+        PokemonAgent().perform(
+            action="start",
+            rom_path=str(rom),
+            runtime_dir=str(runtime_dir),
+            **{field: value},
+        )
+    )
+
+    assert result["status"] == "error", result
+    assert field in result["message"], result["message"]


### PR DESCRIPTION
## The round's stated target came up clean

I set out to apply #281's skip audit to the other two runtimes. Both are fine,
and that is worth recording rather than padding:

- **Python** skips 6 tests. Four need `rapp-keyring`, and `rapp-conformance.yml`
  installs it, runs them, and **already fails if any skip**. Two are Windows-only
  and `flight-recorder.yml` and `release.yml` run that file on `windows-latest`.
  Every skip has a job where it runs. CI's set matches local.
- **Swift** has no skip concept — its hand-written harness runs every registered
  test or fails, and suite registration is separately guarded.

So there was no Python or Swift equivalent of the sixteen never-run tests, and I
did not build a guard for a gap that is not there.

## What I found instead

Sweeping for the defect class behind #260 and #262 — a caller-supplied value
coerced to a number — `pokemon_agent` builds its supervisor command line like
this:

```python
"--port", str(int(kwargs.get("port", DEFAULT_PORT))),
"--max-clips", str(int(kwargs.get("max_clips", DEFAULT_MAX_CLIPS))),
"--max-storage-gb", str(float(kwargs.get("max_storage_gb", ...))),
```

Those kwargs are chosen by a model. `int("abc")` raises `ValueError`, the only
nearby `except` catches `RuntimeError`, and `perform()` has no top-level
handler — so a single odd argument propagates out of the agent instead of
coming back as a refusal.

Reproduced before fixing, with `subprocess.Popen` patched to assert it is never
reached:

```
FAILED ...[port-abc]           ValueError
FAILED ...[port-]              ValueError
FAILED ...[max_clips-lots]     ValueError
FAILED ...[max_storage_gb-big] ValueError
```

## The fix

A `numeric_setting` helper alongside the file's existing `positive_finite_float`
— which is already defensive, so the convention was there and these five sites
simply predated it or missed it. Settings are coerced **before** the command is
built, and a bad one returns `{"status": "error"}` naming the field.

The empty-string case is in the tests deliberately. That is the exact shape of
#260, where `stale_days: ""` deleted every eligible memory, and #262, where
`maxLineLength: ""` flagged every line. Python is kinder here than JavaScript —
`int("")` raises where `Number("")` is `0` — but only if something catches it.

I also pointed the viewer URL at the validated port rather than coercing
`kwargs` a second time, so there is one place that decides what the port is.

## Also checked, no action

The TypeScript numeric-coercion sites are safe. `parseInt("")` yields `NaN`, and
Node rejects that loudly — `ERR_SOCKET_BAD_PORT` — rather than binding a random
port. I measured that instead of assuming it, because `Number("")` is `0` and
the two are easy to conflate.

## Evidence

- 4 new tests, failing with `ValueError` before the fix and passing after
- `test_pokemon_agent.py`: **84 passed**
- Python suite: **1576 passed**, 6 skipped
- `conformance.py`: **8 passed, 0 failed**
