### PR TITLE
Add `openrappter backup`, and require auth to restore

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`openrappter backup`** — create, list, restore and delete snapshots of
+  `~/.openrappter/` from the terminal. The gateway has served all four
+  operations since the feature landed and the code behind them does real work,
+  but nothing shipped ever called them: an update could snapshot before it ran
+  and the user still had no way to reach that snapshot afterwards. A backup you
+  cannot restore is not a backup. `restore` overwrites the live files in place
+  and keeps no copy of what it replaced, so it requires an explicit `--yes`.
 - **`openrappter approvals`** — list, approve and deny commands the safety
   policy has gated, from the terminal. The gateway has served `exec.pending`
   and `exec.respond` for some time and the only client calling them was the
@@ -374,6 +381,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **`backup.restore` replaced your data without authentication** — the gateway
+  required auth to *delete* a backup but not to restore one, though restoring
+  overwrites every file in `~/.openrappter/` in place and keeps no copy of what
+  it replaced. The more destructive of the two was the unguarded one. Restore
+  now requires auth, like delete.
 - **An environment assignment or a plantable path reached a safe-listed name** —
   the binary parser skips leading `VAR=value` assignments and takes the
   basename, both of which are right for classifying a command and neither of

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -19,6 +19,7 @@ Run `openrappter <command> --help` for a command's own options.
 | `twin` | `[options]` | Your digital twin — local-first, never leaves this machine |
 | `cron` |  | Manage cron jobs |
 | `approvals` |  | Review commands waiting on your approval |
+| `backup` |  | Snapshot and restore your OpenRappter data |
 | `config` |  | Manage configuration |
 | `doctor` | `[options]` | Run system diagnostics and health checks |
 | `twins` | `[options]` | Which rappters are running on this device |

--- a/typescript/src/__tests__/parity/gateway-rpc-methods.test.ts
+++ b/typescript/src/__tests__/parity/gateway-rpc-methods.test.ts
@@ -651,16 +651,29 @@ describe('Gateway RPC Methods', () => {
       });
     });
 
-    it('should default to requiresAuth: false when not specified', () => {
-      // Most methods don't specify requiresAuth, so should default to false
-      const authRequiredCount = Array.from(methods.values()).filter(
-        (info) => info.requiresAuth
-      ).length;
+    it('should require auth for exactly the methods that change or expose rappter state', () => {
+      // Asserted as a set rather than a count: a count still passes when one
+      // method quietly loses auth and another gains it.
+      const authRequired = Array.from(methods.entries())
+        .filter(([, info]) => info.requiresAuth)
+        .map(([name]) => name)
+        .sort();
 
-      // rappter.summon, rappter.create, rappter.load, rappter.unload,
-      // rappter.reload, rappter.load-template, rappter.save, rappter.restore,
-      // rappter.forget, backup.delete require auth
-      expect(authRequiredCount).toBe(10);
+      expect(authRequired).toEqual([
+        // Destructive on ~/.openrappter/: restore overwrites the live files in
+        // place and keeps no copy of what it replaced.
+        'backup.delete',
+        'backup.restore',
+        'rappter.create',
+        'rappter.forget',
+        'rappter.load',
+        'rappter.load-template',
+        'rappter.reload',
+        'rappter.restore',
+        'rappter.save',
+        'rappter.summon',
+        'rappter.unload',
+      ]);
     });
   });
 });

