### PR TITLE
fix(cli): every RPC-backed command hung for 30s after printing its result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capability its syntax tree can reach, per the RAPP agent contract.
 
 ### Fixed
+- Every RPC-backed CLI command (`backup`, `approvals`, `cron`, `memory`, `flight`, ...) printed its output instantly and then hung for 30 seconds before exiting. `RpcClient.call()` armed a 30s timeout and never cleared it once the response arrived; a pending timer keeps Node's event loop alive. `openrappter backup list` went from 30.1s to 0.1s.
 - `openrappter channel status` threw `ReferenceError: __dirname is not defined` on every invocation. `infra/channel.ts` is ESM but used a bare `__dirname`, which type-checks (`@types/node` declares it) and only fails when the statement runs -- so `channel promote`, which never reaches that line, worked. Four other files already defined the `fileURLToPath(import.meta.url)` shim; this one was missed.
 - Removed `src/cli/channel.ts`, an unregistered duplicate of the live inline `channel` command. Two copies of the same logic means a fix can land in the unreachable one.
 

--- a/typescript/src/__tests__/integration/rpc-client-timer.test.ts
+++ b/typescript/src/__tests__/integration/rpc-client-timer.test.ts
@@ -1,0 +1,113 @@
+/**
+ * `RpcClient.call()` armed a 30s timeout and never cleared it on success.
+ *
+ * Nothing failed, so nothing looked wrong: the response arrived in
+ * milliseconds, the promise resolved, and the CLI printed the right answer
+ * immediately. But an un-cleared `setTimeout` is an active libuv handle, and
+ * Node will not exit while one is pending -- so every RPC-backed command sat
+ * in the terminal for the full 30 seconds after doing its work:
+ *
+ *     $ time openrappter backup list
+ *     No backups yet. Create one with:
+ *         openrappter backup create
+ *     real  0m30.143s        <- output was instant; the process was not
+ *
+ * After clearing the timer in both settle paths, the same command is 0.107s.
+ *
+ * These tests assert on the handle itself rather than on wall-clock time, so
+ * they cannot flake on a slow machine and cannot pass merely because the test
+ * runner happened to be quick.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { WebSocketServer, type WebSocket as WS } from 'ws';
+import { RpcClient } from '../../cli/rpc-client.js';
+
+/** Count pending timers held open by the process. */
+function timerCount(): number {
+  return process.getActiveResourcesInfo().filter((r) => r === 'Timeout').length;
+}
+
+let server: WebSocketServer | undefined;
+let client: RpcClient | undefined;
+
+afterEach(async () => {
+  client?.disconnect();
+  client = undefined;
+  await new Promise<void>((resolve) => {
+    if (!server) return resolve();
+    server.close(() => resolve());
+  });
+  server = undefined;
+});
+
+/** A gateway that answers `echo` and never answers `blackhole`. */
+async function startServer(): Promise<number> {
+  server = new WebSocketServer({ port: 0 });
+  server.on('connection', (socket: WS) => {
+    socket.on('message', (raw) => {
+      const frame = JSON.parse(String(raw)) as { type: string; id: string; method: string };
+      if (frame.type !== 'req') return;
+      if (frame.method === 'blackhole') return; // deliberately silent
+      if (frame.method === 'boom') {
+        socket.send(
+          JSON.stringify({ type: 'res', id: frame.id, ok: false, error: { message: 'nope' } }),
+        );
+        return;
+      }
+      socket.send(JSON.stringify({ type: 'res', id: frame.id, ok: true, payload: { ok: true } }));
+    });
+  });
+  await new Promise<void>((resolve) => server!.on('listening', () => resolve()));
+  return (server!.address() as { port: number }).port;
+}
+
+describe('RpcClient timer lifecycle', () => {
+  it('holds a timer open only while a call is in flight', async () => {
+    const port = await startServer();
+    client = new RpcClient();
+    await client.connect(port);
+
+    const before = timerCount();
+
+    // A call that never gets a response must keep its timeout armed --
+    // otherwise the 30s guard would not exist at all, and this test would
+    // pass vacuously against a client that simply never sets a timer.
+    const pending = client.call('blackhole');
+    expect(timerCount()).toBeGreaterThan(before);
+
+    // A resolved call must leave nothing behind.
+    await client.call('echo');
+    expect(timerCount()).toBe(before + 1); // still just the blackhole's
+
+    void pending.catch(() => undefined);
+  });
+
+  it('clears the timer when a call resolves', async () => {
+    const port = await startServer();
+    client = new RpcClient();
+    await client.connect(port);
+
+    const before = timerCount();
+    await client.call('echo');
+    await client.call('echo');
+    await client.call('echo');
+
+    // Three round-trips, zero residue. Before the fix this was `before + 3`,
+    // and each one kept the CLI alive for 30 seconds.
+    expect(timerCount()).toBe(before);
+  });
+
+  it('clears the timer when a call rejects', async () => {
+    const port = await startServer();
+    client = new RpcClient();
+    await client.connect(port);
+
+    const before = timerCount();
+    await expect(client.call('boom')).rejects.toThrow('nope');
+
+    // The error path matters just as much: `approvals list` against an older
+    // gateway rejects with "method not found", and used to leave the CLI
+    // hanging on top of printing a stack trace.
+    expect(timerCount()).toBe(before);
+  });
+});

