### PR TITLE
The config schema did not know settings the runtime reads

### DIFF
--- a/docs/docs.html
+++ b/docs/docs.html
@@ -207,10 +207,10 @@ openrappter models get</pre>
       <p>Any string value can reference environment variables with <code>${VAR_NAME}</code>. Unset variables resolve to an empty string; use <code>${VAR_NAME:-default_value}</code> to supply a fallback. This is the recommended way to handle API keys — keep them out of the config file and source them from your shell profile or a <code>.env</code> file.</p>
 
       <h3>Zod Validation</h3>
-      <p>The configuration schema is defined and validated with Zod v4 at <code>typescript/src/config/schema.ts</code>. On startup, if any field has the wrong type, openrappter prints a structured error with the exact path and expected type — not a raw crash. Note that unknown keys are <em>discarded silently</em> rather than rejected, which is why a misspelled or invented key validates cleanly and does nothing.</p>
+      <p>The schema is defined with Zod v4 at <code>typescript/src/config/schema.ts</code>, and <code>openrappter config validate</code> checks a file against it. It is not run on startup: the CLI loads <code>~/.openrappter/config.json</code> through a separate path that reads fields directly and does not validate. Unknown keys are <em>discarded silently</em> rather than rejected, which is why a misspelled or invented key validates cleanly and does nothing — and why a key the schema has not been taught about is worth reporting rather than assuming harmless.</p>
 
       <h3>Live Reload</h3>
-      <p>The config system uses a file watcher. When <code>config.json5</code> is saved, the running process picks up the new values without a restart. Log levels, rate limits, and gateway settings all hot-reload. Changes to the memory backend require a restart.</p>
+      <p>There is none. <code>config/watcher.ts</code> implements one and nothing constructs it, in either runtime — no other code watches the file either. Earlier revisions of this page said a running process picks up a saved config without a restart, and that log levels, rate limits and gateway settings all hot-reload. Restart after changing configuration.</p>
 
       <h3>Environment Variables Reference</h3>
       <table class="doc-table">

--- a/typescript/src/__tests__/integration/config-schema-completeness.test.ts
+++ b/typescript/src/__tests__/integration/config-schema-completeness.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+
+import { openRappterConfigSchema, channelConfigSchema } from '../../config/schema.js';
+import { readIMessageConfig } from '../../channels/imessage-gateway.js';
+
+/**
+ * Settings the product reads have to survive the schema that validates them.
+ *
+ * There are two config systems. The CLI loads `~/.openrappter/config.json`
+ * through `env.ts` and reads fields off the raw object; `config/loader.ts`
+ * parses `config.json5` and runs it through Zod. Zod strips unknown keys rather
+ * than rejecting them, so a key one side depends on and the other has never
+ * heard of disappears silently.
+ *
+ * `readIMessageConfig` reads `mode`, `pollInterval` and `staleAfterMs`.
+ * `channelConfigSchema` knew only `enabled`, `allowFrom` and `mentionGating`.
+ * A config running the iMessage channel over BlueBubbles therefore came back out
+ * of the schema without its transport, and re-reading it selected the
+ * `applescript` default — a working setup quietly reconfigured.
+ *
+ * Nothing routes channels through the schema today, so this was latent. It is
+ * the kind of latent that stops being latent the moment someone wires the two
+ * systems together, which is exactly the sort of change that looks safe.
+ */
+
+describe('config the runtime reads survives the schema', () => {
+  it('keeps every iMessage setting readIMessageConfig understands', () => {
+    const working = {
+      channels: {
+        imessage: {
+          enabled: true,
+          mode: 'bluebubbles',
+          pollInterval: 500,
+          staleAfterMs: 60_000,
+          allowFrom: ['+15550000000'],
+        },
+      },
+    };
+
+    const direct = readIMessageConfig(working);
+    const viaSchema = readIMessageConfig(openRappterConfigSchema.parse(working));
+
+    expect(viaSchema).toEqual(direct);
+    // Named explicitly: an equality that passed because both sides defaulted
+    // would prove nothing.
+    expect(viaSchema.mode).toBe('bluebubbles');
+    expect(viaSchema.pollInterval).toBe(500);
+  });
+
+  it('declares the keys the iMessage reader looks for', () => {
+    const shape = Object.keys(channelConfigSchema.shape).sort();
+    expect(shape).toEqual([
+      'allowFrom',
+      'enabled',
+      'mentionGating',
+      'mode',
+      'pollInterval',
+      'staleAfterMs',
+    ]);
+  });
+
+  it('still rejects a mode the reader would not accept', () => {
+    const result = channelConfigSchema.safeParse({ enabled: true, mode: 'carrier-pigeon' });
+    expect(result.success).toBe(false);
+  });
+});

