### PR TITLE
fix(cli): login claimed to save credentials it discards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capability its syntax tree can reach, per the RAPP agent contract.
 
 ### Fixed
+- `openrappter login <provider>` printed "Credentials have been saved to your config." while saving nothing: `initiateOAuthFlow` returns the token and `auth/oauth.ts` performs no filesystem writes at all. It now states plainly that the token is discarded and that persistent credential storage is not implemented. (The command remains unregistered.)
 - RPC-backed CLI commands printed a raw Node stack trace, naming internal `ws` frames, whenever the gateway was unreachable, refused the token, or did not know a method. Commander does not await an async action handler, so the rejection escaped as an unhandled promise rejection. Failures now print one actionable line and exit non-zero.
 - Consolidated six byte-identical private copies of `withClient` (`approvals`, `backup`, `channels`, `cron`, `send`, `sessions`) into `cli/with-client.ts`. The duplication is why the missing error handling existed in six places at once.
 - Every RPC-backed CLI command (`backup`, `approvals`, `cron`, `memory`, `flight`, ...) printed its output instantly and then hung for 30 seconds before exiting. `RpcClient.call()` armed a 30s timeout and never cleared it once the response arrived; a pending timer keeps Node's event loop alive. `openrappter backup list` went from 30.1s to 0.1s.

