### PR TITLE
Point the memory CLI at the memory the product keeps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`openrappter memory`** — search, record and forget what a rappter remembers.
+  The module was complete and had never been registered, so `openrappter memory`
+  fell through to the `[message]` positional and went to the model as a chat
+  prompt. It was left unregistered deliberately, because it built a
+  `MemoryManager` that holds everything in `Map`s and performs no file I/O: `add`
+  printed an id and discarded it on exit, and `list` reported nothing afterwards.
+  It now drives `MemoryAgent`, which is the memory the product actually keeps in
+  `~/.openrappter/memory.json` — the same file `anatomy` reads and `doctor`
+  inspects — so what one invocation records, the next one finds. There is no
+  `clear`: `MemoryAgent` forgets by query, and a command that said "delete all"
+  while doing nothing of the sort is the mistake this module already made once.
+
 - **`openrappter backup`** — create, list, restore and delete snapshots of
   `~/.openrappter/` from the terminal. The gateway has served all four
   operations since the feature landed and the code behind them does real work,

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -20,6 +20,7 @@ Run `openrappter <command> --help` for a command's own options.
 | `cron` |  | Manage cron jobs |
 | `approvals` |  | Review commands waiting on your approval |
 | `backup` |  | Snapshot and restore your OpenRappter data |
+| `memory` |  | Search and record what this rappter remembers |
 | `config` |  | Manage configuration |
 | `doctor` | `[options]` | Run system diagnostics and health checks |
 | `twins` | `[options]` | Which rappters are running on this device |

