### PR TITLE
Onboarding and Settings installed two different launch agents

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Onboarding and Settings installed two different launch agents.** Onboarding
+  wrote its own `com.openrappter.daemon.plist` while `LaunchAgentManager` — which
+  the Settings "Start at login" toggle reads and writes — manages
+  `com.openrappter.gateway.plist`. So the toggle showed off immediately after
+  onboarding had installed auto-start, turning it on added a second launchd job
+  starting the same gateway on the same port, and turning it off could never
+  remove the one onboarding made. Onboarding now installs through the shared
+  manager, which also brings the better plist it always had — restart only on
+  crash rather than on every clean exit, a throttle interval, background process
+  type, `Umask 0o077` and separate stdout/stderr logs. A stale
+  `com.openrappter.daemon` agent from an earlier onboarding is unloaded and
+  removed.
+
 - **Pressing Stop in the Bar could do nothing, silently.** `abortChat` caught
   its failure and discarded it, and `chatState` is only set to `.idle` on the
   success path — so a refused or undelivered abort left the UI streaming, with

--- a/macos/Sources/OpenRappterBar/Services/LaunchAgentManager.swift
+++ b/macos/Sources/OpenRappterBar/Services/LaunchAgentManager.swift
@@ -10,7 +10,13 @@ public final class LaunchAgentManager {
 
     private let fileManager = FileManager.default
 
-    public init() {}
+    /// Injectable so callers under test can point at a scratch directory rather
+    /// than writing a real launch agent into the developer's home.
+    private let launchAgentsDir: String
+
+    public init(launchAgentsDir: String = NSHomeDirectory() + "/Library/LaunchAgents") {
+        self.launchAgentsDir = launchAgentsDir
+    }
 
     // MARK: - Public API
 
@@ -134,11 +140,7 @@ public final class LaunchAgentManager {
 
     // MARK: - Private
 
-    private var launchAgentsDir: String {
-        NSHomeDirectory() + "/Library/LaunchAgents"
-    }
-
-    private var plistPath: String {
+    public var plistPath: String {
         launchAgentsDir + "/" + Self.plistFilename
     }
 

--- a/macos/Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift
+++ b/macos/Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift
@@ -328,7 +328,6 @@ public final class OnboardingViewModel {
     /// Internal rather than private so the failure path is reachable from a
     /// test without writing a real launch agent or invoking launchctl.
     func installLaunchAgent() {
-        let plistPath = launchAgentsDir + "/com.openrappter.daemon.plist"
         let nodePath = resolveNodePath()
         // Resolve the CODE directory, which is not the data directory.
         //
@@ -340,60 +339,33 @@ public final class OnboardingViewModel {
         // machine. `resolveProjectPath()` already ranks the released build above
         // that directory; it simply was not being asked.
         let projectPath = ProcessManager.resolveProjectPath()
-        let indexPath = projectPath + "/typescript/dist/index.js"
-        let fallbackIndexPath = projectPath + "/dist/index.js"
         // A deployed release has dist/ at its root; a source checkout has it
-        // under typescript/. Pick whichever actually exists rather than assuming.
-        let resolvedIndex = FileManager.default.fileExists(atPath: indexPath) ? indexPath : fallbackIndexPath
-        let logPath = homeDir + "/daemon.log"
+        // under typescript/. `LaunchAgentManager` appends `/dist/index.js`, so
+        // hand it whichever base makes that true rather than assuming one.
+        let base = FileManager.default.fileExists(atPath: projectPath + "/typescript/dist/index.js")
+            ? projectPath + "/typescript"
+            : projectPath
 
-        // PATH comes from `nodeSearchPath()`, not from this app's own
-        // environment. A Finder-launched menu-bar app inherits launchd's
-        // session PATH, so the previous version baked a four-entry PATH with
-        // no node and no copilot into the plist — which is exactly the
-        // configuration the daemon on this machine was running under.
-        let plist = """
-        <?xml version="1.0" encoding="UTF-8"?>
-        <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
-        <plist version="1.0">
-        <dict>
-            <key>Label</key><string>com.openrappter.daemon</string>
-            <key>ProgramArguments</key><array>
-                <string>\(nodePath)</string>
-                <string>\(resolvedIndex)</string>
-                <string>--daemon</string>
-            </array>
-            <key>RunAtLoad</key><true/>
-            <key>KeepAlive</key><true/>
-            <key>StandardOutPath</key><string>\(logPath)</string>
-            <key>StandardErrorPath</key><string>\(logPath)</string>
-            <key>EnvironmentVariables</key><dict>
-                <key>PATH</key><string>\(ProcessManager.nodeSearchPath())</string>
-                <key>HOME</key><string>\(NSHomeDirectory())</string>
-            </dict>
-        </dict>
-        </plist>
-        """
-
-        try? FileManager.default.createDirectory(atPath: (plistPath as NSString).deletingLastPathComponent, withIntermediateDirectories: true)
-
-        // Every step here used to be `try?` with `autoStartInstalled = true`
-        // after it, so a failed write or a failed `launchctl load` still showed
-        // "Auto-start ✓" on the completion screen — and the daemon simply did
-        // not come back on the next login, with nothing to explain why. The CLI
-        // path has always said "Auto-start not installed" when this fails.
+        // Onboarding used to write its own plist, at
+        // `com.openrappter.daemon.plist`, while `LaunchAgentManager` — which
+        // Settings' "Start at login" toggle reads and writes — manages
+        // `com.openrappter.gateway.plist`. Two different agents: the toggle
+        // showed off after onboarding had just installed one, turning it on
+        // added a second job starting the same gateway on the same port, and
+        // turning it off could never remove the one onboarding made. The
+        // duplicate plist builder is gone; there is one agent now.
+        let manager = LaunchAgentManager(launchAgentsDir: launchAgentsDir)
         do {
-            try plist.write(toFile: plistPath, atomically: true, encoding: .utf8)
+            try manager.install(nodePath: nodePath, projectPath: base, port: 18790)
         } catch {
             autoStartInstalled = false
             errorMessage = "Could not install auto-start: \(error.localizedDescription)"
             return
         }
 
-        // `launchctl load` reports refusal through its exit status, and
-        // `shellSync` throws away the status along with stderr, so it cannot be
-        // used to tell whether this worked.
-        let status = shellStatus("launchctl", args: ["load", "-w", plistPath])
+        // `launchctl` reports refusal through its exit status, which the Bar's
+        // `shellSync` discards along with stderr.
+        let status = shellStatus("launchctl", args: ["load", "-w", manager.plistPath])
         guard status == 0 else {
             autoStartInstalled = false
             errorMessage = "Auto-start was written but launchctl refused it (exit \(status)). "
@@ -401,7 +373,20 @@ public final class OnboardingViewModel {
             return
         }
 
+        removeLegacyDaemonAgent()
         autoStartInstalled = true
+    }
+
+    /// Remove the agent onboarding used to install under its own label.
+    ///
+    /// Anyone who onboarded before this was unified has a
+    /// `com.openrappter.daemon` job that Settings cannot see or remove, still
+    /// starting a second gateway on every login.
+    private func removeLegacyDaemonAgent() {
+        let legacyPath = launchAgentsDir + "/com.openrappter.daemon.plist"
+        guard FileManager.default.fileExists(atPath: legacyPath) else { return }
+        _ = shellStatus("launchctl", args: ["unload", "-w", legacyPath])
+        try? FileManager.default.removeItem(atPath: legacyPath)
     }
 
     /// Exit status of a command, for the cases where the status is the answer.

--- a/macos/Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift
+++ b/macos/Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift
@@ -87,5 +87,36 @@ func runOnboardingEnvWriteTests() async {
             try expectNotNil(model.errorMessage)
             try expect(!FileManager.default.fileExists(atPath: agents + "/com.openrappter.daemon.plist"))
         }
+
+        await test("onboarding installs the same launch agent Settings manages") {
+            // Onboarding used to write its own `com.openrappter.daemon.plist`
+            // while `LaunchAgentManager` — which the "Start at login" toggle
+            // reads and writes — manages `com.openrappter.gateway.plist`. Two
+            // agents: the toggle showed off right after onboarding installed
+            // one, turning it on added a second job for the same gateway on the
+            // same port, and turning it off could never remove onboarding's.
+            //
+            // Source-level, in the style of ApprovalBannerTests: loading a real
+            // agent to observe this would mean calling launchctl for real.
+            let path = #filePath.replacingOccurrences(
+                of: "Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift",
+                with: "Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift"
+            )
+            let source = try String(contentsOfFile: path, encoding: .utf8)
+
+            try expect(source.contains("LaunchAgentManager("),
+                       "onboarding must install through the shared manager")
+            // Counting code only: the comments above the removal path explain
+            // the old label and would otherwise inflate this.
+            let code = source
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+                .joined(separator: "\n")
+            let mentions = code.components(separatedBy: "com.openrappter.daemon").count - 1
+            try expect(mentions == 1,
+                       "expected one code reference to the legacy label, in the removal path, found \(mentions)")
+            try expect(source.contains("removeLegacyDaemonAgent"),
+                       "a stale daemon agent from an earlier onboarding must be removed")
+        }
     }
 }


### PR DESCRIPTION
## Two agents, one gateway

`LaunchAgentManager` manages `com.openrappter.gateway.plist`. It is what the Settings **Start at login** toggle reads (`startAtLogin = launchAgent.isInstalled`) and writes.

`OnboardingViewModel.installLaunchAgent` built its own plist, by hand, at **`com.openrappter.daemon.plist`**.

Three consequences, all visible to someone who just finished onboarding:

1. The toggle shows **off** — immediately after onboarding installed auto-start — because it is looking for the other file.
2. Turning it on installs a **second** launchd job, so two agents start the same gateway on the same port at every login.
3. Turning it off removes only the gateway one. **Nothing in the UI can ever remove what onboarding wrote.**

## The plist onboarding was missing out on

Onboarding now installs through the shared manager, which was already building a better plist:

| key | manager | onboarding |
| --- | --- | --- |
| `KeepAlive` | `{ SuccessfulExit: false }` — restart on crash only | `true` — restarts after a deliberate shutdown |
| `ThrottleInterval` | 15 | — |
| `ProcessType` | Background | — |
| `Umask` | `0o077` | — |
| logs | separate stdout/stderr | one combined |

The one thing onboarding did **better** is preserved: it resolves whether `dist/` sits at the project root or under `typescript/`, which the manager assumes. Rather than duplicate that, it hands the manager whichever base makes `projectPath + "/dist/index.js"` true.

## Cleaning up after the old one

`removeLegacyDaemonAgent` unloads and deletes a `com.openrappter.daemon` plist if present — anyone who onboarded before this has a second job Settings cannot see, starting a second gateway on every login.

## Testing without installing anything

`launchAgentsDir` is injectable on `LaunchAgentManager` now, for the same reason it is on the view model: the alternative is a test that writes a real launch agent into whoever's home directory ran it.

The unification is guarded at **source level**, in the style of `ApprovalBannerTests` — observing it at runtime would mean calling `launchctl` for real. The test requires the shared manager to be used and allows exactly one code reference to the old label, in the removal path. Comment lines are excluded, since the explanation above the removal necessarily names it.

**Mutation-tested:** adding a second code reference fails with *"expected one code reference to the legacy label, in the removal path, found 2"*.

## Verification

- **185** Swift tests passing, up from 184
- Confirmed no launch agent was created on the machine that ran them
