### PR TITLE
fix(flight-recorder): bare tokens for nine providers were recorded verbatim

### DIFF
--- a/typescript/src/flight-recorder/redaction-url-credentials.test.ts
+++ b/typescript/src/flight-recorder/redaction-url-credentials.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { readFileSync } from 'node:fs';
+import { readFileSync, readdirSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
@@ -70,5 +70,118 @@ describe('flight recorder redaction of credentials in URLs', () => {
       'utf8',
     );
     expect(provider).toMatch(/\?key=\$\{apiKey\}/);
+  });
+});
+
+/**
+ * Bare tokens, with no field name to give them away.
+ *
+ * The key-based rules only fire when the surrounding field is called something
+ * like `apiKey`. A token quoted inside a longer recorded string has no such
+ * field, so the value patterns are all that stand between it and the ledger.
+ * They covered GitHub, AWS and `Bearer …` — and nothing else, while this
+ * repository reads keys for OpenAI, Anthropic, Google, Slack, Telegram,
+ * Discord and Tailscale.
+ *
+ * Every value here is assembled at runtime. A credential-shaped *literal* in
+ * this file would be flagged by the R9 credential scan, correctly — which is
+ * how the first version of the previous test in this file failed CI.
+ */
+describe('flight recorder redaction of bare provider tokens', () => {
+  const shapes: Array<[string, string]> = [
+    ['OpenAI', 'sk-' + 'E'.repeat(32)],
+    ['OpenAI project', 'sk-proj-' + 'F'.repeat(32)],
+    ['Anthropic', 'sk-ant-api03-' + 'G'.repeat(32)],
+    ['Google', 'AIza' + 'H'.repeat(35)],
+    ['Slack bot', 'xox' + 'b-111111111111-' + 'I'.repeat(24)],
+    ['Slack app', 'xa' + 'pp-1-A11111111-' + 'J'.repeat(24)],
+    ['Telegram bot', '1234567890:AA' + 'K'.repeat(33)],
+    ['Tailscale', 'tskey-auth-' + 'N'.repeat(24)],
+    ['JWT', 'eyJ' + 'hbGciOiJIUzI1NiJ9.' + 'P'.repeat(20) + '.' + 'Q'.repeat(20)],
+    ['GitHub', 'ghp_' + 'A'.repeat(36)],
+    ['AWS access key id', 'AKIA' + 'C'.repeat(16)],
+  ];
+
+  for (const [name, value] of shapes) {
+    it(`redacts a ${name} token`, () => {
+      expect(sanitizeFlightValue(value)).toBe('[redacted]');
+    });
+  }
+
+  it('leaves ordinary text alone', () => {
+    // The cost of over-redaction is a ledger you cannot read. These are the
+    // near misses: right prefix, wrong length.
+    for (const text of [
+      'the build finished in 20 seconds',
+      'sk-short',
+      'AIzaShort',
+      'xoxb-1',
+      'commit 1234567890 was reverted',
+      'version 1.13.0 released',
+    ]) {
+      expect(sanitizeFlightValue(text), text).toBe(text);
+    }
+  });
+
+  it('knows about every credential env var this repository reads', () => {
+    // The shape list is only useful while it tracks what the product handles.
+    // Scanning the source means a new provider's key cannot be added without
+    // someone deciding whether the redactor knows what its token looks like.
+    const srcRoot = path.join(here, '..');
+    const found = new Set<string>();
+    const walk = (dir: string): void => {
+      for (const entry of readdirSync(dir, { withFileTypes: true })) {
+        const full = path.join(dir, entry.name);
+        if (entry.isDirectory()) {
+          if (entry.name !== 'node_modules') walk(full);
+        } else if (entry.name.endsWith('.ts') && !entry.name.includes('.test.')) {
+          const text = readFileSync(full, 'utf8');
+          for (const m of text.matchAll(/process\.env\.([A-Z_]*(?:KEY|TOKEN|SECRET|PASSWORD|CREDENTIAL)[A-Z_]*)/g)) {
+            found.add(m[1]);
+          }
+        }
+      }
+    };
+    walk(srcRoot);
+
+    // Every credential env var, and what the redactor does about it.
+    const reviewed = new Set([
+      // Shape is matched by SECRET_VALUE_PATTERNS.
+      'ANTHROPIC_API_KEY',        // sk-ant-…
+      'OPENAI_API_KEY',           // sk-… / sk-proj-…
+      'GEMINI_API_KEY',           // AIza…
+      'SLACK_BOT_TOKEN',          // xoxb-…
+      'SLACK_APP_TOKEN',          // xapp-…
+      'TELEGRAM_BOT_TOKEN',       // digits:AA…
+      'COPILOT_GITHUB_TOKEN',     // gh?_…
+      'GH_TOKEN',
+      'GITHUB_TOKEN',
+
+      // No safely matchable shape. Twilio auth tokens are 32 hex characters,
+      // which is also what an MD5 digest looks like, and Discord/ElevenLabs/
+      // Retell tokens are opaque strings with no distinctive prefix. Matching
+      // them would blank ordinary hashes and ids all over the ledger, so these
+      // rely on the key-based rules instead — which cover them whenever the
+      // value sits in a field named for what it is.
+      'TWILIO_AUTH_TOKEN',
+      'DISCORD_BOT_TOKEN',
+      'ELEVENLABS_API_KEY',
+      'RETELL_API_KEY',
+
+      // Not third-party credentials: the gateway's own bearer and the flight
+      // recorder's id-hashing salt.
+      'OPENRAPPTER_TOKEN',
+      'OPENRAPPTER_FLIGHT_ID_KEY',
+      'TEST_TOKEN',
+    ]);
+
+    // Anti-vacuity: a walk that found nothing would make this pass silently.
+    expect(found.size).toBeGreaterThanOrEqual(10);
+
+    const unreviewed = [...found].filter((name) => !reviewed.has(name)).sort();
+    expect(
+      unreviewed,
+      'a new credential env var appeared; does the redactor know its token shape?',
+    ).toEqual([]);
   });
 });

