### PR TITLE
A config valid in one runtime was rejected by the other

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A config valid in one runtime was rejected by the other.** TypeScript's
+  schema declares 21 top-level sections; Python's validator required one of six
+  and refused anything else, so a file holding only `logging` or only `security`
+  was accepted by one runtime and rejected by the other with "Config must contain
+  at least one recognized section". Python now recognises the same 21, and
+  `contracts/config-sections.json` pins the vocabulary with a test on each side,
+  so adding a section to one runtime fails the other until it is added to both.
+  The validators still differ in kind — Zod strips unknown keys, Python returns
+  the data untouched — which is deliberate and unchanged.
+
 - **The config schema did not know settings the runtime reads.** `channels.*`
   accepted only `enabled`, `allowFrom` and `mentionGating`, while
   `readIMessageConfig` reads `mode`, `pollInterval` and `staleAfterMs` off the

--- a/contracts/config-sections.json
+++ b/contracts/config-sections.json
@@ -1,0 +1,41 @@
+{
+  "schema": "rapp-config-sections/1.0",
+  "why": [
+    "The two config validators disagreed about what a config file may contain.",
+    "TypeScript's Zod schema declares 21 top-level sections. Python's validator",
+    "required at least one of six, and rejected anything else outright, so a file",
+    "holding only `logging` or only `security` was valid in one runtime and refused",
+    "by the other with 'Config must contain at least one recognized section'.",
+    "",
+    "The two validators also differ in kind, which is fine and is not what this",
+    "file pins: Zod strips unknown keys, Python returns the data untouched. What",
+    "has to agree is the vocabulary — which sections are real.",
+    "",
+    "This file is the pin. Each runtime has a test asserting its own list matches",
+    "`sections` exactly. Adding a section to one runtime now fails the other's test",
+    "until it is added here too."
+  ],
+  "sections": [
+    "agents",
+    "auth",
+    "browser",
+    "channels",
+    "configVersion",
+    "cron",
+    "env",
+    "experimental",
+    "gateway",
+    "hooks",
+    "logging",
+    "media",
+    "memory",
+    "models",
+    "network",
+    "plugins",
+    "security",
+    "session",
+    "tools",
+    "ui",
+    "voice"
+  ]
+}

--- a/python/openrappter/config/schema.py
+++ b/python/openrappter/config/schema.py
@@ -1,4 +1,12 @@
-RECOGNIZED_SECTIONS = {'gateway', 'models', 'agents', 'channels', 'memory', 'cron'}
+RECOGNIZED_SECTIONS = {
+    # Pinned by contracts/config-sections.json, which both runtimes test against.
+    # This set held six names while the TypeScript schema declared twenty-one, so
+    # a config containing only `logging` or only `security` was valid there and
+    # rejected here — the vocabularies had drifted with nothing comparing them.
+    'agents', 'auth', 'browser', 'channels', 'configVersion', 'cron', 'env',
+    'experimental', 'gateway', 'hooks', 'logging', 'media', 'memory', 'models',
+    'network', 'plugins', 'security', 'session', 'tools', 'ui', 'voice',
+}
 
 
 def validate_config(data: dict) -> dict:

--- a/python/tests/test_config_section_parity.py
+++ b/python/tests/test_config_section_parity.py
@@ -1,0 +1,51 @@
+"""The config vocabulary both runtimes have to share.
+
+TypeScript's Zod schema declared 21 top-level sections; this validator required
+one of six and rejected everything else, so a file holding only `logging` or
+only `security` was valid there and refused here. Nothing compared the two.
+
+contracts/config-sections.json is the pin. The equivalent TypeScript test is
+typescript/src/__tests__/integration/config-section-parity.test.ts.
+"""
+
+import json
+from pathlib import Path
+
+from openrappter.config.schema import RECOGNIZED_SECTIONS, validate_config
+
+CONTRACT = (
+    Path(__file__).resolve().parents[2] / 'contracts' / 'config-sections.json'
+)
+
+
+def _contract_sections():
+    return set(json.loads(CONTRACT.read_text())['sections'])
+
+
+def test_contract_file_is_present_and_populated():
+    # Guards the loader: an empty or missing contract would make the comparison
+    # below pass against nothing.
+    sections = _contract_sections()
+    assert len(sections) >= 20
+    assert 'gateway' in sections
+
+
+def test_recognized_sections_match_the_contract():
+    assert RECOGNIZED_SECTIONS == _contract_sections()
+
+
+def test_a_logging_only_config_is_accepted():
+    # The concrete case that failed: valid in TypeScript, rejected here.
+    result = validate_config({'logging': {'level': 'debug'}})
+    assert result['success'] is True
+
+
+def test_a_security_only_config_is_accepted():
+    result = validate_config({'security': {'approvalPolicy': 'deny'}})
+    assert result['success'] is True
+
+
+def test_a_config_with_no_recognized_section_is_still_rejected():
+    result = validate_config({'nonsense': True})
+    assert result['success'] is False
+    assert 'recognized section' in result['error']