--- a/typescript/src/cli/__tests__/backup.test.ts
+++ b/typescript/src/cli/__tests__/backup.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi } from 'vitest';
+import { Command } from 'commander';
+
+import { registerBackupCommand } from '../backup.js';
+import { registerBackupMethods } from '../../gateway/methods/backup-methods.js';
+
+/**
+ * A backup you cannot restore is not a backup.
+ *
+ * `infra/backup.ts` copies files, writes a manifest and can put them back, and
+ * the gateway has served all four operations since the feature landed. No
+ * shipped client called any of them. An update could snapshot before it ran and
+ * the user still had no way to reach that snapshot afterwards — no command, no
+ * menu item, no button.
+ *
+ * These assert the wire contract, and that the destructive paths stay behind an
+ * explicit confirmation.
+ */
+
+const calls: Array<{ method: string; params?: unknown }> = [];
+
+vi.mock('../rpc-client.js', () => ({
+  RpcClient: class {
+    async connect(): Promise<void> {}
+    disconnect(): void {}
+    async call(method: string, params?: unknown): Promise<unknown> {
+      calls.push({ method, params });
+      if (method === 'backup.list') {
+        return [{
+          id: '2026-02-11T09-00-00',
+          path: '/home/u/.openrappter/backups/2026-02-11T09-00-00',
+          createdAt: '2026-02-11T09:00:00.000Z',
+          sizeBytes: 2048,
+          fileCount: 7,
+        }];
+      }
+      if (method === 'backup.delete') return { deleted: true };
+      return {
+        id: '2026-02-11T09-00-00',
+        path: '/home/u/.openrappter/backups/2026-02-11T09-00-00',
+        createdAt: '2026-02-11T09:00:00.000Z',
+        sizeBytes: 2048,
+        fileCount: 7,
+      };
+    }
+  },
+}));
+
+async function run(args: string[]): Promise<string[]> {
+  calls.length = 0;
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...a) => {
+    lines.push(a.join(' '));
+  });
+  try {
+    const program = new Command();
+    program.exitOverride();
+    registerBackupCommand(program);
+    await program.parseAsync(['node', 'openrappter', 'backup', ...args]);
+  } finally {
+    spy.mockRestore();
+  }
+  return lines;
+}
+
+describe('openrappter backup', () => {
+  it('lists backups over backup.list', async () => {
+    const lines = await run(['list']);
+    expect(calls).toEqual([{ method: 'backup.list', params: undefined }]);
+    const text = lines.join('\n');
+    expect(text).toContain('2026-02-11T09-00-00');
+    expect(text).toContain('7 files');
+  });
+
+  it('creates over backup.create and passes the reason through', async () => {
+    await run(['create', '--reason', 'before upgrade']);
+    expect(calls).toEqual([
+      { method: 'backup.create', params: { reason: 'before upgrade' } },
+    ]);
+  });
+
+  it('restores the most recent when no id is given', async () => {
+    await run(['restore', '--yes']);
+    expect(calls).toEqual([{ method: 'backup.restore', params: {} }]);
+  });
+
+  it('restores a specific backup by id', async () => {
+    await run(['restore', '2026-02-11T09-00-00', '--yes']);
+    expect(calls).toEqual([
+      { method: 'backup.restore', params: { id: '2026-02-11T09-00-00' } },
+    ]);
+  });
+
+  // restoreBackup overwrites the live files in place and keeps no copy of what
+  // it replaced. Without --yes it must not reach the gateway at all.
+  it('refuses to restore without --yes, and calls nothing', async () => {
+    const lines = await run(['restore']);
+    expect(calls).toEqual([]);
+    expect(lines.join('\n')).toContain('WARNING');
+  });
+
+  it('refuses to delete without --yes, and calls nothing', async () => {
+    const lines = await run(['delete', '2026-02-11T09-00-00']);
+    expect(calls).toEqual([]);
+    expect(lines.join('\n')).toContain('WARNING');
+  });
+
+  it('deletes over backup.delete once confirmed', async () => {
+    await run(['delete', '2026-02-11T09-00-00', '--yes']);
+    expect(calls).toEqual([
+      { method: 'backup.delete', params: { id: '2026-02-11T09-00-00' } },
+    ]);
+  });
+});
+
+describe('backup RPC registration', () => {
+  function registeredOptions(): Map<string, { requiresAuth?: boolean } | undefined> {
+    const seen = new Map<string, { requiresAuth?: boolean } | undefined>();
+    registerBackupMethods({
+      registerMethod(name: string, _handler: unknown, options?: { requiresAuth?: boolean }) {
+        seen.set(name, options);
+      },
+    } as Parameters<typeof registerBackupMethods>[0]);
+    return seen;
+  }
+
+  it('serves every operation the CLI depends on', () => {
+    const names = [...registeredOptions().keys()].sort();
+    expect(names).toEqual([
+      'backup.create',
+      'backup.delete',
+      'backup.list',
+      'backup.restore',
+    ]);
+  });
+
+  // Restore replaces the live data directory with no undo. It is at least as
+  // destructive as delete, which has always required auth.
+  it('requires auth to restore, not just to delete', () => {
+    const options = registeredOptions();
+    expect(options.get('backup.restore')?.requiresAuth).toBe(true);
+    expect(options.get('backup.delete')?.requiresAuth).toBe(true);
+  });
+});

