### PR TITLE
fix(agents): the updater could restore a stash it never made, and reported success when it could not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`openrappter update` could restore a stash it never made** — the updater
+  stashes local changes, pulls, rebuilds, then pops. But `git stash` on a clean
+  tree prints "No local changes to save" and exits 0 *without creating an
+  entry*, while the pop ran unconditionally. Updating a clean checkout that had
+  an older stash therefore restored that older work into the tree and dropped
+  the entry. The pop was also written `git stash pop 2>/dev/null || true`, so a
+  pop that conflicted with the pulled version left conflict markers in the
+  working tree and reported the update as a success; and any failure between
+  the stash and the pop said only "Update failed", sending you to look for
+  changes that were sitting in a stash entry you never made. The updater now
+  pops only what it saved, reports a failed restore as a failure, and names the
+  stash entry when it cannot finish.
 - **A non-numeric Pokemon setting crashed the agent instead of being refused** —
   `port`, `max_clips`, `max_states`, `max_storage_gb`, `min_free_gb` and
   `startup_timeout` are chosen by a model, so they arrive as whatever it

--- a/typescript/src/agents/UpdateAgent.ts
+++ b/typescript/src/agents/UpdateAgent.ts
@@ -47,7 +47,7 @@ export class UpdateAgent extends BasicAgent {
   private homeDir: string;
   private tsDir: string;
 
-  constructor() {
+  constructor(homeDir?: string) {
     const metadata: AgentMetadata = {
       name: 'Update',
       description: 'Check for updates and self-update openrappter from the public repo.',
@@ -64,7 +64,9 @@ export class UpdateAgent extends BasicAgent {
       },
     };
     super('Update', metadata);
-    this.homeDir = path.join(os.homedir(), '.openrappter');
+    // Injectable so the stash handling can be tested against a real repository
+    // rather than a replica of it.
+    this.homeDir = homeDir ?? path.join(os.homedir(), '.openrappter');
     this.tsDir = path.join(this.homeDir, 'typescript');
   }
 
@@ -221,16 +223,25 @@ export class UpdateAgent extends BasicAgent {
       });
     }
 
