### PR TITLE
fix(security): the approval queue told the reviewer what, not why

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The approval queue told the reviewer what, not why** — the safety policy
+  works out precisely why a command needs a person (dual-use binary,
+  environment assignment, plantable path) and sent that explanation to the
+  *caller* in the agent's error message. The queue a human reads recorded
+  `Approval token issued for: <command>`, so the reviewer saw the command
+  restated back at them and had to re-derive the danger themselves. The
+  policy's reason now reaches the queue. On the Python side the reviewer saw
+  nothing at all — its approval token carries no reason field — so it gains the
+  same merged `list_pending_approvals` view TypeScript has.
 - **`git log` silently omitted commits whose subject contains a quote** — both
   runtimes asked git to build JSON directly, with
   `--pretty=format:{"hash":"%H",…,"subject":"%s"}`. A subject containing a

--- a/python/openrappter/agents/shell_agent.py
+++ b/python/openrappter/agents/shell_agent.py
@@ -206,7 +206,7 @@ class ShellAgent(BasicAgent):
                     })
                 # Approval verified and consumed (single-use) — fall through to execution.
             else:
-                token = self._exec_safety.issue_approval_token(normalized)
+                token = self._exec_safety.issue_approval_token(normalized, reason=reason)
                 return json.dumps({
                     "status": "error",
                     "message": f"Command blocked by safety policy: {reason}. "

--- a/python/openrappter/security/exec_safety.py
+++ b/python/openrappter/security/exec_safety.py
@@ -227,7 +227,12 @@ class ExecSafety:
     # consumed exactly once for the exact same normalized command it was
     # issued for.
 
-    def issue_approval_token(self, cmd: str, ttl_seconds: float = 300.0) -> ApprovalToken:
+    def issue_approval_token(
+        self,
+        cmd: str,
+        ttl_seconds: float = 300.0,
+        reason: str | None = None,
+    ) -> ApprovalToken:
         token_id = f'token_{uuid.uuid4().hex}'
         normalized = self.normalize_command(cmd)
         token = ApprovalToken(
@@ -244,7 +249,15 @@ class ExecSafety:
             cmd=normalized,
             binary=self._parse_binary(normalized),
             safe=False,
-            reason=f'Approval token issued for: {normalized}',
+            # The policy already worked out why this needs a person; without
+            # it the reviewer sees the command restated back at them and has
+            # to re-derive the danger. The caller was getting this
+            # explanation and the reviewer was not.
+            reason=(
+                reason
+                if reason
+                else f'Approval token issued for: {normalized}'
+            ),
             status='pending',
         ))
 
@@ -299,6 +312,36 @@ class ExecSafety:
 
     def get_pending_approval_tokens(self) -> List[ApprovalToken]:
         return [t for t in self._tokens.values() if t.status == 'pending']
+
+    def list_pending_approvals(self) -> List[dict]:
+        """What a reviewer needs to decide, not just what is pending.
+
+        ApprovalToken carries no reason, so a reviewer listing tokens saw the
+        command and nothing about why it needs them. check_command already
+        worked that out; it is recorded on the audit entry and joined back
+        here. Mirrors the TypeScript view of the same name.
+        """
+        now = time.time()
+        pending = []
+        for token in self._tokens.values():
+            if token.status != 'pending' or token.expires_at <= now:
+                continue
+            entry = next(
+                (e for e in self._audit_log if e.id == token.id), None
+            )
+            pending.append({
+                'id': token.id,
+                'cmd': token.cmd,
+                'binary': self._parse_binary(token.cmd),
+                'reason': (
+                    entry.reason if entry and entry.reason
+                    else f'Approval required for: {token.cmd}'
+                ),
+                'created_at': token.created_at,
+                'expires_at': token.expires_at,
+                'kind': 'token',
+            })
+        return sorted(pending, key=lambda p: p['created_at'])
 
     def get_approval_token(self, token_id: str) -> Optional[ApprovalToken]:
         return self._tokens.get(token_id)

--- a/python/tests/test_shell_agent.py
+++ b/python/tests/test_shell_agent.py
@@ -352,3 +352,36 @@ class TestReachingASafeNameByAnotherRoute:
         result = self._safety().check_command("scripts/build.sh")
         assert result.safe is False
         assert "not in the safe list" in result.reason
+
+
+class TestTheApprovalQueueTellsTheReviewerWhy:
+    """check_command works out precisely why a command needs a person, and that
+    explanation went to the caller in the agent's error message. The approval
+    queue recorded 'Approval token issued for: <cmd>', so the human deciding
+    saw the command restated back at them.
+
+    Gating a command only helps if the person approving it can judge it.
+    """
+
+    def _pending_for(self, command):
+        from openrappter.security.exec_safety import ExecSafety
+        safety = ExecSafety()
+        ShellAgent(exec_safety=safety).perform(command=command)
+        return safety.list_pending_approvals()[0]
+
+    def test_names_the_environment_assignment(self):
+        pending = self._pending_for("LD_PRELOAD=/tmp/evil.so ls")
+        assert "Environment assignment" in pending["reason"], pending
+        assert "LD_PRELOAD" in pending["cmd"]
+
+    def test_names_the_plantable_path(self):
+        pending = self._pending_for("./ls")
+        assert "not necessarily the system tool" in pending["reason"], pending
+
+    def test_names_the_dual_use_binary(self):
+        pending = self._pending_for("curl https://example.com")
+        assert "Dual-use binary" in pending["reason"], pending
+
+    def test_does_not_restate_the_command_as_its_own_justification(self):
+        pending = self._pending_for("LD_PRELOAD=/tmp/evil.so ls")
+        assert not pending["reason"].startswith("Approval token issued for:"), pending

--- a/typescript/src/agents/ShellAgent.ts
+++ b/typescript/src/agents/ShellAgent.ts
@@ -194,7 +194,7 @@ export class ShellAgent extends BasicAgent {
         }
         // Approval verified and consumed (single-use) — fall through to execution.
       } else {
-        const token = this.execSafety.issueApprovalToken(normalized);
+        const token = this.execSafety.issueApprovalToken(normalized, undefined, reason);
         return JSON.stringify({
           status: 'error',
           message: `Command blocked by safety policy: ${reason}. Request approval and retry with the same command plus approval_id.`,

--- a/typescript/src/agents/__tests__/shell-agent-newline-bypass.test.ts
+++ b/typescript/src/agents/__tests__/shell-agent-newline-bypass.test.ts
@@ -167,3 +167,51 @@ describe('ShellAgent gates commands that reach a safe name by another route', ()
     expect(r.reason).toMatch(/not in the safe list/);
   });
 });