--- a/typescript/src/cli/backup.ts
+++ b/typescript/src/cli/backup.ts
@@ -1,0 +1,132 @@
+import type { Command } from 'commander';
+import { RpcClient } from './rpc-client.js';
+
+/**
+ * Snapshot and restore ~/.openrappter/ from the terminal.
+ *
+ * The gateway has served `backup.create`, `backup.list`, `backup.restore` and
+ * `backup.delete` since the feature landed, and `infra/backup.ts` behind them
+ * does real work — it copies files, writes a manifest and can put them back.
+ * Nothing shipped ever called any of it. An update could auto-snapshot before
+ * it ran, but if that update went wrong the user had no way to reach the
+ * snapshot: no CLI command, no menu item, no button. The restore path existed
+ * and was unreachable, which is the same as not having one.
+ *
+ * These commands are a thin wrapper over those four RPC methods, so the
+ * terminal and any future UI share one contract.
+ */
+
+interface BackupInfo {
+  id: string;
+  path: string;
+  createdAt: string;
+  sizeBytes: number;
+  fileCount: number;
+}
+
+async function withClient<T>(fn: (client: RpcClient) => Promise<T>): Promise<T> {
+  const client = new RpcClient();
+  try {
+    await client.connect(18790, process.env.OPENRAPPTER_TOKEN);
+    return await fn(client);
+  } finally {
+    client.disconnect();
+  }
+}
+
+function formatSize(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return 'unknown size';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function describe(backup: BackupInfo): string {
+  const files = backup.fileCount === 1 ? '1 file' : `${backup.fileCount} files`;
+  return `${files}, ${formatSize(backup.sizeBytes)}`;
+}
+
+export function registerBackupCommand(program: Command): void {
+  const backup = program
+    .command('backup')
+    .description('Snapshot and restore your OpenRappter data');
+
+  backup
+    .command('list', { isDefault: true })
+    .description('List available backups, most recent first')
+    .option('--json', 'Print the raw response')
+    .action(async (options: { json?: boolean }) => {
+      await withClient(async (client) => {
+        const result = (await client.call('backup.list')) as BackupInfo[] | undefined;
+        const backups = Array.isArray(result) ? result : [];
+
+        if (options.json) {
+          console.log(JSON.stringify(backups, null, 2));
+          return;
+        }
+        if (backups.length === 0) {
+          console.log('No backups yet. Create one with:');
+          console.log('    openrappter backup create');
+          return;
+        }
+        for (const item of backups) {
+          console.log(`\n  ${item.id}`);
+          console.log(`    created: ${item.createdAt}`);
+          console.log(`    holds:   ${describe(item)}`);
+        }
+        console.log(`\n  ${backups.length} available. Restore the most recent with:`);
+        console.log('    openrappter backup restore --yes');
+      });
+    });
+
+  backup
+    .command('create')
+    .description('Create a new backup of ~/.openrappter/')
+    .option('--reason <text>', 'Why this backup was taken', 'manual')
+    .action(async (options: { reason: string }) => {
+      await withClient(async (client) => {
+        const result = (await client.call('backup.create', {
+          reason: options.reason,
+        })) as BackupInfo;
+        console.log(`Created ${result.id} (${describe(result)})`);
+      });
+    });
+
+  backup
+    .command('restore [id]')
+    .description('Restore from a backup (defaults to the most recent)')
+    .option('--yes', 'Skip confirmation prompt')
+    .action(async (id: string | undefined, options: { yes?: boolean }) => {
+      // restoreBackup copies over the live files in place and takes no
+      // snapshot of what it replaces, so there is no undo after this runs.
+      if (!options.yes) {
+        const which = id ? `backup ${id}` : 'the most recent backup';
+        console.log(`WARNING: This overwrites your current OpenRappter data with ${which}.`);
+        console.log('Existing files are replaced and are not backed up first.');
+        console.log('Run with --yes to confirm.');
+        return;
+      }
+      await withClient(async (client) => {
+        const result = (await client.call('backup.restore', id ? { id } : {})) as BackupInfo;
+        const files = result.fileCount === 1 ? '1 file' : `${result.fileCount} files`;
+        console.log(`Restored ${files} from ${result.id}.`);
+        console.log('Restart OpenRappter for the restored data to take effect.');
+      });
+    });
+
+  backup
+    .command('delete <id>')
+    .description('Delete a backup')
+    .option('--yes', 'Skip confirmation prompt')
+    .action(async (id: string, options: { yes?: boolean }) => {
+      if (!options.yes) {
+        console.log(`WARNING: This permanently deletes backup ${id}.`);
+        console.log('Run with --yes to confirm.');
+        return;
+      }
+      await withClient(async (client) => {
+        const result = (await client.call('backup.delete', { id })) as { deleted: boolean };
+        console.log(result?.deleted ? `Deleted ${id}.` : `No backup matched ${id}.`);
+      });
+    });
+}

--- a/typescript/src/gateway/methods/backup-methods.ts
+++ b/typescript/src/gateway/methods/backup-methods.ts
@@ -43,11 +43,15 @@ export function registerBackupMethods(
     }
   );
 
