### PR TITLE
fix(agents): startup_timeout was validated after the supervisor was already spawned

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,13 +40,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - **A non-numeric Pokemon setting crashed the agent instead of being refused** —
-  `port`, `max_clips`, `max_states`, `max_storage_gb` and `min_free_gb` are
-  chosen by a model, so they arrive as whatever it produced, and each was
-  passed straight to `int()` or `float()` while building the supervisor command
-  line. `int("abc")` raises `ValueError`, nothing above it caught `ValueError`,
-  and one odd argument took the agent down rather than coming back as an error.
-  They are now coerced before the command is built, and a bad one names the
-  setting that was wrong.
+  `port`, `max_clips`, `max_states`, `max_storage_gb`, `min_free_gb` and
+  `startup_timeout` are chosen by a model, so they arrive as whatever it
+  produced, and each was passed straight to `int()` or `float()`. `int("abc")`
+  raises `ValueError`, nothing above it caught `ValueError`, and one odd
+  argument took the agent down rather than coming back as an error.
+  `startup_timeout` was worse than the rest: it was read *after* the supervisor
+  had been spawned, so a bad value left a live process behind with nothing
+  tracking it. All six are now coerced before anything is started, and a bad
+  one names the setting that was wrong.
 - **Two conformance checks could not fail** — R8 asserts the RAPP substrate is
   attributed, which its own docstring calls the licence condition, but it
   tested for `rapp` as a plain substring, and open**rapp**ter contains it; the

--- a/python/openrappter/agents/pokemon_agent.py
+++ b/python/openrappter/agents/pokemon_agent.py
@@ -1083,6 +1083,20 @@ class PokemonAgent(BasicAgent):
             min_free_setting = numeric_setting(
                 kwargs, "min_free_gb", DEFAULT_MIN_FREE_GB, float
             )
+            # Validated here rather than where it is used, which is after the
+            # supervisor has been spawned: a bad value there left a live
+            # process behind with nothing tracking it.
+            minimum_startup_timeout = (
+                COPILOT_START_TIMEOUT_SECONDS
+                + COPILOT_STOP_TIMEOUT_SECONDS * 2
+                + 10
+            )
+            startup_timeout = max(
+                numeric_setting(
+                    kwargs, "startup_timeout", minimum_startup_timeout, float
+                ),
+                minimum_startup_timeout,
+            )
         except SettingError as error:
             log_handle.close()
             return json.dumps({"status": "error", "message": str(error)})
@@ -1122,15 +1136,6 @@ class PokemonAgent(BasicAgent):
             start_new_session=True,
         )
         log_handle.close()
-        minimum_startup_timeout = (
-            COPILOT_START_TIMEOUT_SECONDS
-            + COPILOT_STOP_TIMEOUT_SECONDS * 2
-            + 10
-        )
-        startup_timeout = max(
-            float(kwargs.get("startup_timeout", minimum_startup_timeout)),
-            minimum_startup_timeout,
-        )
         deadline = time.monotonic() + startup_timeout
         viewer_url = f"http://127.0.0.1:{port_setting}"
         while time.monotonic() < deadline:

--- a/python/tests/test_pokemon_agent.py
+++ b/python/tests/test_pokemon_agent.py
@@ -1985,6 +1985,7 @@ def test_clip_indices_continue_beyond_four_digits(tmp_path):
         ("port", ""),
         ("max_clips", "lots"),
         ("max_storage_gb", "big"),
+        ("startup_timeout", "soon"),
     ],
 )
 def test_a_non_numeric_setting_is_an_error_not_a_crash(monkeypatch, tmp_path, field, value):


### PR DESCRIPTION
## I missed one in #282, and it was the bad one

#282 guarded five model-chosen numeric settings in `pokemon_agent`. Auditing
the rest of the agents for the same shape, the only remaining unguarded
coercion in any Python agent was **in the file I had just fixed**:

```python
startup_timeout = max(
    float(kwargs.get("startup_timeout", minimum_startup_timeout)),
    minimum_startup_timeout,
)
```

My try block covered the five settings used to build the command line. This one
is read seventy lines further down.

## Why the position matters more than the coercion

The other five are read while assembling argv, so a bad value fails *before*
anything starts. `startup_timeout` is read **after** `subprocess.Popen`.

The test made that visible rather than my reading it off the source. The
harness patches `Popen` to refuse:

```
AssertionError: must not spawn a supervisor with an invalid setting
```

So `startup_timeout: "soon"` did not merely crash the agent — it **spawned the
supervisor, then crashed**, leaving a live process with nothing tracking it. A
caller retrying with a corrected value would start a second one.

I had assumed this was a fifth instance of the same defect. It is a worse one,
and I only know that because the fake `Popen` asserts instead of returning a
stub.

## The fix

`startup_timeout` is validated in the same pre-spawn block as the others,
including the `minimum_startup_timeout` floor it clamps to. The late
computation is deleted rather than left as a second place that decides the
same thing.

## The rest of the audit came up clean

Every other `int(`/`float(` on `kwargs` across all Python agents is already
guarded — `hacker_news_agent` uses `_bounded_int`, `pokemon_agent`'s
`clip_minutes` uses `positive_finite_float`.

TypeScript agents are guarded too: `CodeReviewAgent` routes `maxLineLength`
through `usableNumber` (the #262 fix) and `DreamAgent` clamps
`similarity_threshold` and `stale_days` through `clampNumber`. Those are the
two agents that produced #260 and #262, and the helpers introduced then are
holding.

## Evidence

- The new case fails before the fix with the spawn assertion, passes after
- `test_pokemon_agent.py`: **85 passed**
- Python suite: **1577 passed**, 6 skipped
