### PR TITLE
fix(security): git is dual-use — its configuration executes arbitrary commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`git` is now treated as dual-use, because its configuration executes
+  commands** — `git -c alias.x='!cmd' x` runs `cmd`, and `-c core.pager=` does
+  the same wherever a pager is used. There is no separator and no substitution
+  for the injection patterns to catch, and `git` was on the safe list, so the
+  shell agent ran it without asking. It stays on the safe list but now requires
+  approval, alongside `find`, `awk`, `sed` and `tar` — which were already
+  listed for exactly this reason.
 - **A single `&` chained commands past the safety policy** — the injection
   patterns covered `&&` but not `&`, and `ls & touch /tmp/x` runs both: the
   first goes to the background and the second executes immediately. Since `ls`

--- a/python/openrappter/security/exec_safety.py
+++ b/python/openrappter/security/exec_safety.py
@@ -33,6 +33,12 @@ DUAL_USE_BINS = {
     'node', 'python', 'python3', 'tsx', 'tsc', 'vitest',
     'chmod', 'chown',
     'find', 'awk', 'sed', 'tar', 'env',
+    # git runs whatever its configuration tells it to.
+    # `git -c alias.x='!cmd' x` executes `cmd`, and `-c core.pager=` does the
+    # same wherever a pager is used. Verified: the alias form creates the file.
+    # Nothing in the injection patterns can see this — there is no separator,
+    # no substitution, and the binary is on the safe list.
+    'git',
     'mkdir', 'cp', 'mv', 'touch', 'gzip', 'gunzip', 'zip', 'unzip',
     'date', 'sort', 'uniq',
 }

--- a/python/tests/test_shell_agent.py
+++ b/python/tests/test_shell_agent.py
@@ -281,3 +281,28 @@ class TestSingleAmpersandChain:
         safety = ExecSafety()
         for cmd in ("echo hello", "ls -la", "git status"):
             assert safety.check_command(cmd).safe is True, cmd
+
+
+class TestGitIsDualUse:
+    """git runs whatever its configuration tells it to.
+
+    `git -c alias.x='!cmd' x` executes `cmd`; there is no separator and no
+    substitution, so nothing in the injection patterns can see it, and git was
+    on the safe list. Verified against a real repository: the alias form
+    creates the marker file.
+    """
+
+    def test_git_is_classified_dual_use(self):
+        from openrappter.security.exec_safety import ExecSafety, DUAL_USE_BINS
+        assert "git" in DUAL_USE_BINS
+        result = ExecSafety().check_command("git -c alias.x=!touch /tmp/x x")
+        assert result.safe is True            # still on the safe list
+        assert result.requires_approval is True  # but a human has to look
+
+    def test_ordinary_read_only_binaries_are_still_not_dual_use(self):
+        from openrappter.security.exec_safety import ExecSafety
+        safety = ExecSafety()
+        for cmd in ("ls -la", "cat f", "grep x f", "echo hi"):
+            result = safety.check_command(cmd)
+            assert result.safe is True, cmd
+            assert not result.requires_approval, cmd