+  // Restoring overwrites the live data directory in place and keeps no copy
+  // of what it replaced, so it is at least as destructive as backup.delete —
+  // which has always required auth. Held to the same bar.
   server.registerMethod<{ id?: string }, BackupInfo>(
     'backup.restore',
     async (params) => {
       return restoreBackup(params?.id, dataDir);
-    }
+    },
+    { requiresAuth: true }
   );
 
   server.registerMethod<{ id: string }, { deleted: boolean }>(

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -18,6 +18,7 @@ import { registerTelephonyCommands } from './telephony/cli.js';
 import { registerTwinCommands } from './twin/index.js';
 import { registerCronCommand } from './cli/cron.js';
 import { registerApprovalsCommand } from './cli/approvals.js';
+import { registerBackupCommand } from './cli/backup.js';
 import { registerConfigCommand } from './cli/config.js';
 import { registerDoctorCommand } from './cli/doctor.js';
 import { registerRappterCommand } from './cli/rappters.js';
@@ -2594,6 +2595,7 @@ registerTwinCommands(program);
 // instead of an error.
 registerCronCommand(program);
 registerApprovalsCommand(program);
+registerBackupCommand(program);
 registerConfigCommand(program);
 registerDoctorCommand(program);
 // Seeing and creating the rappters on this device. #107


### PR DESCRIPTION
## A backup you cannot restore is not a backup

The gateway serves `backup.create`, `backup.list`, `backup.restore` and `backup.delete`, and `infra/backup.ts` behind them does real work — it copies files, writes a manifest, and can put them back. The module is registered in `gateway/methods/index.ts`. Everything is wired.

Nothing shipped ever called any of it. I checked the TypeScript CLI, the web UI, the Swift client and the Python client; I also checked for a generic `openrappter rpc <method>` escape hatch, because that would make the question moot. There isn't one. All four operations were unreachable from every client in the repository.

That matters most in exactly the case the feature exists for. An update can snapshot before it runs. If the update then goes wrong, the user had no way to reach the snapshot — no command, no menu item, no button. The restore path existed, was correct, and could not be invoked.

## What this adds

```
openrappter backup list                  # most recent first
openrappter backup create --reason "before upgrade"
openrappter backup restore --yes         # or: restore <id> --yes
openrappter backup delete <id> --yes
```

A thin wrapper over the same four RPC methods, so the terminal and any future UI share one contract rather than growing two. Same shape as `openrappter approvals` in #296, for the same reason.

## The security half

Found while wiring it up: **`backup.delete` required auth and `backup.restore` did not.**

`restoreBackup` copies over every file in `~/.openrappter/` in place and takes no snapshot of what it replaces. It is at least as destructive as deleting one backup, and it was the unguarded one of the pair. It now requires auth as well.

Restore and delete both refuse to run without an explicit `--yes`, following the convention `memory clear` already uses. The confirmation is checked before the client connects, so an unconfirmed restore reaches the gateway not at all.

## Mutation testing

Both directions, each reverted after:

| mutation | result |
| --- | --- |
| dropped `requiresAuth` from `backup.restore` | registration test fails |
| neutralised the `--yes` check on restore | confirmation test fails |

The confirmation test fails by observing that the RPC was called at all, not by matching console output — so it is testing the guard, not the wording.

## One existing assertion changed

`gateway-rpc-methods.test.ts` asserted that exactly 10 methods require auth. With `backup.restore` it is 11.

Rather than bump the number, it now asserts the sorted **set** of method names. A count passes just as happily when one method quietly loses auth and another gains it — which is the same "guard that doesn't say what it guards" shape as several findings earlier in this series. The set it produced on first run matched the list I'd written from the source, independently.

## Verification

- `tsc --noEmit` clean
- `npm run lint` clean at `--max-warnings 0`
- **4852** TypeScript tests passing, up from 4843 — the 9 new ones
- `conformance.py`: 8 passed, 0 failed, 1 skipped (R9 needs the keyring installed)

Python does not serve backup methods, so no cross-runtime parity obligation is triggered.

## Scope note

This came out of auditing the 12 served RPC methods with no in-repo client. I am deliberately **not** adding a blanket "served but uncalled" guard: the gateway is a public RPC surface, so absence of an in-repo caller doesn't imply dead code. The remaining 11 are being judged individually; backup was the one where the gap had teeth, because the whole point of the feature is to be there on the worst day.