--- a/typescript/src/__tests__/integration/dormant-cli-commands-stay-dormant.test.ts
+++ b/typescript/src/__tests__/integration/dormant-cli-commands-stay-dormant.test.ts
@@ -35,10 +35,9 @@ import { resolve } from 'path';
  *    delete`); `sessions.reset` is registered but reads `sessionKey`, not the
  *    `{id}` this sends, so even that throws "sessionKey required".
  *  - registerLoginCommand    — `initiateOAuthFlow` persists nothing, yet the
- *    command prints "Credentials have been saved to your config." Same lie the
- *    memory CLI would tell (#204).
- *  - registerMemoryCommand   — `MemoryManager` holds chunks in in-memory `Map`s
- *    with zero file I/O, so every CLI process starts empty. Filed as #204.
+ *    command prints "Credentials have been saved to your config." The shape the
+ *    memory CLI had before #204 rewired it onto `MemoryAgent`, which is the
+ *    store the product actually keeps; `memory` left this list then.
  *
  * This asserts the source of truth — which functions `index.ts` actually calls.
  * The neighbouring `cli-registration.test.ts` asks the built CLI which command
@@ -76,11 +75,7 @@ const INTENTIONALLY_DORMANT = new Map<string, string>([
   ],
   [
     'registerLoginCommand',
-    'initiateOAuthFlow persists nothing while the command prints "Credentials have been saved to your config" (identical to the memory case, #204)',
-  ],
-  [
-    'registerMemoryCommand',
-    'MemoryManager keeps chunks in in-memory Maps with zero file I/O, so every CLI process starts empty (#204)',
+    'initiateOAuthFlow persists nothing while the command prints "Credentials have been saved to your config" — the shape the memory CLI had before #204 rewired it onto MemoryAgent',
   ],
 ]);
 

--- a/typescript/src/__tests__/parity/cli-registration.test.ts
+++ b/typescript/src/__tests__/parity/cli-registration.test.ts
@@ -62,6 +62,7 @@ const REGISTERED = [
   'gateway',
   'rappterhub',
   'clawhub',
+  'memory',
 ];
 
 /**
@@ -69,9 +70,15 @@ const REGISTERED = [
  *
  * Without this list the next person to notice an exported-but-unreachable
  * module has no way to tell a decision from an oversight, and "make it
- * reachable" is the obvious wrong move for all four.
+ * reachable" is the obvious wrong move for all of them.
+ *
+ * `memory` left this list in #204. It was here because the module built a
+ * `MemoryManager`, which has no file I/O, so registering it would have shipped
+ * an `add` that discarded what it stored. It now drives `MemoryAgent`, which is
+ * the memory the product actually keeps, so reachable is no longer the wrong
+ * move — the objection was to the implementation, not to the command existing.
  */
-const DELIBERATELY_UNREGISTERED = ['memory', 'sessions', 'channels', 'send', 'login'];
+const DELIBERATELY_UNREGISTERED = ['sessions', 'channels', 'send', 'login'];
 
 let commands: string[];
 

--- a/typescript/src/cli/__tests__/memory.test.ts
+++ b/typescript/src/cli/__tests__/memory.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, afterEach, vi } from 'vitest';
+import { Command } from 'commander';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { registerMemoryCommand } from '../memory.js';
+
+/**
+ * `openrappter memory` has to reach the memory the product keeps.
+ *
+ * The module was complete and never registered, so the command fell through to
+ * the `[message]` positional and was sent to the model as a chat prompt. It was
+ * left unregistered on purpose: it built a `MemoryManager`, which holds
+ * everything in `Map`s and performs no file I/O, so `add` printed an id and
+ * discarded it on exit. Registering that would have been worse than the command
+ * not existing. #204
+ *
+ * The product's memory is `MemoryAgent`'s, in `~/.openrappter/memory.json`.
+ * What matters is therefore not that the command runs, but that what it writes
+ * is still there afterwards — so this asserts a round trip through a scratch
+ * home, which the previous implementation could not have passed.
+ */
+
+const originalHome = process.env.HOME;
+const scratchHomes: string[] = [];
+
+afterEach(() => {
+  if (originalHome === undefined) delete process.env.HOME;
+  else process.env.HOME = originalHome;
+  for (const dir of scratchHomes.splice(0)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function scratchHome(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-cli-'));
+  scratchHomes.push(dir);
+  process.env.HOME = dir;
+  return dir;
+}
+
+async function runMemory(args: string[]): Promise<string> {
+  const lines: string[] = [];
+  const spy = vi.spyOn(console, 'log').mockImplementation((...a) => {
+    lines.push(a.join(' '));
+  });
+  try {
+    const program = new Command();
+    program.exitOverride();
+    registerMemoryCommand(program);
+    await program.parseAsync(['node', 'openrappter', 'memory', ...args]);
+  } finally {
+    spy.mockRestore();
+  }
+  return lines.join('\n');
+}
+
+describe('openrappter memory', () => {
+  it('writes to the file the product reads', async () => {
+    const home = scratchHome();
+    await runMemory(['add', 'the kettle is in the third cupboard']);
+
+    const stored = path.join(home, '.openrappter', 'memory.json');
+    expect(fs.existsSync(stored)).toBe(true);
+    expect(fs.readFileSync(stored, 'utf8')).toContain('third cupboard');
+  });
+
+  it('recalls what an earlier invocation remembered', async () => {
+    scratchHome();
+    await runMemory(['add', 'the kettle is in the third cupboard']);
+
+    // A separate command object, reading from disk rather than from anything
+    // the first invocation left in memory — the distinction the old
+    // implementation could not make.
+    const found = await runMemory(['search', 'kettle']);
+    expect(found).toMatch(/1 matching|third cupboard/i);
+  });
+
+  it('refuses to forget without --yes', async () => {
+    scratchHome();
+    await runMemory(['add', 'the kettle is in the third cupboard']);
+    const output = await runMemory(['forget', 'kettle']);
+
+    expect(output).toContain('WARNING');
+    const found = await runMemory(['search', 'kettle']);
+    expect(found).toMatch(/1 matching|third cupboard/i);
+  });
+});

--- a/typescript/src/cli/memory.ts
+++ b/typescript/src/cli/memory.ts
@@ -1,112 +1,110 @@
+import type { Command } from 'commander';
+
+import { MemoryAgent } from '../agents/MemoryAgent.js';
+
 /**
- * Memory Command
- * CLI interface for the OpenRappter memory system.
- * Subcommands: search, add, list, clear, stats
+ * Read and write the memory the product actually keeps.
+ *
+ * This module existed, implemented `search`/`add`/`list`/`clear`/`stats`, was
+ * re-exported from `cli/index.ts` — and was never registered, so `openrappter
+ * memory` fell through to the `[message]` positional and went to the model as a
+ * chat prompt.
+ *
+ * Registering it as it stood would have been worse than leaving it out. It built
+ * a `MemoryManager`, which keeps everything in `Map`s and performs no file I/O
+ * at all, so every invocation started empty: `memory add` printed an id and
+ * discarded it on exit, `memory list` reported nothing afterwards, and
+ * `memory clear` cleared zero. #204
+ *
+ * The memory the product keeps is `MemoryAgent`'s, in
+ * `~/.openrappter/memory.json` — the same file `anatomy.ts` reads and `doctor`
+ * inspects. So this drives that agent rather than standing a second,
+ * non-persistent store beside it.
+ *
+ * There is no `clear`. `MemoryAgent` forgets by query, not wholesale, and a
+ * command that said "Delete all memories" while doing nothing of the sort is the
+ * mistake this file already made once.
  */
 
-import type { Command } from 'commander';
-import { MemoryManager } from '../memory/manager.js';
+interface AgentResult {
+  status?: string;
+  message?: string;
+  error?: string;
+  [key: string]: unknown;
+}
 
-function createManager(): MemoryManager {
-  return new MemoryManager();
+/**
+ * Agents here do not throw: `execute()` returns a JSON string and reports
+ * failure as `{"status":"error"}` inside it. Trusting the absence of an
+ * exception is how #134 recorded an alert as delivered that was never sent.
+ */
+async function run(input: Record<string, unknown>): Promise<AgentResult> {
+  const raw = await new MemoryAgent().execute(input);
+  let parsed: AgentResult;
+  try {
+    parsed = JSON.parse(raw) as AgentResult;
+  } catch {
+    throw new Error(`Memory returned something that is not JSON: ${raw.slice(0, 200)}`);
+  }
+  if (parsed.status === 'error') {
+    throw new Error(parsed.error ?? parsed.message ?? 'Memory reported an error');
+  }
+  return parsed;
+}
+
+function show(result: AgentResult, json: boolean): void {
+  if (json) {
+    console.log(JSON.stringify(result, null, 2));
+    return;
+  }
+  const text = result.message ?? result.response ?? result.result;
+  console.log(typeof text === 'string' && text ? text : JSON.stringify(result, null, 2));
 }
 
 export function registerMemoryCommand(program: Command): void {
-  const memory = program.command('memory').description('Manage agent memory');
+  const memory = program
+    .command('memory')
+    .description('Search and record what this rappter remembers');
+
+  memory
+    .command('list', { isDefault: true })
+    .description('List what is remembered')
+    .option('--json', 'Print the raw response')
+    .action(async (options: { json?: boolean }) => {
+      show(await run({ action: 'list' }), Boolean(options.json));
+    });
 
   memory
     .command('search <query>')
-    .description('Search memories using a natural language query')
-    .option('-l, --limit <n>', 'Maximum number of results', '10')
-    .option('-t, --threshold <n>', 'Minimum similarity score (0-1)', '0')
-    .action(async (query: string, options: { limit: string; threshold: string }) => {
-      const manager = createManager();
-      const limit = parseInt(options.limit, 10);
-      const threshold = parseFloat(options.threshold);
-
-      const results = await manager.search(query, { limit, threshold });
-
-      if (results.length === 0) {
-        console.log('No memories found.');
-        return;
-      }
-
-      console.log(`\nFound ${results.length} memory chunk(s):\n`);
-      for (const r of results) {
-        const score = r.score.toFixed(2);
-        console.log(`  (${score}) ${r.chunk.content.slice(0, 120)}`);
-        if (r.chunk.content.length > 120) console.log('         ...');
-        console.log(`    [source: ${r.chunk.source}, created: ${r.chunk.createdAt}]`);
-        console.log('');
-      }
+    .description('Recall memories matching a query')
+    .option('--json', 'Print the raw response')
+    .action(async (query: string, options: { json?: boolean }) => {
+      show(await run({ action: 'recall', query }), Boolean(options.json));
     });
 
   memory
     .command('add <content>')
-    .description('Add a new memory entry')
-    .option('-s, --source <source>', 'Memory source (session|workspace|memory)', 'memory')
-    .action(async (content: string, options: { source: string }) => {
-      const manager = createManager();
-      const source = options.source as 'session' | 'workspace' | 'memory';
-      const id = await manager.add(content, source, '', {});
-      console.log(`Memory added: ${id}`);
+    .description('Remember something')
+    .option('--theme <theme>', 'Group this memory under a theme')
+    .option('--json', 'Print the raw response')
+    .action(async (content: string, options: { theme?: string; json?: boolean }) => {
+      show(
+        await run({ action: 'remember', message: content, theme: options.theme }),
+        Boolean(options.json),
+      );
     });
 
   memory
-    .command('list')
-    .description('List recent memories')
-    .option('-l, --limit <n>', 'Maximum number of entries to show', '20')
-    .action(async (options: { limit: string }) => {
-      const manager = createManager();
-      const limit = parseInt(options.limit, 10);
-
-      const chunks = manager.listChunks().slice(0, limit);
-
-      if (chunks.length === 0) {
-        console.log('No memories stored.');
-        return;
-      }
-
-      console.log(`\nRecent Memories (${chunks.length}):\n`);
-      for (const chunk of chunks) {
-        console.log(`  [${chunk.id}] ${chunk.content.slice(0, 80)}${chunk.content.length > 80 ? '...' : ''}`);
-        console.log(`    source: ${chunk.source} | created: ${chunk.createdAt}`);
-        console.log('');
-      }
-    });
-
-  memory
-    .command('clear')
-    .description('Clear all memories')
+    .command('forget <query>')
+    .description('Forget memories matching a query')
     .option('--yes', 'Skip confirmation prompt')
-    .action(async (options: { yes?: boolean }) => {
+    .option('--json', 'Print the raw response')
+    .action(async (query: string, options: { yes?: boolean; json?: boolean }) => {
       if (!options.yes) {
-        console.log('WARNING: This will delete all memories.');
+        console.log(`WARNING: This deletes memories matching "${query}".`);
         console.log('Run with --yes to confirm.');
         return;
       }
-
-      const manager = createManager();
-      const before = manager.getStatus().totalChunks;
-      manager.clear();
-
-      console.log(`Cleared ${before} memory chunk(s).`);
-    });
-
-  memory
-    .command('stats')
-    .description('Show memory statistics')
-    .action(async () => {
-      const manager = createManager();
-      const status = manager.getStatus();
-
-      console.log('\nMemory Statistics:\n');
-      console.log(`  Total chunks:   ${status.totalChunks}`);
-      console.log(`  Indexed chunks: ${status.indexedChunks}`);
-      console.log(`  Pending sync:   ${status.pendingSync}`);
-      if (status.lastSync) {
-        console.log(`  Last sync:      ${status.lastSync}`);
-      }
-      console.log('');
+      show(await run({ action: 'forget', query }), Boolean(options.json));
     });
 }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -19,6 +19,7 @@ import { registerTwinCommands } from './twin/index.js';
 import { registerCronCommand } from './cli/cron.js';
 import { registerApprovalsCommand } from './cli/approvals.js';
 import { registerBackupCommand } from './cli/backup.js';
+import { registerMemoryCommand } from './cli/memory.js';
 import { registerConfigCommand } from './cli/config.js';
 import { registerDoctorCommand } from './cli/doctor.js';
 import { registerRappterCommand } from './cli/rappters.js';
@@ -2596,6 +2597,7 @@ registerTwinCommands(program);
 registerCronCommand(program);
 registerApprovalsCommand(program);
 registerBackupCommand(program);
+registerMemoryCommand(program);
 registerConfigCommand(program);
 registerDoctorCommand(program);
 // Seeing and creating the rappters on this device. #107


### PR DESCRIPTION
## Built on the wrong component, next to a working one

`cli/memory.ts` implemented `search`, `add`, `list`, `clear`, `stats` and was re-exported from `cli/index.ts`. Nothing registered it, so `openrappter memory` fell through to the `[message]` positional and went to the model as a chat prompt.

It was unregistered **on purpose**, and the purpose was sound. It built a `MemoryManager`, which keeps chunks in `Map`s with no file I/O:

```
memory add "..."   -> Memory added: <id>, discarded on exit
memory list        -> No memories stored.
memory clear       -> Cleared 0 memory chunk(s).
```

#204 filed that rather than wiring it up, which was the right call.

**What the issue doesn't say is that the memory the product keeps is somewhere else.** `MemoryAgent` persists to `~/.openrappter/memory.json` — the file `anatomy.ts` reads and `doctor` inspects, and there's one on this machine predating all of this. The command wasn't missing persistence; it was built on the wrong component, beside a working one.

## Measured across two processes

The thing the old implementation could not do:

```
$ HOME=$scratch openrappter memory add "the kettle is in the third cupboard"
Remembered: "the kettle is in the third cupboard"

$ HOME=$scratch openrappter memory search kettle      # separate process
Found 1 matching memories

$ ls $scratch/.openrappter/memory.json
286 bytes
```

## What changed shape

- **`clear` is gone.** `MemoryAgent` forgets by query, not wholesale — a `clear` announcing "Delete all memories" would be the same class of statement the old module already made. `forget <query>` takes its place, behind `--yes`, the convention `backup restore` uses.
- **`stats` is gone** with the manager that reported them.
- The result is **parsed, not trusted**: agents here return a JSON string with `{"status":"error"}` inside, and believing the absence of an exception is how #134 recorded an alert as delivered that was never sent.

## Two guards had to be told

| guard | change |
| --- | --- |
| `cli-registration.test.ts` | `memory` left the deliberately-unregistered list, with a comment saying the objection was to the *implementation*, not to the command existing |
| `dormant-cli-commands-stay-dormant.test.ts` | same entry removed; `registerLoginCommand` keeps its own, and its cross-reference now points at what the memory CLI **was** |

Closes #204.

## Verification

- `tsc --noEmit` clean, `npm run lint` clean at `--max-warnings 0`
- **4875** TypeScript tests, up from 4872
