### PR TITLE
fix(flight-recorder): a credential in a ?key= parameter was recorded verbatim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **A credential in a `?key=` parameter was recorded verbatim** — the flight
+  recorder scans recorded values for embedded secrets and already caught
+  `?token=`, `?api_key=`, `?access_token=` and `https://user:pass@host`. It did
+  not catch `?key=`, which is the parameter name Google uses, and which the
+  shipped Gemini provider builds into every request URL — so any recorded value
+  carrying that URL wrote the API key into the ledger in the clear. `?sig=`,
+  used to sign Azure blob URLs, had the same hole. Both are redacted now, with
+  a value-length guard so an ordinary `?key=name` is left readable.
 - **The installer's checksum check could pass having verified nothing** — the
   one-line install downloads a `gum` release tarball and verifies it against
   the project's published `checksums.txt` using `sha256sum --ignore-missing`.

--- a/typescript/src/flight-recorder/redaction-url-credentials.test.ts
+++ b/typescript/src/flight-recorder/redaction-url-credentials.test.ts
@@ -25,7 +25,7 @@ describe('flight recorder redaction of credentials in URLs', () => {
   it('redacts a Google-style key parameter', () => {
     const url =
       'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro'
-      + ':generateContent?key=AIzaSyD-EXAMPLE-1234567890abcdef';
+      + ':generateContent?key=EXAMPLE-NOT-A-REAL-VALUE-000000';
     expect(sanitizeFlightValue(url)).toBe('[redacted]');
   });
 
@@ -41,10 +41,10 @@ describe('flight recorder redaction of credentials in URLs', () => {
   it('still redacts the parameter names it already knew', () => {
     // Anti-regression: the new pattern must not have replaced the old one.
     for (const url of [
-      'https://api.example.com/v1?token=EXAMPLE1234567890abcdef',
-      'https://api.example.com/v1?api_key=sk-EXAMPLE1234567890abcdef',
-      'https://api.example.com/v1?access_token=ghp_EXAMPLE1234567890abc',
-      'https://user:hunter2@api.example.com/v1',
+      'https://api.example.com/v1?token=EXAMPLE-NOT-A-REAL-VALUE-333333',
+      'https://api.example.com/v1?api_key=EXAMPLE-NOT-A-REAL-VALUE-222222',
+      'https://api.example.com/v1?access_token=EXAMPLE-NOT-A-REAL-VALUE-111111',
+      'https://user:not-a-real-password@api.example.com/v1',
     ]) {
       expect(sanitizeFlightValue(url), url).toBe('[redacted]');
     }

--- a/typescript/src/flight-recorder/redaction-url-credentials.test.ts
+++ b/typescript/src/flight-recorder/redaction-url-credentials.test.ts
@@ -1,0 +1,74 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { sanitizeFlightValue } from './redaction.js';
+
+/**
+ * A credential in a query string is still a credential.
+ *
+ * `sanitizeFlightValue` scans recorded values for embedded secrets, and it
+ * already caught `?token=`, `?api_key=`, `?access_token=` and
+ * `https://user:pass@host`. It did not catch `?key=`, which is the parameter
+ * name Google uses — and which the shipped Gemini provider builds:
+ *
+ *     `…/models/${model}:generateContent?key=${apiKey}`
+ *
+ * so a recorded value carrying that URL wrote the API key into the ledger
+ * verbatim. `?sig=` had the same hole, which is how Azure signs a blob URL.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+
+describe('flight recorder redaction of credentials in URLs', () => {
+  it('redacts a Google-style key parameter', () => {
+    const url =
+      'https://generativelanguage.googleapis.com/v1beta/models/gemini-pro'
+      + ':generateContent?key=AIzaSyD-EXAMPLE-1234567890abcdef';
+    expect(sanitizeFlightValue(url)).toBe('[redacted]');
+  });
+
+  it('redacts signature parameters', () => {
+    for (const url of [
+      'https://blob.example.net/container/file?sig=abcdef1234567890XYZ',
+      'https://api.example.com/v1?signature=abcdef1234567890XYZ',
+    ]) {
+      expect(sanitizeFlightValue(url), url).toBe('[redacted]');
+    }
+  });
+
+  it('still redacts the parameter names it already knew', () => {
+    // Anti-regression: the new pattern must not have replaced the old one.
+    for (const url of [
+      'https://api.example.com/v1?token=EXAMPLE1234567890abcdef',
+      'https://api.example.com/v1?api_key=sk-EXAMPLE1234567890abcdef',
+      'https://api.example.com/v1?access_token=ghp_EXAMPLE1234567890abc',
+      'https://user:hunter2@api.example.com/v1',
+    ]) {
+      expect(sanitizeFlightValue(url), url).toBe('[redacted]');
+    }
+  });
+
+  it('leaves an ordinary short key parameter alone', () => {
+    // Over-redaction has a cost too: a recorder that blanks everything tells
+    // you nothing. `key` is a common non-secret parameter name.
+    for (const url of [
+      'https://api.example.com/items?key=name',
+      'https://api.example.com/docs?key=id',
+      'https://api.example.com/x?sig=v2',
+    ]) {
+      expect(sanitizeFlightValue(url), url).toBe(url);
+    }
+  });
+
+  it('covers the parameter the Gemini provider actually builds', () => {
+    // Pins the link between the provider and this rule: if that URL shape
+    // changes, this test should be revisited rather than quietly passing.
+    const provider = readFileSync(
+      path.join(here, '..', 'providers', 'gemini.ts'),
+      'utf8',
+    );
+    expect(provider).toMatch(/\?key=\$\{apiKey\}/);
+  });
+});

--- a/typescript/src/flight-recorder/redaction.ts
+++ b/typescript/src/flight-recorder/redaction.ts
@@ -61,6 +61,12 @@ const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   /\b(?:password|pwd)\s*=\s*[^;\s]+/i,
   /\b(?:api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret|credential)\s*[:=]\s*["']?[A-Za-z0-9._~+/=-]{8,}/i,
   /[?&](?:token|secret|password|credential|authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)=/i,
+  // `key` and `sig` are credentials in a query string too, and the first is
+  // not hypothetical: the shipped Gemini provider builds
+  // `…:generateContent?key=<apiKey>`, so a recorded value carrying that URL
+  // wrote the key into the ledger. Guarded by a value length so an ordinary
+  // `?key=name` is left alone.
+  /[?&](?:key|sig|signature)=[A-Za-z0-9._~+/=-]{8,}/i,
   /(?:^|[{,\s])["']?(?:password|pwd|token|secret|credential|authorization|api[_-]?key|access[_-]?token|refresh[_-]?token|client[_-]?secret)["']?\s*[:=]/i,
   /-----BEGIN [A-Z0-9 ]*PRIVATE KEY-----/i,
 ];


### PR DESCRIPTION
## The hunt

#285 was structured output built by interpolation instead of a serializer. I
checked the other places that shape could hide:

- **SQL** — `ledger.ts` builds `INSERT INTO flight_events (…) VALUES (?, …)`
  from a constant column list with placeholders. Parameterised correctly.
- **Hand-built JSON** — none left outside comments and one constant literal.
- **URLs** — `clawhub.ts` encodes its query; the rest interpolate numeric ids
  or `?t=${Date.now()}` cache-busters.

Except one.

## The finding

`providers/gemini.ts` builds every request URL as:

```ts
`https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${apiKey}`
```

That is Google's documented API shape, so it is not wrong. What is wrong is
that the flight recorder did not know `key` is a credential.

`sanitizeFlightValue` scans recorded values for embedded secrets and was
already good at it. Measured, before this change:

```
LEAKS    …?key=AIzaSyD-EXAMPLE-1234567890abcdef
redacts  …?api_key=sk-EXAMPLE1234567890abcdef
redacts  …?access_token=ghp_EXAMPLE1234567890abcdef
redacts  …?token=EXAMPLE1234567890abcdef
redacts  https://user:hunter2@api.example.com/v1
LEAKS    …?q=hello&sig=abcdef1234567890
```

`api_key`, `access_token`, `token`, `user:pass@host` — all covered. The bare
`key` parameter, which is the one this codebase actually produces, was not.
Neither was `sig`, which is how Azure signs a blob URL.

`sanitizeFlightValue` is what `recorder.ts` runs over recorded values, so any
recorded value carrying that URL wrote the API key into the ledger in the clear.
The ledger is persisted, and show-and-tell can share it.

**`summarizeFlightError` is fine** — it hashes messages rather than storing
them, so an exception whose text contains the URL was never the exposure. I
checked that before assuming the worst.

## The fix

One pattern, with a value-length guard:

```
/[?&](?:key|sig|signature)=[A-Za-z0-9._~+/=-]{8,}/i
```

The guard matters. Over-redaction is not a safe default: a recorder that blanks
everything keeps the record and loses the ability to read it. `?key=name` and
`?key=id` stay readable; `?key=AIzaSy…` does not.

## Tests

Five, including two I would want if I were reviewing this:

- an **anti-regression** case asserting the parameter names that already worked
  still work, since a new alternation is an easy place to replace rather than
  extend
- a case pinning the rule to `gemini.ts` itself, so if that URL stops carrying
  `?key=${apiKey}` this test is revisited rather than quietly passing over a
  provider that no longer exists in that form

Mutation-tested: removing the pattern fails exactly the two new redaction cases.

## Python is different, and I have not touched it

Python's redactor is **key-based only** — it blanks a value whose key looks
sensitive and never inspects the value, so the same URL under a key named `url`
survives there. That is a design difference rather than an oversight, and
porting the pattern list is a set of judgement calls I would rather you make.
Filed separately with the measurement.

## Evidence

TypeScript **4804 passed**, 21 skipped; `tsc` clean; lint clean.
