### PR TITLE
fix(cli): sessions called three methods that do not exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capability its syntax tree can reach, per the RAPP agent contract.
 
 ### Fixed
+- `openrappter sessions` now works and is registered. All four subcommands failed before: `sessions.list`/`get`/`delete` are not gateway methods at all (the real ones are `chat.*`), and `sessions.reset` reads `sessionId`/`sessionKey` while the CLI sent `{ id }`, so it threw `sessionKey required`. `sessions delete` also reports when it deleted nothing instead of claiming success.
 - `openrappter login <provider>` printed "Credentials have been saved to your config." while saving nothing: `initiateOAuthFlow` returns the token and `auth/oauth.ts` performs no filesystem writes at all. It now states plainly that the token is discarded and that persistent credential storage is not implemented. (The command remains unregistered.)
 - RPC-backed CLI commands printed a raw Node stack trace, naming internal `ws` frames, whenever the gateway was unreachable, refused the token, or did not know a method. Commander does not await an async action handler, so the rejection escaped as an unhandled promise rejection. Failures now print one actionable line and exit non-zero.
 - Consolidated six byte-identical private copies of `withClient` (`approvals`, `backup`, `channels`, `cron`, `send`, `sessions`) into `cli/with-client.ts`. The duplication is why the missing error handling existed in six places at once.

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -21,6 +21,7 @@ Run `openrappter <command> --help` for a command's own options.
 | `approvals` |  | Review commands waiting on your approval |
 | `backup` |  | Snapshot and restore your OpenRappter data |
 | `memory` |  | Search and record what this rappter remembers |
+| `sessions` |  | Inspect and manage chat sessions |
 | `config` |  | Manage configuration |
 | `doctor` | `[options]` | Run system diagnostics and health checks |
 | `twins` | `[options]` | Which rappters are running on this device |

--- a/typescript/src/__tests__/integration/dormant-cli-commands-stay-dormant.test.ts
+++ b/typescript/src/__tests__/integration/dormant-cli-commands-stay-dormant.test.ts
@@ -27,10 +27,6 @@ import { resolve } from 'path';
  *  - registerSendCommand     — sends `{channel, message, target}`;
  *    `channels.send` reads `{channelId, conversationId, content}`, and `--all`
  *    calls `channels.broadcast`, which the gateway never registers.
- *  - registerSessionsCommand — calls `sessions.list/get/delete`, none of which
- *    the gateway registers (the real ones are `chat.list/session/messages/
- *    delete`); `sessions.reset` is registered but reads `sessionKey`, not the
- *    `{id}` this sends, so even that throws "sessionKey required".
  *  - registerLoginCommand    — `initiateOAuthFlow` persists nothing, yet the
  *    command prints "Credentials have been saved to your config." The shape the
  *    memory CLI had before #204 rewired it onto `MemoryAgent`, which is the
@@ -64,12 +60,8 @@ const INTENTIONALLY_DORMANT = new Map<string, string>([
     'sends {channel,message,target}; channels.send reads {channelId,conversationId,content}, and --all calls channels.broadcast which the gateway never registers',
   ],
   [
-    'registerSessionsCommand',
-    'calls sessions.list/get/delete (unregistered — real methods are chat.list/session/messages/delete); sessions.reset reads sessionKey, not the {id} this sends',
-  ],
-  [
     'registerLoginCommand',
-    'initiateOAuthFlow persists nothing while the command prints "Credentials have been saved to your config" — the shape the memory CLI had before #204 rewired it onto MemoryAgent',
+    'initiateOAuthFlow persists nothing and there is no credential store to wire it to (see the OAuth storage issue); the command now says so rather than claiming a save',
   ],
 ]);
 