--- a/typescript/src/security/__tests__/security.test.ts
+++ b/typescript/src/security/__tests__/security.test.ts
@@ -586,12 +586,26 @@ describe('ExecSafety — dual-use classification (RAI hardening)', () => {
   });
 
   it('does not flag ordinary read-only binaries as dual-use', () => {
-    for (const cmd of ['ls -la', 'cat f', 'grep x f', 'git status', 'echo hi']) {
+    // `git status` was in this list. git is not read-only in the sense that
+    // matters here: `git -c alias.x='!cmd' x` executes `cmd`, and there is no
+    // separator or substitution for the injection patterns to catch. Verified
+    // against a real repository — the alias form creates the marker file — so
+    // git is now classified dual-use alongside find, awk, sed and tar.
+    for (const cmd of ['ls -la', 'cat f', 'grep x f', 'echo hi']) {
       const result = safety.checkCommand(cmd);
       expect(result.safe).toBe(true);
       expect(result.dualUse).toBeUndefined();
       expect(result.requiresApproval).toBeUndefined();
     }
+  });
+
+  it('classifies git as dual-use because its configuration executes commands', () => {
+    // `git -c alias.x='!touch /tmp/marker' x` runs the command. Confirmed in a
+    // scratch repository rather than inferred from the manual.
+    expect(safety.isDualUse('git')).toBe(true);
+    const result = safety.checkCommand("git -c alias.x=!touch /tmp/x x");
+    expect(result.safe).toBe(true);          // still on the safe list
+    expect(result.requiresApproval).toBe(true);  // but a human has to look
   });
 
   it('isDualUse reports classification directly', () => {

--- a/typescript/src/security/exec-safety.ts
+++ b/typescript/src/security/exec-safety.ts
@@ -113,6 +113,12 @@ export const DUAL_USE_BINS = new Set([
   'chmod', 'chown',
   // Utilities with built-in command execution or shell escapes
   'find', 'awk', 'sed', 'tar', 'env',
+  // git runs whatever its configuration tells it to. `git -c alias.x='!cmd' x`
+  // executes `cmd`, and `-c core.pager=` does the same wherever a pager is
+  // used. Verified: `git -c alias.x='!touch /tmp/marker' x` creates the file.
+  // Nothing in the injection patterns can see this — there is no separator,
+  // no substitution, and the binary is on the safe list.
+  'git',
   // Filesystem-mutating utilities
   'mkdir', 'cp', 'mv', 'touch', 'gzip', 'gunzip', 'zip', 'unzip',
   // Commands with output-file or system-mutation modes


### PR DESCRIPTION
## Looking past separators

#290 and #291 were both separators — one the policy could not see, one it did
not know. This round asks the other question: which *binaries* on the safe list
can execute a command with no separator at all?

The dual-use list already answers that well. It names `find`, `awk`, `sed`,
`tar` and `env` under "Utilities with built-in command execution or shell
escapes", which is exactly the right instinct.

It does not name `git`.

## git executes what its configuration says

```
git -c alias.x='!touch /tmp/git-alias-proof' x
  EXECUTED: git -c alias.x='!touch …' ran the command
```

Confirmed against a real repository rather than inferred from the manual. An
alias beginning with `!` is a shell command, and `-c` sets it for a single
invocation, so no repository state is needed and nothing is left behind.

The policy's verdict on that exact string, before this change:

```
SAFE   approval=false   "git -c alias.x=!touch /tmp/git-alias-proof x"
```

No separator, no substitution, no redirect — nothing for `INJECTION_PATTERNS`
to match — and `git` was on the safe list, so the shell agent ran it without
asking anyone.

Both runtimes.

## Honest scope

I also tried `-c core.pager=`, which is the more commonly cited vector. **It
did not fire**, because git only invokes a pager when stdout is a terminal, and
the agent's is not. It is still listed in the comment as a reason, since it
fires wherever a pager is used, but the alias form is the one I demonstrated.

`git` remains `safe: true`. What changes is `requiresApproval`, so a human sees
the command first — the same treatment `curl`, `npm` and `node` already get.

`GitAgent` is unaffected: it builds argument vectors and never routes through
the shell agent.

## A test asserted the opposite

`security.test.ts` had `git status` in a list titled *"does not flag ordinary
read-only binaries as dual-use"*. That test encoded the belief this PR
contradicts, so I have not just deleted the entry — the list now carries the
reason, and there is a new test asserting the classification with the vector
that motivated it.

That felt worth doing carefully. A failing test that disagrees with a security
finding is exactly the moment to check which one is wrong, and here it was the
test.

## Evidence

- TypeScript **4829 passed**, `tsc` and lint clean; Python **1589 passed**
- `conformance.py` **8 passed, 0 failed**; `parity_harness.py` **PASS**
