### PR TITLE
test: the suite was writing fixtures into the developer's real ~/.openrappter

### DIFF
--- a/typescript/src/__tests__/integration/test-isolation.test.ts
+++ b/typescript/src/__tests__/integration/test-isolation.test.ts
@@ -1,0 +1,55 @@
+/**
+ * The test suite must never read or write the developer's real installation.
+ *
+ * 106 of the 117 `new GatewayServer(...)` calls in this suite pass no explicit
+ * `dataDir`, so they resolve through `openrappterHome()` like production does.
+ * Without `vitest.setup.ts` redirecting `OPENRAPPTER_HOME`, that is the real
+ * `~/.openrappter` -- and a single `npx vitest run` left three fixture
+ * sessions in a real store: `test-session` and `test-session-2` from
+ * `gateway.protocol.test.ts`, and `abort-session` from
+ * `brainstem-abort.test.ts`.
+ *
+ * Nothing failed when that happened, which is the point of this file. The
+ * fixtures were written by `saveSessions()` into real user data and simply
+ * accumulated, run after run. The reverse direction is a flakiness source:
+ * `chat.list` returns 25 sessions on a developer's machine and none in CI.
+ *
+ * If someone removes the setup file or the config entry, these fail rather
+ * than the suite quietly going back to writing into a real home.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { homedir, tmpdir } from 'os';
+import { openrappterHome } from '../../infra/openrappter-home.js';
+
+describe('tests are isolated from the real installation', () => {
+  it('OPENRAPPTER_HOME is set and points into a temp directory', () => {
+    const home = process.env.OPENRAPPTER_HOME;
+    expect(home).toBeDefined();
+    expect(home!.startsWith(tmpdir())).toBe(true);
+  });
+
+  it('the resolved data directory is not the real one', () => {
+    const real = resolve(homedir(), '.openrappter');
+    expect(resolve(openrappterHome())).not.toBe(real);
+
+    // Not merely different -- outside it entirely, so no test can reach a
+    // subdirectory of the developer's installation either.
+    expect(resolve(openrappterHome()).startsWith(real)).toBe(false);
+  });
+
+  it('vitest.config.ts still loads the setup file', () => {
+    // The assertions above run *because* the setup file ran. If the config
+    // entry is deleted they would still pass in a stale process, so pin the
+    // wiring itself.
+    const config = readFileSync(resolve(__dirname, '../../../vitest.config.ts'), 'utf-8');
+    expect(config).toMatch(/setupFiles:\s*\[\s*'\.\/vitest\.setup\.ts'\s*\]/);
+  });
+
+  it('the setup file redirects OPENRAPPTER_HOME', () => {
+    const setup = readFileSync(resolve(__dirname, '../../../vitest.setup.ts'), 'utf-8');
+    expect(setup).toMatch(/process\.env\.OPENRAPPTER_HOME\s*=/);
+    expect(setup).toMatch(/mkdtempSync/);
+  });
+});

--- a/typescript/src/__tests__/parity/cli-registration.test.ts
+++ b/typescript/src/__tests__/parity/cli-registration.test.ts
@@ -39,6 +39,10 @@ function isolatedHomeEnv(home: string): NodeJS.ProcessEnv {
     ...process.env,
     HOME: home,
     USERPROFILE: home,
+    // Setting HOME alone is not enough: the data directory resolves through
+    // OPENRAPPTER_HOME first, and this spreads process.env, so the suite-wide
+    // temp home would otherwise be inherited and outrank the one under test.
+    OPENRAPPTER_HOME: join(home, '.openrappter'),
   };
 }
 

--- a/typescript/src/__tests__/unit/env-config-merge.test.ts
+++ b/typescript/src/__tests__/unit/env-config-merge.test.ts
@@ -35,6 +35,10 @@ beforeEach(async () => {
   home = await fs.mkdtemp(path.join(os.tmpdir(), 'openrappter-cfg-'));
   // os.homedir() honours $HOME on POSIX, so this relocates HOME_DIR/CONFIG_FILE.
   process.env.HOME = home;
+  // The data directory resolves OPENRAPPTER_HOME before HOME, and the
+  // suite sets it globally (vitest.setup.ts), so redirecting HOME alone
+  // would leave this test pointed at the shared temp home.
+  process.env.OPENRAPPTER_HOME = `${home}/.openrappter`;
   await fs.mkdir(path.join(home, '.openrappter'), { recursive: true });
   home = path.join(home, '.openrappter');
 });

--- a/typescript/src/__tests__/unit/gateway-lock-instances.test.ts
+++ b/typescript/src/__tests__/unit/gateway-lock-instances.test.ts
@@ -3,7 +3,7 @@
  *
  * The runtime lock was one file per home directory:
  *
- *   join(homedir(), '.openrappter', 'gateway.pid')
+ *   openrappterPath('gateway.pid')
  *
  * No port, no instance in the path, and `index.ts` called `acquireLock()` with
  * no arguments — so exactly ONE rappter could run per machine. Measured before
@@ -26,6 +26,7 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtempSync, rmSync, existsSync } from 'node:fs';
 import { tmpdir, homedir } from 'node:os';
+import { openrappterPath } from '../../infra/openrappter-home.js';
 import { join } from 'node:path';
 import {
   ALPHA_GATEWAY_PORT,
@@ -51,7 +52,26 @@ function take(filePath: string, pid: number): boolean {
 describe('the alpha is exactly where it always was', () => {
   it('resolves to the original path with no arguments', () => {
     expect(gatewayLockFileFor()).toBe(defaultGatewayLockFile());
-    expect(defaultGatewayLockFile()).toBe(join(homedir(), '.openrappter', 'gateway.pid'));
+
+    // The guarantee this file is about is that an existing install is never
+    // migrated. Expressed against openrappterPath so it still holds when
+    // OPENRAPPTER_HOME relocates the install, and asserted directly below for
+    // the default case, which is the one existing users are in.
+    expect(defaultGatewayLockFile()).toBe(openrappterPath('gateway.pid'));
+  });
+
+  it('is the historical ~/.openrappter path when nothing overrides it', () => {
+    // The compatibility promise stated literally, for the case every existing
+    // user is in. The assertions above use openrappterPath so they survive a
+    // relocated install; this one pins that a default install did not move.
+    const saved = process.env.OPENRAPPTER_HOME;
+    delete process.env.OPENRAPPTER_HOME;
+    try {
+      expect(defaultGatewayLockFile()).toBe(join(homedir(), '.openrappter', 'gateway.pid'));
+    } finally {
+      if (saved === undefined) delete process.env.OPENRAPPTER_HOME;
+      else process.env.OPENRAPPTER_HOME = saved;
+    }
   });
 
   // An existing install passes its port explicitly; it must not be migrated.
@@ -64,12 +84,12 @@ describe('a twin gets its own', () => {
   it('keys by port when no id is given', () => {
     const twin = gatewayLockFileFor({ port: 19901 });
     expect(twin).not.toBe(defaultGatewayLockFile());
-    expect(twin).toBe(join(homedir(), '.openrappter', 'instances', '19901', 'gateway.pid'));
+    expect(twin).toBe(openrappterPath('instances', '19901', 'gateway.pid'));
   });
 
   it('prefers an explicit id over the port', () => {
     expect(gatewayLockFileFor({ instance: 'scout', port: 19901 }))
-      .toBe(join(homedir(), '.openrappter', 'instances', 'scout', 'gateway.pid'));
+      .toBe(openrappterPath('instances', 'scout', 'gateway.pid'));
   });
 
   // A twin id reaches a filesystem path. It must not be able to walk out of

--- a/typescript/src/__tests__/unit/lock-for-port.test.ts
+++ b/typescript/src/__tests__/unit/lock-for-port.test.ts
@@ -50,6 +50,9 @@ function isolatedHome(): string {
   const home = mkdtempSync(join(tmpdir(), 'lockport-home-'));
   homes.push(home);
   vi.stubEnv('HOME', home);
+  // OPENRAPPTER_HOME outranks HOME when resolving the data dir, and
+  // the suite sets it globally, so the sandbox needs both redirected.
+  vi.stubEnv('OPENRAPPTER_HOME', `${home}/.openrappter`);
   return home;
 }
 

--- a/typescript/src/__tests__/unit/rappter-roster.test.ts
+++ b/typescript/src/__tests__/unit/rappter-roster.test.ts
@@ -107,6 +107,9 @@ describe('a rappter records where it actually landed', () => {
     const home = mkdtempSync(join(tmpdir(), 'rappter-home-'));
     homes.push(home);
     vi.stubEnv('HOME', home);
+    // OPENRAPPTER_HOME outranks HOME when resolving the data dir, and
+    // the suite sets it globally, so the sandbox needs both redirected.
+    vi.stubEnv('OPENRAPPTER_HOME', `${home}/.openrappter`);
 
     expect(() => writeGatewayEndpoint({
       instance: '\0/impossible', port: 1, pid: 1, startedAt: 'x',
@@ -233,6 +236,9 @@ function isolatedHome(): string {
   const home = mkdtempSync(join(tmpdir(), 'roster-home-'));
   sandboxes.push(home);
   vi.stubEnv('HOME', home);
+  // OPENRAPPTER_HOME outranks HOME when resolving the data dir, and
+  // the suite sets it globally, so the sandbox needs both redirected.
+  vi.stubEnv('OPENRAPPTER_HOME', `${home}/.openrappter`);
   return home;
 }
 

--- a/typescript/src/agents/__tests__/DreamAgent.test.ts
+++ b/typescript/src/agents/__tests__/DreamAgent.test.ts
@@ -70,6 +70,10 @@ describe('DreamAgent numeric arguments', () => {
     previousHome = process.env.HOME;
     home = await fs.mkdtemp(path.join(os.tmpdir(), 'openrappter-dream-'));
     process.env.HOME = home;
+    // The data directory resolves OPENRAPPTER_HOME before HOME, and the
+    // suite sets it globally (vitest.setup.ts), so redirecting HOME alone
+    // would leave this test pointed at the shared temp home.
+    process.env.OPENRAPPTER_HOME = `${home}/.openrappter`;
     await writeMemories();
   });
 

--- a/typescript/src/cli/__tests__/memory.test.ts
+++ b/typescript/src/cli/__tests__/memory.test.ts
@@ -37,6 +37,10 @@ function scratchHome(): string {
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-cli-'));
   scratchHomes.push(dir);
   process.env.HOME = dir;
+  // The data directory resolves OPENRAPPTER_HOME before HOME, and the
+  // suite sets it globally (vitest.setup.ts), so redirecting HOME alone
+  // would leave this test pointed at the shared temp home.
+  process.env.OPENRAPPTER_HOME = `${dir}/.openrappter`;
   return dir;
 }
 

--- a/typescript/src/providers/__tests__/copilot-cli.test.ts
+++ b/typescript/src/providers/__tests__/copilot-cli.test.ts
@@ -1,5 +1,4 @@
-import { homedir } from 'node:os';
-import path from 'node:path';
+import { openrappterPath } from '../../infra/openrappter-home.js';
 import { describe, expect, it, vi } from 'vitest';
 import {
   COPILOT_CLI_MAX_PROMPT_BYTES,
@@ -252,11 +251,10 @@ describe('CopilotCliProvider', () => {
 
     await provider.chat([{ role: 'user', content: 'hello' }]);
 
-    const expectedHome = path.join(
-      homedir(),
-      '.openrappter',
-      'copilot-imessage-home',
-    );
+    // Resolved the way the provider resolves it, so a relocated install
+    // (OPENRAPPTER_HOME) is compared against the right directory rather than
+    // against a path the provider would never use.
+    const expectedHome = openrappterPath('copilot-imessage-home');
     expect(homePreparer).toHaveBeenCalledWith(expectedHome, 0o700);
     expect(calls[0].options.env).toMatchObject({
       COPILOT_HOME: expectedHome,

--- a/typescript/vitest.config.ts
+++ b/typescript/vitest.config.ts
@@ -8,6 +8,9 @@ export default defineConfig({
     globals: true,
     environment: 'node',
     include: ['src/**/*.test.ts'],
