### PR TITLE
Onboarding started the daemon from the data directory, not the code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Onboarding started the daemon from the data directory, not the code.**
+  `startDaemon` hardcoded `~/.openrappter/typescript/dist/index.js`, which is the
+  runtime data directory. On a machine where that path happened to hold an old
+  checkout it started a build that had stopped updating; on one where it does
+  not — most installs — the spawn throws and onboarding reports "Could not start
+  daemon" on a perfectly good installation. `installLaunchAgent` had already been
+  corrected to ask `ProcessManager.resolveProjectPath()`; `startDaemon`, twenty
+  lines above it in the same file, had not. It also passed this app's own
+  environment to the daemon, so a Finder-launched Bar handed down launchd's
+  session `PATH` — the one with no node and no copilot in it, which the plist
+  beneath it already explains — leaving the daemon's own children unable to find
+  the tools they shell out to.
+
 - **Onboarding and Settings installed two different launch agents.** Onboarding
   wrote its own `com.openrappter.daemon.plist` while `LaunchAgentManager` — which
   the Settings "Start at login" toggle reads and writes — manages

--- a/macos/Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift
+++ b/macos/Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift
@@ -209,14 +209,33 @@ public final class OnboardingViewModel {
             // Start daemon via shell
             do {
                 let nodePath = resolveNodePath()
-                let indexPath = homeDir + "/typescript/dist/index.js"
+                // Same resolution the launch agent uses, and for the same
+                // reason. This hardcoded `homeDir + "/typescript/dist/index.js"`,
+                // where homeDir is ~/.openrappter — the runtime DATA directory,
+                // not the code. On a machine where that directory happened to
+                // contain an old checkout it started a build that had stopped
+                // updating; on one where it does not, `process.run()` throws and
+                // onboarding reports "Could not start daemon" on a perfectly good
+                // install. `installLaunchAgent` was corrected to ask
+                // `resolveProjectPath()`; this, twenty lines above it, was not.
+                let projectPath = ProcessManager.resolveProjectPath()
+                let nested = projectPath + "/typescript/dist/index.js"
+                let root = projectPath + "/dist/index.js"
+                let indexPath = FileManager.default.fileExists(atPath: nested) ? nested : root
 
                 let process = Process()
                 process.executableURL = URL(fileURLWithPath: nodePath)
                 process.arguments = [indexPath, "--daemon"]
                 process.standardOutput = FileHandle.nullDevice
                 process.standardError = FileHandle.nullDevice
-                process.environment = ProcessInfo.processInfo.environment
+                // PATH from `nodeSearchPath()`, not this app's own environment.
+                // A Finder-launched menu bar app inherits launchd's session PATH,
+                // which is the four-entry one with no node and no copilot in it —
+                // the plist below already says so, and the daemon started here
+                // was inheriting exactly that for its own children.
+                var environment = ProcessInfo.processInfo.environment
+                environment["PATH"] = ProcessManager.nodeSearchPath()
+                process.environment = environment
                 try process.run()
 
                 // Wait for gateway to start

--- a/macos/Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift
+++ b/macos/Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift
@@ -118,5 +118,32 @@ func runOnboardingEnvWriteTests() async {
             try expect(source.contains("removeLegacyDaemonAgent"),
                        "a stale daemon agent from an earlier onboarding must be removed")
         }
+
+        await test("starts the daemon from the code directory, not the data directory") {
+            // `installLaunchAgent` was corrected to resolve the project path
+            // rather than assume the daemon lives under ~/.openrappter, which is
+            // where runtime data goes. `startDaemon` kept the original
+            // assumption, so onboarding either started a stale checkout that
+            // happened to be there or failed to start anything at all.
+            //
+            // Source-level: spawning a real daemon to observe this is not
+            // something a test should do.
+            let path = #filePath.replacingOccurrences(
+                of: "Tests/OpenRappterBarTests/OnboardingEnvWriteTests.swift",
+                with: "Sources/OpenRappterBar/ViewModels/OnboardingViewModel.swift"
+            )
+            let source = try String(contentsOfFile: path, encoding: .utf8)
+            let code = source
+                .split(separator: "\n", omittingEmptySubsequences: false)
+                .filter { !$0.trimmingCharacters(in: .whitespaces).hasPrefix("//") }
+                .joined(separator: "\n")
+
+            try expect(!code.contains("homeDir + \"/typescript/dist/index.js\""),
+                       "the daemon path must not be assumed under the data directory")
+            try expect(code.contains("ProcessManager.resolveProjectPath()"),
+                       "startDaemon and installLaunchAgent must resolve the same way")
+            try expect(code.contains("ProcessManager.nodeSearchPath()"),
+                       "a Finder-launched app's inherited PATH has no node in it")
+        }
     }
 }


### PR DESCRIPTION
## The bug its own neighbour has a comment about

`startDaemon` had:

```swift
let indexPath = homeDir + "/typescript/dist/index.js"
```

`homeDir` is `~/.openrappter` — the runtime **data** directory. The code lives wherever the release or checkout is.

`installLaunchAgent`, **twenty lines below in the same file**, already carries the explanation:

> This used to hardcode `homeDir + "/typescript/dist/index.js"`, where homeDir is ~/.openrappter — the runtime DATA dir. That directory also happened to contain an old checkout, so onboarding quietly pinned the daemon to a build that stopped updating months ago…

The launch agent was corrected to ask `ProcessManager.resolveProjectPath()`. `startDaemon` was not.

| machine | outcome |
| --- | --- |
| has a stale checkout under `~/.openrappter` | starts that build |
| doesn't (most installs) | `process.run()` throws — onboarding reports **"Could not start daemon"** on a perfectly good installation |

## The environment was wrong too

```swift
process.environment = ProcessInfo.processInfo.environment
```

The plist immediately below explains why that PATH is wrong: a Finder-launched menu bar app inherits launchd's session PATH, which has neither node nor copilot in it. The plist was given `nodeSearchPath()` for exactly that reason — the daemon spawned here was not, so its own children (the copilot CLI, `gh`) inherited the impoverished one.

Both now use what the rest of the file uses.

## What I deliberately did not do

Route this through `ProcessManager.start()`, which is the fuller answer.

`OnboardingViewModel` is constructed standalone and `AppViewModel` owns the only `ProcessManager` — so reaching for one here means a second lifecycle owner racing the first over the same port. That is a larger change than the defect warrants.

## Verification

Guarded at source level, in the style of #319's launch-agent test — starting a real daemon to observe this is not something a test should do. It requires the data-directory assumption to be gone and both resolution helpers to be used.

**Mutation-tested:** restoring the hardcoded path fails with *"the daemon path must not be assumed under the data directory"*.

- **186** Swift tests passing, up from 185
