### PR TITLE
The two runtimes defaulted to different OpenAI models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **The two runtimes defaulted to different OpenAI models.** `providers/openai.ts`
+  used `gpt-4o` and `providers/openai_compatible.py` used `gpt-4o-mini` for the
+  same provider against the same endpoint, so an identical call answered from a
+  different model — and a different cost and capability — depending on which
+  runtime made it. Neither value was written down and nothing compared them. The
+  grail brainstem settles it: its default and its safety net are both `gpt-4o`,
+  which TypeScript already matched. Python now does too, and a test reads the
+  constant out of the TypeScript source so neither side can move alone.
+
 - **The two runtimes disagreed on which `/chat` requests are valid.** The grail
   brainstem rejects a `conversation_history` entry whose role is not `user`,
   `assistant` or `tool` — including a caller-supplied `system` turn — with an

--- a/python/openrappter/providers/openai_compatible.py
+++ b/python/openrappter/providers/openai_compatible.py
@@ -40,7 +40,13 @@ from openrappter.providers.types import (
 )
 
 DEFAULT_BASE_URL = "https://api.openai.com/v1"
-DEFAULT_MODEL = "gpt-4o-mini"
+# Matches `DEFAULT_MODEL` in typescript/src/providers/openai.ts and the grail
+# brainstem, whose default and safety net are both `gpt-4o`. This was
+# `gpt-4o-mini`, so the same provider on the same endpoint answered from a
+# different model depending on which runtime you asked — a difference in cost
+# and capability, not a deliberate one: the Copilot provider agrees across both
+# runtimes on `gpt-4.1`, which is what drift looks like next to a decision. #276
+DEFAULT_MODEL = "gpt-4o"
 DEFAULT_TIMEOUT = 30.0
 DEFAULT_MAX_RESPONSE_BYTES = 1_000_000
 DEFAULT_MAX_RESPONSE_HEADER_BYTES = 64 * 1024

--- a/python/tests/test_openai_provider_parity.py
+++ b/python/tests/test_openai_provider_parity.py
@@ -1,0 +1,49 @@
+"""The two runtimes must default to the same OpenAI model.
+
+`providers/openai.ts` and `providers/openai_compatible.py` describe the same
+provider against the same endpoint. They defaulted to different models —
+`gpt-4o` and `gpt-4o-mini` — which differ in both cost and capability, so the
+same call answered from a different model depending on which runtime you asked.
+
+Neither value was written down anywhere, and nothing compared them. The grail
+brainstem settles which is right: its default and its safety net are both
+`gpt-4o`, and TypeScript matched it. For contrast the Copilot provider already
+agreed across runtimes on `gpt-4.1`, which is what a decision looks like next to
+drift. #276
+
+Read out of the TypeScript source rather than duplicated here, so this fails if
+either side moves alone.
+"""
+
+import re
+from pathlib import Path
+
+from openrappter.providers.openai_compatible import DEFAULT_BASE_URL, DEFAULT_MODEL
+
+TS_PROVIDER = (
+    Path(__file__).resolve().parents[2] / 'typescript' / 'src' / 'providers' / 'openai.ts'
+)
+
+
+def _ts_const(name):
+    source = TS_PROVIDER.read_text(encoding='utf-8')
+    match = re.search(rf'const {name}\s*=\s*[\'"]([^\'"]+)[\'"]', source)
+    assert match, f'{name} not found in {TS_PROVIDER.name}'
+    return match.group(1)
+
+
+def test_the_typescript_provider_is_readable():
+    # Guards the reader: a regex that matched nothing would make the comparisons
+    # below pass against an empty string.
+    assert TS_PROVIDER.exists()
+    assert _ts_const('DEFAULT_MODEL').startswith('gpt-')
+
+
+def test_default_model_matches_typescript():
+    assert DEFAULT_MODEL == _ts_const('DEFAULT_MODEL')
+
+
+def test_default_base_url_matches_typescript():
+    # The constant is spelled `OPENAI_API_URL` on that side. The names differ,
+    # the values must not.
+    assert DEFAULT_BASE_URL == _ts_const('OPENAI_API_URL')


### PR DESCRIPTION
## Same provider, same endpoint, different model

| runtime | default |
| --- | --- |
| `providers/openai.ts` | `gpt-4o` |
| `providers/openai_compatible.py` | `gpt-4o-mini` |

An identical call answered from a different model depending on which runtime made it — at a different cost and a different capability. Neither value was written down anywhere, and nothing compared them.

## The grail settles it

```python
MODEL             = MODEL_ENV if MODEL_PINNED else "gpt-4o"
_SAFETY_NET_MODEL = "gpt-4o"
```

TypeScript already matched the reference; **Python is the one that drifted**. That reading is supported by the Copilot provider, which agrees across both runtimes on `gpt-4.1` — what a decision looks like next to an accident.

## The guard

It reads the constant out of `typescript/src/providers/openai.ts` rather than restating it, so neither side can move alone.

It also pins the base URL, where the two runtimes agree on the **value** and disagree on the **name** — `OPENAI_API_URL` there, `DEFAULT_BASE_URL` here. My first version assumed the names matched and failed honestly; that's why it compares values rather than spellings.

Guarded against passing vacuously too: a regex matching nothing would leave both comparisons checking an empty string, so one assertion requires the extracted model to actually look like a model.

**Mutation-tested:** putting `gpt-4o-mini` back fails `test_default_model_matches_typescript`.

## Scope

Narrow. The Python class is exported from `openrappter.providers` but is not wired into the Python CLI's chat path, which uses Copilot — so this reaches people using it as a library rather than the default CLI experience.

Closes #276.

## Verification

- **1610** Python tests, up from 1607
- `conformance.py` 8 passed / 0 failed
