### PR TITLE
Five documented environment variables that nothing reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Five documented environment variables did nothing.** `OPENRAPPTER_CONFIG`,
+  `OPENRAPPTER_LOG_LEVEL`, `OPENRAPPTER_PROVIDER` and `GATEWAY_SECRET` were
+  listed in the reference tables and read by nothing anywhere in either runtime.
+  So was `OPENRAPPTER_NO_TELEMETRY`, described as disabling anonymous usage
+  stats — there are none, and none are collected or sent, so the sentence
+  described a product that does not exist while quietly contradicting the
+  local-first promise. The page now says so. A new guard requires every
+  documented variable in the project's own namespace to be read by the source,
+  or explicitly marked as unimplemented.
+
 - **The documented configuration file was one neither runtime reads.** The docs
   site showed `~/.openrappter/config.yaml` throughout, in YAML. The loader is
   `JSON5.parse` in TypeScript and a comment-stripping `json.loads` in Python,

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -151,7 +151,7 @@ openrappter doctor
       <p>OpenRappter reads its configuration from <code>~/.openrappter/config.json5</code>. The format is JSON5 — JSON with comments, unquoted keys and trailing commas. The file is optional; when it is absent the defaults below apply.</p>
 
       <div class="info-box">
-        <strong>It is <code>config.json5</code>, not <code>config.yaml</code>.</strong> Earlier revisions of this page showed YAML throughout. Neither runtime has ever parsed YAML — the loader is <code>JSON5.parse</code> in TypeScript and a comment-stripping <code>json.loads</code> in Python — and it only ever looks for <code>config.json5</code>. A <code>config.yaml</code> written from those examples was not read, and produced no error, because a missing config file is a supported state.
+        <strong>It is <code>config.json5</code>, not <code>config.yaml</code>.</strong> Earlier revisions of this page showed YAML throughout. Neither runtime has ever parsed YAML — the loaders are <code>JSON5.parse</code> in TypeScript and a comment-stripping <code>json.loads</code> in Python — so a <code>config.yaml</code> written from those examples was not read, and produced no error, because a missing config file is a supported state. (A previous revision of this box said the runtime looks only at <code>config.json5</code>. That was too strong: see <a href="#config-system">Loading Order</a>.)
       </div>
 
       <h3>Example config.json5</h3>
@@ -221,12 +221,16 @@ openrappter models get</pre>
           <tr><td><code>ANTHROPIC_API_KEY</code></td><td>Anthropic Claude API key</td><td>—</td></tr>
           <tr><td><code>OPENAI_API_KEY</code></td><td>OpenAI API key</td><td>—</td></tr>
           <tr><td><code>GEMINI_API_KEY</code></td><td>Google Gemini API key</td><td>—</td></tr>
-          <tr><td><code>OPENRAPPTER_CONFIG</code></td><td>Override config file path</td><td><code>~/.openrappter/config.json5</code></td></tr>
-          <tr><td><code>OPENRAPPTER_LOG_LEVEL</code></td><td>Override log level</td><td><code>info</code></td></tr>
+          <tr><td><code>OLLAMA_URL</code></td><td>Ollama endpoint</td><td><code>http://localhost:11434</code></td></tr>
+          <tr><td><code>COPILOT_GITHUB_TOKEN</code></td><td>GitHub token for the Copilot provider</td><td>—</td></tr>
+          <tr><td><code>OPENRAPPTER_MODEL</code></td><td>Active model; written by <code>openrappter models set</code></td><td>—</td></tr>
           <tr><td><code>OPENRAPPTER_PORT</code></td><td>Override gateway port</td><td><code>18790</code></td></tr>
-          <tr><td><code>OPENRAPPTER_PROVIDER</code></td><td>Override default provider</td><td><code>copilot</code></td></tr>
         </tbody>
       </table>
+
+      <div class="info-box">
+        <!-- unimplemented --><strong>There is no telemetry, so there is nothing to opt out of.</strong> Earlier revisions of this page listed <code>OPENRAPPTER_NO_TELEMETRY</code> as disabling anonymous usage stats. Nothing anywhere in either runtime read that variable, and no usage stats are collected or sent — so the variable did nothing and the sentence described a product that does not exist. Local-first means this one.
+      </div>
     </div>
 
     <!-- ── 3. Agents Reference ── -->
@@ -953,11 +957,10 @@ openrappter flight export <span class="cm"># integrity-checked bundle</span></pr
       <h3>Loading Order</h3>
       <p>Configuration is resolved in this priority order (highest wins):</p>
       <ol>
