### PR TITLE
The agent-authoring example could not work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The agent-authoring example could not work.** The page that teaches the
+  framework's main extension point opened with
+  `import { BasicAgent, AgentMetadata } from 'openrappter'`. The package entry
+  point is the CLI, not a library — it exports one unrelated function, and
+  importing it starts the interactive prompt. Both examples also returned a bare
+  object from `perform`, which is declared `Promise<string>` and is
+  `json.dumps(...)` in all 240 returns across the Python agents. The examples are
+  corrected, and the contract for an agent you add yourself — a
+  `createAgent(BasicAgent)` factory in `~/.openrappter/agents/`, which exists
+  precisely because that import cannot work — is documented for the first time.
+
 - **The Security page promised two protections that do not exist.** It
   described a prompt-injection detector in the slosh pipeline, matching phrases
   like "ignore previous instructions" and adding a `suspicious_input: true`

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -247,7 +247,7 @@ openrappter models get</pre>
           <button class="code-tab-btn" onclick="switchTab(this,'py-agent')">Python</button>
         </div>
         <div id="ts-agent" class="code-tab-content active">
-<pre><span class="kw">import</span> { BasicAgent, AgentMetadata } <span class="kw">from</span> <span class="str">'openrappter'</span>;
+<pre><span class="kw">import</span> { BasicAgent, type AgentMetadata } <span class="kw">from</span> <span class="str">'./BasicAgent.js'</span>;
 
 <span class="kw">export class</span> <span class="typ">MyAgent</span> <span class="kw">extends</span> <span class="typ">BasicAgent</span> {
   <span class="fn">constructor</span>() {
@@ -267,11 +267,13 @@ openrappter models get</pre>
     <span class="kw">const</span> query <span class="op">=</span> kwargs.query <span class="kw">as</span> string;
     <span class="cm">// access sloshed context signals</span>
     <span class="kw">const</span> timeOfDay <span class="op">=</span> <span class="kw">this</span>.<span class="fn">getSignal</span>(<span class="str">'temporal.time_of_day'</span>);
-    <span class="kw">return</span> { result<span class="op">:</span> <span class="str">`Hello from MyAgent at ${timeOfDay}`</span> };
+    <span class="kw">return</span> JSON.stringify({ result<span class="op">:</span> <span class="str">`Hello from MyAgent at ${timeOfDay}`</span> };
   }
 }</pre>
         </div>
         <div id="py-agent" class="code-tab-content">
+<span class="kw">import</span> json
+
 <pre><span class="kw">from</span> openrappter.agents.basic_agent <span class="kw">import</span> BasicAgent
 
 <span class="kw">class</span> <span class="typ">MyAgent</span>(BasicAgent):
@@ -292,7 +294,31 @@ openrappter models get</pre>
         query <span class="op">=</span> kwargs.get(<span class="str">"query"</span>, <span class="str">""</span>)
         <span class="cm"># access sloshed context signals</span>
         time_of_day <span class="op">=</span> self.<span class="fn">get_signal</span>(<span class="str">"temporal.time_of_day"</span>)
-        <span class="kw">return</span> {<span class="str">"result"</span><span class="op">:</span> <span class="str">f"Hello from MyAgent at {time_of_day}"</span>}</pre>
+        <span class="kw">return</span> json.dumps({<span class="str">"result"</span><span class="op">:</span> <span class="str">f"Hello from MyAgent at {time_of_day}"</span>})</pre>
+
+      <div class="info-box">
+        <strong><code>perform</code> returns a string, not an object.</strong> Every shipped agent returns <code>JSON.stringify(...)</code> in TypeScript and <code>json.dumps(...)</code> in Python — the base class declares <code>Promise&lt;string&gt;</code>, and the 240 <code>json.dumps</code> returns across the Python agents are the same contract. Earlier revisions of this page returned a bare object from both examples.
+      </div>
+
+      <h3>Agents you add yourself</h3>
+      <p>The example above is how an agent inside the repository is written. An agent you drop into <code>~/.openrappter/agents/</code> cannot import <code>BasicAgent</code> — the package entry point is the CLI, not a library, and importing it would run the CLI. Local agents are ESM modules that receive the base class instead:</p>
+      <pre><span class="cm">// ~/.openrappter/agents/my-agent.mjs</span>
+<span class="kw">export function</span> createAgent(BasicAgent) {
+  <span class="kw">class</span> MyAgent <span class="kw">extends</span> BasicAgent {
+    constructor() {
+      <span class="kw">super</span>(<span class="str">'MyAgent'</span>, {
+        name<span class="op">:</span> <span class="str">'MyAgent'</span>,
+        description<span class="op">:</span> <span class="str">'Does something useful'</span>,
+        parameters<span class="op">:</span> { type<span class="op">:</span> <span class="str">'object'</span>, properties<span class="op">:</span> { query<span class="op">:</span> { type<span class="op">:</span> <span class="str">'string'</span> } }, required<span class="op">:</span> [] },
+      });
+    }
+    <span class="kw">async</span> perform(kwargs) {
+      <span class="kw">return</span> JSON.stringify({ status<span class="op">:</span> <span class="str">'success'</span>, echo<span class="op">:</span> kwargs.query });
+    }
+  }
+  <span class="kw">return</span> MyAgent;
+}</pre>
+      <p>This is the shape <code>LearnNewAgent</code> generates and loads, and the reason for it is stated in its source: the factory avoids import resolution entirely, because the host passes the base class in.</p>
         </div>
       </div>
 


### PR DESCRIPTION
## The main extension point, documented with an import that does not exist

The Agents Reference teaches how to write an agent. Its TypeScript example opens with:

```ts
import { BasicAgent, AgentMetadata } from 'openrappter';
```

There is no such export.

- `package.json` names `dist/index.js` as `main`, with no `exports` map
- that file is the **CLI**
- `src/index.ts` exports exactly one symbol: `describeCopilotAuth`

Importing the package does not give you `BasicAgent`. It **starts the interactive prompt** — which I confirmed by doing it.

### The codebase already knew

`LearnNewAgent` generates local agents as a factory, and says why in its own header:

> Generated agents are JavaScript ESM modules using a factory pattern:
> `export function createAgent(BasicAgent) { ... return AgentClass; }`
> **This avoids import resolution issues — the host passes BasicAgent in.**

The documented import is the exact thing the loader was designed around.

## Both examples returned the wrong type

```ts
return { result: `Hello from MyAgent at ${timeOfDay}` };
```

`BasicAgent` declares `abstract perform(kwargs): Promise<string>` — so the TypeScript example does not compile. The Python example has the same shape, against a runtime where **every** shipped agent returns `json.dumps(...)`; there are 240 of them.

Corrected: the in-repo example imports `./BasicAgent.js` and returns `JSON.stringify(...)`; the Python example returns `json.dumps(...)` and imports `json` to do it.

## Agents you add yourself — documented for the first time

The page only ever showed the in-repo pattern. An agent dropped into `~/.openrappter/agents/` can't import the base class at all, so it receives it:

```js
// ~/.openrappter/agents/my-agent.mjs
export function createAgent(BasicAgent) {
  class MyAgent extends BasicAgent { /* ... */ }
  return MyAgent;
}
```

That is what `LearnNewAgent` writes and loads, and the requirements it sends the model are effectively the specification: factory, `super(name, metadata)`, `async perform(kwargs)` returning `JSON.stringify({ status: 'success', ... })`, Node built-ins only.

## I ran the example

Given this PR is about documentation that was never executed, executing mine seemed like the minimum. I extracted the new block back out of the HTML, stripped the tags, and loaded it the way the host does:

```
name    : MyAgent
returns : string {"status":"success","echo":"hello"}
```

Factory returns the class, the class constructs, `perform` returns a string.

## Verification

- 4862 TypeScript tests, 393 integration tests
- tags balanced: `<div>` 47/47, `<pre>` 49/49