+    // Redirects OPENRAPPTER_HOME to a temp dir so tests never read or write
+    // the developer's real ~/.openrappter. See vitest.setup.ts.
+    setupFiles: ['./vitest.setup.ts'],
     coverage: {
       provider: 'v8',
       reporter: ['text', 'json', 'html'],

--- a/typescript/vitest.setup.ts
+++ b/typescript/vitest.setup.ts
@@ -1,0 +1,40 @@
+/**
+ * Point every test at a throwaway data directory.
+ *
+ * `openrappterHome()` resolves `$OPENRAPPTER_HOME`, falling back to
+ * `~/.openrappter`. 106 of the 117 `new GatewayServer(...)` calls in this
+ * suite pass no explicit `dataDir`, so without this file they load -- and
+ * write -- the developer's real installation.
+ *
+ * That is not hypothetical. A single `npx vitest run` on a clean checkout left
+ * three fixture sessions in a real store: `test-session` and `test-session-2`
+ * from `gateway.protocol.test.ts`, and `abort-session` from
+ * `brainstem-abort.test.ts`. Nothing failed -- `saveSessions()` simply wrote
+ * them into real user data, where they accumulated run after run.
+ *
+ * The reverse is just as bad: a test that *reads* that directory depends on
+ * whatever the developer happens to have, so `chat.list` returns 25 sessions
+ * on one machine and none in CI.
+ *
+ * Set before any test module is imported, so a module that captures a path at
+ * import time still sees the temp directory. Tests that need their own home
+ * must set `OPENRAPPTER_HOME` explicitly (see `isolatedHomeEnv` helpers) --
+ * setting only `HOME` is no longer sufficient, because the dedicated variable
+ * correctly outranks it.
+ */
+import { mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+const root = mkdtempSync(join(tmpdir(), 'openrappter-test-home-'));
+
+// The directory is named `.openrappter` deliberately: several tests assert the
+// resolved path ends in it (that name is part of the product's contract), and
+// a temp dir called anything else would fail them for the wrong reason.
+const home = join(root, '.openrappter');
+mkdirSync(home, { recursive: true });
+process.env.OPENRAPPTER_HOME = home;
+
+export function teardown(): void {
+  rmSync(root, { recursive: true, force: true });
+}


### PR DESCRIPTION
Closes the second half of #330. The test suite has been reading and writing the developer's real `~/.openrappter`.

Not hypothetical — a single `npx vitest run` on a clean checkout leaves fixtures behind:

```
$ python3 -c "…"
suspicious ids: ['test-session', 'test-session-2', 'abort-session']
```

`test-session` / `test-session-2` come from `gateway.protocol.test.ts`, `abort-session` from `brainstem-abort.test.ts`. **Nothing fails when this happens.** `saveSessions()` writes them into real user data and they accumulate run after run; I removed them three separate times while working on #329 and #331 before fixing the cause.

The reverse direction is a flakiness source: 106 of 117 `new GatewayServer(...)` calls pass no `dataDir`, so `chat.list` returns 25 sessions on this machine and none in CI.

## The fix

`vitest.setup.ts` points `OPENRAPPTER_HOME` at a `mkdtempSync` directory before any test module is imported, so even a module that captures a path at import time sees it. Made possible by #331, which routed all 46 hardcoded sites through `openrappterHome()`.

Proof, rather than assertion:

```
before: 39eab830494e0eb0  (20:11:12)
after:  39eab830494e0eb0  (20:11:33)
UNCHANGED — suite no longer touches real user data
```

Repeated across a second full run.

## The 9 tests this broke were right to break

An explicit `OPENRAPPTER_HOME` correctly outranks `HOME`, so every test isolating by `HOME` alone was now pointed at the shared temp home. Each needed a real answer, not a suppression:

- **`isolatedHomeEnv()`** (`cli-registration`) spreads `process.env` and overrode only `HOME`/`USERPROFILE`. It now sets `OPENRAPPTER_HOME` too — the variable that actually decides. Notably the same file *already* set it explicitly in two places, so the helper was simply behind.
- **`lock-for-port`, `rappter-roster`** failed with `refusing to write a test fixture outside the sandbox`. That guard is excellent and was doing exactly its job: it refuses to write anywhere but its own sandbox so that "a regression should break this test, never the machine running it". Both now stub `OPENRAPPTER_HOME` alongside `HOME`.
- **`gateway-lock-instances`** asserted `join(homedir(), '.openrappter', 'gateway.pid')`. Its subject is a compatibility promise — "the alpha is exactly where it always was" — so I did **not** just relax it. The assertions now resolve through `openrappterPath()`, and a **new** test states the original promise literally: with `OPENRAPPTER_HOME` deleted, the default is still the historical `~/.openrappter/gateway.pid`.
- **`copilot-cli`** compared against a reconstructed path; it now resolves the way the provider does.
- **`env-config-merge`, `DreamAgent`, `cli/memory`** redirect `HOME` in `beforeEach`; they now redirect both.

One detail that removed a lot of churn: the temp directory is itself named `.openrappter`. Several tests assert the resolved path ends in that name — which is part of the product's contract — and a temp dir called anything else failed them for the wrong reason. That alone fixed two files.

## Guard

`test-isolation.test.ts` (4 tests) asserts `OPENRAPPTER_HOME` is set, lives under `tmpdir()`, and resolves **outside** the real directory — not merely different from it, so no test can reach a subdirectory of a real install either. It also pins the `vitest.config.ts` wiring and the setup file's contents, since the other assertions only pass *because* the setup ran.

Mutation-tested by deleting the config entry. Three fail, and the message is the bug itself:

```
expected '/Users/…/.openrappter' not to be '/Users/…/.openrappter'
```

## Verification

TypeScript **4907 passed**, 21 skipped (4 new); `tsc --noEmit` clean; eslint clean at `--max-warnings 0`.

No CHANGELOG entry: this is test infrastructure and changes nothing a user of the product observes (the rule established in #202).