-        <li>Environment variables (e.g. <code>OPENRAPPTER_LOG_LEVEL=debug</code>)</li>
-        <li>Config file specified by <code>OPENRAPPTER_CONFIG</code> env var</li>
-        <li><code>~/.openrappter/config.json5</code> (default location)</li>
-        <li><code>~/.openrappter/config.json</code> (JSON alternative)</li>
-        <li>Built-in defaults compiled into the binary</li>
+        <li>An explicit path passed by the caller — used by the config file watcher</li>
+        <li><code>~/.openrappter/config.json</code>, which wins any conflict</li>
+        <li><code>~/.openrappter/config.json5</code>, merged underneath it</li>
+        <li>Defaults declared in the Zod schema</li>
       </ol>
 
       <h3>Zod Schema Validation</h3>
@@ -1081,12 +1084,7 @@ openrappter backup delete &lt;id&gt; --yes</pre>
           <tr><td><code>SLACK_BOT_TOKEN</code></td><td>—</td><td>Slack bot token for channel integration</td></tr>
           <tr><td><code>DISCORD_BOT_TOKEN</code></td><td>—</td><td>Discord bot token</td></tr>
           <tr><td><code>TELEGRAM_BOT_TOKEN</code></td><td>—</td><td>Telegram BotFather token</td></tr>
-          <tr><td><code>GATEWAY_SECRET</code></td><td>—</td><td>Bearer secret for gateway authentication</td></tr>
-          <tr><td><code>OPENRAPPTER_CONFIG</code></td><td><code>~/.openrappter/config.json5</code></td><td>Override config file location</td></tr>
-          <tr><td><code>OPENRAPPTER_LOG_LEVEL</code></td><td><code>info</code></td><td>debug / info / warn / error</td></tr>
           <tr><td><code>OPENRAPPTER_PORT</code></td><td><code>18790</code></td><td>Gateway WebSocket port</td></tr>
-          <tr><td><code>OPENRAPPTER_PROVIDER</code></td><td><code>copilot</code></td><td>Override default LLM provider</td></tr>
-          <tr><td><code>OPENRAPPTER_NO_TELEMETRY</code></td><td>—</td><td>Set to any value to disable anonymous usage stats</td></tr>
         </tbody>
       </table>
 