--- a/typescript/src/__tests__/integration/login-no-false-save.test.ts
+++ b/typescript/src/__tests__/integration/login-no-false-save.test.ts
@@ -1,0 +1,68 @@
+/**
+ * `openrappter login <provider>` printed:
+ *
+ *     Credentials have been saved to your config.
+ *
+ * Nothing saved anything. `initiateOAuthFlow` (`auth/oauth.ts`) runs the OAuth
+ * dance and *returns* an `OAuthToken`; the module performs no filesystem
+ * writes at all, and the `OAuthTokenStore` beside it is two in-memory `Map`s
+ * that the flow never calls. The token is garbage-collected when the process
+ * exits.
+ *
+ * Same class as the macOS Bar reporting `.success` from a discarded write
+ * (#316) and the memory CLI that persisted nothing (#204): the user is told to
+ * stop worrying about something that did not happen. Here it is worse than
+ * useless -- someone told their credentials are stored has no reason to
+ * re-authenticate, and no reason to look for why the integration is silent.
+ *
+ * The command stays dormant (see `dormant-cli-commands-stay-dormant.test.ts`);
+ * this only makes it stop lying if it is ever wired up.
+ *
+ * These two assertions are deliberately coupled. If someone implements real
+ * persistence, the second one fails and forces the message to be revisited --
+ * so the code cannot become *more* correct while the text stays wrong in the
+ * other direction.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+const LOGIN = resolve(__dirname, '../../cli/login.ts');
+const OAUTH = resolve(__dirname, '../../auth/oauth.ts');
+
+describe('login does not claim a save that never happens', () => {
+  it('the command makes no claim of saving credentials', () => {
+    const text = readFileSync(LOGIN, 'utf-8');
+
+    // Only the strings the command actually prints; the doc comment above
+    // this file's fix explains the history and legitimately says "saved".
+    const printed = [...text.matchAll(/console\.log\(\s*'([^']*)'/g)].map((m) => m[1]);
+    expect(printed.length).toBeGreaterThan(2);
+
+    // A *positive* claim only. "This token was NOT saved" is the correction,
+    // not the defect, so negated forms are excluded explicitly rather than by
+    // loosening the pattern.
+    const claims = printed
+      .filter((line) => /\b(saved|stored|persisted)\b/i.test(line))
+      .filter((line) => !/\b(not|never|no)\b/i.test(line));
+    expect(claims).toEqual([]);
+  });
+
+  it('tells the user the token is discarded', () => {
+    const printed = readFileSync(LOGIN, 'utf-8');
+    expect(printed).toMatch(/NOT saved/);
+  });
+
+  it('the OAuth flow still has no persistence to claim', () => {
+    const text = readFileSync(OAUTH, 'utf-8');
+
+    // Guard the guard: a regex that matched nothing would make the check below
+    // pass against any file at all.
+    expect(text).toMatch(/export async function initiateOAuthFlow/);
+
+    // If this fails, credentials ARE now persisted somewhere -- go update the
+    // message in cli/login.ts to say where.
+    const writes = /writeFileSync|writeFile\(|appendFileSync|fs\.promises\.write/.test(text);
+    expect(writes).toBe(false);
+  });
+});

--- a/typescript/src/cli/login.ts
+++ b/typescript/src/cli/login.ts
@@ -38,7 +38,14 @@ export function registerLoginCommand(program: Command): void {
         if (result.refreshToken) {
           console.log('A refresh token was issued.');
         }
-        console.log('\nCredentials have been saved to your config.');
+        // Nothing persists this token. `initiateOAuthFlow` returns it and
+        // returns nothing else -- `auth/oauth.ts` performs no filesystem
+        // writes at all, and `OAuthTokenStore` is two in-memory Maps that the
+        // flow never calls. Claiming a save here is the same defect as the
+        // macOS Bar reporting success from a discarded write (#316): the user
+        // is told to stop worrying about something that did not happen.
+        console.log('\nThis token was NOT saved -- it is discarded when this command exits.');
+        console.log('Persistent credential storage is not implemented yet.');
       } catch (err) {
         console.error('\n\x1b[31mAuthentication failed:\x1b[0m', err instanceof Error ? err.message : String(err));
         process.exit(1);


### PR DESCRIPTION
Item 4 of #206. `openrappter login <provider>` ended with:

```
Authentication successful!
Signed in to github.

Credentials have been saved to your config.
```

Nothing saved anything.

## Evidence

`initiateOAuthFlow` (`auth/oauth.ts:339`) runs the OAuth dance and **returns** an `OAuthToken`. The module performs no filesystem writes at all:

```
$ grep -nE "writeFile|writeFileSync|saveConfig|setConfig|fs\." src/auth/oauth.ts
253:export class OAuthTokenStore {
332:export function createOAuthTokenStore(): OAuthTokenStore {
```

Three hits, none of them a write. And `OAuthTokenStore` — the one thing named like a store — is two in-memory `Map`s:

```ts
export class OAuthTokenStore {
  private tokens = new Map<string, OAuthToken>();
  private clients = new Map<string, OAuthClient>();
```

`initiateOAuthFlow` never calls it. The token is garbage-collected when the process exits.

Same class as the macOS Bar reporting `.success` from a discarded write (#316) and the memory CLI that persisted nothing (#204). Here the consequence is specific: someone told their credentials are stored has no reason to re-authenticate, and no reason to look for why the integration went quiet.

The message now says what is true:

```
This token was NOT saved -- it is discarded when this command exits.
Persistent credential storage is not implemented yet.
```

## What this PR deliberately does not do

It does not implement persistence. Unlike #204 — where the memory CLI was wired to the wrong object and a working store (`MemoryAgent`) already existed — there is **no** credential store anywhere in the TypeScript source to wire this to. I checked before assuming:

```
$ grep -rnE "credentials\.json|tokens\.json|secrets\.json" --include=*.ts src   # nothing
```

So "where do OAuth tokens live, with what file permissions, encrypted or not" is an open security design question, not a mechanical fix. Filed separately rather than decided here. The command stays unregistered either way.

## Tests

`login-no-false-save.test.ts` (3 tests). The two halves are **coupled on purpose**: one asserts the command makes no positive claim of saving, the other asserts `oauth.ts` still has no persistence to claim. If someone implements storage, the second fails and forces the message to be revisited — so the code cannot become more correct while the text drifts wrong in the opposite direction.

It matches only *positive* claims: `"This token was NOT saved"` is the correction, so negated forms are excluded explicitly rather than by loosening the pattern. It also asserts the extractor found >2 printed strings, so a broken regex cannot pass vacuously.

Both directions mutation-tested — restoring the old message fails 2 tests; adding a `writeFileSync` to `oauth.ts` fails the coupling test.

## Swept the rest of the CLI for the same shape

Three other positive claims exist, all honest. `backup.ts` reports what the RPC returned. `models.ts` was worth checking and is exemplary — it writes via `saveEnv`, fails loudly if the write fails, and `saveEnv` verifies its own read-back.

## Verification

TypeScript **4891 passed**, 21 skipped (3 new); `tsc --noEmit` clean; eslint clean at `--max-warnings 0`.
