### PR TITLE
fix(security): an environment assignment or plantable path reached a safe-listed name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -358,6 +358,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **An environment assignment or a plantable path reached a safe-listed name** —
+  the binary parser skips leading `VAR=value` assignments and takes the
+  basename, both of which are right for classifying a command and neither of
+  which was treated as a risk. So `LD_PRELOAD=/tmp/x.so ls` was judged an
+  ordinary `ls` while the loader read the assignment after exec, and `./ls` was
+  judged the system tool while running whatever sits in the working directory.
+  The `env LD_PRELOAD=… ls` spelling already required approval, because `env`
+  is dual-use; the shell's own assignment syntax did not. Both now require
+  approval rather than being blocked, and `/bin` and `/usr/bin` stay ungated
+  since they are not writable without root.
 - **`git` is now treated as dual-use, because its configuration executes
   commands** — `git -c alias.x='!cmd' x` runs `cmd`, and `-c core.pager=` does
   the same wherever a pager is used. There is no separator and no substitution

--- a/python/openrappter/security/exec_safety.py
+++ b/python/openrappter/security/exec_safety.py
@@ -155,6 +155,44 @@ class ExecSafety:
             self._record_audit(cmd, binary, result, 'blocked')
             return result
 
+        # Two shapes reach a safe-listed name while running something else,
+        # and both are gated rather than blocked:
+        #
+        #   LD_PRELOAD=/tmp/x.so ls  — _parse_binary skips assignments to find
+        #     the binary, which is right for classification, but the assignment
+        #     is the dangerous part: the loader reads it after exec. The `env`
+        #     spelling already required approval because env is dual-use; the
+        #     shell's own assignment syntax did not.
+        #
+        #   ./ls                     — _parse_binary takes the basename, so a
+        #     file planted in the working directory is judged as the system
+        #     tool of the same name. Standard system directories are not
+        #     writable without root, so those stay ungated.
+        trimmed = cmd.strip()
+        has_env_prefix = bool(re.match(r'[A-Za-z_][A-Za-z0-9_]*=', trimmed))
+        invoked = next(
+            (part for part in trimmed.split() if '=' not in part), ''
+        )
+        trusted_dirs = ('/bin/', '/usr/bin/', '/sbin/', '/usr/sbin/')
+        path_qualified = '/' in invoked and not invoked.startswith(trusted_dirs)
+
+        if binary not in DUAL_USE_BINS and (has_env_prefix or path_qualified):
+            why = (
+                'Environment assignment before the command can change what it '
+                'loads'
+                if has_env_prefix
+                else f"Command is a path, so '{binary}' is not necessarily the "
+                     "system tool"
+            )
+            result = SafetyCheckResult(
+                safe=True,
+                binary=binary,
+                requires_approval=True,
+                reason=f'{why} — requires explicit approval',
+            )
+            self._record_audit(cmd, binary, result, 'pending')
+            return result
+
         result = (
             SafetyCheckResult(
                 safe=True,

--- a/python/tests/test_shell_agent.py
+++ b/python/tests/test_shell_agent.py
@@ -306,3 +306,49 @@ class TestGitIsDualUse:
             result = safety.check_command(cmd)
             assert result.safe is True, cmd
             assert not result.requires_approval, cmd
+
+
+class TestReachingASafeNameByAnotherRoute:
+    """_parse_binary skips leading VAR=value assignments and takes the
+    basename. Both are right for classifying the command and neither was
+    evaluated as a risk, so two shapes ran ungated:
+
+      LD_PRELOAD=/tmp/x.so ls   the loader reads the assignment after exec;
+                                the `env LD_PRELOAD=...` spelling already
+                                required approval because env is dual-use
+      ./ls                      judged as the system ls by basename
+    """
+
+    def _safety(self):
+        from openrappter.security.exec_safety import ExecSafety
+        return ExecSafety()
+
+    def test_environment_assignment_is_gated(self):
+        safety = self._safety()
+        for cmd in ("LD_PRELOAD=/tmp/evil.so ls",
+                    "DYLD_INSERT_LIBRARIES=/tmp/evil.dylib ls"):
+            result = safety.check_command(cmd)
+            assert result.requires_approval is True, cmd
+            assert "Environment assignment" in result.reason, cmd
+
+    def test_a_plantable_path_is_gated(self):
+        safety = self._safety()
+        for cmd in ("./ls", "/tmp/ls"):
+            result = safety.check_command(cmd)
+            assert result.requires_approval is True, cmd
+
+    def test_system_directories_stay_ungated(self):
+        # Over-gating has a cost: every gated command needs a human.
+        safety = self._safety()
+        for cmd in ("/bin/ls -la", "/usr/bin/grep x f"):
+            assert not safety.check_command(cmd).requires_approval, cmd
+
+    def test_ordinary_commands_stay_ungated(self):
+        safety = self._safety()
+        for cmd in ("ls -la", "cat f", "echo hi"):
+            assert not safety.check_command(cmd).requires_approval, cmd
+
+    def test_an_unknown_path_binary_is_blocked_not_gated(self):
+        result = self._safety().check_command("scripts/build.sh")
+        assert result.safe is False
+        assert "not in the safe list" in result.reason

--- a/typescript/src/agents/__tests__/shell-agent-newline-bypass.test.ts
+++ b/typescript/src/agents/__tests__/shell-agent-newline-bypass.test.ts
@@ -106,3 +106,64 @@ describe('ShellAgent treats a single ampersand as a chain', () => {
     }
   });
 });
