### PR TITLE
Pressing Stop in the Bar could do nothing, silently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Pressing Stop in the Bar could do nothing, silently.** `abortChat` caught
+  its failure and discarded it, and `chatState` is only set to `.idle` on the
+  success path — so a refused or undelivered abort left the UI streaming, with
+  a Stop button that renders only while streaming and did nothing however many
+  times it was pressed. The failure is now reported, which also restores the
+  input, since `.error` is not `.streaming`.
+
 - **The Bar claimed auto-start was installed when it was not.** Writing the
   launchd plist and loading it were both discarded failures, with
   `autoStartInstalled = true` set immediately after regardless, so the completion

--- a/macos/Sources/OpenRappterBar/ViewModels/ChatViewModel.swift
+++ b/macos/Sources/OpenRappterBar/ViewModels/ChatViewModel.swift
@@ -139,7 +139,13 @@ public final class ChatViewModel {
                 chatState = .idle
                 streamingText = ""
             } catch {
-                // Silently ignore abort failures
+                // Not silent: the Stop button only renders while `chatState` is
+                // `.streaming`, so a failed abort left the UI streaming with a
+                // button that did nothing however many times it was pressed, and
+                // no way to tell that the request had not landed. Surfacing the
+                // failure also restores the input, because `.error` is not
+                // `.streaming`.
+                chatState = .error("Could not stop the response: \(error.localizedDescription)")
             }
         }
     }

--- a/macos/Tests/OpenRappterBarTests/ChatAbortFailureTests.swift
+++ b/macos/Tests/OpenRappterBarTests/ChatAbortFailureTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+@testable import OpenRappterBarLib
+
+/// Pressing Stop has to do something visible.
+///
+/// `abortChat` caught its failure and did nothing with it — the comment said
+/// "Silently ignore abort failures". `chatState` is only set to `.idle` on the
+/// success path, and the Stop button only renders `if case .streaming`, so a
+/// failed abort left the UI streaming with a button that did nothing however
+/// many times it was pressed, and nothing to say the request had not landed.
+@MainActor
+func runChatAbortFailureTests() async {
+    await suite("Chat abort failures") {
+
+        func errorFrame(requestId: String, message: String) throws -> Data {
+            try JSONSerialization.data(withJSONObject: [
+                "type": "res",
+                "id": requestId,
+                "ok": false,
+                "error": ["code": -32000, "message": message],
+            ] as [String: Any])
+        }
+
+        func connectedClient() async throws -> (MockWebSocket, RpcClient) {
+            let mock = MockWebSocket()
+            let conn = GatewayConnection(transportFactory: { _ in mock })
+            mock.enqueueReceive(try makeHelloOk(requestId: "rpc-1"))
+            try await conn.connect()
+            return (mock, RpcClient(connection: conn))
+        }
+
+        await test("a refused abort leaves the UI able to say so") {
+            let (mock, rpc) = try await connectedClient()
+            let vm = ChatViewModel()
+            vm.configure(rpcClient: rpc, sessionStore: SessionStore())
+            vm.currentSessionKey = "session-1"
+            vm.chatState = .streaming
+
+            vm.abortChat()
+
+            // The response must not be enqueued until the request has actually
+            // been sent: the mock's receive loop is already parked, and would
+            // otherwise dequeue and discard it before `sendRequest` registers
+            // the pending continuation for that id. Documented at
+            // `withDeferredResponse` in RpcClientContractTests.
+            let sent = try await mock.waitForSentCount(2)
+            guard let data = sent.last,
+                  let frame = try JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let requestId = frame["id"] as? String else {
+                throw AssertionError(description: "could not read the abort request id")
+            }
+            mock.enqueueReceive(try errorFrame(requestId: requestId, message: "no active stream"))
+
+            for _ in 0..<80 {
+                if case .streaming = vm.chatState {
+                    try? await Task.sleep(for: .milliseconds(25))
+                } else {
+                    break
+                }
+            }
+
+            switch vm.chatState {
+            case .error(let message):
+                try expect(message.contains("Could not stop the response"),
+                           "the failure has to name what did not happen, got: \(message)")
+            default:
+                throw AssertionError(
+                    description: "expected .error after a refused abort, got \(vm.chatState)")
+            }
+        }
+    }
+}

--- a/macos/Tests/OpenRappterBarTests/main.swift
+++ b/macos/Tests/OpenRappterBarTests/main.swift
@@ -20,6 +20,7 @@ await runBonesInspectorTests()
 await runBonesWindowTests()
 await runChatTargetTests()
 await runOnboardingEnvWriteTests()
+await runChatAbortFailureTests()
 try runSuiteRegistrationTests()
 
 printResults()


### PR DESCRIPTION
## Stop was a button that could do nothing

```swift
do {
    try await rpc.abortChat(sessionKey: sessionKey)
    chatState = .idle
    streamingText = ""
} catch {
    // Silently ignore abort failures
}
```

`chatState` is only cleared on the success path, and the Stop button renders `if case .streaming = viewModel.chatState`.

So a refused or undelivered abort left the UI **streaming, with the Stop button still there**, doing nothing each time it was pressed, and nothing anywhere to say the request hadn't landed. The only way out is for the stream to end on its own — which is exactly what isn't happening when someone reaches for Stop.

The failure is reported now. That also returns the input to the user, since `.error` is not `.streaming`, so Send comes back.

## The alternative I rejected

Forcing `.idle` locally — the user asked it to stop, so honour that.

If the abort never reached the gateway, the server may still be generating. A UI that has decided the stream is over while tokens are still arriving is a **worse** lie than the one being fixed.

## Two inert catches I checked and left alone

| location | why it stays |
| --- | --- |
| `SessionsViewModel` | continues with a local delete when the gateway call fails — deliberate, documented |
| `ChatViewModel` history | falls back to cached messages — deliberate, documented |

Both give a reason. This one said *"Silently ignore abort failures"*, which describes the bug rather than justifying it.

## The test took two attempts

The first enqueued the error response **before** calling `abortChat`, losing the race documented at `withDeferredResponse` in `RpcClientContractTests`: the mock's receive loop is already parked, so it dequeues and discards the response before `sendRequest` registers a pending continuation for that id.

It now waits for the request to land, reads the **real request id off the wire**, and answers that.

**Mutation-tested:** restoring the silent catch fails with *"expected .error after a refused abort, got streaming"*.

## Verification

- **184** Swift tests passing, up from 183
