### PR TITLE
fix(security): a single ampersand chained commands past the safety policy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **A single `&` chained commands past the safety policy** — the injection
+  patterns covered `&&` but not `&`, and `ls & touch /tmp/x` runs both: the
+  first goes to the background and the second executes immediately. Since `ls`
+  is a safe binary the policy judged the pair safe, so neither command was
+  reviewed and no approval was requested. This is the same shape as the newline
+  bypass below — a separator the policy did not know about, hidden behind a
+  harmless-looking binary.
 - **The shell agent checked one command and executed another** — it normalized
   the command, ran the safety policy against the normalized form, and then
   executed the *raw* input. `normalizeCommand` collapses all whitespace,

--- a/python/openrappter/security/exec_safety.py
+++ b/python/openrappter/security/exec_safety.py
@@ -46,6 +46,10 @@ INJECTION_PATTERNS = [
     (re.compile(r'<\(.*\)'), 'process-substitution'),
     (re.compile(r'\|\|'), 'or-chain'),
     (re.compile(r'&&'), 'and-chain'),
+    # A single `&` is a separator too, not just a background marker:
+    # `ls & rm x` runs both. `&&` was covered and this was not, so the policy
+    # called it safe and the second command ran unreviewed.
+    (re.compile(r'(?<!&)&(?!&)'), 'background-chain'),
     (re.compile(r';'), 'semicolon-chain'),
     (re.compile(r'(?<!\|)\|(?!\|)'), 'pipe-chain'),
     # Any output redirection can mutate absolute, relative, or home paths.

--- a/python/tests/test_shell_agent.py
+++ b/python/tests/test_shell_agent.py
@@ -249,3 +249,35 @@ class TestNewlineBypass:
         result = json.loads(agent.perform(command="echo hello"))
         assert result["status"] == "success", result
         assert "hello" in result["output"]
+
+
+class TestSingleAmpersandChain:
+    """A single `&` chains commands too.
+
+    The injection patterns covered `&&` and not `&`, so "ls & touch /tmp/x" was
+    judged safe and both commands ran. Verified in a real shell:
+    `sh -c 'ls / >/dev/null & touch /tmp/marker'` creates the marker.
+    """
+
+    def test_a_background_chain_is_blocked(self):
+        agent = ShellAgent()
+        result = json.loads(agent.perform(command="ls & touch /tmp/amp-bypass-proof"))
+        assert result.get("blocked") is True, result
+        assert "background-chain" in result["message"], result
+
+    def test_a_trailing_ampersand_is_blocked(self):
+        from openrappter.security.exec_safety import ExecSafety
+        assert ExecSafety().check_command("ls &").safe is False
+
+    def test_double_ampersand_keeps_its_own_reason(self):
+        # The new rule must not swallow the existing one.
+        from openrappter.security.exec_safety import ExecSafety
+        result = ExecSafety().check_command("ls && touch /tmp/x")
+        assert result.safe is False
+        assert "and-chain" in result.reason
+
+    def test_ordinary_commands_are_untouched(self):
+        from openrappter.security.exec_safety import ExecSafety
+        safety = ExecSafety()
+        for cmd in ("echo hello", "ls -la", "git status"):
+            assert safety.check_command(cmd).safe is True, cmd

--- a/typescript/src/agents/__tests__/shell-agent-newline-bypass.test.ts
+++ b/typescript/src/agents/__tests__/shell-agent-newline-bypass.test.ts
@@ -65,3 +65,44 @@ describe('ShellAgent runs only what the safety policy checked', () => {
     expect(String(result.output)).toContain('hello');
   });
 });