+
+/**
+ * The reviewer has to be told why, not just what.
+ *
+ * `checkCommand` works out precisely why a command needs a person — dual-use
+ * binary, environment assignment, plantable path — and that explanation went
+ * to the *caller* in the agent's error message. The approval queue recorded
+ * `Approval token issued for: <cmd>`, so the human deciding saw the command
+ * restated back at them and had to re-derive the danger themselves.
+ *
+ * Gating a command only helps if the person approving it can judge it.
+ */
+describe('the approval queue tells the reviewer why', () => {
+  async function pendingFor(command: string) {
+    const safety = new ExecSafety();
+    await new ShellAgent(safety).perform({ command });
+    const [pending] = safety.listPendingApprovals();
+    return pending;
+  }
+
+  it('names the environment assignment', async () => {
+    const p = await pendingFor('LD_PRELOAD=/tmp/evil.so ls');
+    expect(p.reason).toMatch(/Environment assignment/);
+    expect(p.cmd).toContain('LD_PRELOAD');
+  });
+
+  it('names the plantable path', async () => {
+    const p = await pendingFor('./ls');
+    expect(p.reason).toMatch(/not necessarily the system tool/);
+  });
+
+  it('names the dual-use binary', async () => {
+    const p = await pendingFor('curl https://example.com');
+    expect(p.reason).toMatch(/Dual-use binary 'curl'/);
+  });
+
+  it('does not restate the command as its own justification', async () => {
+    // The old text was `Approval token issued for: <cmd>`, which is what the
+    // reviewer already sees in the cmd field.
+    const p = await pendingFor('LD_PRELOAD=/tmp/evil.so ls');
+    expect(p.reason).not.toMatch(/^Approval token issued for:/);
+  });
+
+  it('still shows the full command, not just the binary', async () => {
+    const p = await pendingFor('LD_PRELOAD=/tmp/evil.so ls');
+    expect(p.cmd).toBe('LD_PRELOAD=/tmp/evil.so ls');
+  });
+});

