### PR TITLE
The gateway advertised a payload limit it did not enforce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -480,6 +480,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **The gateway advertised a payload limit it did not enforce.** The handshake
+  has always reported `policy.maxPayload: 5000000`, while `WebSocketServer` was
+  constructed without a `maxPayload` option — so `ws` applied its own 100 MB
+  default and the gateway accepted twenty times what it told every client its
+  limit was. The number is now one constant, read both by the server that
+  enforces it and the handshake that reports it. Nothing legitimate is affected:
+  `zen.publish` frames are capped at 256 KB and the HTTP body limit is 2 MB.
+
 - **`backup.restore` replaced your data without authentication** — the gateway
   required auth to *delete* a backup but not to restore one, though restoring
   overwrites every file in `~/.openrappter/` in place and keeps no copy of what

--- a/typescript/src/__tests__/integration/gateway-payload-limit.test.ts
+++ b/typescript/src/__tests__/integration/gateway-payload-limit.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import WebSocket from 'ws';
+
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * The advertised payload limit has to be the enforced one.
+ *
+ * `handleConnect` has always reported `policy.maxPayload: 5_000_000`, and
+ * `WebSocketServer` was constructed without a `maxPayload` option — so `ws`
+ * applied its own default of 100 MB. The gateway told every client its limit
+ * was 5 MB and accepted twenty times that.
+ *
+ * The number existed in two places and only one of them did anything, which is
+ * why this asserts the two agree rather than asserting a literal: a limit that
+ * is merely written down is the thing that failed here.
+ */
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+async function handshake(port: number): Promise<Record<string, unknown>> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', () => resolve());
+      ws.once('error', reject);
+    });
+    const reply = new Promise<Record<string, unknown>>((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(String(data))));
+    });
+    ws.send(JSON.stringify({
+      type: 'req',
+      id: '1',
+      method: 'connect',
+      params: { client: { id: 'test', version: '1', platform: 'test', mode: 'test' } },
+    }));
+    return await reply;
+  } finally {
+    ws.close();
+  }
+}
+
+describe('gateway payload limit', () => {
+  it('enforces the limit it advertises', async () => {
+    const port = await reserveTestPort();
+    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    await server.start();
+
+    const res = await handshake(port);
+    const payload = res.payload as { policy?: { maxPayload?: number } } | undefined;
+    const advertised = payload?.policy?.maxPayload;
+    expect(typeof advertised).toBe('number');
+
+    // A frame one byte over the advertised limit must be refused. `ws` closes
+    // with 1009 (message too big) rather than answering, so the close code is
+    // the observable.
+    const ws = new WebSocket(`ws://127.0.0.1:${port}`, { maxPayload: 200_000_000 });
+    const closed = new Promise<number>((resolve) => {
+      ws.once('close', (code) => resolve(code));
+    });
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', () => resolve());
+      ws.once('error', reject);
+    });
+    ws.send('x'.repeat((advertised as number) + 1));
+
+    await expect(closed).resolves.toBe(1009);
+  }, 30_000);
+
+  it('accepts a frame comfortably inside the limit', async () => {
+    const port = await reserveTestPort();
+    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    await server.start();
+
+    const res = await handshake(port);
+    // The handshake itself is the proof: a connection that completes a request
+    // and gets an answer has not been closed for size.
+    expect(res.ok).toBe(true);
+  }, 30_000);
+});

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -121,6 +121,26 @@ export function normalizeChatTarget(value: unknown): ChatTarget {
 const DEFAULT_HEARTBEAT_INTERVAL = 30000;
 const DEFAULT_CONNECTION_TIMEOUT = 120000;
 const DEFAULT_SHUTDOWN_TIMEOUT = 250;
+
+/**
+ * Largest inbound WebSocket frame the gateway will accept, in bytes.
+ *
+ * The handshake has always advertised this number in `policy.maxPayload`, and
+ * nothing enforced it: `WebSocketServer` was constructed without a `maxPayload`
+ * option, so `ws` applied its own 100 MB default. The gateway told every client
+ * its limit was 5 MB and accepted twenty times that.
+ *
+ * It is one constant now, read by both the server that enforces it and the
+ * handshake that reports it, because the bug was that the number existed twice
+ * and only one copy did anything.
+ *
+ * Comfortably above everything that legitimately arrives: `zen.publish` frames
+ * are capped at 256 KB by `ZEN_MAX_FRAME_BYTES`, and the HTTP body limit is
+ * 2 MB, described there as generous for a chat turn carrying forty turns of
+ * history.
+ */
+const MAX_WS_PAYLOAD_BYTES = 5_000_000;
+
 const RATE_LIMIT_WINDOW_MS = 60000;
 const RATE_LIMIT_MAX_REQUESTS = 100;
 /**
@@ -761,6 +781,7 @@ export class GatewayServer {
 
     this.wss = new WebSocketServer({
       server: this.httpServer,
+      maxPayload: MAX_WS_PAYLOAD_BYTES,
       verifyClient: (info: { req: IncomingMessage }) => this.validateRequestSource(info.req).ok,
     });
     this.startedAt = Date.now();
@@ -2168,7 +2189,7 @@ export class GatewayServer {
         events: Object.values(GatewayEvents),
       },
       policy: {
-        maxPayload: 5_000_000,
+        maxPayload: MAX_WS_PAYLOAD_BYTES,
         maxBufferedBytes: 10_000_000,
         tickIntervalMs: this.config.heartbeatInterval ?? DEFAULT_HEARTBEAT_INTERVAL,
       },


### PR DESCRIPTION
## A limit that was only ever written down

`handleConnect` reports this to every client:

```js
policy: { maxPayload: 5_000_000, ... }
```

And the server was constructed like this:

```js
new WebSocketServer({ server, verifyClient })
```

**No `maxPayload` option** — so `ws` applied its own default of **100 MB**. The gateway stated a 5 MB limit and accepted twenty times that.

The number existed in two places and only one of them did anything. It is one constant now, read by the server that enforces it *and* the handshake that reports it, so they cannot disagree again.

## Nothing legitimate is affected

| path | limit |
| --- | --- |
| `zen.publish` frames | 256 KB (`ZEN_MAX_FRAME_BYTES`) |
| HTTP body | 2 MB — described at its own definition as "generous for a chat turn carrying forty turns of history" |
| WS inbound | now 5 MB, as advertised |

The limit applies only to frames clients *send*.

## The test asserts agreement, not a literal

A limit that is merely written down is precisely what failed here — so the test reads `policy.maxPayload` out of a **real handshake**, sends one byte more than that, and expects close code 1009.

### Mutation testing

With the `maxPayload` option removed again: the oversized frame is accepted, no close ever arrives, and the test times out. That is the honest failure mode — the connection genuinely is not closed.

## Related

Found while comparing the two gateways' handshakes for **#313**, which records a separate problem: both runtimes send a `policy` object and the field names have **no overlap at all** (`maxPayload`/`maxBufferedBytes`/`tickIntervalMs` vs `maxMessageBytes`/`maxOutputBytes`/`executionTimeoutSeconds`). That one is a wire-protocol decision rather than a defect, so it is filed rather than fixed here.

## Verification

- `tsc --noEmit` clean, `npm run lint` clean at `--max-warnings 0`
- **4871** TypeScript tests (up from 4869)
