### PR TITLE
Stop the show-and-tell suite flaking the Windows gate

### DIFF
--- a/typescript/src/show-and-tell/show-and-tell.test.ts
+++ b/typescript/src/show-and-tell/show-and-tell.test.ts
@@ -31,6 +31,22 @@ const roots: string[] = [];
 const originalSkills = process.env.OPENRAPPTER_SKILLS_DIR;
 const originalAutomations = process.env.OPENRAPPTER_AUTOMATIONS_DIR;
 
+/**
+ * These tests drive a real SQLite store and a real temp directory per case,
+ * which is the point of them -- the privacy guarantees they cover are about
+ * what actually reaches disk. That cost is fine on Linux and macOS and is not
+ * fine against vitest's 5s default on the Windows runner, where this file was
+ * measured at 62s for 25 tests, one case at 8.4s and its neighbour at 3.0s.
+ *
+ * The 5s default made the slowest case a coin flip in the merge gate: it
+ * failed the cross-runtime job on an unrelated PR, then passed unchanged on
+ * re-run. Raising the ceiling for this file keeps the failure signal honest --
+ * a test here now fails because the behaviour is wrong, not because the runner
+ * was busy. Scoped to this file rather than the global config so every other
+ * suite keeps the tighter default.
+ */
+vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
+
 function tempRoot(): string {
   const root = mkdtempSync(path.join(os.tmpdir(), 'openrappter-show-'));
   roots.push(root);


### PR DESCRIPTION
## A red gate that clears itself

`show-and-tell.test.ts` drives a real SQLite store and a real temp directory per case. That is deliberate — the privacy guarantees it covers are about what actually reaches disk — and it is genuinely slow on the Windows runner.

Measured there, on an unrelated PR:

| | |
| --- | --- |
| whole file | 62,615 ms for 25 tests |
| `deletes a frame when the page becomes sign-in-related during capture` | **8,457 ms** |
| its neighbour | 3,051 ms |
| vitest default | **5,000 ms** |

So the slowest case is a coin flip in the merge gate. It failed the cross-runtime job on #298 — a PR that touched only `update.ts`, a doc comment and the changelog — and then passed unchanged on re-run.

That is the worst kind of red: it teaches everyone to hit re-run instead of reading the failure. The next real Windows regression in this file arrives looking exactly like this one.

## The change

```ts
vi.setConfig({ testTimeout: 30_000, hookTimeout: 30_000 });
```

Scoped to this one file — roughly 3.5× headroom over the slowest observed case. **The global config is untouched**, so every other suite keeps the tighter 5s default. This does not weaken timeouts anywhere else.

## Verifying the fix isn't inert

Worth doing explicitly here, because a timeout setting that silently did nothing would look identical to a working fix while leaving the flake in place:

| `testTimeout` | result |
| --- | --- |
| `1` | every case fails with `Test timed out in 1ms` |
| `30_000` | 25 passed |

So the setting demonstrably governs these tests.

## Verification

- `tsc --noEmit` clean
- `npm run lint` clean at `--max-warnings 0`
- 4854 TypeScript tests passing

## What this is not

This does not make the tests faster, and it does not paper over a hang — the work is real filesystem and SQLite I/O that the test exists to exercise. If this file ever times out at 30s, something is actually wrong.