+
+/**
+ * Reaching a safe-listed name while running something else.
+ *
+ * `parseBinary` skips leading `VAR=value` assignments and takes the basename.
+ * Both are right for *classifying* the command and neither is evaluated as a
+ * risk, so two shapes slipped through ungated:
+ *
+ *   LD_PRELOAD=/tmp/x.so ls   the loader reads the assignment after exec. The
+ *                             `env LD_PRELOAD=… ls` spelling already required
+ *                             approval, because `env` is dual-use; the shell's
+ *                             own assignment syntax did not.
+ *   ./ls                      judged as the system `ls` by basename.
+ *
+ * Neither is blocked — both are gated, the same treatment `curl` and `npm`
+ * already get.
+ */
+describe('ShellAgent gates commands that reach a safe name by another route', () => {
+  const safety = new ExecSafety();
+
+  it('gates an environment assignment before the command', () => {
+    for (const cmd of [
+      'LD_PRELOAD=/tmp/evil.so ls',
+      'DYLD_INSERT_LIBRARIES=/tmp/evil.dylib ls',
+    ]) {
+      const r = safety.checkCommand(cmd);
+      expect(r.requiresApproval, cmd).toBe(true);
+      expect(r.reason, cmd).toMatch(/Environment assignment/);
+    }
+  });
+
+  it('gates a command given as a plantable path', () => {
+    for (const cmd of ['./ls', '/tmp/ls']) {
+      const r = safety.checkCommand(cmd);
+      expect(r.requiresApproval, cmd).toBe(true);
+      expect(r.reason, cmd).toMatch(/not necessarily the system tool/);
+    }
+  });
+
+  it('leaves the standard system directories ungated', () => {
+    // Over-gating has a cost: every gated command needs a human. /bin and
+    // /usr/bin are not writable without root, so the name is the tool.
+    for (const cmd of ['/bin/ls -la', '/usr/bin/grep x f']) {
+      expect(safety.checkCommand(cmd).requiresApproval, cmd).toBeFalsy();
+    }
+  });
+
+  it('leaves ordinary commands ungated', () => {
+    for (const cmd of ['ls -la', 'cat f', 'echo hi', 'jq .']) {
+      expect(safety.checkCommand(cmd).requiresApproval, cmd).toBeFalsy();
+    }
+  });
+
+  it('does not confuse an unknown path binary for a gated one', () => {
+    // `scripts/build.sh` is not on the safe list at all, so it is blocked
+    // outright rather than routed to approval.
+    const r = safety.checkCommand('scripts/build.sh');
+    expect(r.safe).toBe(false);
+    expect(r.reason).toMatch(/not in the safe list/);
+  });
+});