--- a/typescript/src/config/schema.ts
+++ b/typescript/src/config/schema.ts
@@ -58,6 +58,16 @@ export const channelConfigSchema = z.object({
   enabled: z.boolean().default(false),
   allowFrom: z.array(z.string()).optional(),
   mentionGating: z.boolean().optional(),
+  // `readIMessageConfig` reads these three straight off the raw config, and the
+  // schema did not know them. Unknown keys are stripped rather than rejected, so
+  // a config that ran the iMessage channel over BlueBubbles came back out of the
+  // schema with `mode` and `pollInterval` gone — and re-reading it selected the
+  // `applescript` default instead. Nothing loads channels through the schema
+  // today, which is the only reason that was latent rather than a transport
+  // silently changing under someone.
+  mode: z.enum(['applescript', 'bluebubbles']).optional(),
+  pollInterval: z.number().int().min(250).optional(),
+  staleAfterMs: z.number().int().positive().optional(),
 });
 
 export const gatewayConfigSchema = z.object({


### PR DESCRIPTION
## Two config systems, one vocabulary each

The CLI loads `~/.openrappter/config.json` through `env.ts` and reads fields straight off the raw object. `config/loader.ts` parses `config.json5` and runs it through Zod. **Zod strips unknown keys rather than rejecting them**, so a key one side depends on and the other has never heard of disappears without a word.

- `readIMessageConfig` reads `mode`, `pollInterval`, `staleAfterMs`
- `channelConfigSchema` knew `enabled`, `allowFrom`, `mentionGating`

## Measured

With a config that runs iMessage over BlueBubbles:

```
what the CLI reads from it   : {"enabled":true,"mode":"bluebubbles","pollInterval":500,...}
what the schema keeps        : {"channels":{"imessage":{"enabled":true}}}
what the CLI reads after that: {"enabled":true,"mode":"applescript",...}
```

**The transport changes.** Not an error, not a warning — the reader falls back to its default because the key it was looking for is gone.

Nothing routes channels through the schema today, so this is latent. It is the kind of latent that stops being latent the moment someone connects the two config systems — precisely the change that looks like tidying up.

The schema now declares all three keys, still rejects a `mode` the reader would not accept, and a test asserts that what the reader understands survives a round-trip through validation.

## Two false claims in the same area

I should have caught the second in #303 — **I edited that very paragraph** to correct the filename in it, without asking whether the sentence was true.

**Live Reload.** *"When the config is saved, the running process picks up the new values without a restart… log levels, rate limits and gateway settings all hot-reload."*

`config/watcher.ts` implements a watcher and **nothing constructs it**. No other code in either runtime watches the file. Restart after changing configuration.

**Zod Validation.** *"On startup, if any field has the wrong type, openrappter prints a structured error with the exact path and expected type."*

Validation is not run on startup; the CLI's path does not validate at all. It runs when you run `openrappter config validate`.

That second one also explains why an incomplete schema mattered less than it looks: `config validate` reports a file as valid while silently knowing nothing about half of it.

## Verification

- Mutation-tested: removing `mode` from the schema again fails all three new tests
- `tsc --noEmit` clean, `npm run lint` clean at `--max-warnings 0`
- **4867** TypeScript tests (up from 4864), **1602** Python tests
- `conformance.py` 8 passed / 0 failed
