### PR TITLE
The Bar could wipe your other credentials while saving one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Bar could wipe your other credentials while saving one.** Onboarding
+  wrote `~/.openrappter/.env` by reading it, dropping the key being replaced, and
+  writing the result — but the read was `(try? String(contentsOfFile:)) ?? ""`,
+  so a file that exists and cannot be decoded became an empty string and the
+  rewrite replaced everything in it with the single variable being saved. That
+  file is shared with the CLI, which keeps `OPENRAPPTER_MODEL` there, so the
+  blast radius was not limited to onboarding's own keys. The write was `try?`
+  too, and `saveManualToken` reported success immediately after it, so a token
+  that never reached disk looked exactly like one that did. The read now
+  distinguishes absent from unreadable and refuses to overwrite what it could not
+  read, the write is verified by reading it back — as the TypeScript `saveEnv`
+  has done since #159 — and a failure is surfaced instead of reported as success.
+
 - **A config valid in one runtime was rejected by the other.** TypeScript's
   schema declares 21 top-level sections; Python's validator required one of six
   and refused anything else, so a file holding only `logging` or only `security`

--- a/macos/Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift
+++ b/macos/Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift
@@ -65,11 +65,15 @@ public final class OnboardingViewModel {
 
     // MARK: - Paths
 
-    private let homeDir = NSHomeDirectory() + "/.openrappter"
+    /// Injectable so the write path can be tested against a temp directory
+    /// rather than the real `~/.openrappter`. Defaults to the real one.
+    private let homeDir: String
     private var envFilePath: String { homeDir + "/.env" }
     private var configFilePath: String { homeDir + "/config.json" }
 
-    public init() {}
+    public init(homeDir: String = NSHomeDirectory() + "/.openrappter") {
+        self.homeDir = homeDir
+    }
 
     // MARK: - Step Navigation
 
@@ -154,7 +158,10 @@ public final class OnboardingViewModel {
 
     public func saveManualToken(_ token: String) {
         guard !token.isEmpty else { return }
-        saveEnvVar("GITHUB_TOKEN", value: token)
+        guard saveEnvVar("GITHUB_TOKEN", value: token) else {
+            authState = .failed("Could not write the token to \(envFilePath)")
+            return
+        }
         authState = .success
     }
 
@@ -162,7 +169,10 @@ public final class OnboardingViewModel {
 
     public func connectTelegram() {
         guard !telegramToken.isEmpty else { return }
-        saveEnvVar("TELEGRAM_BOT_TOKEN", value: telegramToken)
+        guard saveEnvVar("TELEGRAM_BOT_TOKEN", value: telegramToken) else {
+            errorMessage = "Could not write the Telegram token to \(envFilePath)"
+            return
+        }
         telegramSkipped = false
         // Validate token
         Task {
@@ -249,14 +259,52 @@ public final class OnboardingViewModel {
         return nil
     }
 
-    private func saveEnvVar(_ key: String, value: String) {
+    /// Write one variable into `~/.openrappter/.env`, preserving the rest.
+    ///
+    /// Returns `false` if the value did not reach disk, and the caller is
+    /// expected to say so rather than report success.
+    ///
+    /// Two failures were previously indistinguishable from success. The read was
+    /// `(try? String(contentsOfFile:)) ?? ""`, so a file that exists and cannot
+    /// be decoded produced an empty string, and the rewrite below then replaced
+    /// every other variable with just this one. `.env` is shared with the CLI —
+    /// `openrappter models set` keeps `OPENRAPPTER_MODEL` there — so that is not
+    /// confined to onboarding's own keys. And the write itself was `try?`, so a
+    /// failure to save a token looked exactly like saving it.
+    ///
+    /// The TypeScript `saveEnv` has verified its own read-back since #159. This
+    /// does the same thing, for the same reason.
+    @discardableResult
+    private func saveEnvVar(_ key: String, value: String) -> Bool {
         try? FileManager.default.createDirectory(atPath: homeDir, withIntermediateDirectories: true)
-        var content = (try? String(contentsOfFile: envFilePath, encoding: .utf8)) ?? ""
-        // Remove existing key
+
+        var content: String
+        if FileManager.default.fileExists(atPath: envFilePath) {
+            // Present but unreadable is the dangerous case: starting from "" here
+            // discards everything already in the file.
+            guard let existing = try? String(contentsOfFile: envFilePath, encoding: .utf8) else {
+                return false
+            }
+            content = existing
+        } else {
+            content = ""
+        }
+
         content = content.split(separator: "\n").filter { !$0.hasPrefix("\(key)=") }.joined(separator: "\n")
         if !content.isEmpty { content += "\n" }
         content += "\(key)=\(value)\n"
-        try? content.write(toFile: envFilePath, atomically: true, encoding: .utf8)
+
+        do {
+            try content.write(toFile: envFilePath, atomically: true, encoding: .utf8)
+        } catch {
+            return false
+        }
+
+        guard let readBack = try? String(contentsOfFile: envFilePath, encoding: .utf8),
+              readBack == content else {
+            return false
+        }
+        return true
     }
 
     private func saveConfig() {

--- a/macos/Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift
+++ b/macos/Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift
@@ -1,0 +1,73 @@
+import Foundation
+@testable import OpenRappterBarLib
+
+/// Saving a token has to actually save it, and must not take the others with it.
+///
+/// `saveEnvVar` read the file as `(try? String(contentsOfFile:)) ?? ""` and then
+/// rewrote it. A file that exists and cannot be decoded therefore became an
+/// empty string, and the rewrite replaced every variable in it with the single
+/// one being saved. `~/.openrappter/.env` is shared with the CLI — `openrappter
+/// models set` keeps `OPENRAPPTER_MODEL` there — so the blast radius was not
+/// limited to onboarding's own keys.
+///
+/// The write was `try?` as well, and `saveManualToken` set `authState = .success`
+/// immediately after it. A token that never reached disk looked identical to one
+/// that did.
+@MainActor
+func runOnboardingEnvWriteTests() async {
+    await suite("Onboarding env writes") {
+
+        func scratchHome() throws -> String {
+            let path = NSTemporaryDirectory() + "onboarding-env-\(UUID().uuidString)"
+            try FileManager.default.createDirectory(atPath: path, withIntermediateDirectories: true)
+            return path
+        }
+
+        await test("keeps variables it is not writing") {
+            let home = try scratchHome()
+            let envPath = home + "/.env"
+            try "OPENRAPPTER_MODEL=gpt-4o\nGITHUB_TOKEN=old\n"
+                .write(toFile: envPath, atomically: true, encoding: .utf8)
+
+            let model = OnboardingViewModel(homeDir: home)
+            model.saveManualToken("new")
+
+            let written = try String(contentsOfFile: envPath, encoding: .utf8)
+            try expect(written.contains("OPENRAPPTER_MODEL=gpt-4o"),
+                           "the CLI's variable must survive the Bar saving a token")
+            try expect(written.contains("GITHUB_TOKEN=new"))
+            try expect(!written.contains("GITHUB_TOKEN=old"))
+        }
+
+        await test("reports success only when the token reached disk") {
+            let home = try scratchHome()
+            let model = OnboardingViewModel(homeDir: home)
+            model.saveManualToken("new")
+
+            switch model.authState {
+            case .success: break
+            default: throw AssertionError(description: "expected .success, got \(model.authState)")
+            }
+        }
+
+        await test("refuses to overwrite a file it could not read") {
+            let home = try scratchHome()
+            let envPath = home + "/.env"
+            // Bytes that are not valid UTF-8: the file exists and decoding fails,
+            // which is the case that used to yield "" and take everything with it.
+            try Data([0xFF, 0xFE, 0x00, 0x81]).write(to: URL(fileURLWithPath: envPath))
+            let before = try Data(contentsOf: URL(fileURLWithPath: envPath))
+
+            let model = OnboardingViewModel(homeDir: home)
+            model.saveManualToken("new")
+
+            let after = try Data(contentsOf: URL(fileURLWithPath: envPath))
+            try expect(before == after, "an unreadable env file must be left alone")
+
+            switch model.authState {
+            case .failed: break
+            default: throw AssertionError(description: "expected .failed, got \(model.authState)")
+            }
+        }
+    }
+}

--- a/macos/Tests/OpenRappterBarTests/main.swift
+++ b/macos/Tests/OpenRappterBarTests/main.swift
@@ -19,6 +19,7 @@ await runOnboardingSpawnTests()
 await runBonesInspectorTests()
 await runBonesWindowTests()
 await runChatTargetTests()
+await runOnboardingEnvWriteTests()
 try runSuiteRegistrationTests()
 
 printResults()


### PR DESCRIPTION
## Saving one credential could destroy the others

`saveEnvVar` wrote `~/.openrappter/.env` by reading it, dropping the line being replaced, and writing the result back. The read was:

```swift
var content = (try? String(contentsOfFile: envFilePath, encoding: .utf8)) ?? ""
```

A file that **exists and cannot be decoded** becomes an empty string — and the rewrite below then replaces every variable in it with the single one being saved.

### The blast radius is not onboarding's own keys

The CLI keeps `OPENRAPPTER_MODEL` in that file; `openrappter models set` writes it through `saveEnv`. So the reachable outcome is the Bar saving a Telegram token and taking the GitHub token and the selected model with it, silently.

Onboarding calls `saveEnvVar` twice in sequence, so the second call is already re-reading a file the first one wrote.

### And the write was `try?` too

```swift
saveEnvVar("GITHUB_TOKEN", value: token)
authState = .success
```

A token that never reached disk was indistinguishable from one that did.

## Three changes

1. **Absent and unreadable are now different.** A missing file starts from empty, as before. A file that exists and fails to decode aborts rather than being treated as empty.
2. **The write is verified by reading it back** — which the TypeScript `saveEnv` has done since #159, for exactly this reason.
3. **Failure is surfaced.** `saveManualToken` sets `.failed(...)`; `connectTelegram` sets `errorMessage`.

`homeDir` became an injectable initialiser parameter defaulting to the real path, so the write path can be tested against a temp directory rather than the developer's own `~/.openrappter`.

## Mutation testing

Restoring the `?? ""` read:

```
FAIL: refuses to overwrite a file it could not read — an unreadable env file must be left alone
```

The data loss reproduced, rather than described.

## Verification

- **182** Swift tests passing, up from 179
- `swift build --product RunTests` clean
