### PR TITLE
A client that stopped reading was buffered without limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -480,6 +480,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Security
 
+- **A client that stopped reading was buffered without limit.** The handshake
+  advertised `policy.maxBufferedBytes: 10000000` and `sendFrame` was
+  `ws.send(...)` with nothing consulting `bufferedAmount`, so the limit was
+  announced and never applied. `zen.publish` carries frames of up to 256 KB at
+  up to 30fps, so a stalled subscriber could accumulate megabytes a second in a
+  process meant to run for weeks. A connection past the limit is now closed with
+  1013 rather than fed, and the advertised number and the enforced one are one
+  constant.
+
 - **The gateway advertised a payload limit it did not enforce.** The handshake
   has always reported `policy.maxPayload: 5000000`, while `WebSocketServer` was
   constructed without a `maxPayload` option — so `ws` applied its own 100 MB

--- a/typescript/src/__tests__/integration/gateway-buffer-limit.test.ts
+++ b/typescript/src/__tests__/integration/gateway-buffer-limit.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, afterEach } from 'vitest';
+import WebSocket from 'ws';
+
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+/**
+ * A client that stops reading must not be buffered without limit.
+ *
+ * The handshake has always advertised `policy.maxBufferedBytes`, and
+ * `sendFrame` was `ws.send(...)` with nothing consulting `bufferedAmount`. The
+ * limit was announced and never applied. `zen.publish` carries frames of up to
+ * 256 KB at up to 30fps, so a subscriber that stalls can accumulate megabytes a
+ * second in a process meant to run for weeks.
+ *
+ * The guard is exercised directly with a stub socket rather than by trying to
+ * stall a real client: making a real peer stop reading on demand is unreliable,
+ * and a flaky test about resource exhaustion is worse than a direct one.
+ */
+
+interface FrameSender {
+  sendFrame(ws: unknown, frame: Record<string, unknown>): void;
+}
+
+interface StubSocket {
+  bufferedAmount: number;
+  sent: string[];
+  closedWith: [number, string] | null;
+  send(data: string): void;
+  close(code: number, reason: string): void;
+}
+
+function stubSocket(bufferedAmount: number): StubSocket {
+  return {
+    bufferedAmount,
+    sent: [],
+    closedWith: null,
+    send(data: string) { this.sent.push(data); },
+    close(code: number, reason: string) { this.closedWith = [code, reason]; },
+  };
+}
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+async function advertisedLimit(port: number): Promise<number> {
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  try {
+    await new Promise<void>((resolve, reject) => {
+      ws.once('open', () => resolve());
+      ws.once('error', reject);
+    });
+    const reply = new Promise<Record<string, unknown>>((resolve) => {
+      ws.once('message', (data) => resolve(JSON.parse(String(data))));
+    });
+    ws.send(JSON.stringify({
+      type: 'req',
+      id: '1',
+      method: 'connect',
+      params: { client: { id: 'test', version: '1', platform: 'test', mode: 'test' } },
+    }));
+    const res = await reply;
+    const payload = res.payload as { policy: { maxBufferedBytes: number } };
+    return payload.policy.maxBufferedBytes;
+  } finally {
+    ws.close();
+  }
+}
+
+describe('gateway outbound buffer limit', () => {
+  it('enforces the buffer limit it advertises', async () => {
+    const port = await reserveTestPort();
+    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    await server.start();
+
+    const limit = await advertisedLimit(port);
+    expect(typeof limit).toBe('number');
+
+    const sender = server as unknown as FrameSender;
+
+    // Comfortably inside the limit: the frame goes out.
+    const healthy = stubSocket(limit - 1);
+    sender.sendFrame(healthy, { type: 'event', name: 'tick' });
+    expect(healthy.sent).toHaveLength(1);
+    expect(healthy.closedWith).toBeNull();
+
+    // Past it: nothing more is queued, and the connection is closed rather than
+    // left to grow.
+    const stalled = stubSocket(limit + 1);
+    sender.sendFrame(stalled, { type: 'event', name: 'tick' });
+    expect(stalled.sent).toHaveLength(0);
+    expect(stalled.closedWith?.[0]).toBe(1013);
+  }, 30_000);
+});

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -141,6 +141,22 @@ const DEFAULT_SHUTDOWN_TIMEOUT = 250;
  */
 const MAX_WS_PAYLOAD_BYTES = 5_000_000;
 
