### PR TITLE
test(flight-recorder): pin why the key rules deliberately do not redact generic names

### DIFF
--- a/typescript/src/flight-recorder/redaction-url-credentials.test.ts
+++ b/typescript/src/flight-recorder/redaction-url-credentials.test.ts
@@ -185,3 +185,49 @@ describe('flight recorder redaction of bare provider tokens', () => {
     ).toEqual([]);
   });
 });
+
+/**
+ * What the key rules deliberately do *not* redact.
+ *
+ * `isSensitiveKey` splits a field name into words and fires on `token`,
+ * `secret`, `password…`, `credential…`, `cookie…`, `authorization`, plus a few
+ * compounds. It does not fire on `key`, `auth`, `salt`, `nonce` or `bearer`.
+ *
+ * That looks like a gap and is not one. `key` is one of the most common field
+ * names there is — map entries, config entries, cache entries, sort keys — and
+ * redacting it would blank most of a ledger whose whole purpose is to be read
+ * afterwards. `salt` and `nonce` are not secrets. `bearer` appears in this
+ * codebase only as a local variable holding a header value, never as a
+ * recorded field.
+ *
+ * This is written down because the instinct on seeing the list is to add those
+ * words, and the damage from doing so is invisible: nothing fails, the ledger
+ * just quietly stops saying anything. I had that instinct while auditing it.
+ */
+describe('flight recorder redaction is deliberately conservative', () => {
+  const value = 'zzzz0000zzzz0000zzzz';
+
+  it('does not redact generic field names that are usually not secrets', () => {
+    for (const name of ['key', 'auth', 'salt', 'nonce', 'id', 'name', 'path']) {
+      const out = sanitizeFlightValue({ [name]: value }) as Record<string, unknown>;
+      expect(out[name], `${name} should stay readable`).toBe(value);
+    }
+  });
+
+  it('still redacts the compound names those words appear in', () => {
+    // The conservatism is about the bare word, not the concept: a field that
+    // says what it holds is still redacted.
+    for (const name of ['apiKey', 'privateKey', 'identityKey', 'authToken', 'sessionToken']) {
+      const out = sanitizeFlightValue({ [name]: value }) as Record<string, unknown>;
+      expect(out[name], `${name} should be redacted`).toBe('[redacted]');
+    }
+  });
+
+  it('redacts a client secret through the excluded-path rules', () => {
+    // Not via [redacted] — `client_secret` matches DEFAULT_EXCLUDED_PATH_PATTERNS,
+    // so the whole entry is replaced. Worth pinning: a reader checking only for
+    // '[redacted]' would conclude this leaks, which is what I first concluded.
+    const out = sanitizeFlightValue({ clientSecret: value }) as Record<string, unknown>;
+    expect(Object.values(out)).not.toContain(value);
+  });
+});


### PR DESCRIPTION
## The investigation was a negative

#288 found that the redactor's *value* patterns missed nine provider token
shapes. The obvious next question was whether its *key* rules miss field names
this codebase uses. They do not, and this PR is about writing down why, because
the reasoning is not obvious and the mistake it prevents is silent.

I tested twenty-four field names. Eleven are not redacted:

```
bearer  auth  key  passphrase  pat  sessionKey
sshKey  encryptionKey  masterKey  salt  nonce
```

Then I checked which of those this repository actually uses to hold a
credential. **None of them.** `passphrase`, `sshKey`, `encryptionKey` and
`masterKey` appear in no production file. `bearer` appears twice, both times as
a *local variable* holding a header value — never a recorded field.
`sessionKey` appears twice, holding a session identifier.

## Why the list should stay as it is

`key` is one of the most common field names in any codebase — map entries,
config entries, cache entries, sort keys. Redacting it would blank most of a
ledger whose entire purpose is to be read afterwards. `salt` and `nonce` are
not secrets at all.

The current rules fire on `token`, `secret`, `password…`, `credential…`,
`cookie…`, `authorization` and a few compounds. That is a considered line, and
the compounds show the intent: `apiKey`, `privateKey`, `identityKey` and
`sessionToken` are all redacted. The conservatism is about the bare word, not
the concept.

## Why write a test for a non-change

Because the instinct on reading that list is to add the missing words, and the
damage from doing so is invisible. Nothing fails. The ledger just quietly stops
saying anything, and you find out months later when you need it.

**I had that instinct while auditing it**, which is the best argument that the
next person will too.

Mutation-tested: adding `key` to the word rules — the single most tempting
edit — fails two tests, one of which explains why in its name.

## A correction I nearly shipped as a finding

My first pass reported `clientSecret` as leaking. It does not. It matches
`DEFAULT_EXCLUDED_PATH_PATTERNS`, so the whole entry becomes
`{"[excluded-path]":"[excluded-path]"}` — redacted *more* aggressively than
`[redacted]`. My assertion compared against the string `'[redacted]'` and read
the stronger result as a failure.

Pinned as a test, since checking for `'[redacted]'` is the obvious way to write
that assertion and it is wrong.

## Evidence

TypeScript **4820 passed**, 21 skipped; `tsc` clean; lint clean. Test-only, so
no changelog entry.
