### PR TITLE
ci: the Windows smoke test had a cold-start escape hatch nothing used

### DIFF
--- a/.github/workflows/desktop.yml
+++ b/.github/workflows/desktop.yml
@@ -67,6 +67,13 @@ jobs:
         shell: pwsh
         run: |
           $env:OPENRAPPTER_DESKTOP_SMOKE = "1"
+          # A cold Windows runner does not always start the gateway inside the
+          # 30s default, and the smoke test then fails with "did not become
+          # ready in 30 seconds" while passing unchanged on re-run. The module
+          # already exposes this budget for exactly that case; the step just
+          # never used it. 120s is still far below the 5-minute step timeout,
+          # so a genuinely hung gateway still fails the job.
+          $env:OPENRAPPTER_GATEWAY_READY_TIMEOUT_MS = "120000"
           .\node_modules\.bin\electron.cmd .
 
       - name: Build unpacked macOS application


### PR DESCRIPTION
The Windows Electron smoke test fails intermittently on a cold runner:

```
OPENRAPPTER_SMOKE_ERROR Error: OpenRappter gateway did not become ready in 30 seconds.
```

Hit it on #333, a CLI-only change that cannot affect gateway startup. Re-running the same commit unchanged passed in 2m44s, which is what a cold-start flake looks like rather than a defect.

## The remedy already existed and was never used

`gateway-ready.js` exposes `OPENRAPPTER_GATEWAY_READY_TIMEOUT_MS`, added precisely for this. Its own comment is explicit:

> `waitForGatewayReady` has always accepted a `timeoutMs`, and until now no caller passed one and nothing read an environment variable — so the escape hatch the module documents existed only for its own tests. The person who actually hits a 30s cold start had no remedy at all.

No workflow set it:

```
$ grep -rn "GATEWAY_READY_TIMEOUT" .github/workflows/
(nothing)
```

So the budget was reachable in principle and unreached in practice — the same shape as the dormant modules in #206.

## Verified the override is actually live, not another dead escape hatch

That was the thing worth checking, given the class of bug. `waitForGatewayReady` resolves it only when the caller passes no explicit value:

```js
const timeoutMs = options.timeoutMs ?? resolveGatewayReadyTimeout();
```

and the one production caller passes none:

```
dist/main.js:267  await waitForGatewayReady(child, { port: gatewayPort });
```

Then measured it rather than trusting the read:

```
default            -> 30000
with CI value      -> 120000
rejects nonsense   -> 30000
caps absurd value  -> 600000
```

So the value takes effect, a typo cannot silently disable the budget, and an absurd value is capped at 10 minutes.

## Why 120s

Comfortably above a cold Windows start, and far below the step's existing `timeout-minutes: 5`. A gateway that is genuinely hung still fails the job — this widens a flaky margin without removing the failure mode.

## Verification

Desktop suite: **25 pass, 0 fail**. Workflow parsed with `yaml.safe_load` to confirm the variable landed inside the Windows smoke step and nowhere else.

Note this does not fix a slow cold start, it stops one from being reported as a failure. If the Windows gateway genuinely takes >30s to become ready, that is worth its own investigation — but a test that fails on timing it does not control was giving no useful signal about it either.