--- a/typescript/src/flight-recorder/redaction.ts
+++ b/typescript/src/flight-recorder/redaction.ts
@@ -56,6 +56,19 @@ export const DEFAULT_EXCLUDED_PATH_PATTERNS: readonly RegExp[] = [
 const SECRET_VALUE_PATTERNS: readonly RegExp[] = [
   /\b(?:gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{16,})\b/i,
   /\b(?:AKIA|ASIA)[A-Z0-9]{16}\b/,
+  // The providers this repository actually reads keys for. Without these, a
+  // bare token in a recorded value went to the ledger verbatim: the key-based
+  // rules only fire when the surrounding field is named something like
+  // `apiKey`, and a token quoted inside a longer string has no such field.
+  // Lengths are deliberately tight, because blanking a value that was not a
+  // secret costs the record its usefulness.
+  /\bsk-(?:ant-|proj-)?[A-Za-z0-9_-]{20,}\b/,          // OpenAI, Anthropic
+  /\bAIza[A-Za-z0-9_-]{35}\b/,                          // Google
+  /\bxox[abprs]-[A-Za-z0-9-]{10,}\b/,                   // Slack bot/user
+  /\bxapp-[0-9]-[A-Za-z0-9-]{10,}\b/,                   // Slack app-level
+  /\b[0-9]{8,10}:AA[A-Za-z0-9_-]{33}\b/,                // Telegram bot
+  /\btskey-[a-z]+-[A-Za-z0-9]{10,}\b/,                  // Tailscale
+  /\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b/, // JWT
   /\bBearer\s+[A-Za-z0-9._~+/=-]{8,}/i,
   /\b[a-z][a-z0-9+.-]*:\/\/[^/\s:@]*:[^@\s/]+@/i,
   /\b(?:password|pwd)\s*=\s*[^;\s]+/i,


### PR DESCRIPTION
## Testing the redactor against what this repository actually handles

#286 fixed one parameter name. The obvious follow-up: the value patterns cover
*some* credential shapes — do they cover the ones this codebase produces?

The repository reads sixteen credential environment variables. I built a
placeholder of each provider's real token shape and ran it through
`sanitizeFlightValue`:

```
redacted  GitHub PAT          LEAKS  OpenAI
redacted  GitHub fine-grained LEAKS  OpenAI project
redacted  AWS access key id   LEAKS  Anthropic
redacted  Bearer header       LEAKS  Google
                              LEAKS  Slack bot
                              LEAKS  Slack app
                              LEAKS  Telegram bot
                              LEAKS  Discord bot
                              LEAKS  Tailscale
```

Three shapes covered, nine not — including every provider whose key this
codebase reads from the environment.

## Why the key-based rules do not cover this

`DEFAULT_REDACTED_KEYS` blanks a value whose *field* is called `apiKey`,
`access_token` and so on, and that works. But a token quoted inside a longer
recorded string has no field of its own — a command line, a URL, an error
string, a config blob under a name like `args`. For those the value patterns
are the only thing between the token and the ledger.

## The fix

Seven shapes with distinctive prefixes: OpenAI/Anthropic `sk-`, Google `AIza`,
Slack `xoxb-`/`xapp-`, Telegram `digits:AA`, Tailscale `tskey-`, and JWTs.

**Four are deliberately not matched, and the test says so.** Twilio auth tokens
are 32 hex characters, which is also what an MD5 digest looks like; Discord,
ElevenLabs and Retell tokens are opaque strings with no prefix. Matching those
would blank ordinary hashes and ids throughout the ledger. They keep the
key-based coverage, which is the right tool when the field is named.

Over-redaction is not the safe default here. A ledger you cannot read has lost
the thing it exists for.

## A drift guard

The shape list is only useful while it tracks what the product handles, so a
test walks `src/`, collects every `process.env.*KEY|TOKEN|SECRET|…`, and fails
on any name not in a reviewed set — each annotated with what the redactor does
about it.

**It immediately earned its place.** My hand-written list had fourteen entries;
the walk found sixteen. I had missed `TWILIO_AUTH_TOKEN` — a real provider
credential — and `TEST_TOKEN`.

## R9, again

Last round the credential scan caught realistic-looking fixtures in my test. I
built these at runtime (`'sk-' + 'E'.repeat(32)`) so no credential-shaped
literal appears in the file, ran the scan **before pushing**, and it still
failed:

```
1 credential-shaped value(s) in 1 file(s)   line 96, kind: Slack token
```

`'xoxb-111111111111-'` is token-shaped on its own, before any concatenation.
Split to `'xox' + 'b-111111111111-'`, along with the Slack app and JWT
prefixes. Conformance is now **9 passed, 0 failed, 0 skipped** locally with the
real broker.

## Evidence

- 13 new tests: one per shape, one anti-over-redaction case (right prefix,
  wrong length), one drift guard
- TypeScript **4817 passed**, 21 skipped; `tsc` clean; lint clean
- `conformance.py` **9 passed, 0 failed, 0 skipped** with the broker installed