+    const stashLabel = `openrappter-update-${Date.now()}`;
+    let stashed = false;
     try {
-      // Stash any local changes
-      execSync('git stash --include-untracked 2>/dev/null || true', {
-        cwd: this.homeDir,
-        stdio: 'pipe',
-        timeout: 10000,
-      });
+      // Stash any local changes.
+      //
+      // `git stash` on a clean tree prints "No local changes to save" and
+      // exits 0 without creating an entry, so an unconditional `git stash pop`
+      // afterwards restores whatever was on top of the stack — which may be
+      // work the owner stashed days ago, and pop drops it. Only pop what this
+      // update actually saved.
+      const stashOutput = execFileSync(
+        'git',
+        ['stash', 'push', '--include-untracked', '-m', stashLabel],
+        { cwd: this.homeDir, encoding: 'utf-8', timeout: 10000 },
+      );
+      stashed = !stashOutput.includes('No local changes to save');
 
       // Pull latest
-      const pullOutput = execSync('git pull origin main 2>&1', {
+      const pullOutput = execFileSync('git', ['pull', 'origin', 'main'], {
         cwd: this.homeDir,
         encoding: 'utf-8',
         timeout: 30000,
@@ -248,12 +259,26 @@ export class UpdateAgent extends BasicAgent {
         });
       }
 
-      // Pop stash
-      execSync('git stash pop 2>/dev/null || true', {
-        cwd: this.homeDir,
-        stdio: 'pipe',
-        timeout: 10000,
-      });
+      // Restore what we stashed. A failing pop leaves conflict markers in the
+      // working tree and keeps the entry; reporting success there would tell
+      // the owner their update worked while their build is full of `<<<<<<<`.
+      if (stashed) {
+        try {
+          execFileSync('git', ['stash', 'pop'], {
+            cwd: this.homeDir,
+            encoding: 'utf-8',
+            timeout: 10000,
+          });
+        } catch {
+          return JSON.stringify({
+            status: 'error',
+            message:
+              `Updated, but your local changes could not be restored: they conflict `
+              + `with the new version. They are safe in the stash entry "${stashLabel}" — `
+              + `resolve with: git stash pop`,
+          });
+        }
+      }
 
       const newVersion = this.getLocalVersion();
 
@@ -280,9 +305,16 @@ export class UpdateAgent extends BasicAgent {
         restart_needed: !alreadyUpToDate,
       });
     } catch (err) {
+      // Anything failing between the stash and the pop leaves the owner's work
+      // saved but not restored. Saying "Update failed" alone sends them looking
+      // for changes that are sitting in a stash entry they never made.
+      const stranded = stashed
+        ? ` Your local changes are saved in the stash entry "${stashLabel}" — `
+          + 'restore them with: git stash pop'
+        : '';
       return JSON.stringify({
         status: 'error',
-        message: `Update failed: ${(err as Error).message}`,
+        message: `Update failed: ${(err as Error).message}.${stranded}`,
         local_version: local,
       });
     }

--- a/typescript/src/agents/__tests__/update-agent-stash.test.ts
+++ b/typescript/src/agents/__tests__/update-agent-stash.test.ts
@@ -1,0 +1,116 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { execFileSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+
+import { UpdateAgent } from '../UpdateAgent.js';
+
+/**
+ * The updater stashes local changes, pulls, rebuilds, and pops.
+ *
+ * Two things went wrong with that, and both are about the stash *stack* rather
+ * than the stash itself.
+ *
+ * `git stash` on a clean tree prints "No local changes to save" and exits 0
+ * without creating an entry. The old code popped unconditionally, so an update
+ * run on a clean checkout restored — and dropped — whatever the owner had
+ * stashed previously, possibly days earlier.
+ *
+ * And the pop was written `git stash pop 2>/dev/null || true`, so a pop that
+ * conflicted with the freshly pulled version left conflict markers in the
+ * working tree, kept the entry, and the update reported success.
+ *
+ * These run against a real repository with a real remote, because the bug was
+ * in what git does, not in what the code says it does.
+ */
+
+function git(repo: string, ...args: string[]): string {
+  return execFileSync('git', args, { cwd: repo, encoding: 'utf-8' });
+}
+
+describe('UpdateAgent stash handling', () => {
+  let root: string;
+  let origin: string;
+  let home: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(path.join(tmpdir(), 'update-agent-'));
+    origin = path.join(root, 'origin');
+    home = path.join(root, '.openrappter');
+
+    mkdirSync(origin);
+    git(origin, 'init', '-q', '--bare', '--initial-branch=main');
+
+    const seed = path.join(root, 'seed');
+    mkdirSync(seed);
+    git(seed, 'init', '-q', '--initial-branch=main');
+    git(seed, 'config', 'user.email', 'test@example.com');
+    git(seed, 'config', 'user.name', 'Test');
+    writeFileSync(path.join(seed, 'file.txt'), 'v1\n');
+    git(seed, 'add', '.');
+    git(seed, 'commit', '-qm', 'init');
+    git(seed, 'remote', 'add', 'origin', origin);
+    git(seed, 'push', '-q', 'origin', 'main');
+
+    execFileSync('git', ['clone', '-q', origin, home], { encoding: 'utf-8' });
+    git(home, 'config', 'user.email', 'test@example.com');
+    git(home, 'config', 'user.name', 'Test');
+    // typescript/ must exist: the agent reads a version file from it.
+    mkdirSync(path.join(home, 'typescript'), { recursive: true });
+    writeFileSync(
+      path.join(home, 'typescript', 'package.json'),
+      JSON.stringify({ name: 'openrappter', version: '1.0.0' }),
+    );
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not restore a stash it did not create', async () => {
+    // The owner stashed something earlier and their tree is now clean.
+    writeFileSync(path.join(home, 'file.txt'), 'WORK FROM LAST TUESDAY\n');
+    git(home, 'stash', 'push', '-q', '--include-untracked', '-m', 'owner-work');
+    expect(git(home, 'stash', 'list')).toContain('owner-work');
+    expect(git(home, 'status', '--porcelain').trim()).toBe('');
+
+    await new UpdateAgent(home).perform({ action: 'update' });
+
+    // The old entry must still be there, and must not have been dumped into
+    // the working tree.
+    expect(git(home, 'stash', 'list')).toContain('owner-work');
+    expect(readFileSync(path.join(home, 'file.txt'), 'utf-8')).toBe('v1\n');
+  });
+
+  it('restores changes it did stash', async () => {
+    writeFileSync(path.join(home, 'file.txt'), 'MY EDIT\n');
+
+    await new UpdateAgent(home).perform({ action: 'update' });
+
+    expect(readFileSync(path.join(home, 'file.txt'), 'utf-8')).toBe('MY EDIT\n');
+    expect(git(home, 'stash', 'list').trim()).toBe('');
+  });
+
+  it('says where the work is when the update fails before restoring it', async () => {
+    // Local edit to the same line the upstream update changes.
+    writeFileSync(path.join(home, 'file.txt'), 'MY EDIT\n');
+
+    // Upstream moves that line.
+    const seed = path.join(root, 'seed');
+    writeFileSync(path.join(seed, 'file.txt'), 'v2-from-upstream\n');
+    git(seed, 'commit', '-qam', 'upstream change');
+    git(seed, 'push', '-q', 'origin', 'main');
+
+    const raw = await new UpdateAgent(home).perform({ action: 'update' });
+    const result = JSON.parse(raw as string);
+
+    // The rebuild fails here (this fixture is not an npm project), which is
+    // the realistic case: anything between the stash and the pop can fail.
+    expect(result.status).toBe('error');
+    expect(result.message).toMatch(/stash entry "openrappter-update-/);
+    expect(result.message).toMatch(/git stash pop/);
+    // And the work really is there to recover.
+    expect(git(home, 'stash', 'list')).toContain('openrappter-update-');
+  });
+});


### PR DESCRIPTION
## How I got here

`UpdateAgent` and `PongAgent` are the only TypeScript agents with no test
referencing them. That census found five real defects in earlier rounds, so I
looked at the auto-updater — the one that runs `git pull` and `npm ci` against
the owner's checkout.

## Three defects, all in eight lines

```ts
execSync('git stash --include-untracked 2>/dev/null || true', ...);
const pullOutput = execSync('git pull origin main 2>&1', ...);
if (!alreadyUpToDate) execSync('npm ci --ignore-scripts && npm run build', ...);
execSync('git stash pop 2>/dev/null || true', ...);
```

### 1. It could restore a stash it never made

`git stash` on a clean tree prints `No local changes to save` and **exits 0
without creating an entry**. The pop ran unconditionally, so it took whatever
was on top of the stack.

Demonstrated in a scratch repository: stash some work, let the tree go clean,
run the updater's two commands, and the work from before reappears in the tree
with the entry dropped:

```
No local changes to save
Dropped refs/stash@{0} (34da5a3…)
  after the updater's pop, file.txt contains:
    OLD UNRELATED WORK
```

Someone updating a clean checkout gets changes they stashed days ago silently
merged into their working tree, and the stash entry is gone.

### 2. A failed pop reported success

`2>/dev/null || true` swallows a conflicting pop:

```
CONFLICT (content): Merge conflict in f.txt
The stash entry is kept in case you need it again.
```

The updater then returned `status: success`. The owner is told the update
worked while their tree contains `<<<<<<<` markers.

### 3. A mid-update failure stranded the work silently

This one I found by accident: my third test kept failing with
`Update failed: spawnSync /bin/sh ENOENT` because the fixture is not an npm
project. That is the realistic case — anything between the stash and the pop
can fail — and the message says only "Update failed". The owner goes looking
for their changes, which are in a stash entry they never made and cannot guess
the name of.

## The fix

- stash with an explicit label and detect whether an entry was actually created
- pop only that
- a failed pop is an **error**, naming the entry
- a failure anywhere between stash and pop appends where the work is

Also converted the surrounding `execSync` string commands to `execFileSync`
argument vectors, which is what removed the need for `2>/dev/null || true` in
the first place.

## Tests

`UpdateAgent` had none, so these are the first. They run against a **real git
repository with a real remote** — a bare origin, a seed clone, a working clone
— because every one of these bugs is about what git actually does, not what the
code reads like. A replica would have tested my replica.

The constructor takes an optional `homeDir` so the tests can point at a
temporary checkout. That matches how `GitAgent` takes an `ExecFn` and
`ShowAndTellAgent` a `SpawnCollector`.

Mutation-tested: making the pop unconditional again fails
*"does not restore a stash it did not create"* and nothing else.

## Evidence

- 3 new tests, all passing; suite **4798 passed**, `tsc` clean, lint clean
- `PongAgent` also has no tests. I read it and found nothing of this kind, so I
  have not manufactured a PR for it.