--- a/typescript/src/__tests__/integration/sessions-cli-contract.test.ts
+++ b/typescript/src/__tests__/integration/sessions-cli-contract.test.ts
@@ -1,0 +1,149 @@
+/**
+ * The `sessions` CLI called four methods; three of them did not exist.
+ *
+ * `sessions.list`, `sessions.get` and `sessions.delete` are not registered by
+ * the gateway at all -- the chat-session methods are named `chat.*`. The
+ * fourth, `sessions.reset`, *is* registered but reads `sessionId`/`sessionKey`
+ * while the CLI sent `{ id }`, so it threw `sessionKey required` every time.
+ * All four subcommands failed, and the module was left unregistered rather
+ * than fixed (#206).
+ *
+ * These tests drive a real `GatewayServer` with the exact parameter names the
+ * CLI now sends. Asserting against the source of `cli/sessions.ts` would only
+ * prove the file says what I think it says; asserting against a live gateway
+ * proves the contract holds -- which is the thing that was broken.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join, resolve } from 'path';
+import { GatewayServer } from '../../gateway/server.js';
+
+let server: GatewayServer | undefined;
+let dataDir: string | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+  if (dataDir) rmSync(dataDir, { recursive: true, force: true });
+  dataDir = undefined;
+});
+
+type Handler = (params: unknown, ctx: unknown) => Promise<unknown>;
+
+/** Start a gateway and return a direct caller for its registered methods. */
+async function startGateway(): Promise<(m: string, p?: unknown) => Promise<unknown>> {
+  // A dataDir is mandatory here, not tidiness. GatewayServer defaults to
+  // ~/.openrappter and loads sessions.json from it, so a test without one
+  // reads the developer's real sessions -- and `chat.session` + saveSessions()
+  // write test fixtures back into them. The first run of this file left two
+  // sessions named s1 and s2 in a real store holding 27 of them.
+  dataDir = mkdtempSync(join(tmpdir(), 'openrappter-sessions-test-'));
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  await server.start();
+  const methods = (server as unknown as { methods: Map<string, { handler: Handler }> }).methods;
+
+  return async (method: string, params: unknown = {}) => {
+    const entry = methods.get(method);
+    if (!entry) throw new Error(`Method '${method}' not found`);
+    return entry.handler(params, { authenticated: true });
+  };
+}
+
+/** The exact method names and parameter shapes `cli/sessions.ts` sends. */
+const CLI_CONTRACT = {
+  list: { method: 'chat.list', params: undefined },
+  show: { method: 'chat.messages', params: { sessionId: 'x' } },
+  delete: { method: 'chat.delete', params: { sessionId: 'x' } },
+  reset: { method: 'sessions.reset', params: { sessionId: 'x' } },
+};
+
+describe('sessions CLI contract', () => {
+  it('every method the CLI calls is registered', async () => {
+    const call = await startGateway();
+    const missing: string[] = [];
+
+    for (const { method } of Object.values(CLI_CONTRACT)) {
+      const methods = (server as unknown as { methods: Map<string, unknown> }).methods;
+      if (!methods.has(method)) missing.push(method);
+    }
+
+    // Before the fix this list was ['sessions.list','sessions.get','sessions.delete'].
+    expect(missing).toEqual([]);
+    expect(await call('chat.list')).toEqual([]);
+  });
+
+  it('creates, lists, reads, resets and deletes a session end to end', async () => {
+    const call = await startGateway();
+
+    const created = (await call('chat.session', { sessionId: 's1' })) as { id: string };
+    expect(created.id).toBe('s1');
+
+    const listed = (await call('chat.list')) as Array<{ id: string; messageCount: number }>;
+    expect(listed.map((s) => s.id)).toContain('s1');
+
+    // `show` reads messages, and must not resurrect a missing session.
+    expect(await call('chat.messages', { sessionId: 's1' })).toEqual([]);
+
+    const reset = (await call('sessions.reset', { sessionId: 's1' })) as {
+      reset: boolean;
+      clearedMessages: number;
+    };
+    expect(reset.reset).toBe(true);
+    expect(reset.clearedMessages).toBe(0);
+
+    const deleted = (await call('chat.delete', { sessionId: 's1' })) as { deleted: boolean };
+    expect(deleted.deleted).toBe(true);
+
+    // And the delete really happened.
+    expect((await call('chat.list')) as unknown[]).toEqual([]);
+  });
+
+  it('reports a delete that removed nothing, instead of claiming success', async () => {
+    const call = await startGateway();
+
+    // The old CLI printed "Deleted session: <id>" unconditionally. The gateway
+    // has always said otherwise, and the CLI now reads the answer.
+    const result = (await call('chat.delete', { sessionId: 'never-existed' })) as {
+      deleted: boolean;
+    };
+    expect(result.deleted).toBe(false);
+  });
+
+  it('rejects the parameter name the old CLI sent', async () => {
+    const call = await startGateway();
+    await call('chat.session', { sessionId: 's2' });
+
+    // `{ id }` was the bug: resolveSessionId reads sessionId ?? sessionKey, so
+    // `id` resolves to undefined and reset throws. Pinning this keeps the CLI
+    // from drifting back to a name the gateway does not read.
+    await expect(call('sessions.reset', { id: 's2' })).rejects.toThrow(/sessionKey required/);
+
+    // ...and the correct name works on the very same session.
+    const ok = (await call('sessions.reset', { sessionId: 's2' })) as { reset: boolean };
+    expect(ok.reset).toBe(true);
+  });
+
+  it('show does not create the session it was asked to display', async () => {
+    const call = await startGateway();
+
+    // chat.session is getOrCreateSession; using it for `show` would report an
+    // empty session into existence for a typo'd id. chat.messages throws.
+    await expect(call('chat.messages', { sessionId: 'typo' })).rejects.toThrow(/not found/i);
+    expect((await call('chat.list')) as unknown[]).toEqual([]);
+  });
+
+  it('the CLI actually sends these names', () => {
+    // The tests above drive the gateway directly, so they would still pass if
+    // cli/sessions.ts drifted back to `sessions.list` or `{ id }`. Read what
+    // the CLI sends and hold it to the same contract.
+    const source = readFileSync(resolve(__dirname, '../../cli/sessions.ts'), 'utf-8');
+    const called = [...source.matchAll(/client\.call\(\s*'([^']+)'/g)].map((m) => m[1]).sort();
+
+    expect(called).toEqual(['chat.delete', 'chat.list', 'chat.messages', 'sessions.reset']);
+
+    // Every id it passes must use the name resolveSessionId reads.
+    expect(source).not.toMatch(/client\.call\([^)]*\{\s*id\s*[,}]/);
+    expect(source.match(/sessionId:/g)?.length).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/typescript/src/__tests__/parity/cli-registration.test.ts
+++ b/typescript/src/__tests__/parity/cli-registration.test.ts
@@ -78,7 +78,7 @@ const REGISTERED = [
  * the memory the product actually keeps, so reachable is no longer the wrong
  * move — the objection was to the implementation, not to the command existing.
  */
-const DELIBERATELY_UNREGISTERED = ['sessions', 'channels', 'send', 'login'];
+const DELIBERATELY_UNREGISTERED = ['channels', 'send', 'login'];
 
 let commands: string[];
 

--- a/typescript/src/cli/sessions.ts
+++ b/typescript/src/cli/sessions.ts
@@ -1,46 +1,136 @@
+/**
+ * Inspect and manage chat sessions from the terminal.
+ *
+ * Every subcommand here was broken, in two different ways (#206):
+ *
+ *   - `sessions.list`, `sessions.get` and `sessions.delete` are **not
+ *     registered by the gateway at all**. The chat-session methods are named
+ *     `chat.*`. All three failed with method-not-found.
+ *   - `sessions.reset` *is* registered, but reads `sessionId`/`sessionKey`
+ *     (via `resolveSessionId`), while this module sent `{ id }` -- so it threw
+ *     `sessionKey required` on every invocation.
+ *
+ * `show` deliberately uses `chat.messages` rather than `chat.session`. The
+ * latter is `getOrCreateSession`: asking it to display a session that does not
+ * exist would silently create one, so a typo'd id would report an empty
+ * session into existence instead of saying it is not there.
+ *
+ * `chat.delete` and `sessions.reset` require auth; `withClient` forwards
+ * `OPENRAPPTER_TOKEN`.
+ */
 import type { Command } from 'commander';
 import { withClient } from './with-client.js';
 
+interface SessionSummary {
+  id: string;
+  agentId?: string;
+  messageCount: number;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+interface ChatMessage {
+  role?: string;
+  content?: string;
+  timestamp?: string;
+}
+
 export function registerSessionsCommand(program: Command): void {
-  const sessions = program.command('sessions').description('Manage chat sessions');
+  const sessions = program.command('sessions').description('Inspect and manage chat sessions');
 
   sessions
-    .command('list')
-    .description('List all active sessions')
-    .action(async () => {
+    .command('list', { isDefault: true })
+    .description('List chat sessions')
+    .option('--json', 'Print the raw response')
+    .action(async (options: { json?: boolean }) => {
       await withClient(async (client) => {
-        const result = await client.call('sessions.list');
-        console.log(JSON.stringify(result, null, 2));
+        const result = (await client.call('chat.list')) as SessionSummary[] | undefined;
+        const list = Array.isArray(result) ? result : [];
+
+        if (options.json) {
+          console.log(JSON.stringify(list, null, 2));
+          return;
+        }
+        if (list.length === 0) {
+          console.log('No chat sessions yet.');
+          return;
+        }
+        for (const session of list) {
+          console.log(`\n  ${session.id}`);
+          if (session.agentId) console.log(`    agent:    ${session.agentId}`);
+          console.log(`    messages: ${session.messageCount}`);
+          if (session.updatedAt) console.log(`    updated:  ${session.updatedAt}`);
+        }
+        console.log(`\n  ${list.length} session${list.length === 1 ? '' : 's'}.`);
       });
     });
 
   sessions
     .command('show <id>')
-    .description('Show session details')
-    .action(async (id: string) => {
+    .description('Show the messages in a session')
+    .option('--limit <n>', 'Only the last n messages')
+    .option('--json', 'Print the raw response')
+    .action(async (id: string, options: { limit?: string; json?: boolean }) => {
       await withClient(async (client) => {
-        const result = await client.call('sessions.get', { id });
-        console.log(JSON.stringify(result, null, 2));
+        const limit = options.limit ? Number.parseInt(options.limit, 10) : undefined;
+        if (options.limit !== undefined && (!Number.isFinite(limit) || limit! <= 0)) {
+          console.error(`\n  --limit must be a positive number, got "${options.limit}"\n`);
+          process.exitCode = 1;
+          return;
+        }
+
+        const result = (await client.call('chat.messages', {
+          sessionId: id,
+          ...(limit ? { limit } : {}),
+        })) as ChatMessage[] | undefined;
+        const messages = Array.isArray(result) ? result : [];
+
+        if (options.json) {
+          console.log(JSON.stringify(messages, null, 2));
+          return;
+        }
+        if (messages.length === 0) {
+          console.log(`Session ${id} has no messages.`);
+          return;
+        }
+        for (const message of messages) {
+          console.log(`\n  ${message.role ?? 'unknown'}${message.timestamp ? `  ${message.timestamp}` : ''}`);
+          console.log(`    ${message.content ?? ''}`);
+        }
       });
     });
 
   sessions
     .command('delete <id>')
-    .description('Delete a session')
+    .description('Delete a session and abort anything it is running')
     .action(async (id: string) => {
       await withClient(async (client) => {
-        await client.call('sessions.delete', { id });
-        console.log(`Deleted session: ${id}`);
+        const result = (await client.call('chat.delete', { sessionId: id })) as
+          | { deleted?: boolean }
+          | undefined;
+
+        // The gateway reports whether it actually deleted anything. Printing
+        // "Deleted" regardless -- as this module used to -- tells someone who
+        // mistyped an id that their session is gone when it is still there.
+        if (result?.deleted) {
+          console.log(`Deleted session: ${id}`);
+        } else {
+          console.log(`No session named ${id}; nothing was deleted.`);
+          process.exitCode = 1;
+        }
       });
     });
 
   sessions
     .command('reset <id>')
-    .description('Reset session history')
+    .description('Empty a session without deleting it')
     .action(async (id: string) => {
       await withClient(async (client) => {
-        await client.call('sessions.reset', { id });
-        console.log(`Reset session: ${id}`);
+        const result = (await client.call('sessions.reset', { sessionId: id })) as
+          | { clearedMessages?: number }
+          | undefined;
+        const cleared = result?.clearedMessages ?? 0;
+        console.log(`Reset session ${id}: cleared ${cleared} message${cleared === 1 ? '' : 's'}.`);
       });
     });
 }

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -20,6 +20,7 @@ import { registerCronCommand } from './cli/cron.js';
 import { registerApprovalsCommand } from './cli/approvals.js';
 import { registerBackupCommand } from './cli/backup.js';
 import { registerMemoryCommand } from './cli/memory.js';
+import { registerSessionsCommand } from './cli/sessions.js';
 import { registerConfigCommand } from './cli/config.js';
 import { registerDoctorCommand } from './cli/doctor.js';
 import { registerRappterCommand } from './cli/rappters.js';
@@ -2598,6 +2599,7 @@ registerCronCommand(program);
 registerApprovalsCommand(program);
 registerBackupCommand(program);
 registerMemoryCommand(program);
+registerSessionsCommand(program);
 registerConfigCommand(program);
 registerDoctorCommand(program);
 // Seeing and creating the rappters on this device. #107


### PR DESCRIPTION
Item 3 of #206. `openrappter sessions` had four subcommands and all four were broken, in two different ways.

**Three methods do not exist.** The chat-session methods are named `chat.*`; the CLI called `sessions.list`, `sessions.get` and `sessions.delete`, none of which the gateway registers.

**The fourth had the wrong parameter name.** `sessions.reset` *is* registered, but reads `sessionId`/`sessionKey` via `resolveSessionId` (`server.ts:215`), while the CLI sent `{ id }` — so it threw `sessionKey required` every time.

Rewired against the real contract, and registered:

| subcommand | called | now calls |
|---|---|---|
| `list` | `sessions.list` (absent) | `chat.list` |
| `show <id>` | `sessions.get` (absent) | `chat.messages` `{ sessionId }` |
| `delete <id>` | `sessions.delete` (absent) | `chat.delete` `{ sessionId }` |
| `reset <id>` | `sessions.reset` `{ id }` | `sessions.reset` `{ sessionId }` |

Working against the running gateway:

```
$ openrappter sessions list
  session_2ae7854e
    agent:    default
    messages: 8
    updated:  2026-03-26T18:46:41.312Z
```

Two deliberate choices:

- **`show` uses `chat.messages`, not `chat.session`.** The latter is `getOrCreateSession` — asking it to display a missing session would silently create one, so a typo'd id would report an empty session into existence instead of saying it isn't there. There's a test for exactly that.
- **`delete` reads the answer.** `chat.delete` returns `{ deleted: boolean }`; the old CLI printed `Deleted session: <id>` unconditionally. Someone who mistypes an id was told their session was gone while it was still there. It now says so and exits non-zero.

## I contaminated the developer's real data, and that turned out to be the bigger find

The first run of the new test failed with `expected [ …(29) ] to deeply equal []`. `GatewayServer` defaults `dataDir` to `~/.openrappter` and loads `sessions.json` from it — so the test was reading **27 real sessions**, and `chat.session` + `saveSessions()` wrote two fixtures (`s1`, `s2`) back into them. I removed exactly those two and kept a backup; the store is verified back at 27 with no artifacts and an untouched mtime.

The test now creates a `mkdtempSync` dataDir and removes it afterwards. But **106 of 117** `new GatewayServer(...)` calls across the suite pass no `dataDir`, so this is not unique to my test.

Chasing that turned up something worse, which I've filed separately rather than fixing here: `OPENRAPPTER_HOME` is a real, README-documented override (line 670), honoured in exactly **4** places and ignored by **46** that hardcode `~/.openrappter`. `GatewayServer.dataDir` is one of the 46. Setting it splits a user's data across two directories.

## Tests

`sessions-cli-contract.test.ts` (6 tests) drives a real `GatewayServer` with the exact parameter names the CLI sends — asserting against the CLI's source would only prove the file says what I think it says, when the contract is the thing that was broken. It covers a full create/list/read/reset/delete cycle, that `{ id }` is still rejected while `{ sessionId }` works on the same session, and that a delete which removed nothing reports `deleted: false`.

A final test closes the loop the other way: the gateway-driven tests would still pass if `cli/sessions.ts` drifted back to `{ id }`, so one test reads the CLI's own `client.call(...)` names and holds them to the same contract. Mutation-tested — reverting that one parameter fails it.

## Verification

TypeScript **4896 passed**, 21 skipped; tsc clean; eslint clean at `--max-warnings 0`. Exercised against the live gateway, including exit codes (`1` for a missing session and a bad `--limit`, `0` for success).

Two existing guards caught the registration and were updated deliberately, not bypassed: `sessions` is now documented in `docs/cli-commands.md`, and `registerSessionsCommand` has left the dormant allowlist. `channels`, `send` and `login` remain dormant.