--- a/typescript/src/security/exec-safety.ts
+++ b/typescript/src/security/exec-safety.ts
@@ -433,7 +433,7 @@ export class ExecSafety {
    * Issue a single-use approval token scoped to the exact normalized command.
    * Does not block; the token starts out 'pending' until resolved.
    */
-  issueApprovalToken(cmd: string, ttlMs = 300_000): ApprovalToken {
+  issueApprovalToken(cmd: string, ttlMs = 300_000, reason?: string): ApprovalToken {
     const id = `token_${Date.now()}_${Math.random().toString(36).slice(2)}`;
     const normalized = this.normalizeCommand(cmd);
     const token: ApprovalToken = {
@@ -450,7 +450,13 @@ export class ExecSafety {
       cmd: normalized,
       binary: this.parseBinary(normalized),
       safe: false,
-      reason: `Approval token issued for: ${normalized}`,
+      reason: reason
+        // The policy already worked out why this needs a person; without it the
+        // reviewer sees the command restated back at them and has to re-derive
+        // the danger themselves. The caller was getting this explanation and
+        // the reviewer was not, which is the wrong way round.
+        ? reason
+        : `Approval token issued for: ${normalized}`,
       status: 'pending',
       timestamp: token.createdAt,
     });


### PR DESCRIPTION
## Gating only helps if the reviewer can judge

#292 and #293 routed more commands to a human. That is only worth doing if the
human is told enough to decide, so I went to look at what the approval queue
actually shows.

`checkCommand` already works out precisely why a command needs a person:

```
Dual-use binary 'curl' requires explicit approval
Environment assignment before the command can change what it loads — requires explicit approval
Command is a path, so 'ls' is not necessarily the system tool — requires explicit approval
```

That string went into the agent's error message — to the **caller**. The queue
a human reads recorded something else:

```
Approval token issued for: LD_PRELOAD=/tmp/evil.so ls
```

Which is the command restated, next to a field already showing the command. The
reviewer had to spot the `LD_PRELOAD` themselves, having been told nothing the
system had not already worked out.

The explanation was going to the model and not to the person. Now:

```
"LD_PRELOAD=/tmp/x.so ls"    Environment assignment before the command can change what it loads — requires explicit approval
"./ls"                       Command is a path, so 'ls' is not necessarily the system tool — requires explicit approval
"git status"                 Dual-use binary 'git' requires explicit approval
```

## Python was worse, and I found it through a failing test

I wrote the Python tests as a mirror of the TypeScript ones and they failed on
`AttributeError: 'ExecSafety' object has no attribute 'list_pending_approvals'`.

Python has no merged view, and its `ApprovalToken` has **no reason field at
all** — `id`, `cmd`, `status`, `created_at`, `expires_at`. A reviewer listing
pending approvals there saw the command and nothing else, with no way to reach
the reason even though the audit log had it.

So Python gains `list_pending_approvals`, joining tokens to their audit entry,
matching the TypeScript view of the same name. Its single-queue design is left
alone: unlike TypeScript it has no promise-based approval path, so there is
nothing to merge, and inventing one would be scope I have no reason for.

## A detail worth the extra pass

My first version appended `— approval required` to the reason, which produced:

> Environment assignment … — requires explicit approval — approval required

The policy's reasons already end that way. Doubling it reads as carelessness in
exactly the surface where a person is deciding whether to trust the system.
Removed.

## Tests

Five in TypeScript, four in Python, including one that asserts the reason
**does not** start with `Approval token issued for:` — the old text — so a
regression to restating the command fails rather than passing quietly. Plus one
that the full command is still shown, not just the parsed binary: knowing it is
`ls` is precisely the misleading part.

## Evidence

TypeScript **4839 passed**, `tsc` and lint clean. Python **1598 passed**.
`conformance.py` **8 passed, 0 failed**. `parity_harness.py` **PASS**.