+
+/**
+ * A single `&` chains commands too.
+ *
+ * `INJECTION_PATTERNS` covered `&&` and not `&`, so `ls & touch /tmp/x` was
+ * judged safe and both commands ran — `ls` is a safe binary, which is what
+ * made the pair look unremarkable. Verified in a real shell:
+ * `sh -c 'ls / >/dev/null & touch /tmp/marker'` creates the marker.
+ *
+ * Same shape as the newline bypass above: a separator the policy did not know
+ * about, on a command whose visible binary is harmless.
+ */
+describe('ShellAgent treats a single ampersand as a chain', () => {
+  it('blocks a background chain', async () => {
+    const agent = new ShellAgent(new ExecSafety());
+    const result = JSON.parse(await agent.perform({ command: 'ls & touch /tmp/amp-bypass-proof' }));
+    expect(result.blocked).toBe(true);
+    expect(result.message).toMatch(/background-chain/);
+  });
+
+  it('blocks a trailing ampersand', async () => {
+    const safety = new ExecSafety();
+    expect(safety.checkCommand('ls &').safe).toBe(false);
+  });
+
+  it('still reports && as an and-chain rather than reclassifying it', async () => {
+    // The new rule must not swallow the existing one: `&&` has its own reason,
+    // and a lookaround that matched it would change every existing message.
+    const safety = new ExecSafety();
+    const result = safety.checkCommand('ls && touch /tmp/x');
+    expect(result.safe).toBe(false);
+    expect(result.reason).toMatch(/and-chain/);
+  });
+
+  it('leaves ordinary commands alone', () => {
+    const safety = new ExecSafety();
+    for (const cmd of ['echo hello', 'ls -la', 'git status']) {
+      expect(safety.checkCommand(cmd).safe, cmd).toBe(true);
+    }
+  });
+});

--- a/typescript/src/security/exec-safety.ts
+++ b/typescript/src/security/exec-safety.ts
@@ -131,6 +131,10 @@ const INJECTION_PATTERNS: Array<{ pattern: RegExp; type: string }> = [
   // Command chaining (must come before pipe-chain to avoid || matching as pipe)
   { pattern: /\|\|/, type: 'or-chain' },
   { pattern: /&&/, type: 'and-chain' },
+  // A single `&` is a separator too, not just a background marker: `ls & rm x`
+  // runs both. `&&` was covered and this was not, so the policy called it safe
+  // and the second command ran unreviewed. Same shape as the pipe rule below.
+  { pattern: /(?<!&)&(?!&)/, type: 'background-chain' },
   { pattern: /;/, type: 'semicolon-chain' },
   // Pipe chains (single | only, after || is already handled)
   { pattern: /(?<!\|)\|(?!\|)/, type: 'pipe-chain' },


### PR DESCRIPTION
## Following #290 to the rest of the pattern list

#290 fixed a separator the policy could not see because the caller had
normalized it away. The obvious next question is whether the list itself is
complete.

It is not. `INJECTION_PATTERNS` covers `&&` and not `&`:

```
blocked  "ls && touch /tmp/x"   <- and-chain
blocked  "ls; touch /tmp/x"     <- semicolon-chain
blocked  "ls | grep x"          <- pipe-chain
SAFE     "ls & touch /tmp/x"
SAFE     "ls &"
```

A single `&` is a separator, not just a background marker. Confirmed in a real
shell rather than assumed:

```
$ sh -c 'ls / >/dev/null & touch /tmp/amp-proof'
  shell ran BOTH commands: marker created
```

So `ls & touch /tmp/x` passed the policy, requested no approval, and ran an
unreviewed second command. `ls` being a safe binary is what makes the pair look
unremarkable — the same reason the newline pair did in #290.

Both runtimes had it, in identical lists.

## The rule

```
/(?<!&)&(?!&)/   background-chain
```

Deliberately shaped like the existing pipe rule `(?<!\|)\|(?!\|)`, which solves
the same problem of not swallowing the doubled form.

There is a test for that specifically: `&&` must still report `and-chain`. A
lookaround that matched the doubled form would silently change every existing
message and reclassify a rule that already worked, which is a worse outcome
than the bug.

## On false positives

An unquoted `&` in a URL — `curl http://x/?a=1&b=2` — now needs approval. That
is the correct answer: unquoted, that ampersand *does* background the curl and
run `b=2` as a command. The file already takes this stance for `>`, whose
comment says "Require exact-command approval for all forms."

## Also checked, nothing found

The other patterns are not vulnerable to the #290 normalization blind spot.
`normalizeCommand` only collapses whitespace, and the remaining rules key on
`$()`, backticks, `<()`, `;`, `|`, `>` and `${}` — none of which whitespace
folding can hide. If anything it helps: `$(\nrm\n)` does not match `/\$\(.*\)/`
raw, because `.` excludes newlines, but does after folding.

## Evidence

- 4 new tests per runtime, including the `&&`-still-reports-and-chain guard and
  an anti-vacuity case for ordinary commands
- mutation-tested: removing the pattern fails exactly the two blocking tests
- TypeScript **4828 passed**, `tsc` and lint clean; Python **1587 passed**
- `conformance.py` **8 passed, 0 failed**; `parity_harness.py` **PASS**
