### PR TITLE
test: fix the flaky timer test I added in #324 (retracts a claim)

### DIFF
--- a/typescript/src/__tests__/integration/rpc-client-timer.test.ts
+++ b/typescript/src/__tests__/integration/rpc-client-timer.test.ts
@@ -14,23 +14,32 @@
  *
  * After clearing the timer in both settle paths, the same command is 0.107s.
  *
- * These tests assert on the handle itself rather than on wall-clock time, so
- * they cannot flake on a slow machine and cannot pass merely because the test
- * runner happened to be quick.
+ * ## Why this file does not count process-wide timers
+ *
+ * The first version of these tests asserted on `process.getActiveResourcesInfo()`
+ * -- a process-wide count of pending handles. That reads like a strong
+ * end-to-end check and is in fact flaky: vitest runs test files concurrently
+ * in one process, so timers armed by an unrelated file land in the same count
+ * and the delta stops being attributable to this client. It passed locally and
+ * failed in CI, which is the worst way to find out.
+ *
+ * These tests instead identify the RPC timer precisely -- by the handle
+ * `setTimeout` returned, discriminated by its 30s delay -- and assert that
+ * exact handle reached `clearTimeout`. Deterministic regardless of what else
+ * the process is doing.
  */
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, afterEach, vi } from 'vitest';
 import { WebSocketServer, type WebSocket as WS } from 'ws';
 import { RpcClient } from '../../cli/rpc-client.js';
 
