### PR TITLE
Make `${VAR:-default}` work, and stop documenting three keys that do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`${VAR:-default}` in config did nothing.** The documented fallback form —
+  `api_key: ${ANTHROPIC_API_KEY:-sk-placeholder}` on the docs site — was matched
+  by neither runtime's substitution pattern, since `\w` covers neither `:` nor
+  `-`. The value survived into the config as that literal string and surfaced
+  much later as a rejected credential rather than as a config error. Both
+  runtimes now support it, and agree that a set-but-empty variable stays empty
+  while only an unset one falls back. A second, fuller implementation existed in
+  `config/env-expand.ts` with tests proving the fallback worked; nothing outside
+  those tests ever called it, so the tests passed for years while the feature
+  did not exist.
+
 - **`openrappter update` now says how to be able to go back.** `backup.create`
   was documented as auto-running before updates. It never did: nothing in
   either runtime called it, and updating is a manual

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -927,17 +927,27 @@ openrappter approvals deny &lt;id&gt;</pre>
       <p>The WebSocket gateway enforces per-connection rate limits. For channel adapters, each channel can set its own rate limit in addition to the global gateway limit. Rate limits apply to both inbound message handling and outbound LLM API calls, protecting against runaway loops.</p>
 
       <h3>Audit Logging</h3>
-      <p>When <code>logging.level: debug</code> or when <code>logging.audit: true</code> is set, all agent invocations, shell commands executed, files written, and channel messages sent are written to the audit log at <code>~/.openrappter/logs/audit.jsonl</code>. Each entry is a newline-delimited JSON object with timestamp, agent name, action, arguments, result status, and duration.</p>
+      <p>There is no separate audit log. Earlier revisions of this page described one at <code>~/.openrappter/logs/audit.jsonl</code>, enabled with <code>logging.audit: true</code>. No such key exists in the schema and no such file is ever written, so a reader who set it got a config that validated cleanly and an audit trail that was never there.</p>
+      <p>The <a href="#local-capture">Flight Recorder</a> is the mechanism that does exist. It is a correlated ledger of trace, context, provider, tool and agent lifecycle events, shared by both runtimes, and it is what to reach for when you need to know what a rappter actually did:</p>
+      <pre>openrappter flight status
+openrappter flight events
+openrappter flight export <span class="cm"># integrity-checked bundle</span></pre>
+      <p><code>logging.level: debug</code> raises log verbosity. The real logging keys are <code>level</code>, <code>file</code>, <code>maxSize</code>, <code>rotation</code> and <code>redaction</code>.</p>
 
       <h3>Gateway Authentication</h3>
-      <p>By default the gateway binds to <code>127.0.0.1</code> and is not accessible from external networks. For remote access, set a shared secret in <code>config.yaml</code>:</p>
+      <p>By default the gateway binds to <code>127.0.0.1</code> and is not reachable from other machines. For remote access, set the bind and a password in <code>config.yaml</code>:</p>
       <pre><span class="cm"># config.yaml</span>
 gateway:
-  host: 0.0.0.0
-  secret: ${GATEWAY_SECRET}    <span class="cm"># required in Authorization: Bearer header</span></pre>
+  bind: all                      <span class="cm"># 'loopback' (default) or 'all'</span>
+  auth:
+    mode: password               <span class="cm"># 'none' (default) or 'password'</span>
+    password: ${GATEWAY_PASSWORD}</pre>
 
       <div class="warning-box">
-        <strong>Warning:</strong> Never expose the gateway on <code>0.0.0.0</code> without setting a <code>gateway.secret</code>. Without a secret, any process on the network can invoke agents and execute shell commands.
+        <strong>Warning:</strong> Never expose the gateway on all interfaces without a password. This one is enforced rather than advised: <code>bind: all</code> with <code>auth.mode: none</code> refuses to start, with <em>"Gateway auth is required when binding to all interfaces"</em>.
+      </div>
+      <div class="info-box">
+        <strong>The keys are <code>bind</code> and <code>auth</code>, not <code>host</code> and <code>secret</code>.</strong> Earlier revisions of this page showed <code>gateway.host</code> and <code>gateway.secret</code>. Neither exists in the schema, and unknown keys are discarded silently, so that example validated cleanly and configured nothing — leaving the gateway on loopback with no auth while the reader believed they had done the opposite. Parsed against the schema it yields exactly <code>{"port":18790,"bind":"loopback"}</code>.
       </div>
 
       <h3>Prompt Injection Mitigations</h3>

--- a/python/openrappter/config/loader.py
+++ b/python/openrappter/config/loader.py
@@ -27,9 +27,18 @@ def substitute_env_vars(config: dict) -> dict:
         if isinstance(value, list):
             return [_substitute(item) for item in value]
         if isinstance(value, str):
