### PR TITLE
Guard the agent examples, and fix three the guard found

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -489,7 +489,7 @@ openrappter models get</pre>
       query<span class="op">:</span> kwargs.topic,
       upstream_slush<span class="op">:</span> <span class="kw">this</span>.lastDataSlush
     });
-    <span class="kw">return</span> { plan<span class="op">:</span> research.summary };
+    <span class="kw">return</span> JSON.stringify({ plan<span class="op">:</span> research.summary });
   }
 }</pre>
     </div>

--- a/docs/tutorial.html
+++ b/docs/tutorial.html
@@ -392,7 +392,7 @@ describe(<span class="str">'GreeterAgent'</span>, () => {
   <span class="kw">const</span> confidence = <span class="kw">this</span>.<span class="fn">getSignal</span>&lt;string&gt;(<span class="str">'orientation.confidence'</span>, <span class="str">'medium'</span>);
   <span class="kw">const</span> approach   = <span class="kw">this</span>.<span class="fn">getSignal</span>&lt;string&gt;(<span class="str">'orientation.approach'</span>);
   <span class="kw">if</span> (confidence === <span class="str">'low'</span>) {
-    <span class="kw">return</span> { status: <span class="str">'clarify'</span>, message: <span class="str">'Could you be more specific?'</span> };
+    <span class="kw">return</span> JSON.stringify({ status: <span class="str">'clarify'</span>, message: <span class="str">'Could you be more specific?'</span> });
   }
 
   <span class="comment">// Query signals — understand what the user is asking</span>
@@ -420,7 +420,7 @@ describe(<span class="str">'GreeterAgent'</span>, () => {
     confidence = self.<span class="fn">get_signal</span>(<span class="str">'orientation.confidence'</span>, <span class="str">'medium'</span>)
     approach   = self.<span class="fn">get_signal</span>(<span class="str">'orientation.approach'</span>)
     <span class="kw">if</span> confidence == <span class="str">'low'</span>:
-        <span class="kw">return</span> {<span class="str">"status"</span>: <span class="str">"clarify"</span>, <span class="str">"message"</span>: <span class="str">"Could you be more specific?"</span>}
+        <span class="kw">return</span> json.dumps({<span class="str">"status"</span>: <span class="str">"clarify"</span>, <span class="str">"message"</span>: <span class="str">"Could you be more specific?"</span>})
 
     <span class="comment"># Query signals — understand what the user is asking</span>
     is_question  = self.<span class="fn">get_signal</span>(<span class="str">'query_signals.is_question'</span>, <span class="kw">False</span>)

--- a/typescript/src/__tests__/integration/docs-agent-examples.test.ts
+++ b/typescript/src/__tests__/integration/docs-agent-examples.test.ts
@@ -1,0 +1,118 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * A documented agent has to return what `perform` is declared to return.
+ *
+ * `BasicAgent.perform` is `abstract perform(kwargs): Promise<string>`, and every
+ * shipped agent honours it — `JSON.stringify(...)` in TypeScript, `json.dumps(...)`
+ * in Python, 240 times over in the Python agents alone.
+ *
+ * Two of the three places that teach agent authoring had drifted from that. The
+ * Agents Reference (#307) and the tutorial (#308) both returned a bare object,
+ * so the TypeScript they showed did not compile and the Python disagreed with
+ * every real agent. README.md had it right the whole time, which is what makes
+ * this worth a test rather than a third correction: the examples are supposed to
+ * agree, and nothing was checking that they did.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(here, '..', '..', '..', '..');
+
+interface Block {
+  file: string;
+  line: number;
+  body: string;
+}
+
+function stripTags(html: string): string {
+  return html
+    .replace(/<[^>]*>/g, '')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&amp;/g, '&')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+}
+
+/** Code blocks that define an agent's `perform`, from HTML `<pre>` and fenced markdown. */
+function agentExamples(): Block[] {
+  const found: Block[] = [];
+  const docsDir = path.join(repoRoot, 'docs');
+  const files = fs.existsSync(docsDir)
+    ? fs.readdirSync(docsDir)
+        .filter((f) => f.endsWith('.html') || f.endsWith('.md'))
+        .map((f) => path.join(docsDir, f))
+    : [];
+  files.push(path.join(repoRoot, 'README.md'));
+
+  for (const file of files.filter((f) => fs.existsSync(f))) {
+    const raw = fs.readFileSync(file, 'utf8');
+    const lines = raw.split('\n');
+    const rel = path.relative(repoRoot, file);
+
+    if (file.endsWith('.md')) {
+      let open = -1;
+      lines.forEach((line, i) => {
+        if (!/^\s*```/.test(line)) return;
+        if (open < 0) { open = i; return; }
+        const body = lines.slice(open + 1, i).join('\n');
+        if (/\bperform\s*\(/.test(body)) found.push({ file: rel, line: open + 1, body });
+        open = -1;
+      });
+      continue;
+    }
+
+    for (let i = 0; i < lines.length; i++) {
+      if (!/<pre>/.test(lines[i])) continue;
+      let j = i;
+      while (j < lines.length && !/<\/pre>/.test(lines[j])) j++;
+      const body = stripTags(lines.slice(i, j + 1).join('\n'));
+      if (/\bperform\s*\(/.test(body)) found.push({ file: rel, line: i + 1, body });
+      i = j;
+    }
+  }
+  return found;
+}
+
+describe('documented agents return what perform is declared to return', () => {
+  const examples = agentExamples();
+
+  it('finds the agent examples', () => {
+    // Guards the extractor: matching nothing would make the test below pass
+    // over an empty list, which is the failure this whole area keeps producing.
+    expect(examples.length).toBeGreaterThanOrEqual(3);
+    expect(examples.map((e) => e.file)).toContain('README.md');
+  });
+
+  it('returns a serialised string, never a bare object', () => {
+    const problems: string[] = [];
+
+    for (const example of examples) {
+      const lines = example.body.split('\n');
+      const start = lines.findIndex((l) => /\bperform\s*\(/.test(l));
+      if (start < 0) continue;
+
+      lines.slice(start).forEach((line, offset) => {
+        // A return whose value opens an object literal or dict on the spot.
+        if (!/^\s*return\s*\{/.test(line)) return;
+        problems.push(
+          `  ${example.file}:${example.line + start + offset}\n` +
+          `    ${line.trim().slice(0, 72)}\n` +
+          '    perform is Promise<string>: wrap it in JSON.stringify(...) or json.dumps(...)',
+        );
+      });
+    }
+
+    expect(
+      problems,
+      problems.length
+        ? 'An agent example returns an object where the base class requires a string.\n' +
+          'The TypeScript form does not compile; the Python form disagrees with every\n' +
+          `shipped agent.\n\n${problems.join('\n\n')}\n`
+        : '',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Reading found two. The test found the rest in one run.

#307 and #308 each corrected an agent example returning a bare object from `perform`, which is declared `Promise<string>`. Both were found by reading, one page at a time. README.md had it right the whole time — so the three places that teach agent authoring disagreed with each other, and nothing noticed.

This adds a test: every documented code block defining `perform` must return `JSON.stringify(...)` or `json.dumps(...)`, never an object literal opened on the spot.

It immediately found three more, all of which I had read past **twice**:

| location | code |
| --- | --- |
| `docs/docs.html:492` | `return { plan: research.summary };` — the subagent example |
| `docs/tutorial.html:395` | `return { status: 'clarify', ... };` |
| `docs/tutorial.html:423` | the Python form of the same line |

**Three pages, five wrong returns, one correct reference implementation.**

## Guarding the guard

A matcher that quietly finds nothing is the exact failure this area keeps producing — it would make the assertion pass over an empty list. So a second test requires at least three examples, and that `README.md` is among them.

## Mutation testing

Breaking the example that was already right:

```
× returns a serialised string, never a bare object
  README.md:477
```

## Negatives worth recording

- **README.md was already correct** in both runtimes — including the relative `./BasicAgent.js` import that `docs.html` got wrong in #307. It is the reference the other two had drifted from.
- The remaining flagged block in the tutorial is a **method-body fragment** with no imports of its own. The complete example earlier on that page imports `json` (added in #308), so a reader following in order has it in scope.

## Verification

- `tsc --noEmit` clean, `npm run lint` clean at `--max-warnings 0`
- **4864** TypeScript tests (up from 4862)