-/** Count pending timers held open by the process. */
-function timerCount(): number {
-  return process.getActiveResourcesInfo().filter((r) => r === 'Timeout').length;
-}
+/** The delay `RpcClient.call` arms; distinguishes its timer from ws internals. */
+const RPC_TIMEOUT_MS = 30_000;
 
 let server: WebSocketServer | undefined;
 let client: RpcClient | undefined;
 
 afterEach(async () => {
+  vi.restoreAllMocks();
   client?.disconnect();
   client = undefined;
   await new Promise<void>((resolve) => {
@@ -40,7 +49,7 @@ afterEach(async () => {
   server = undefined;
 });
 
-/** A gateway that answers `echo` and never answers `blackhole`. */
+/** A gateway that answers `echo`, errors on `boom`, and ignores `blackhole`. */
 async function startServer(): Promise<number> {
   server = new WebSocketServer({ port: 0 });
   server.on('connection', (socket: WS) => {
@@ -61,23 +70,52 @@ async function startServer(): Promise<number> {
   return (server!.address() as { port: number }).port;
 }
 
+/** Watch the timer functions, reporting only timers armed at the RPC delay. */
+function watchTimers() {
+  const armed: unknown[] = [];
+  const cleared: unknown[] = [];
+
+  const realSet = global.setTimeout;
+  vi.spyOn(global, 'setTimeout').mockImplementation(((
+    fn: (...a: unknown[]) => void,
+    ms?: number,
+    ...rest: unknown[]
+  ) => {
+    const handle = realSet(fn, ms as number, ...rest);
+    if (ms === RPC_TIMEOUT_MS) armed.push(handle);
+    return handle;
+  }) as unknown as typeof global.setTimeout);
+
+  const realClear = global.clearTimeout;
+  vi.spyOn(global, 'clearTimeout').mockImplementation(((handle: unknown) => {
+    cleared.push(handle);
+    return realClear(handle as Parameters<typeof global.clearTimeout>[0]);
+  }) as unknown as typeof global.clearTimeout);
+
+  return {
+    armed,
+    allCleared: () => armed.length > 0 && armed.every((h) => cleared.includes(h)),
+    clearedCount: () => armed.filter((h) => cleared.includes(h)).length,
+  };
+}
+
 describe('RpcClient timer lifecycle', () => {
-  it('holds a timer open only while a call is in flight', async () => {
+  it('arms a timeout for each call and keeps it while unanswered', async () => {
     const port = await startServer();
     client = new RpcClient();
     await client.connect(port);
 
-    const before = timerCount();
-
-    // A call that never gets a response must keep its timeout armed --
-    // otherwise the 30s guard would not exist at all, and this test would
-    // pass vacuously against a client that simply never sets a timer.
+    const timers = watchTimers();
     const pending = client.call('blackhole');
-    expect(timerCount()).toBeGreaterThan(before);
+    await new Promise((resolve) => setTimeout(resolve, 20));
 
-    // A resolved call must leave nothing behind.
-    await client.call('echo');
-    expect(timerCount()).toBe(before + 1); // still just the blackhole's
+    // Guard the guard: if no timer is ever armed, every "was it cleared?"
+    // assertion below would pass vacuously against a client with no timeout
+    // at all -- and the 30s safety net would silently not exist.
+    expect(timers.armed.length).toBe(1);
+
+    // An unanswered call must KEEP its timer: that is the guard working.
+    expect(timers.clearedCount()).toBe(0);
 
     void pending.catch(() => undefined);
   });
@@ -87,14 +125,15 @@ describe('RpcClient timer lifecycle', () => {
     client = new RpcClient();
     await client.connect(port);
 
-    const before = timerCount();
+    const timers = watchTimers();
     await client.call('echo');
     await client.call('echo');
     await client.call('echo');
 
-    // Three round-trips, zero residue. Before the fix this was `before + 3`,
+    // Three round-trips, three timers, all cleared. Before the fix none were,
     // and each one kept the CLI alive for 30 seconds.
-    expect(timerCount()).toBe(before);
+    expect(timers.armed.length).toBe(3);
+    expect(timers.allCleared()).toBe(true);
   });
 
   it('clears the timer when a call rejects', async () => {
@@ -102,12 +141,13 @@ describe('RpcClient timer lifecycle', () => {
     client = new RpcClient();
     await client.connect(port);
 
-    const before = timerCount();
+    const timers = watchTimers();
     await expect(client.call('boom')).rejects.toThrow('nope');
 
     // The error path matters just as much: `approvals list` against an older
     // gateway rejects with "method not found", and used to leave the CLI
     // hanging on top of printing a stack trace.
-    expect(timerCount()).toBe(before);
+    expect(timers.armed.length).toBe(1);
+    expect(timers.allCleared()).toBe(true);
   });
 });


### PR DESCRIPTION
**Retracting a claim I made in #324.** That PR said its new test "cannot flake on a slow machine". It flaked in CI two hours later, on an unrelated PR (#326), and blocked it.

```
Cross-runtime gate — NOT ACCEPTED — 1 of 16 failing

 ❯ src/__tests__/integration/rpc-client-timer.test.ts:97:26
     95|     // Three round-trips, zero residue. Before the fix this was `befor…
     97|     expect(timerCount()).toBe(before);
       |                          ^
```

## What I got wrong

I reasoned that asserting on a *handle* rather than on wall-clock time made the test immune to timing. That much is true, and it is not the property that mattered.

`process.getActiveResourcesInfo()` is **process-wide**. Vitest runs test files concurrently in a single process, so a timer armed by any other file lands in the same count between my `before` snapshot and the assertion. The delta stops being attributable to `RpcClient` at all. Nothing about the client changed — the neighbours did.

It passed locally, three times, and on 18/18 checks in #324. The suite is only dense enough to collide under the acceptance gate's particular ordering. That is the worst way to find out, and my "cannot flake" made it likelier that the next person would blame their own change.

## The fix

Identify the RPC timer *precisely* instead of counting everything: spy on `setTimeout`/`clearTimeout`, keep the handle returned for calls armed at the 30s RPC delay (which excludes `ws` internals), and assert that exact handle reached `clearTimeout`. Independent of what any other test file is doing.

The three cases are unchanged in intent:

- an unanswered call **keeps** its timer — the 30s guard still exists
- a resolved call clears it — three round-trips, three handles, all cleared
- a rejected call clears it too — the path `approvals list` takes against an older gateway

The vacuity guard is now stronger: `expect(timers.armed.length).toBe(1)` fails if no timer is armed at all, so a client that simply never sets a timeout cannot pass by having nothing to clear.

## Verification

- Mutation-tested: restoring `{ resolve, reject }` fails 2 of 3 with `expected false to be true`.
- Full suite **3×**: 4888 passed each run, no variation.
- **Ran the acceptance gate locally** — the check that caught this, `full regression suite (three proven platform baselines excluded)`, now passes.

The gate's one remaining local failure is `full Python regression suite — exit=0, skipped checks present`, an artifact of my venv rather than this change; that check passed in CI on #326.

## Note

#326 is blocked by this and needs no changes of its own; it should go green once this lands.