+            # `${VAR}` and `${VAR:-default}`. The fallback form is documented on
+            # the docs site with `api_key: ${ANTHROPIC_API_KEY:-sk-placeholder}`,
+            # but the pattern here was `\$\{(\w+)\}` — neither `:` nor `-` is
+            # `\w` — so that example matched nothing and survived into the config
+            # as the literal string, to fail later as a rejected credential.
+            # A set-but-empty variable stays empty; only an unset one falls back,
+            # which is what the TypeScript loader does.
             return re.sub(
-                r'\$\{(\w+)\}',
-                lambda m: os.environ.get(m.group(1), ''),
+                r'\$\{(\w+)(?::-(.*?))?\}',
+                lambda m: os.environ.get(m.group(1))
+                if m.group(1) in os.environ
+                else (m.group(2) if m.group(2) is not None else ''),
                 value,
             )
         return value

--- a/python/tests/test_showcase_config_hotswap.py
+++ b/python/tests/test_showcase_config_hotswap.py
@@ -116,6 +116,46 @@ def test_substitute_env_vars_missing_var_becomes_empty_string(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# 6b. ${VAR:-default} — the documented fallback form
+#
+# The docs site shows `api_key: ${ANTHROPIC_API_KEY:-sk-placeholder}`, but the
+# pattern was `\$\{(\w+)\}`, and neither ':' nor '-' is \w. That example matched
+# nothing and survived into the config as the literal string, to be rejected
+# later as a bad credential rather than at load time. Both runtimes had the same
+# gap, so fixing only one would have traded a bug for a parity divergence.
+# ---------------------------------------------------------------------------
+
+def test_substitute_env_vars_uses_default_when_unset(monkeypatch):
+    monkeypatch.delenv('ABSENT_API_KEY', raising=False)
+    config = {'providers': {'api_key': '${ABSENT_API_KEY:-sk-placeholder}'}}
+    result = substitute_env_vars(config)
+    assert result['providers']['api_key'] == 'sk-placeholder'
+
+
+def test_substitute_env_vars_prefers_the_variable_over_the_default(monkeypatch):
+    monkeypatch.setenv('PRESENT_API_KEY', 'sk-real')
+    config = {'providers': {'api_key': '${PRESENT_API_KEY:-sk-placeholder}'}}
+    result = substitute_env_vars(config)
+    assert result['providers']['api_key'] == 'sk-real'
+
+
+def test_substitute_env_vars_default_may_contain_punctuation(monkeypatch):
+    monkeypatch.delenv('ABSENT_URL', raising=False)
+    config = {'providers': {'url': '${ABSENT_URL:-http://localhost:8080/v1}'}}
+    result = substitute_env_vars(config)
+    assert result['providers']['url'] == 'http://localhost:8080/v1'
+
+
+def test_substitute_env_vars_empty_variable_is_not_replaced_by_default(monkeypatch):
+    # Set but empty is a deliberate value, not an absent one. TypeScript's `??`
+    # draws the line in the same place, and the two runtimes have to agree.
+    monkeypatch.setenv('EMPTY_API_KEY', '')
+    config = {'providers': {'api_key': '${EMPTY_API_KEY:-sk-placeholder}'}}
+    result = substitute_env_vars(config)
+    assert result['providers']['api_key'] == ''
+
+
+# ---------------------------------------------------------------------------
 # 7. JSON Schema export
 # ---------------------------------------------------------------------------
 

--- a/typescript/src/__tests__/integration/config-integration.test.ts
+++ b/typescript/src/__tests__/integration/config-integration.test.ts
@@ -129,6 +129,36 @@ describe('Config Integration', () => {
       delete process.env.B_VAR;
     });
 
+    /**
+     * `${VAR:-default}` is documented on the docs site, with
+     * `api_key: ${ANTHROPIC_API_KEY:-sk-placeholder}` as the example.
+     *
+     * The loader's own regex was `/\$\{(\w+)\}/g`, which matches neither `:`
+     * nor `-`, so that example expanded to nothing and survived into the config
+     * as the literal string — surfacing much later as a rejected credential.
+     * A second implementation in `config/env-expand.ts` did support the form and
+     * had tests proving it, but nothing outside those tests ever called it.
+     *
+     * These cover the function the loader actually uses.
+     */
+    it('should use the default when the variable is unset', () => {
+      delete process.env.ABSENT_API_KEY;
+      expect(substituteEnvVars('${ABSENT_API_KEY:-sk-placeholder}')).toBe('sk-placeholder');
+    });
+
+    it('should prefer the variable over the default when it is set', () => {
+      process.env.PRESENT_API_KEY = 'sk-real';
+      expect(substituteEnvVars('${PRESENT_API_KEY:-sk-placeholder}')).toBe('sk-real');
+      delete process.env.PRESENT_API_KEY;
+    });
+
+    it('should accept a default containing punctuation', () => {
+      delete process.env.ABSENT_URL;
+      expect(substituteEnvVars('${ABSENT_URL:-http://localhost:8080/v1}')).toBe(
+        'http://localhost:8080/v1',
+      );
+    });
+
     it('should leave strings without vars unchanged', () => {
       expect(substituteEnvVars('no vars here')).toBe('no vars here');
     });

--- a/typescript/src/config/loader.ts
+++ b/typescript/src/config/loader.ts
@@ -8,12 +8,26 @@ import { homedir } from 'node:os';
 import JSON5 from 'json5';
 import { validateConfig } from './schema.js';
 import type { OpenRappterConfig } from './types.js';
+import { expandEnvVars } from './env-expand.js';
 
 const DEFAULT_CONFIG_DIR = join(homedir(), '.openrappter');
 const DEFAULT_CONFIG_FILE = 'config.json5';
 
+/**
+ * Expand `${VAR}` and `${VAR:-default}` in a config value.
+ *
+ * This used to carry its own regex, `/\$\{(\w+)\}/g`, while `config/env-expand.ts`
+ * carried a second one that also understood `:-default`. Only this copy ran:
+ * nothing outside its own tests imported the other. So the documented
+ * `${ANTHROPIC_API_KEY:-sk-placeholder}` form matched nothing here — neither `:`
+ * nor `-` is `\w` — and survived into the config as that literal string, to fail
+ * later as a bad credential rather than at load. The tests covering the fallback
+ * passed the whole time, because they exercised the copy that was never wired in.
+ *
+ * One implementation now, the one with the behaviour the documentation promises.
+ */
 export function substituteEnvVars(value: string): string {
-  return value.replace(/\$\{(\w+)\}/g, (_, key) => process.env[key] ?? '');
+  return expandEnvVars(value);
 }
 
 function substituteDeep(obj: unknown): unknown {


### PR DESCRIPTION
## A documented feature that never worked

The docs site says configuration supports `${VAR_NAME:-default_value}`, with this worked example:

```yaml
api_key: ${ANTHROPIC_API_KEY:-sk-placeholder}
```

Neither runtime supported it. Both substituted with `\$\{(\w+)\}` — and `\w` covers neither `:` nor `-` — so the example matched nothing and survived into the config as a literal string, failing later as a **rejected credential at request time**, far from the cause.

```
substituteEnvVars('${ANTHROPIC_API_KEY:-sk-placeholder}')
  before -> "${ANTHROPIC_API_KEY:-sk-placeholder}"
  after  -> "sk-placeholder"
```

### The part worth pausing on

A second implementation already existed at `typescript/src/config/env-expand.ts` which **did** handle the fallback, and `config-system.test.ts` proved it worked:

```ts
expect(expandEnvVars('${NONEXISTENT_VAR:-fallback}')).toBe('fallback');  // passing
```

Nothing outside those tests ever imported it. **The tests passed for as long as they have existed while the documented feature did not work**, because they exercised the copy that was never wired in. The loader now calls that implementation, so there is one — and those existing tests now describe reality.

Python had the identical gap, so fixing only TypeScript would have traded a bug for a parity divergence. Both now agree, including on the case worth being deliberate about: **a variable that is set but empty stays empty; only an unset one falls back.** That is where TypeScript's `??` already drew the line.

## Three keys that do not exist

While confirming the schema, two more documented keys turned out to be fictional. This page *already* carried an admission of a third (`shell.allowlist`), so this is a recurring shape rather than an isolated slip — unknown keys are discarded silently, so a fake key validates cleanly and configures nothing.

**`gateway.host` / `gateway.secret`** — in the instructions for exposing the gateway to a network. The real keys are `bind` and `auth.mode` / `auth.password`. Parsing the documented example against the schema gives:

```
{"port":18790,"bind":"loopback"}
```

The reader believed they had published the gateway behind a shared secret, and had configured nothing. Failing safe, but not what it said. The replacement also notes that `bind: all` with `auth.mode: none` **refuses to start** — enforcement rather than advice.

**`logging.audit`** — in a section describing an audit log at `~/.openrappter/logs/audit.jsonl` holding every agent invocation, shell command and file write. There is no such key and no such file anywhere in the repository. Someone hardening a deployment would have believed they had an audit trail. That section now says so plainly and points at the Flight Recorder, which is the ledger that does exist.

## Mutation testing

| runtime | mutation | result |
| --- | --- | --- |
| TypeScript | restore `/\$\{(\w+)\}/g` | 3 new tests fail |
| Python | restore `r'\$\{(\w+)\}'` | 4 new tests fail |

## Verification

- `tsc --noEmit` clean, `npm run lint` clean at `--max-warnings 0`
- **4857** TypeScript tests (up from 4854)
- **1602** Python tests
- `conformance.py` 8 passed / 0 failed, `parity_harness.py` PASS
- Every command line added to the page is validated against the real CLI by the guard from #300
