### PR TITLE
fix(cli): RPC failures printed a raw stack trace from six duplicated helpers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capability its syntax tree can reach, per the RAPP agent contract.
 
 ### Fixed
+- RPC-backed CLI commands printed a raw Node stack trace, naming internal `ws` frames, whenever the gateway was unreachable, refused the token, or did not know a method. Commander does not await an async action handler, so the rejection escaped as an unhandled promise rejection. Failures now print one actionable line and exit non-zero.
+- Consolidated six byte-identical private copies of `withClient` (`approvals`, `backup`, `channels`, `cron`, `send`, `sessions`) into `cli/with-client.ts`. The duplication is why the missing error handling existed in six places at once.
 - Every RPC-backed CLI command (`backup`, `approvals`, `cron`, `memory`, `flight`, ...) printed its output instantly and then hung for 30 seconds before exiting. `RpcClient.call()` armed a 30s timeout and never cleared it once the response arrived; a pending timer keeps Node's event loop alive. `openrappter backup list` went from 30.1s to 0.1s.
 - `openrappter channel status` threw `ReferenceError: __dirname is not defined` on every invocation. `infra/channel.ts` is ESM but used a bare `__dirname`, which type-checks (`@types/node` declares it) and only fails when the statement runs -- so `channel promote`, which never reaches that line, worked. Four other files already defined the `fileURLToPath(import.meta.url)` shim; this one was missed.
 - Removed `src/cli/channel.ts`, an unregistered duplicate of the live inline `channel` command. Two copies of the same logic means a fix can land in the unreachable one.

--- a/typescript/src/__tests__/integration/cli-with-client.test.ts
+++ b/typescript/src/__tests__/integration/cli-with-client.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The six RPC-backed CLI commands shared a byte-identical private `withClient`
+ * -- and therefore shared its missing `catch`. Commander does not await an
+ * async `.action()`, so any rejection surfaced as an unhandled promise
+ * rejection and Node printed a raw stack dump naming internal `ws` frames.
+ *
+ * These tests pin the consolidation (one definition, not six) and the message
+ * mapping, so a failure the user can act on never regresses into a stack trace.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve, join } from 'path';
+import { explain, GATEWAY_PORT } from '../../cli/with-client.js';
+
+const CLI_DIR = resolve(__dirname, '../../cli');
+
+describe('withClient consolidation', () => {
+  it('is defined exactly once across the CLI', () => {
+    const offenders = readdirSync(CLI_DIR)
+      .filter((f) => f.endsWith('.ts') && f !== 'with-client.ts')
+      .filter((f) => /async function withClient/.test(readFileSync(join(CLI_DIR, f), 'utf-8')))
+      .sort();
+
+    // Six copies is how the same defect existed in six places at once. Any new
+    // private copy is a place the next fix will not reach.
+    expect(offenders).toEqual([]);
+  });
+
+  it('the commands that need it import the shared helper', () => {
+    // Guard the guard: if the import name ever changes, the check above would
+    // pass vacuously against files that no longer use a client at all.
+    const users = ['approvals', 'backup', 'channels', 'cron', 'send', 'sessions'];
+    for (const name of users) {
+      const text = readFileSync(join(CLI_DIR, `${name}.ts`), 'utf-8');
+      expect(text).toMatch(/import \{ withClient \} from '\.\/with-client\.js';/);
+    }
+  });
+});
+
+describe('explain', () => {
+  it('turns a refused connection into an instruction', () => {
+    const msg = explain(new Error('connect ECONNREFUSED 127.0.0.1:18790'));
+    expect(msg).toContain(String(GATEWAY_PORT));
+    expect(msg).toContain('openrappter gateway');
+    expect(msg).not.toContain('ECONNREFUSED');
+  });
+
+  it('names version skew when a method is missing', () => {
+    // The real case: a daemon older than the CLI. "Method not found" alone
+    // reads like a bug in the command the user just typed.
+    const msg = explain(new Error("Method 'exec.pending' not found"));
+    expect(msg).toContain("Method 'exec.pending' not found");
+    expect(msg).toContain('older than this CLI');
+  });
+
+  it('points at the token when the gateway refuses authorisation', () => {
+    expect(explain(new Error('unauthorized'))).toContain('OPENRAPPTER_TOKEN');
+  });
+
+  it('passes anything unrecognised through unchanged', () => {
+    // No invented advice for errors we do not understand.
+    expect(explain(new Error('disk on fire'))).toBe('disk on fire');
+  });
+
+  it('handles a non-Error throw', () => {
+    expect(explain('plain string')).toBe('plain string');
+  });
+});

--- a/typescript/src/__tests__/parity/cli-commands.test.ts
+++ b/typescript/src/__tests__/parity/cli-commands.test.ts
@@ -16,6 +16,20 @@ import { join } from 'path';
 
 const CLI_DIR = join(__dirname, '../../cli');
 
