### PR TITLE
feat(cli): openrappter approvals — a gated command could be requested and never granted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`openrappter approvals`** — list, approve and deny commands the safety
+  policy has gated, from the terminal. The gateway has served `exec.pending`
+  and `exec.respond` for some time and the only client calling them was the
+  macOS menu bar app, so on Linux and Windows a gated command could be
+  requested and never granted: the agent hands back an approval id and there
+  was nowhere to take it. `approvals list` shows the command *and why it needs
+  a person*, since `LD_PRELOAD=… ls` reads as an ordinary `ls` otherwise.
 - **A slow machine can start the desktop app** — the app waits for the gateway
   it spawned to report ready and then kills it. That budget only ever runs out
   when the gateway is alive and merely slow (a genuine startup failure is

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -18,6 +18,7 @@ Run `openrappter <command> --help` for a command's own options.
 | `call` |  | Place and manage phone calls the agent makes on your behalf |
 | `twin` | `[options]` | Your digital twin — local-first, never leaves this machine |
 | `cron` |  | Manage cron jobs |
+| `approvals` |  | Review commands waiting on your approval |
 | `config` |  | Manage configuration |
 | `doctor` | `[options]` | Run system diagnostics and health checks |
 | `twins` | `[options]` | Which rappters are running on this device |

--- a/typescript/src/cli/__tests__/approvals.test.ts
+++ b/typescript/src/cli/__tests__/approvals.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Command } from 'commander';
+import { readFileSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { registerApprovalsCommand } from '../approvals.js';
+
+/**
+ * A command the safety policy gates has to be resolvable.
+ *
+ * The gateway has served `exec.pending` and `exec.respond` for some time, and
+ * the only production client calling them was the macOS menu bar app. On Linux
+ * and Windows a gated command could be requested and never granted: the agent
+ * returns an approval id and there was nowhere to take it. Widening what needs
+ * approval — `git`, environment assignments, plantable paths — made that gap
+ * matter more often.
+ *
+ * These assert the wire contract, because the value of this command is that it
+ * speaks the same one the Bar does.
+ */
+
+const calls: Array<{ method: string; params?: unknown }> = [];
+
+vi.mock('../rpc-client.js', () => ({
+  RpcClient: class {
+    async connect(): Promise<void> {}
+    disconnect(): void {}
+    async call(method: string, params?: unknown): Promise<unknown> {
+      calls.push({ method, params });
+      if (method === 'exec.pending') {
+        return [{
+          id: 'token_1',
+          cmd: 'LD_PRELOAD=/tmp/evil.so ls',
+          reason: 'Environment assignment before the command can change what it loads',
+        }];
+      }
+      return { ok: true };
+    }
+  },
+}));
+
+async function run(args: string[]): Promise<void> {
+  calls.length = 0;
+  const program = new Command();
+  program.exitOverride();
+  registerApprovalsCommand(program);
+  await program.parseAsync(['node', 'openrappter', 'approvals', ...args]);
+}
+
+describe('openrappter approvals', () => {
+  it('lists what is waiting, with the reason', async () => {
+    const lines: string[] = [];
+    const spy = vi.spyOn(console, 'log').mockImplementation((...a) => { lines.push(a.join(' ')); });
+    await run(['list']);
+    spy.mockRestore();
+
+    expect(calls[0].method).toBe('exec.pending');
+    const output = lines.join('\n');
+    expect(output).toContain('token_1');
+    expect(output).toContain('LD_PRELOAD=/tmp/evil.so ls');
+    // The reason is the point: the command alone reads as an ordinary `ls`.
+    expect(output).toContain('Environment assignment');
+  });
+
+  it('approves with an explicit boolean, never an inferred decision', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await run(['approve', 'token_1']);
+    spy.mockRestore();
+
+    expect(calls[0]).toEqual({
+      method: 'exec.respond',
+      params: { approvalId: 'token_1', approved: true },
+    });
+  });
+
+  it('denies with an explicit boolean too', async () => {
+    const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+    await run(['deny', 'token_1']);
+    spy.mockRestore();
+
+    expect(calls[0]).toEqual({
+      method: 'exec.respond',
+      params: { approvalId: 'token_1', approved: false },
+    });
+  });
+
+  it('uses the same method names the Bar calls', () => {
+    // If these drift, one client resolves approvals and the other does not,
+    // which is the state this command exists to end. Read from the Bar's own
+    // source rather than restated here, so a rename there fails this.
+    const barClient = readFileSync(
+      path.join(
+        path.dirname(fileURLToPath(import.meta.url)),
+        '../../../../macos/Sources/OpenRappterBar/Services/RpcClient.swift',
+      ),
+      'utf8',
+    );
+    const ours = readFileSync(
+      path.join(path.dirname(fileURLToPath(import.meta.url)), '../approvals.ts'),
+      'utf8',
+    );
+    for (const method of ['exec.pending', 'exec.respond']) {
+      expect(barClient, `Bar should call ${method}`).toContain(`"${method}"`);
+      expect(ours, `this command should call ${method}`).toContain(`'${method}'`);
+    }
+  });
+});