+/**
+ * Most the gateway will hold in a client's outbound queue before giving up on
+ * it, in bytes.
+ *
+ * The handshake has always advertised this in `policy.maxBufferedBytes`, and
+ * `sendFrame` was `ws.send(...)` with nothing looking at `bufferedAmount` — so
+ * a client that stopped reading was buffered without limit. `zen.publish`
+ * carries frames of up to 256 KB at up to 30fps, so a stalled subscriber can
+ * accumulate megabytes a second in a process that is meant to run for weeks.
+ *
+ * Sharing the constant with the handshake is the point, the same way
+ * `MAX_WS_PAYLOAD_BYTES` is shared: the previous value was enforced nowhere and
+ * announced anyway.
+ */
+const MAX_BUFFERED_BYTES = 10_000_000;
+
 const RATE_LIMIT_WINDOW_MS = 60000;
 const RATE_LIMIT_MAX_REQUESTS = 100;
 /**
@@ -2190,7 +2206,7 @@ export class GatewayServer {
       },
       policy: {
         maxPayload: MAX_WS_PAYLOAD_BYTES,
-        maxBufferedBytes: 10_000_000,
+        maxBufferedBytes: MAX_BUFFERED_BYTES,
         tickIntervalMs: this.config.heartbeatInterval ?? DEFAULT_HEARTBEAT_INTERVAL,
       },
     };
@@ -2208,6 +2224,17 @@ export class GatewayServer {
 
   /** Send a protocol frame */
   private sendFrame(ws: WebSocket, frame: Record<string, unknown>): void {
+    // A connection this far behind is not reading. Sending more only grows the
+    // queue, so it is closed rather than fed.
+    //
+    // 1013 rather than 1009: 1009 is "message too big", which describes an
+    // inbound frame the peer could not handle, and this is the opposite — the
+    // peer is not consuming what it asked for. 1013 says the server is shedding
+    // the connection and reconnecting is reasonable, which is the truth here.
+    if (ws.bufferedAmount > MAX_BUFFERED_BYTES) {
+      try { ws.close(1013, 'Outbound buffer limit exceeded'); } catch { /* already gone */ }
+      return;
+    }
     try { ws.send(JSON.stringify(frame)); } catch { /* ignore */ }
   }
 


### PR DESCRIPTION
## The second announced-but-unenforced limit

Same handshake, same shape as #314. `policy.maxBufferedBytes` has always been advertised as 10 MB, and `sendFrame` was:

```ts
try { ws.send(JSON.stringify(frame)); } catch { }
```

Nothing looked at `bufferedAmount`. `maxBufferedBytes` appeared **nowhere else in the source** — announced, never applied.

## Not theoretical for this gateway

`zen.publish` carries rendered frames of up to **256 KB**, at up to **30fps** by the reasoning already written into the rate-limit comment, and every subscriber gets a copy through `sendFrame`.

A subscriber that stops consuming accumulates megabytes a second — in a process designed to run for weeks and be left alone.

A connection past the limit is now closed rather than fed, and the advertised number and the enforced one are the same constant.

## Close code 1013, not 1009

I used 1009 first and corrected it. Per RFC 6455, 1009 is *"message too big"* — an **inbound** frame the peer could not handle. This is the opposite: a peer not consuming what it asked for. **1013 "Try Again Later"** says the server is shedding the connection and reconnecting is reasonable, which is the truth here.

Confirmed sendable and correctly received by a real `ws` client:

```
client saw close code: 1013
```

rather than assumed from the RFC.

## Testing

The guard is exercised with a stub socket rather than by stalling a real client — making a peer stop reading on demand is unreliable, and a flaky test about resource exhaustion is worse than a direct one.

It still reads the limit **out of a real handshake** before asserting, so it tests that the advertised and enforced values agree rather than restating a literal.

**Mutation-tested:** with the check removed, the frame is queued onto a socket already past the limit and the connection stays open.

## Verification

- `tsc --noEmit` clean, `npm run lint` clean at `--max-warnings 0`
- **4872** TypeScript tests (up from 4871)