--- a/typescript/src/__tests__/integration/docs-env-coverage.test.ts
+++ b/typescript/src/__tests__/integration/docs-env-coverage.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A documented environment variable has to be one something reads.
+ *
+ * The reference tables on the docs site listed five that nothing anywhere in
+ * either runtime looked at: `OPENRAPPTER_CONFIG`, `OPENRAPPTER_LOG_LEVEL`,
+ * `OPENRAPPTER_PROVIDER`, `GATEWAY_SECRET` and `OPENRAPPTER_NO_TELEMETRY`.
+ *
+ * Setting one produced no error and no effect, which is the same shape as the
+ * config keys in #303 — except an environment variable has no schema to be
+ * rejected by, so there was nothing that could have caught it.
+ *
+ * `OPENRAPPTER_NO_TELEMETRY` was the one worth fixing quickly. It was described
+ * as disabling anonymous usage stats, which told a reader those stats existed.
+ * They do not, in a product whose stated promise is that it is local-first, so
+ * the documentation was both untrue and unflattering. If telemetry is ever
+ * added, this test also means the opt-out cannot be documented before it works.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..', '..', '..');
+
+/**
+ * Variables in the product's own namespace.
+ *
+ * Restricted to prefixes OpenRappter is responsible for, so a doc mentioning
+ * `PATH` or a third-party variable is not held to this rule.
+ */
+const OWNED = /\b(OPENRAPPTER|GATEWAY|OPENAI|ANTHROPIC|GEMINI|OLLAMA|COPILOT|SLACK|DISCORD|TELEGRAM)_[A-Z0-9_]{2,}\b/g;
+
+function documentedVars(): Map<string, string> {
+  const found = new Map<string, string>();
+  const docsDir = path.join(repoRoot, 'docs');
+  const files = fs
+    .readdirSync(docsDir)
+    .filter((f) => f.endsWith('.html') || f.endsWith('.md'))
+    .map((f) => path.join(docsDir, f));
+  files.push(path.join(repoRoot, 'README.md'));
+
+  for (const file of files.filter((f) => fs.existsSync(f))) {
+    const lines = fs.readFileSync(file, 'utf8').split('\n');
+    lines.forEach((line, i) => {
+      // A passage that exists to say a variable is not real must not be read as
+      // documenting it. Marked explicitly rather than guessed at from wording,
+      // so removing the implementation and adding the marker stays a deliberate
+      // act.
+      if (line.includes('<!-- unimplemented -->')) return;
+      // Only where the docs present it as a variable — a `<code>` span or a
+      // shell `export`. Prose naming one in passing is not a promise.
+      if (!/<code>|export |ENV|environment/i.test(line)) return;
+      for (const match of line.matchAll(OWNED)) {
+        const name = match[0];
+        if (!found.has(name)) {
+          found.set(name, `${path.relative(repoRoot, file)}:${i + 1}`);
+        }
+      }
+    });
+  }
+  return found;
+}
+
+function sourceText(): string {
+  const roots = [
+    path.join(repoRoot, 'typescript', 'src'),
+    path.join(repoRoot, 'typescript', 'desktop', 'src'),
+    path.join(repoRoot, 'python', 'openrappter'),
+    path.join(repoRoot, 'macos'),
+  ].filter((p) => fs.existsSync(p));
+
+  const chunks: string[] = [];
+  const walk = (dir: string): void => {
+    for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+      const full = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (['node_modules', '.build', '__pycache__', 'dist', '__tests__', 'tests'].includes(entry.name)) {
+          continue;
+        }
+        walk(full);
+        continue;
+      }
+      // Tests are excluded deliberately. A variable only a test mentions is not
+      // one the product reads — and this file names the dead ones in its own
+      // comment, which would otherwise make them look alive.
+      if (/\.(test|spec)\.(ts|tsx|js|mjs)$/.test(entry.name)) continue;
+      if (/^test_.*\.py$/.test(entry.name)) continue;
+      if (!/\.(ts|tsx|js|mjs|py|swift)$/.test(entry.name)) continue;
+      chunks.push(fs.readFileSync(full, 'utf8'));
+    }
+  };
+  roots.forEach(walk);
+  return chunks.join('\n');
+}
+
+describe('documented environment variables are variables something reads', () => {
+  it('finds the documented variables', () => {
+    // Guards the extractor: a pattern matching nothing would make the test
+    // below pass over an empty set.
+    const names = [...documentedVars().keys()];
+    expect(names.length).toBeGreaterThanOrEqual(5);
+    expect(names).toContain('OPENRAPPTER_MODEL');
+  });
+
+  it('is read somewhere in the source', () => {
+    const source = sourceText();
+    const orphans: string[] = [];
+    for (const [name, where] of documentedVars()) {
+      if (!source.includes(name)) orphans.push(`  ${name}\n    documented at ${where}`);
+    }
+    expect(
+      orphans,
+      orphans.length
+        ? 'These are documented as environment variables and nothing reads them.\n' +
+          'Setting one produces no error and no effect.\n\n' +
+          `${orphans.sort().join('\n\n')}\n`
+        : '',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Five variables, nothing reading any of them

The reference tables list `OPENRAPPTER_CONFIG`, `OPENRAPPTER_LOG_LEVEL`, `OPENRAPPTER_PROVIDER`, `GATEWAY_SECRET` and `OPENRAPPTER_NO_TELEMETRY`.

None appears anywhere in the TypeScript runtime, the Python runtime, the desktop app or the macOS app. Setting one produces no error and no effect.

This is the shape #303 dealt with in config keys, **minus the safety net**: a config key at least passes through a schema, so a guard could compare the two. An environment variable has no schema, so nothing could have caught these.

## The telemetry one

`OPENRAPPTER_NO_TELEMETRY` was documented as disabling *"anonymous usage stats"* — which tells a reader those stats exist.

They do not. There is no telemetry in either runtime: no analytics client, no endpoint, nothing collected and nothing sent. In a product whose stated promise is that it is local-first, the documentation was simultaneously **untrue and worse than the truth**.

The row is gone, replaced by a note saying plainly that there is nothing to opt out of.

## The guard

Every documented variable in the project's own namespace must be read somewhere in the source, or marked `<!-- unimplemented -->`. The marker is explicit rather than inferred from wording, so retiring a variable and documenting its absence stays a deliberate act.

### Two mistakes of mine, both caught while checking the guard actually guards

| mistake | effect |
| --- | --- |
| first version scanned test files too | the dead variables looked alive, because **this test's own comment names them**. Excluding tests took it from 1 finding to 5. |
| missed `typescript/desktop/src` | reported the implemented `OPENRAPPTER_GATEWAY_READY_TIMEOUT_MS` as an orphan |

The first is worth dwelling on: a guard whose own documentation defeats it is precisely the failure mode this series keeps finding.

## A correction to #303

That PR's note said the runtime *"only ever looks for `config.json5`"*.

Too strong. `config/loader.ts` does — but the CLI uses a **second config system** in `env.ts`, which reads `~/.openrappter/config.json` and merges `config.json5` underneath it, with `config.json` winning conflicts.

So the "JSON alternative" line I was about to delete from the loading order was **right**, and my note was wrong. It now points at the corrected order instead of overstating.

The loading order itself was two-fifths wrong, claiming environment variables and an `OPENRAPPTER_CONFIG` override that do not exist. It now describes the two files, their precedence, and the schema defaults.

## Verification

- Mutation-tested: documenting `OPENRAPPTER_DEBUG_MODE` fails the guard by name
- `tsc --noEmit` clean, `npm run lint` clean at `--max-warnings 0`
- **4862** TypeScript tests (up from 4860)