--- a/typescript/src/cli/rpc-client.ts
+++ b/typescript/src/cli/rpc-client.ts
@@ -1,6 +1,9 @@
 import WebSocket from 'ws';
 import { VERSION } from '../version.js';
 
+/** How long a single RPC may take before the client gives up. */
+const RPC_TIMEOUT_MS = 30_000;
+
 export class RpcClient {
   private ws: WebSocket | null = null;
   private pending = new Map<string, { resolve: (v: unknown) => void; reject: (e: Error) => void }>();
@@ -42,14 +45,29 @@ export class RpcClient {
     if (!this.ws) throw new Error('Not connected');
     const id = `cli_${++this.idCounter}`;
     return new Promise((resolve, reject) => {
-      this.pending.set(id, { resolve, reject });
-      this.ws!.send(JSON.stringify({ type: 'req', id, method, params }));
-      setTimeout(() => {
+      // The timeout must be cleared on every exit path. An un-cleared
+      // setTimeout keeps the Node event loop alive, so the CLI printed its
+      // result immediately and then sat for the full 30s before exiting --
+      // the response had already arrived, but the timer still held the
+      // process open. Clearing it in both settle paths is what lets the
+      // command exit as soon as its work is done.
+      const timer = setTimeout(() => {
         if (this.pending.has(id)) {
           this.pending.delete(id);
-          reject(new Error('RPC timeout'));
+          reject(new Error(`RPC timeout: ${method} did not respond within 30s`));
         }
-      }, 30000);
+      }, RPC_TIMEOUT_MS);
+      this.pending.set(id, {
+        resolve: (value) => {
+          clearTimeout(timer);
+          resolve(value);
+        },
+        reject: (error) => {
+          clearTimeout(timer);
+          reject(error);
+        },
+      });
+      this.ws!.send(JSON.stringify({ type: 'req', id, method, params }));
     });
   }
 


### PR DESCRIPTION
Every RPC-backed CLI command has been hanging for 30 seconds after finishing its work.

```
$ time openrappter backup list
No backups yet. Create one with:
    openrappter backup create

real  0m30.143s
```

The output is instant. The process is not.

## Cause

`RpcClient.call()` armed a 30s timeout and never cleared it:

```ts
this.pending.set(id, { resolve, reject });
this.ws!.send(...);
setTimeout(() => { ... reject(new Error('RPC timeout')); }, 30000);
```

When the response arrives, the frame handler resolves the promise and deletes the pending entry — but the timer is still armed. A pending `setTimeout` is an active libuv handle, and Node will not exit while one exists, so the command sat until the timer fired 30 seconds after the last call.

This is why it was invisible in every test: the promise resolves correctly, the value is correct, the output is correct. Only *process lifetime* was wrong, and no test observes process lifetime.

Clearing it in both settle paths:

| command | before | after |
|---|---|---|
| `backup list` | 30.143s | 0.107s |
| `cron list` | ~30s | 0.187s |
| `flight status` | ~30s | 0.204s |

Output is byte-identical; only the hang is gone.

Also gave the timeout message the method name (`RPC timeout: exec.pending did not respond within 30s`) and lifted the literal into a named `RPC_TIMEOUT_MS`.

## How it was found

Sweeping every registered CLI subcommand looking for latent runtime failures, after #323 showed that "registered" does not imply "works".

Worth recording that **my first sweep was worthless and said everything passed.** It wrapped each command in `timeout 20`, which does not exist on macOS; every run exited 127 with `timeout: command not found`, which matched none of my error patterns, so the loop reported a clean bill of health. The second version used `perl -e 'alarm 20; exec @ARGV'` and asserted the harness could *see* a known failure before trusting its silence — that is when the 30s hangs showed up as `rc=142`.

## Test

`rpc-client-timer.test.ts` runs a real `WebSocketServer` and asserts on the handle that caused the hang, via `process.getActiveResourcesInfo()` — not on wall-clock time, so it cannot flake on a slow machine.

It also pins the *other* direction: a call that never gets a response must still hold its timer, so the suite cannot pass against a client that simply never arms one. Both settle paths are covered, because the error path is where `approvals list` lands against an older gateway.

Mutation-tested by restoring `{ resolve, reject }`; all three fail, and the counts show the leak exactly:

```
expected 4 to be 3
expected 8 to be 5      <- three calls, three leaked timers
expected 10 to be 9
```

## Not fixed here

The sweep also showed `approvals list` printing a raw Node stack trace when an RPC rejects: `withClient` has `try/finally` but no `catch`, so the rejection escapes Commander's un-awaited async action. `backup.ts`, `cron.ts` and `approvals.ts` all share that gap. Left for a follow-up — it is a separate change with a different blast radius.

Note the stack trace I hit came from `Method 'exec.pending' not found`, which is **not** a bug: current `main` registers it at `server.ts:3077`. It reproduced only because the daemon on this machine is v1.10.0 from 5 Aug and ~185 commits behind.

## Verification

TypeScript **4881 passed**, 21 skipped (3 new); `tsc --noEmit` clean; eslint clean at `--max-warnings 0`. Timings measured against the built CLI.