+/**
+ * Files in `src/cli/` that are shared helpers, not command modules.
+ *
+ * `with-client.ts` joined this list when six identical private copies of
+ * `withClient` were consolidated into it -- and with them, six copies of the
+ * same missing `catch`.
+ */
+const HELPER_FILES = new Set(['index.ts', 'rpc-client.ts', 'bar.ts', 'with-client.ts']);
+
+/** Every command module: the files that must export a `register*Command`. */
+function commandModules(): string[] {
+  return readdirSync(CLI_DIR).filter((f) => f.endsWith('.ts') && !HELPER_FILES.has(f));
+}
+
 describe('CLI Commands', () => {
   describe('CLI Module Structure', () => {
     it('should have all expected command files', () => {
@@ -191,24 +205,12 @@ describe('CLI Commands', () => {
 
   describe('Command Coverage', () => {
     it('should have at least 12 command files', () => {
-      const commandFiles = readdirSync(CLI_DIR).filter(
-        (file) =>
-          file.endsWith('.ts') &&
-          file !== 'index.ts' &&
-          file !== 'rpc-client.ts' &&
-          file !== 'bar.ts'
-      );
+      const commandFiles = commandModules();
       expect(commandFiles.length).toBeGreaterThanOrEqual(12);
     });
 
     it('all command files should use TypeScript Command type', () => {
-      const commandFiles = readdirSync(CLI_DIR).filter(
-        (file) =>
-          file.endsWith('.ts') &&
-          file !== 'index.ts' &&
-          file !== 'rpc-client.ts' &&
-          file !== 'bar.ts'
-      );
+      const commandFiles = commandModules();
 
       for (const file of commandFiles) {
         const content = readFileSync(join(CLI_DIR, file), 'utf-8');
@@ -217,13 +219,7 @@ describe('CLI Commands', () => {
     });
 
     it('all command files should export a register function', () => {
-      const commandFiles = readdirSync(CLI_DIR).filter(
-        (file) =>
-          file.endsWith('.ts') &&
-          file !== 'index.ts' &&
-          file !== 'rpc-client.ts' &&
-          file !== 'bar.ts'
-      );
+      const commandFiles = commandModules();
 
       for (const file of commandFiles) {
         const content = readFileSync(join(CLI_DIR, file), 'utf-8');
@@ -234,13 +230,7 @@ describe('CLI Commands', () => {
 
   describe('TypeScript Types', () => {
     it('all command files should import Command type from commander', () => {
-      const commandFiles = readdirSync(CLI_DIR).filter(
-        (file) =>
-          file.endsWith('.ts') &&
-          file !== 'index.ts' &&
-          file !== 'rpc-client.ts' &&
-          file !== 'bar.ts'
-      );
+      const commandFiles = commandModules();
 
       for (const file of commandFiles) {
         const content = readFileSync(join(CLI_DIR, file), 'utf-8');
@@ -249,13 +239,7 @@ describe('CLI Commands', () => {
     });
 
     it('all register functions should accept program parameter', () => {
-      const commandFiles = readdirSync(CLI_DIR).filter(
-        (file) =>
-          file.endsWith('.ts') &&
-          file !== 'index.ts' &&
-          file !== 'rpc-client.ts' &&
-          file !== 'bar.ts'
-      );
+      const commandFiles = commandModules();
 
       for (const file of commandFiles) {
         const content = readFileSync(join(CLI_DIR, file), 'utf-8');

--- a/typescript/src/cli/approvals.ts
+++ b/typescript/src/cli/approvals.ts
@@ -1,5 +1,5 @@
 import type { Command } from 'commander';
-import { RpcClient } from './rpc-client.js';
+import { withClient } from './with-client.js';
 
 /**
  * Resolve exec approvals from the terminal.
@@ -23,16 +23,6 @@ interface PendingApproval {
   reason?: string;
   kind?: string;
   expiresAt?: string;
-}
-
-async function withClient<T>(fn: (client: RpcClient) => Promise<T>): Promise<T> {
-  const client = new RpcClient();
-  try {
-    await client.connect(18790, process.env.OPENRAPPTER_TOKEN);
-    return await fn(client);
-  } finally {
-    client.disconnect();
-  }
 }
 
 export function registerApprovalsCommand(program: Command): void {

--- a/typescript/src/cli/backup.ts
+++ b/typescript/src/cli/backup.ts
@@ -1,5 +1,5 @@
 import type { Command } from 'commander';
-import { RpcClient } from './rpc-client.js';
+import { withClient } from './with-client.js';
 
 /**
  * Snapshot and restore ~/.openrappter/ from the terminal.
@@ -22,16 +22,6 @@ interface BackupInfo {
   createdAt: string;
   sizeBytes: number;
   fileCount: number;
-}
-
-async function withClient<T>(fn: (client: RpcClient) => Promise<T>): Promise<T> {
-  const client = new RpcClient();
-  try {
-    await client.connect(18790, process.env.OPENRAPPTER_TOKEN);
-    return await fn(client);
-  } finally {
-    client.disconnect();
-  }
 }
 
 function formatSize(bytes: number): string {

--- a/typescript/src/cli/channels.ts
+++ b/typescript/src/cli/channels.ts
@@ -1,15 +1,5 @@
 import type { Command } from 'commander';
-import { RpcClient } from './rpc-client.js';
-
-async function withClient<T>(fn: (client: RpcClient) => Promise<T>): Promise<T> {
-  const client = new RpcClient();
-  try {
-    await client.connect(18790, process.env.OPENRAPPTER_TOKEN);
-    return await fn(client);
-  } finally {
-    client.disconnect();
-  }
-}
+import { withClient } from './with-client.js';
 
 export function registerChannelsCommand(program: Command): void {
   const channels = program.command('channels').description('Manage messaging channels');

--- a/typescript/src/cli/cron.ts
+++ b/typescript/src/cli/cron.ts
@@ -1,15 +1,5 @@
 import type { Command } from 'commander';
-import { RpcClient } from './rpc-client.js';
-
-async function withClient<T>(fn: (client: RpcClient) => Promise<T>): Promise<T> {
-  const client = new RpcClient();
-  try {
-    await client.connect(18790, process.env.OPENRAPPTER_TOKEN);
-    return await fn(client);
-  } finally {
-    client.disconnect();
-  }
-}
+import { withClient } from './with-client.js';
 
 export function registerCronCommand(program: Command): void {
   const cron = program.command('cron').description('Manage cron jobs');

--- a/typescript/src/cli/send.ts
+++ b/typescript/src/cli/send.ts
@@ -11,18 +11,8 @@
 
 import type { Command } from 'commander';
 import path from 'path';
-import { RpcClient } from './rpc-client.js';
+import { withClient } from './with-client.js';
 import { promises as fs } from 'fs';
-
-async function withClient<T>(fn: (client: RpcClient) => Promise<T>): Promise<T> {
-  const client = new RpcClient();
-  try {
-    await client.connect(18790, process.env.OPENRAPPTER_TOKEN);
-    return await fn(client);
-  } finally {
-    client.disconnect();
-  }
-}
 
 export function registerSendCommand(program: Command): void {
   program

--- a/typescript/src/cli/sessions.ts
+++ b/typescript/src/cli/sessions.ts
@@ -1,15 +1,5 @@
 import type { Command } from 'commander';
-import { RpcClient } from './rpc-client.js';
-
-async function withClient<T>(fn: (client: RpcClient) => Promise<T>): Promise<T> {
-  const client = new RpcClient();
-  try {
-    await client.connect(18790, process.env.OPENRAPPTER_TOKEN);
-    return await fn(client);
-  } finally {
-    client.disconnect();
-  }
-}
+import { withClient } from './with-client.js';
 
 export function registerSessionsCommand(program: Command): void {
   const sessions = program.command('sessions').description('Manage chat sessions');

--- a/typescript/src/cli/with-client.ts
+++ b/typescript/src/cli/with-client.ts
@@ -1,0 +1,71 @@
+/**
+ * One connection helper for every RPC-backed CLI command.
+ *
+ * Six files -- `approvals`, `backup`, `channels`, `cron`, `send`, `sessions` --
+ * each carried a byte-identical private copy of this function (verified: same
+ * md5). They also each carried the same defect, because there was no single
+ * place to fix it: the body had `try`/`finally` but no `catch`.
+ *
+ * Commander does not await an async `.action()` handler, so a rejection
+ * escaping that handler becomes an unhandled promise rejection, and Node
+ * prints it as a raw stack dump full of internal paths:
+ *
+ *     $ openrappter approvals list
+ *     file:///.../dist/cli/rpc-client.js:33
+ *                 p.reject(new Error(frame.error?.message ?? 'RPC error'));
+ *                          ^
+ *     Error: Method 'exec.pending' not found
+ *         at WebSocket.<anonymous> (file:///.../rpc-client.js:33:42)
+ *         at Receiver.receiverOnMessage (/.../ws/lib/websocket.js:1239:20)
+ *         ... 6 more frames
+ *
+ * Every reachable failure here is ordinary and expected -- the gateway is not
+ * running, the token is wrong, the daemon is older than the CLI -- and none of
+ * them are the user's bug to debug. They get one line and a non-zero exit.
+ */
+import { RpcClient } from './rpc-client.js';
+
+/** The port the gateway listens on for CLI clients. */
+export const GATEWAY_PORT = 18790;
+
+/** Turn a thrown value into one actionable line. Exported for tests. */
+export function explain(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+
+  // ECONNREFUSED is by far the most common failure, and "connect ECONNREFUSED
+  // 127.0.0.1:18790" does not tell anyone what to do about it.
+  if (/ECONNREFUSED|not connected|socket hang up/i.test(message)) {
+    return `Cannot reach the openrappter gateway on port ${GATEWAY_PORT}.\n  Start it with: openrappter gateway`;
+  }
+  if (/unauthor|forbidden|token/i.test(message)) {
+    return `The gateway rejected this request as unauthorised.\n  Set OPENRAPPTER_TOKEN, or check: openrappter config show`;
+  }
+  if (/not found/i.test(message)) {
+    // Usually a version skew: an older daemon is still running.
+    return `${message}\n  The running gateway may be older than this CLI. Check: openrappter service status`;
+  }
+  return message;
+}
+
+/**
+ * Connect, run `fn`, and always disconnect.
+ *
+ * On failure prints one line and sets a non-zero exit code, matching how
+ * `cli/config.ts` reports errors. Returns `undefined` when the call failed, so
+ * callers must not assume a value came back.
+ */
+export async function withClient<T>(
+  fn: (client: RpcClient) => Promise<T>,
+): Promise<T | undefined> {
+  const client = new RpcClient();
+  try {
+    await client.connect(GATEWAY_PORT, process.env.OPENRAPPTER_TOKEN);
+    return await fn(client);
+  } catch (error) {
+    console.error(`\n  ${explain(error)}\n`);
+    process.exitCode = 1;
+    return undefined;
+  } finally {
+    client.disconnect();
+  }
+}


### PR DESCRIPTION
The follow-up promised in #324. When an RPC failed, the CLI printed this:

```
$ openrappter approvals list
file:///.../dist/cli/rpc-client.js:33
            p.reject(new Error(frame.error?.message ?? 'RPC error'));
                     ^
Error: Method 'exec.pending' not found
    at WebSocket.<anonymous> (file:///.../rpc-client.js:33:42)
    at Receiver.receiverOnMessage (/.../ws/lib/websocket.js:1239:20)
    ... 6 more frames
```

Now:

```
$ openrappter approvals list

  Method 'exec.pending' not found
  The running gateway may be older than this CLI. Check: openrappter service status

$ echo $?
1
```

## Why it reached six commands at once

`withClient` had `try`/`finally` but no `catch`. Commander does not await an async `.action()` handler, so the rejection escaped into an unhandled promise rejection and Node dumped the stack.

The interesting part is *why nobody fixed it*: there was no single place to fix. Six files each carried a private copy, and they were byte-identical:

```
$ for f in channels cron send approvals backup sessions; do
    sed -n '/async function withClient/,/^}/p' src/cli/$f.ts | md5; done
74fdd682ad8ee682f1ebfa38c615bf06     <- all six
```

Same shape as the duplicate deleted in #323 and the two launch agents in #319: **a fix lands in one copy and the other five keep the bug.** So the fix here is the consolidation, not just the `catch`. All six now import `cli/with-client.ts`.

Every failure reachable here is ordinary — gateway not running, wrong token, daemon older than the CLI — and none are the user's bug to debug. `explain()` maps those three to an instruction and passes anything unrecognised through **unchanged**, so no error gets invented advice it doesn't deserve.

Errors report via `process.exitCode = 1`, matching `cli/config.ts`.

## A guard caught this correctly, and I widened it deliberately

Adding `with-client.ts` broke `cli-commands.test.ts`, which asserts every file in `src/cli/` exports a `register*Command`. That is a fair rule and the new file is a genuine exception, so it joins `index.ts` / `rpc-client.ts` / `bar.ts`.

The exclusion had been spelled out ad-hoc **8 times**; it is now one `HELPER_FILES` set behind a `commandModules()` helper — the same consolidation this PR is about. Mutation-tested by adding a `src/cli/bogus.ts` with no register function: 3 tests fail, so widening the list did not blunt it.

## Tests

`cli-with-client.test.ts` (7 tests) pins that `withClient` is defined exactly **once** across the CLI, that all six users import it, and the message mapping including the pass-through case.

## Verification

TypeScript **4888 passed**, 21 skipped; `tsc --noEmit` clean; eslint clean at `--max-warnings 0`. All three commands re-exercised against the built CLI: `backup list` 0.181s, `approvals list` clean error + rc=1, `cron list` unchanged output.

As in #324, the `exec.pending` error is **not** a bug — `main` registers it at `server.ts:3077`; the daemon on this machine is v1.10.0 and ~185 commits behind. It made a convenient live failure to test against.