--- a/typescript/src/cli/approvals.ts
+++ b/typescript/src/cli/approvals.ts
@@ -1,0 +1,93 @@
+import type { Command } from 'commander';
+import { RpcClient } from './rpc-client.js';
+
+/**
+ * Resolve exec approvals from the terminal.
+ *
+ * The gateway has served `exec.pending` and `exec.respond` for some time, and
+ * until now the only client that called them was the macOS menu bar app. On
+ * Linux and Windows a command the safety policy gated could be *requested* and
+ * never granted: the agent hands back an approval id and there is nowhere to
+ * take it. That gap widened when `git`, environment assignments and plantable
+ * paths started requiring approval.
+ *
+ * These commands are a thin wrapper over the same two RPC methods the Bar
+ * uses, so there is one approval contract rather than two.
+ */
+
+interface PendingApproval {
+  id: string;
+  cmd?: string;
+  command?: string;
+  binary?: string;
+  reason?: string;
+  kind?: string;
+  expiresAt?: string;
+}
+
+async function withClient<T>(fn: (client: RpcClient) => Promise<T>): Promise<T> {
+  const client = new RpcClient();
+  try {
+    await client.connect(18790, process.env.OPENRAPPTER_TOKEN);
+    return await fn(client);
+  } finally {
+    client.disconnect();
+  }
+}
+
+export function registerApprovalsCommand(program: Command): void {
+  const approvals = program
+    .command('approvals')
+    .description('Review commands waiting on your approval');
+
+  approvals
+    .command('list', { isDefault: true })
+    .description('Show commands waiting for approval')
+    .option('--json', 'Print the raw response')
+    .action(async (options: { json?: boolean }) => {
+      await withClient(async (client) => {
+        const result = await client.call('exec.pending') as PendingApproval[] | undefined;
+        const pending = Array.isArray(result) ? result : [];
+
+        if (options.json) {
+          console.log(JSON.stringify(pending, null, 2));
+          return;
+        }
+        if (pending.length === 0) {
+          console.log('Nothing is waiting for approval.');
+          return;
+        }
+        for (const item of pending) {
+          const command = item.cmd ?? item.command ?? '(unknown command)';
+          console.log(`\n  ${item.id}`);
+          console.log(`    command: ${command}`);
+          // The reason is the point of showing this at all: `LD_PRELOAD=… ls`
+          // reads as an ordinary `ls` until something says otherwise.
+          if (item.reason) console.log(`    why:     ${item.reason}`);
+          if (item.expiresAt) console.log(`    expires: ${item.expiresAt}`);
+        }
+        console.log(`\n  ${pending.length} waiting. Approve with:`);
+        console.log(`    openrappter approvals approve ${pending[0].id}`);
+      });
+    });
+
+  approvals
+    .command('approve <id>')
+    .description('Approve a waiting command')
+    .action(async (id: string) => {
+      await withClient(async (client) => {
+        const result = await client.call('exec.respond', { approvalId: id, approved: true });
+        console.log(JSON.stringify(result, null, 2));
+      });
+    });
+
+  approvals
+    .command('deny <id>')
+    .description('Deny a waiting command')
+    .action(async (id: string) => {
+      await withClient(async (client) => {
+        const result = await client.call('exec.respond', { approvalId: id, approved: false });
+        console.log(JSON.stringify(result, null, 2));
+      });
+    });
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -17,6 +17,7 @@ import { VERSION } from './version.js';
 import { registerTelephonyCommands } from './telephony/cli.js';
 import { registerTwinCommands } from './twin/index.js';
 import { registerCronCommand } from './cli/cron.js';
+import { registerApprovalsCommand } from './cli/approvals.js';
 import { registerConfigCommand } from './cli/config.js';
 import { registerDoctorCommand } from './cli/doctor.js';
 import { registerRappterCommand } from './cli/rappters.js';
@@ -2592,6 +2593,7 @@ registerTwinCommands(program);
 // message, which is why asking for `cron add --help` printed the top-level help
 // instead of an error.
 registerCronCommand(program);
+registerApprovalsCommand(program);
 registerConfigCommand(program);
 registerDoctorCommand(program);
 // Seeing and creating the rappters on this device. #107


### PR DESCRIPTION
## A gate you cannot open

#292 and #293 routed more commands to a human, and #294/#295 made sure the
human is told why. This round asked where that human actually is.

`exec.pending` and `exec.respond` have been served by the gateway for some
time. The only production client calling them:

```
macos/Sources/OpenRappterBar/Services/RpcClient.swift
```

That is the whole list. No CLI command, no web dashboard surface, no Python
client. The web UI's only mention of the word "approval" is a static string in
an unrelated component.

So on Linux and Windows a gated command could be **requested and never
granted**: the agent returns `approval_id: token_…` and there is nowhere to
take it. The command is blocked permanently.

I widened what needs approval two rounds ago, which makes this mine to close
rather than to file.

## `openrappter approvals`

```
$ openrappter approvals

  token_1738...
    command: LD_PRELOAD=/tmp/evil.so ls
    why:     Environment assignment before the command can change what it loads
    expires: 2026-08-18T12:04:11.000Z

  1 waiting. Approve with:
    openrappter approvals approve token_1738...
```

Three subcommands — `list` (default), `approve <id>`, `deny <id>` — over the
same two RPC methods the Bar calls, so there is one approval contract rather
than two implementations of it.

`approve` and `deny` send an explicit `approved: true|false`. The gateway
refuses to infer a decision, with a comment that says why: *"a missing/garbled
field defaulting to 'approved' is an unaudited execution, and defaulting to
'denied' silently kills a command the user approved."* The client should not
undermine that by sending something looser.

## Two guards caught me, which is the point of having them

**#253's docs coverage test** failed the moment I registered the command:

```
expected [ 'approvals' ] to deeply equal []
```

A command that exists and is undocumented is exactly what that guard is for. Now
in `docs/cli-commands.md`.

**My own vacuous test.** I first wrote:

```ts
for (const method of ['exec.pending', 'exec.respond']) {
  expect(typeof method).toBe('string');
}
```

which asserts nothing at all — the failure mode I have spent this session
objecting to in other people's code. Replaced with one that reads the Bar's
`RpcClient.swift` and this command's source and requires both to contain the
same method names, so a rename on either side fails. Mutation-tested: renaming
ours to `exec.pendingX` fails it.

## A trap worth recording

I mutation-tested by editing `approvals.ts`, then ran `git checkout --` to
restore it. The file is **new and untracked**, so checkout could not restore it
and the `|| true` I had written swallowed the error. The mutation was still in
place; I only noticed because I checked. Untracked files need restoring by
hand.

## Evidence

TypeScript **4843 passed**, `tsc` and lint clean; `conformance.py` **8 passed,
0 failed**. `openrappter approvals --help` renders the three subcommands.
