### PR TITLE
The tutorial's agent returned the wrong type too

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The tutorial's agent returned the wrong type too.** `GreeterAgent`, the
+  worked example a reader builds and tests, returned a bare object from
+  `perform` in both runtimes — the same defect corrected in the Agents Reference,
+  and the same one that makes the TypeScript version fail to compile. Both now
+  return `JSON.stringify(...)` / `json.dumps(...)`, the Python example imports
+  `json` to do it, and the accompanying test parses the string before asserting
+  on it. The architecture page's reference to `python/openrappter/config.py` was
+  also updated; that module is now a package.
+
 - **The agent-authoring example could not work.** The page that teaches the
   framework's main extension point opened with
   `import { BasicAgent, AgentMetadata } from 'openrappter'`. The package entry

--- a/docs/docs.html
+++ b/docs/docs.html
@@ -984,7 +984,7 @@ openrappter flight export <span class="cm"># integrity-checked bundle</span></pr
     <!-- ── 12. Config System ── -->
     <div id="config-system" class="doc-section">
       <h2>Config System</h2>
-      <p>The config system is responsible for loading, validating, hot-reloading, and providing typed access to all runtime configuration. It is implemented in TypeScript at <code>typescript/src/config/</code> and mirrors the Python implementation at <code>python/openrappter/config.py</code>.</p>
+      <p>The config system is responsible for loading, validating, hot-reloading, and providing typed access to all runtime configuration. It is implemented in TypeScript at <code>typescript/src/config/</code> and mirrors the Python implementation at <code>python/openrappter/config/</code>.</p>
 
       <h3>Loading Order</h3>
       <p>Configuration is resolved in this priority order (highest wins):</p>

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -268,16 +268,17 @@
     <span class="kw">const</span> name = kwargs.name <span class="kw">as</span> string;
     <span class="kw">const</span> hour = <span class="kw">new</span> <span class="fn">Date</span>().getHours();
     <span class="kw">const</span> greeting = hour &lt; 12 ? <span class="str">'Good morning'</span> : hour &lt; 18 ? <span class="str">'Good afternoon'</span> : <span class="str">'Good evening'</span>;
-    <span class="kw">return</span> {
+    <span class="kw">return</span> JSON.stringify({
       message: <span class="str">`${greeting}, ${name}!`</span>,
       data_slush: { greeted_user: name, time_of_day: greeting }
-    };
+    });
   }
 }</code></pre>
           </div>
           <div class="code-tab-content" id="py-step5">
 <pre><code><span class="comment"># python/openrappter/agents/greeter_agent.py</span>
 <span class="kw">from</span> openrappter.agents.basic_agent <span class="kw">import</span> BasicAgent
+<span class="kw">import</span> json
 <span class="kw">from</span> datetime <span class="kw">import</span> datetime
 
 <span class="kw">class</span> GreeterAgent(BasicAgent):
@@ -300,10 +301,10 @@
         name = kwargs.<span class="fn">get</span>(<span class="str">'name'</span>, <span class="str">'World'</span>)
         hour = datetime.<span class="fn">now</span>().hour
         greeting = <span class="str">'Good morning'</span> <span class="kw">if</span> hour &lt; 12 <span class="kw">else</span> <span class="str">'Good afternoon'</span> <span class="kw">if</span> hour &lt; 18 <span class="kw">else</span> <span class="str">'Good evening'</span>
-        <span class="kw">return</span> {
+        <span class="kw">return</span> json.dumps({
             <span class="str">"message"</span>: <span class="kw">f</span><span class="str">"{greeting}, {name}!"</span>,
             <span class="str">"data_slush"</span>: {<span class="str">"greeted_user"</span>: name, <span class="str">"time_of_day"</span>: greeting}
-        }</code></pre>
+        })</code></pre>
           </div>
         </div>
 
@@ -359,7 +360,8 @@
 describe(<span class="str">'GreeterAgent'</span>, () => {
   it(<span class="str">'returns a greeting with the provided name'</span>, <span class="kw">async</span> () => {
     <span class="kw">const</span> agent = <span class="kw">new</span> <span class="fn">GreeterAgent</span>();
-    <span class="kw">const</span> result = <span class="kw">await</span> agent.<span class="fn">perform</span>({ name: <span class="str">'Alice'</span> });
+    <span class="kw">const</span> raw = <span class="kw">await</span> agent.<span class="fn">perform</span>({ name: <span class="str">'Alice'</span> });
+    <span class="kw">const</span> result = JSON.parse(raw);
     expect(result.message).<span class="fn">toContain</span>(<span class="str">'Alice'</span>);
     expect(result.data_slush.greeted_user).<span class="fn">toBe</span>(<span class="str">'Alice'</span>);
   });


### PR DESCRIPTION
## Same defect, one page over

`GreeterAgent` is the worked example a reader builds, saves and tests. Both versions returned a bare object from `perform`:

```ts
return {
  message: `${greeting}, ${name}!`,
  data_slush: { greeted_user: name, time_of_day: greeting }
};
```

`BasicAgent` declares `abstract perform(kwargs): Promise<string>` — so the TypeScript version does not compile, and the Python one disagrees with all 240 `json.dumps` returns across the shipped agents. This is #307's finding, on the next page.

Both now return `JSON.stringify(...)` / `json.dumps(...)`, matching how `CodeReviewAgent` actually returns `data_slush`.

### The knock-on the tutorial had to follow

The test it tells you to write asserted `result.data_slush.greeted_user` directly. Against a string that fails, so it parses first now:

```ts
const raw = await agent.perform({ name: 'Alice' });
const result = JSON.parse(raw);
```

A tutorial that ends with a passing test has to end with a test that can pass.

## I ran it, and it caught me

Extracted the corrected Python example back out of the HTML and ran it against the real `BasicAgent`:

```
type   : str
parsed : {'message': 'Good afternoon, Alice!',
          'data_slush': {'greeted_user': 'Alice', 'time_of_day': 'Good afternoon'}}
```

That run earned its keep. My first attempt at adding `import json` matched the plain string `from datetime import datetime` against a line that is actually:

```html
<span class="kw">from</span> datetime <span class="kw">import</span> datetime
```

It matched nothing, inserted nothing, reported nothing, and left the example raising `NameError: name 'json' is not defined`.

**A silent no-op, in a change whose entire subject is silent no-ops.** Caught only because I ran the thing instead of reading it.

## Two negative results

Both from checking `architecture.html` after it was called out as stale:

| claim | verdict |
| --- | --- |
| "34 agents (TypeScript) · 20 agents (Python)" | **correct** — exactly what is on disk. My own first count said 35, because I included `BasicAgent` |
| the full directory tree | **correct** — every directory listed exists, including the ones my line-range heuristic flagged because they sit outside `typescript/src` |

The one number I could not settle is *"16 messaging channels"*. There is no channel registry to count from, and the honest range is 15 platforms to 17 adapters depending on whether `cli` and `thread` count. Left alone rather than swapped for a different arbitrary number.

## Also

`docs/docs.html` pointed at `python/openrappter/config.py`, which is now the package `python/openrappter/config/`.

## Verification

- 4862 TypeScript tests, 393 integration tests
- HTML tags balanced (`<pre>` 21/21 in tutorial, `<div>` 47/47 in docs)
