### PR TITLE
The Bar claimed auto-start was installed when it was not

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The Bar claimed auto-start was installed when it was not.** Writing the
+  launchd plist and loading it were both discarded failures, with
+  `autoStartInstalled = true` set immediately after regardless, so the completion
+  screen showed "Auto-start ✓" whether or not anything had been installed — and
+  the daemon simply did not come back after a reboot, with nothing to explain
+  why. `launchctl` reports refusal through its exit status, which the Bar's shell
+  helper discards along with stderr, so a status-aware helper was added. The CLI
+  path has always reported this honestly.
+
+- **The Bar showed a setup step it never performed.** "Scheduling daily tips" was
+  marked complete from `daemonStarted`, which is unrelated, and nothing in the
+  Bar schedules tips — that happens in `openrappter onboard`, in the CLI. The row
+  is gone rather than tied to a different unrelated signal.
+
 - **The Bar could wipe your other credentials while saving one.** Onboarding
   wrote `~/.openrappter/.env` by reading it, dropping the key being replaced, and
   writing the result — but the read was `(try? String(contentsOfFile:)) ?? ""`,

--- a/macos/Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift
+++ b/macos/Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift
@@ -68,11 +68,18 @@ public final class OnboardingViewModel {
     /// Injectable so the write path can be tested against a temp directory
     /// rather than the real `~/.openrappter`. Defaults to the real one.
     private let homeDir: String
+    /// Injectable for the same reason as `homeDir`: the failure path can then
+    /// be exercised without writing a real launch agent or calling launchctl.
+    private let launchAgentsDir: String
     private var envFilePath: String { homeDir + "/.env" }
     private var configFilePath: String { homeDir + "/config.json" }
 
-    public init(homeDir: String = NSHomeDirectory() + "/.openrappter") {
+    public init(
+        homeDir: String = NSHomeDirectory() + "/.openrappter",
+        launchAgentsDir: String = NSHomeDirectory() + "/Library/LaunchAgents"
+    ) {
         self.homeDir = homeDir
+        self.launchAgentsDir = launchAgentsDir
     }
 
     // MARK: - Step Navigation
@@ -318,8 +325,10 @@ public final class OnboardingViewModel {
         }
     }
 
-    private func installLaunchAgent() {
-        let plistPath = NSHomeDirectory() + "/Library/LaunchAgents/com.openrappter.daemon.plist"
+    /// Internal rather than private so the failure path is reachable from a
+    /// test without writing a real launch agent or invoking launchctl.
+    func installLaunchAgent() {
+        let plistPath = launchAgentsDir + "/com.openrappter.daemon.plist"
         let nodePath = resolveNodePath()
         // Resolve the CODE directory, which is not the data directory.
         //
@@ -367,9 +376,52 @@ public final class OnboardingViewModel {
         """
 
         try? FileManager.default.createDirectory(atPath: (plistPath as NSString).deletingLastPathComponent, withIntermediateDirectories: true)
-        try? plist.write(toFile: plistPath, atomically: true, encoding: .utf8)
-        _ = try? shellSync("launchctl", args: ["load", "-w", plistPath])
+
+        // Every step here used to be `try?` with `autoStartInstalled = true`
+        // after it, so a failed write or a failed `launchctl load` still showed
+        // "Auto-start ✓" on the completion screen — and the daemon simply did
+        // not come back on the next login, with nothing to explain why. The CLI
+        // path has always said "Auto-start not installed" when this fails.
+        do {
+            try plist.write(toFile: plistPath, atomically: true, encoding: .utf8)
+        } catch {
+            autoStartInstalled = false
+            errorMessage = "Could not install auto-start: \(error.localizedDescription)"
+            return
+        }
+
+        // `launchctl load` reports refusal through its exit status, and
+        // `shellSync` throws away the status along with stderr, so it cannot be
+        // used to tell whether this worked.
+        let status = shellStatus("launchctl", args: ["load", "-w", plistPath])
+        guard status == 0 else {
+            autoStartInstalled = false
+            errorMessage = "Auto-start was written but launchctl refused it (exit \(status)). "
+                + "The daemon will not start automatically after a reboot."
+            return
+        }
+
         autoStartInstalled = true
+    }
+
+    /// Exit status of a command, for the cases where the status is the answer.
+    ///
+    /// `shellSync` returns stdout and drops the status, which is right for
+    /// reading `gh auth token` and wrong for asking whether `launchctl` accepted
+    /// something.
+    private func shellStatus(_ executable: String, args: [String]) -> Int32 {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = [executable] + args
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            return -1
+        }
+        process.waitUntilExit()
+        return process.terminationStatus
     }
 
     private func isPortOpen(port: Int) -> Bool {

--- a/macos/Sources/OpenRappterBar/Views/OnboardingView.swift
+++ b/macos/Sources/OpenRappterBar/Views/OnboardingView.swift
@@ -248,7 +248,6 @@ public struct OnboardingView: View {
             VStack(alignment: .leading, spacing: 12) {
                 statusRow(label: "Starting daemon", done: viewModel.daemonStarted)
                 statusRow(label: "Installing auto-start", done: viewModel.autoStartInstalled)
-                statusRow(label: "Scheduling daily tips", done: viewModel.daemonStarted)
             }
             .padding()
             .background(Color.gray.opacity(0.05))

--- a/macos/Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift
+++ b/macos/Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift
@@ -69,5 +69,23 @@ func runOnboardingEnvWriteTests() async {
             default: throw AssertionError(description: "expected .failed, got \(model.authState)")
             }
         }
+
+        await test("does not claim auto-start when the plist could not be written") {
+            let home = try scratchHome()
+            // A directory the write cannot succeed into. `installLaunchAgent`
+            // returns before reaching launchctl, so no real launch agent is
+            // touched and nothing is loaded.
+            let agents = try scratchHome()
+            try FileManager.default.setAttributes([.posixPermissions: 0o500], ofItemAtPath: agents)
+            defer { try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: agents) }
+
+            let model = OnboardingViewModel(homeDir: home, launchAgentsDir: agents)
+            model.installLaunchAgent()
+
+            try expect(model.autoStartInstalled == false,
+                       "a plist that was never written must not report auto-start installed")
+            try expectNotNil(model.errorMessage)
+            try expect(!FileManager.default.fileExists(atPath: agents + "/com.openrappter.daemon.plist"))
+        }
     }
 }


### PR DESCRIPTION
## Three discarded failures and an unconditional success

```swift
try? FileManager.default.createDirectory(...)
try? plist.write(toFile: plistPath, atomically: true, encoding: .utf8)
_ = try? shellSync("launchctl", args: ["load", "-w", plistPath])
autoStartInstalled = true
```

The completion screen reads that flag directly — "Installing auto-start", and a green **Auto-start ✓** check. So a user whose plist never landed, or whose `launchctl load` was refused, was told it was installed.

The consequence arrives later and somewhere else: **the daemon does not come back after a reboot**, with nothing connecting that to onboarding.

### Why `try?` wasn't the only problem

`launchctl` reports refusal through its **exit status**, and `shellSync` returns stdout and throws the status away along with stderr. That's the right shape for reading `gh auth token`, and it cannot answer *"did this work"* — so this adds a status-returning helper rather than changing what `shellSync` means.

The write now uses `do`/`catch`, and `autoStartInstalled` is set only after both steps succeed.

### The CLI was already honest

`openrappter onboard` prints:

> Auto-start not installed — run `openrappter --daemon` manually after reboots

Only the Bar claimed otherwise.

## Also removed: "Scheduling daily tips"

That row was marked complete from `daemonStarted` — an unrelated signal — and **nothing in the Bar schedules tips**. The daily-tip cron job is created by `openrappter onboard`, in the CLI.

A row reporting the state of something else, for work this flow does not do, is worse than no row.

## Testing this safely

The honest version of `installLaunchAgent` writes a real launch agent into `~/Library/LaunchAgents` and calls `launchctl load`. So:

- `launchAgentsDir` is injectable now
- the test points it at a directory the write cannot succeed into
- the early return means **launchctl is never reached**

Confirmed afterwards that no plist exists at the real path.

**Mutation-tested:** restoring the `try?` write makes *"does not claim auto-start when the plist could not be written"* fail.

## Verification

- **183** Swift tests passing, up from 182
- `swift build --product RunTests` clean