--- a/typescript/src/__tests__/integration/config-section-parity.test.ts
+++ b/typescript/src/__tests__/integration/config-section-parity.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { openRappterConfigSchema } from '../../config/schema.js';
+
+/**
+ * The config vocabulary both runtimes have to share.
+ *
+ * This schema declares 21 top-level sections. Python's validator required one
+ * of six and rejected everything else outright, so a file holding only
+ * `logging` or only `security` was valid here and refused there with "Config
+ * must contain at least one recognized section". Nothing compared the two.
+ *
+ * The validators still differ in kind, and that is deliberate: Zod strips
+ * unknown keys, Python returns the data untouched. What has to agree is which
+ * sections are real.
+ *
+ * The Python half of this pin is python/tests/test_config_section_parity.py.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const contractPath = path.resolve(here, '..', '..', '..', '..', 'contracts', 'config-sections.json');
+
+function contractSections(): string[] {
+  const parsed = JSON.parse(fs.readFileSync(contractPath, 'utf8')) as { sections: string[] };
+  return [...parsed.sections].sort();
+}
+
+describe('config sections agree with the cross-runtime contract', () => {
+  it('reads a populated contract', () => {
+    // Guards the loader: an empty contract would make the comparison below pass
+    // against nothing.
+    const sections = contractSections();
+    expect(sections.length).toBeGreaterThanOrEqual(20);
+    expect(sections).toContain('gateway');
+  });
+
+  it('declares exactly the sections the contract lists', () => {
+    const declared = Object.keys(openRappterConfigSchema.shape).sort();
+    expect(declared).toEqual(contractSections());
+  });
+});


### PR DESCRIPTION
## Fifteen sections Python had never heard of

TypeScript's Zod schema declares **21** top-level sections. Python's `validate_config` required at least one of **six**, and refused anything else outright:

```python
RECOGNIZED_SECTIONS = {'gateway', 'models', 'agents', 'channels', 'memory', 'cron'}
```

So a file holding only `logging`, or only `security`, is valid in one runtime and fails in the other with *"Config must contain at least one recognized section"*.

Measured:

| config | python | ts |
| --- | --- | --- |
| `{logging: {...}}` | **REJECTED** | OK |
| `{security: {...}}` | **REJECTED** | OK |
| `{gateway: {...}}` | OK | OK |

Nothing compared the two lists, so they drifted as the TypeScript schema grew.

## The pin

Python now recognises the same twenty-one, and `contracts/config-sections.json` pins the vocabulary — the same way `gateway-rpc-parity.json` already pins the RPC surface. Each runtime has a test asserting its own list matches the contract exactly, so **adding a section to one runtime fails the other until it is added to both**.

Both halves are guarded against passing vacuously: each asserts the loaded contract is populated and contains `gateway` before comparing against it. An empty or missing file would otherwise satisfy both sides — which is the failure mode this series keeps running into.

### Mutation testing

Adding a section to the contract alone fails **both** runtimes' tests. That is the direction that matters: the contract cannot drift ahead of either implementation.

## What this deliberately does not change

The two validators still differ *in kind*: Zod strips unknown keys, Python returns the data untouched.

That is a real difference with real consequences — #310 was about precisely what Zod's stripping does to a key it hasn't been taught — but it is not the same thing as disagreeing about which sections exist, and unifying the two behaviours is a larger decision than this PR.

## Verification

- `tsc --noEmit` clean, `npm run lint` clean at `--max-warnings 0`
- **4869** TypeScript tests (up from 4867), **1607** Python tests (up from 1602)
- `conformance.py` 8 passed / 0 failed, `parity_harness.py` PASS