--- a/typescript/src/security/exec-safety.ts
+++ b/typescript/src/security/exec-safety.ts
@@ -242,6 +242,43 @@ export class ExecSafety {
 
     // On the safe list. Dual-use binaries stay `safe` for backward compatibility
     // but are flagged so an approval layer can gate them.
+    //
+    // Two shapes reach a safe-listed name while running something else, and
+    // both are gated the same way rather than blocked outright:
+    //
+    //   LD_PRELOAD=/tmp/x.so ls   — `parseBinary` skips assignments to find the
+    //     binary, which is right for classification, but the assignment is the
+    //     dangerous part: the loader reads it after exec. The spelling with
+    //     `env` already required approval, because `env` is dual-use; the
+    //     shell's own assignment syntax did not.
+    //
+    //   ./ls                      — `parseBinary` takes the basename, so a file
+    //     planted in the working directory is judged as the system tool of the
+    //     same name.
+    const trimmed = cmd.trim();
+    const hasEnvPrefix = /^[A-Za-z_][A-Za-z0-9_]*=/.test(trimmed);
+    const invoked = trimmed.split(/\s+/).find((part) => !part.includes('=')) ?? '';
+    // A path only matters when the file could have been planted. The standard
+    // system directories are not writable without root, so `/usr/bin/git` is
+    // the tool it names; `./ls` or `/tmp/ls` is whatever someone put there.
+    const TRUSTED_BIN_DIRS = ['/bin/', '/usr/bin/', '/sbin/', '/usr/sbin/'];
+    const pathQualified = invoked.includes('/')
+      && !TRUSTED_BIN_DIRS.some((dir) => invoked.startsWith(dir));
+
+    if (!dualUse && (hasEnvPrefix || pathQualified)) {
+      const why = hasEnvPrefix
+        ? 'Environment assignment before the command can change what it loads'
+        : `Command is a path, so '${binary}' is not necessarily the system tool`;
+      const result: SafetyCheckResult = {
+        safe: true,
+        binary,
+        requiresApproval: true,
+        reason: `${why} — requires explicit approval`,
+      };
+      this.recordAudit(cmd, binary, result, 'pending');
+      return result;
+    }
+
     const result: SafetyCheckResult = dualUse
       ? { safe: true, binary, dualUse: true, requiresApproval: true }
       : { safe: true, binary };


### PR DESCRIPTION
## Auditing the rest of the safe list

#292 added `git` to the dual-use list. The obvious follow-up is the other 21
safe-listed binaries that are *not* dual-use:

```
cat cut diff echo export false grep head jq ls printf pwd
seq set sleep tail test true wc which whoami
```

None of them executes commands. `jq` has no shell escape, `diff` has no exec
mode, and the rest read or print. The list is well curated — `sort` is already
dual-use for `--compress-program`, `env` for running a command, `find`/`awk`/
`sed`/`tar` for their escapes.

So the gap was not a binary. It was how the command is read.

## `parseBinary` finds the tool, and nothing judges the route

```ts
const parts = trimmed.split(/\s+/);
for (const part of parts) {
  if (!part.includes('=')) return path.basename(part);   // skip VAR=value
}
```

Both behaviours are correct for *classification*. Neither is evaluated as a
risk, which left two shapes reaching a safe-listed name while running something
else:

| command | judged as | actually |
|---|---|---|
| `LD_PRELOAD=/tmp/x.so ls` | `ls`, safe, ungated | loader reads the assignment after exec |
| `./ls` | `ls`, safe, ungated | whatever is in the working directory |

The first is the more telling one, because **`env LD_PRELOAD=… ls` already
required approval** — `env` is dual-use. The policy knew that shape was
dangerous; it just did not recognise the shell's own spelling of it.

## A hypothesis I had to throw away

I first went after `PATH=/tmp/evil ls`, which the policy also called safe. It
does not work:

```
sh    PATH=... ls  -> not executed
bash  PATH=... ls  -> not executed
zsh   PATH=... ls  -> not executed
```

POSIX resolves the command *before* the assignment takes effect for that
command, so the planted binary is never found. I had planted one and expected a
marker file; there wasn't one. Worth saying plainly, because `PATH=` reads like
the obvious attack and isn't.

`LD_PRELOAD` is different in kind: it is read by the loader after exec, not
during command lookup.

## Gated, not blocked

Both shapes stay `safe: true` and gain `requiresApproval` — the treatment
`curl`, `npm` and `git` already get. A human sees the command.

Absolute paths under `/bin`, `/usr/bin`, `/sbin`, `/usr/sbin` are deliberately
**not** gated. Those directories need root to write, so the name is the tool,
and gating them would mean an approval prompt for `/usr/bin/git`. Over-gating
has its own cost: every gated command needs a person, and a policy that asks
about everything gets waved through.

`scripts/build.sh` is unaffected — it was never on the safe list, so it is
blocked outright rather than routed to approval. There is a test for that
distinction.

## Evidence

- 5 new tests per runtime, including the ungated cases in both directions
- TypeScript **4834 passed**, `tsc` and lint clean; Python **1594 passed**
- `conformance.py` **8 passed, 0 failed**; `parity_harness.py` **PASS**
