### PR TITLE
`openrappter update`: say how to be able to go back

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`openrappter update` now says how to be able to go back.** `backup.create`
+  was documented as auto-running before updates. It never did: nothing in
+  either runtime called it, and updating is a manual
+  `npm install -g openrappter@latest`, so there was no in-product step it could
+  have hung off. The claim was removed, and the moment the CLI tells you a new
+  version exists — the one moment it knows you are about to change the
+  installation — it now points at `openrappter backup create`.
+
 - **The approval queue told the reviewer what, not why** — the safety policy
   works out precisely why a command needs a person (dual-use binary,
   environment assignment, plantable path) and sent that explanation to the

--- a/typescript/src/cli/__tests__/update-command.test.ts
+++ b/typescript/src/cli/__tests__/update-command.test.ts
@@ -123,4 +123,34 @@ describe('update command', () => {
     expect(result.exitCode).toBeUndefined();
     expect(result.stdout).toContain('You are using the latest version.');
   });
+
+  /**
+   * `backup.create` was documented as auto-running before updates. It never
+   * did — nothing called it, and updating is a manual `npm install -g`, so
+   * there is no in-product step it could have hung off. Since the product
+   * cannot snapshot for you, the moment it tells you to change the
+   * installation is where it should say a snapshot is possible.
+   */
+  it('points at a backup when it offers an update', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: '999.0.0' }) }),
+    );
+
+    const result = await runUpdate([]);
+
+    expect(result.stdout).toContain('A new version is available!');
+    expect(result.stdout).toContain('openrappter backup create');
+  });
+
+  it('does not mention backups when there is nothing to update to', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({ version: '0.0.1' }) }),
+    );
+
+    const result = await runUpdate([]);
+
+    expect(result.stdout).not.toContain('openrappter backup create');
+  });
 });

--- a/typescript/src/cli/update.ts
+++ b/typescript/src/cli/update.ts
@@ -33,6 +33,11 @@ export function registerUpdateCommand(program: Command): void {
         console.log('\n\x1b[33mA new version is available!\x1b[0m');
         console.log('\nTo update, run:');
         console.log('  npm install -g openrappter@latest');
+        // Updating is a manual npm install, so nothing in the product can
+        // snapshot first. This is the one moment the user is known to be
+        // about to change the installation, so it is where the offer belongs.
+        console.log('\nTo be able to go back if it goes wrong, first run:');
+        console.log('  openrappter backup create --reason "before upgrade"');
       } else {
         console.log('\n\x1b[32mYou are using the latest version.\x1b[0m');
       }

--- a/typescript/src/gateway/methods/backup-methods.ts
+++ b/typescript/src/gateway/methods/backup-methods.ts
@@ -2,10 +2,16 @@
  * Backup RPC methods — snapshot & restore ~/.openrappter/ user data.
  *
  * Methods:
- *   backup.create   — Create a new backup (auto-runs before updates)
+ *   backup.create   — Create a new backup
  *   backup.list     — List available backups
  *   backup.restore  — Restore from a specific backup (or latest)
  *   backup.delete   — Delete a specific backup
+ *
+ * `backup.create` used to be documented here as auto-running before updates.
+ * It never did: nothing in either runtime called it, and updating is a manual
+ * `npm install -g openrappter@latest`, so there is no in-product step it could
+ * have hung off. `openrappter update` now points at `openrappter backup create`
+ * when it finds a new version, which is the moment the snapshot is worth taking.
  */
 
 import {


### PR DESCRIPTION
## A safety net that never fired

`backup.create` carried the comment **"auto-runs before updates"**.

It never did.

- `createBackup` has exactly one caller in the repository — the RPC handler.
- Until #297, nothing called that handler either.
- There is no in-product updater for it to have hung off: `openrappter update` only *checks* the registry, and the update itself is a manual `npm install -g openrappter@latest` typed by the user.

Confirmed against the live gateway on a machine that has been updated repeatedly:

```
$ openrappter backup list
No backups yet. Create one with:
    openrappter backup create
```

The safety net the comment described has never once fired, for anyone.

## What this changes

Removing the false claim is half of it. The other half is that the product genuinely *cannot* snapshot before an update — so the honest thing is to say so at the point where it matters.

`openrappter update` knows exactly one moment when the user is about to change their installation: when it has just told them a newer version exists. That is where it now points at `openrappter backup create`, which #297 made reachable.

```
A new version is available!

To update, run:
  npm install -g openrappter@latest

To be able to go back if it goes wrong, first run:
  openrappter backup create --reason "before upgrade"
```

Deliberately **not** printed when there is nothing to update to, so it stays a prompt at a decision point rather than background noise.

## Mutation testing

| mutation | result |
| --- | --- |
| removed the two `console.log` lines | "points at a backup when it offers an update" fails |

The paired negative test asserts the suggestion is *absent* on the up-to-date path, so the assertion is about the branch rather than about the string merely existing somewhere in the file.

## Verification

- `tsc --noEmit` clean
- `npm run lint` clean at `--max-warnings 0`
- **4854** TypeScript tests passing, up from 4852 — the 2 new ones
- `openrappter backup list` exercised end-to-end against the running gateway, which is how the empty-backup state above was established

## Note

This is the same defect class as most findings in this series: something that reads as protection and does nothing. The comment was the only thing asserting the behaviour, so nothing failed when the behaviour didn't exist.
