### PR TITLE
feat(gateway): emit agent.tool, a UI feature that never worked

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- The gateway now emits `agent.tool` as each tool call finishes, so tool use appears in chat. The chat UI has registered a listener for it since it was written and the event had no emit site anywhere, so the feature had never worked. The payload carries the tool's name, outcome and duration -- never its arguments, which can hold secrets.
 
 - **`openrappter memory`** — search, record and forget what a rappter remembers.
   The module was complete and had never been registered, so `openrappter memory`

--- a/typescript/src/__tests__/integration/agent-tool-event.test.ts
+++ b/typescript/src/__tests__/integration/agent-tool-event.test.ts
@@ -1,0 +1,151 @@
+/**
+ * `agent.tool` had a listener and no emitter.
+ *
+ * `typescript/ui/src/components/chat.ts:909` registers
+ * `gateway.on('agent.tool', this.handleToolEvent)`, and the name appeared
+ * nowhere else but the `GatewayEvents` catalogue -- so tool use never showed
+ * up in chat, and never had (#195). `event-contract-coverage.test.ts` recorded
+ * it in `LISTENED_BUT_NEVER_EMITTED`, which is shrink-only, so implementing it
+ * is what allows that entry to come off.
+ *
+ * The payload deliberately carries the tool's **name and outcome only**. Tool
+ * arguments can hold secrets: the Flight Recorder omits them by default and
+ * scrubs opt-in IO, and this is broadcast to every subscribed client, which is
+ * a wider audience than a local trace file. These tests assert that absence
+ * rather than leaving it to review.
+ */
+import { describe, it, expect } from 'vitest';
+import { Assistant, type AgentToolEvent } from '../../agents/Assistant.js';
+import { BasicAgent } from '../../agents/BasicAgent.js';
+import type { LLMProvider } from '../../providers/types.js';
+
+/** An agent whose only job is to succeed or throw on demand. */
+class ScriptedTool extends BasicAgent {
+  constructor(private readonly behaviour: 'ok' | 'throws') {
+    super('secret_tool', {
+      name: 'secret_tool',
+      description: 'does a thing',
+      parameters: { type: 'object', properties: {}, required: [] },
+    });
+  }
+
+  async perform(): Promise<string> {
+    if (this.behaviour === 'throws') throw new Error('tool exploded');
+    return 'tool result';
+  }
+}
+
+/** One tool call, then a plain answer. */
+function scriptedProvider(): LLMProvider {
+  let round = 0;
+  return {
+    id: 'scripted',
+    name: 'scripted',
+    isAvailable: async () => true,
+    chat: (async () => {
+      round += 1;
+      if (round === 1) {
+        return {
+          content: '',
+          tool_calls: [
+            {
+              id: 'call_1',
+              type: 'function',
+              // The arguments carry a secret on purpose: the point of the
+              // payload design is that this never reaches a subscriber.
+              function: { name: 'secret_tool', arguments: '{"password":"hunter2"}' },
+            },
+          ],
+        };
+      }
+      return { content: 'done' };
+    }) as LLMProvider['chat'],
+  };
+}
+
+function assistantWithScriptedTool(behaviour: 'ok' | 'throws'): Assistant {
+  const tool = new ScriptedTool(behaviour);
+  return new Assistant(new Map([[tool.name, tool]]), {
+    provider: scriptedProvider(),
+    model: 'test-model',
+    loadWorkspaceContext: false,
+    loadMemoryContext: false,
+    useTwin: false,
+  });
+}
+
+describe('agent.tool is emitted for each finished tool call', () => {
+  it('reports a successful call with its name and outcome', async () => {
+    const assistant = assistantWithScriptedTool('ok');
+    const seen: AgentToolEvent[] = [];
+    assistant.onToolEvent = (event) => seen.push(event);
+
+    await assistant.getResponse('do the thing', undefined, undefined, 'session-a');
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({
+      sessionId: 'session-a',
+      name: 'secret_tool',
+      status: 'ok',
+    });
+    expect(seen[0].durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('reports a failed call rather than staying silent', async () => {
+    // The loop deliberately continues past a tool error so the model can
+    // recover, which is exactly why the failure has to be reported: otherwise
+    // a surface shows a tool starting and never resolving.
+    const assistant = assistantWithScriptedTool('throws');
+    const seen: AgentToolEvent[] = [];
+    assistant.onToolEvent = (event) => seen.push(event);
+
+    await assistant.getResponse('do the thing', undefined, undefined, 'session-b');
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ name: 'secret_tool', status: 'error' });
+  });
+
+  it('never carries the tool arguments', async () => {
+    const assistant = assistantWithScriptedTool('ok');
+    const seen: AgentToolEvent[] = [];
+    assistant.onToolEvent = (event) => seen.push(event);
+
+    await assistant.getResponse('do the thing', undefined, undefined, 'session-c');
+
+    // The scripted call's arguments contain `hunter2`. Serialising the whole
+    // event is the check that matters -- a future field could reintroduce it
+    // without any named property looking wrong.
+    expect(JSON.stringify(seen)).not.toContain('hunter2');
+    expect(JSON.stringify(seen)).not.toContain('password');
+    expect(Object.keys(seen[0]).sort()).toEqual(['durationMs', 'name', 'sessionId', 'status']);
+  });
+
+  it('a throwing subscriber does not break the turn', async () => {
+    // Agents report failure in their return value rather than by throwing
+    // (#134); a broadcast is strictly less important than producing the answer.
+    const assistant = assistantWithScriptedTool('ok');
+    assistant.onToolEvent = () => {
+      throw new Error('subscriber blew up');
+    };
+
+    const result = await assistant.getResponse('do the thing', undefined, undefined, 'session-d');
+    expect(result.content).toBe('done');
+  });
+
+  it('costs nothing when nobody is listening', async () => {
+    const assistant = assistantWithScriptedTool('ok');
+    // Left unset, as the CLI leaves it.
+    const result = await assistant.getResponse('do the thing', undefined, undefined, 'session-e');
+    expect(result.content).toBe('done');
+  });
+
+  it('the gateway forwards it under the catalogued name', async () => {
+    // Guards the wiring rather than the assistant: an emitter nobody forwards
+    // is the same defect one layer along.
+    const { readFileSync } = await import('fs');
+    const { resolve } = await import('path');
+    const source = readFileSync(resolve(__dirname, '../../index.ts'), 'utf-8');
+    expect(source).toMatch(/assistant\.onToolEvent\s*=/);
+    expect(source).toMatch(/broadcastEvent\(GatewayEvents\.AGENT_TOOL/);
+  });
+});

--- a/typescript/src/__tests__/integration/agent-tool-event.test.ts
+++ b/typescript/src/__tests__/integration/agent-tool-event.test.ts
@@ -21,7 +21,7 @@ import type { LLMProvider } from '../../providers/types.js';
 
 /** An agent whose only job is to succeed or throw on demand. */
 class ScriptedTool extends BasicAgent {
-  constructor(private readonly behaviour: 'ok' | 'throws') {
+  constructor(private readonly behaviour: 'ok' | 'throws' | 'resolves-error') {
     super('secret_tool', {
       name: 'secret_tool',
       description: 'does a thing',
@@ -31,6 +31,11 @@ class ScriptedTool extends BasicAgent {
 
   async perform(): Promise<string> {
     if (this.behaviour === 'throws') throw new Error('tool exploded');
+    if (this.behaviour === 'resolves-error') {
+      // The failure mode #134 is about: the agent returns normally and reports
+      // the failure *inside* the envelope. No exception is thrown.
+      return JSON.stringify({ status: 'error', message: 'could not reach service' });
+    }
     return 'tool result';
   }
 }
@@ -63,7 +68,7 @@ function scriptedProvider(): LLMProvider {
   };
 }
 
-function assistantWithScriptedTool(behaviour: 'ok' | 'throws'): Assistant {
+function assistantWithScriptedTool(behaviour: 'ok' | 'throws' | 'resolves-error'): Assistant {
   const tool = new ScriptedTool(behaviour);
   return new Assistant(new Map([[tool.name, tool]]), {
     provider: scriptedProvider(),
@@ -100,6 +105,21 @@ describe('agent.tool is emitted for each finished tool call', () => {
     assistant.onToolEvent = (event) => seen.push(event);
 
     await assistant.getResponse('do the thing', undefined, undefined, 'session-b');
+
+    expect(seen).toHaveLength(1);
+    expect(seen[0]).toMatchObject({ name: 'secret_tool', status: 'error' });
+  });
+
+  it('reports a tool that resolves with an error envelope', async () => {
+    // The branch a throwing tool never reaches. Agents report failure by
+    // resolving with `{"status":"error"}` at least as often as by throwing,
+    // and trusting the absence of an exception is how #134 recorded an
+    // undelivered alert as sent.
+    const assistant = assistantWithScriptedTool('resolves-error');
+    const seen: AgentToolEvent[] = [];
+    assistant.onToolEvent = (event) => seen.push(event);
+
+    await assistant.getResponse('do the thing', undefined, undefined, 'session-f');
 
     expect(seen).toHaveLength(1);
     expect(seen[0]).toMatchObject({ name: 'secret_tool', status: 'error' });

--- a/typescript/src/__tests__/integration/event-contract-coverage.test.ts
+++ b/typescript/src/__tests__/integration/event-contract-coverage.test.ts
@@ -79,15 +79,16 @@ function invokedMethodModules(): Set<string> {
  * than a wiring fix. Shrink-only: the list below fails if one starts being
  * emitted while still listed.
  */
-const LISTENED_BUT_NEVER_EMITTED = new Set([
+const LISTENED_BUT_NEVER_EMITTED = new Set<string>([
   // `channel.status` came off this list when the gateway started emitting it
   // on channels.connect/disconnect — see channel-status-event.test.ts.
-  'agent.tool',
+  // `agent.tool` came off it when the assistant started reporting each
+  // finished tool call — see agent-tool-event.test.ts. The list is empty, and
+  // being shrink-only, it should stay that way.
 ]);
 
 const DECLARED_BUT_NEVER_EMITTED = new Set([
   'agent.stream',
-  'agent.tool',
   'channel',
   'channel.message',
   'chat.message',

--- a/typescript/src/agents/Assistant.ts
+++ b/typescript/src/agents/Assistant.ts
@@ -131,7 +131,30 @@ export interface AssistantConversationMessage {
   content: string;
 }
 
+/**
+ * What a surface is told when the assistant runs a tool.
+ *
+ * Deliberately carries the tool's **name and outcome only**. Tool arguments
+ * can hold secrets -- the Flight Recorder omits them by default and scrubs
+ * opt-in IO for the same reason -- and this payload is broadcast to every
+ * subscribed client, which is a wider audience than a local trace file.
+ */
+export interface AgentToolEvent {
+  /** Conversation this ran in. */
+  sessionId: string;
+  /** The tool the model asked for. */
+  name: string;
+  status: 'ok' | 'error';
+  durationMs: number;
+}
+
 export class Assistant {
+  /**
+   * Notified as each tool call finishes. Optional: the CLI sets nothing and
+   * pays only a null check, while the gateway forwards these as `agent.tool`.
+   */
+  onToolEvent?: (event: AgentToolEvent) => void;
+
   private agents: Map<string, BasicAgent>;
   private config: AssistantConfig;
   private provider: LLMProvider;
@@ -261,6 +284,29 @@ export class Assistant {
         this.getResponseWithinTrace(message, onDelta, memoryContext, key, signal),
       ),
     );
+  }
+
+  /**
+   * Report one finished tool call, never failing the turn.
+   *
+   * A subscriber that throws must not abort the tool loop: agents already
+   * report failure in their return value rather than by throwing (#134), and
+   * a broadcast is strictly less important than the answer being produced.
+   */
+  private emitToolEvent(
+    sessionId: string,
+    name: string,
+    status: 'ok' | 'error',
+    /** A `performance.now()` reading, matching the Flight Recorder's clock. */
+    startedAt: number,
+  ): void {
+    if (!this.onToolEvent) return;
+    try {
+      const durationMs = Math.max(0, Math.round(performance.now() - startedAt));
+      this.onToolEvent({ sessionId, name, status, durationMs });
+    } catch {
+      // Intentionally ignored; see the note above.
+    }
   }
 
   private async withConversationTurn<T>(
@@ -401,7 +447,7 @@ export class Assistant {
           try {
             const result = await getFlightRecorder().withParent(
               providerCall.parentEventId ?? null,
-              () => this.executeToolCall(tc, agentLogs),
+              () => this.executeToolCall(tc, agentLogs, conversationKey),
             );
             history.push({
               role: "tool",
@@ -721,7 +767,7 @@ export class Assistant {
           try {
             const result = await getFlightRecorder().withParent(
               providerParentEventId ?? null,
-              () => this.executeToolCall(tc, agentLogs),
+              () => this.executeToolCall(tc, agentLogs, conversationKey),
             );
             history.push({
               role: "tool",
@@ -942,6 +988,7 @@ export class Assistant {
   private async executeToolCall(
     tc: ToolCall,
     agentLogs: string[],
+    conversationKey: string = "default",
   ): Promise<string> {
     const agentName = tc.function.name;
     const recorder = getFlightRecorder();
@@ -981,6 +1028,7 @@ export class Assistant {
       // product disagreeing on the wire is the failure PARITY §0 is about.
       if (!agent) {
         const msg = `Agent '${agentName}' not found.`;
+        this.emitToolEvent(conversationKey, agentName, 'error', started);
         agentLogs.push(formatFlightAgentLog(agentName, msg));
         await recorder.record({
           kind: "tool.call.failed",
@@ -1007,7 +1055,12 @@ export class Assistant {
         const result = await agent.execute(params);
         const resultStr =
           result == null ? "Agent completed successfully" : String(result);
+        // The same classification the Flight Recorder makes two lines below.
+        // An agent reports failure by *resolving* with `{"status":"error"}` as
+        // often as by throwing (#134), so the absence of an exception proves
+        // nothing on its own.
         const failed = agentResultIsError(resultStr);
+        this.emitToolEvent(conversationKey, agentName, failed ? 'error' : 'ok', started);
         let structuredResult: unknown = sanitizeFlightValue(resultStr);
         try {
           structuredResult = sanitizeFlightValue(JSON.parse(resultStr));
@@ -1038,6 +1091,7 @@ export class Assistant {
         return resultStr;
       } catch (err) {
         const message = (err as Error).message;
+        this.emitToolEvent(conversationKey, agentName, 'error', started);
         agentLogs.push(formatFlightAgentLog(agentName, message, true));
         const result = `Error: ${message}`;
         await recorder.record({

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -503,6 +503,15 @@ async function startGatewayInProcess(opts?: {
     return list;
   });
 
+  // `agent.tool` had a listener in the chat UI and no emit site anywhere, so
+  // tool use never appeared (#195). The assistant reports each finished call
+  // and the gateway forwards it; the payload carries the tool's name and
+  // outcome only, never its arguments.
+  const { GatewayEvents } = await import('./gateway/types.js');
+  assistant.onToolEvent = (event) => {
+    server.broadcastEvent(GatewayEvents.AGENT_TOOL, event);
+  };
+
   server.setAgentHandler(async (req, stream) => {
     const conversationKey = req.sessionId || req.conversationId || 'default';
     if (req.conversationHistory) {


### PR DESCRIPTION
Closes the remaining half of #195. The chat UI has registered `gateway.on('agent.tool', …)` since it was written, and the name appeared nowhere else but the `GatewayEvents` catalogue — so tool use never appeared in chat, and never had.

The other half was already done: `channel.status` is emitted from `channels.connect`/`disconnect` (`server.ts:972`), and had correctly come off the shrink-only list. Checking that first is what #179 and #88 taught.

Proved end to end over a real socket rather than at the callback:

```
client received: {"type":"event","event":"agent.tool",
  "payload":{"sessionId":"s1","name":"weather","status":"ok","durationMs":12}}
```

## The payload carries no arguments

Deliberate, and asserted rather than left to review. Tool arguments can hold secrets — the Flight Recorder omits them by default and scrubs opt-in IO for that reason — and this is broadcast to **every subscribed client**, a wider audience than a local trace file. The test serialises the whole event and greps for the scripted call's `hunter2`, so a future field cannot reintroduce it without a named property looking wrong.

## Two bugs in my own implementation, caught by testing rather than review

**Reporting success for a failed tool.** I first emitted `'ok'` after `executeToolCall` returned and `'error'` from the surrounding `catch`. That is wrong twice over: `executeToolCall` swallows the exception and returns `` `Error: …` ``, so the catch never fires; and agents report failure by *resolving* with `{"status":"error"}` at least as often as by throwing (#134). Every failed tool would have been announced as a success — the exact defect class this cleanup keeps removing.

The emit now sits where the outcome is already classified, beside the Flight Recorder's own `tool.call.completed` / `tool.call.failed` decision, using the same `agentResultIsError` predicate. All three outcomes are covered: unknown agent, resolved-with-error, and thrown.

**A nonsense duration.** `started` is a `performance.now()` reading; my helper subtracted it from `Date.now()`.

## My own test suite had a hole, found by mutation testing

Forcing the classifier to `'ok'` passed **6/6**, because my failing-tool fixture *throws* and so never reaches the branch under test. Added an agent that resolves with an error envelope — the #134 shape — and the mutation now fails.

That is the second time this week a guard of mine passed against a deliberately reintroduced bug. Running the mutation is the only reason either was found.

## Tests

`agent-tool-event.test.ts` (7 tests): success, thrown failure, resolved-error failure, no arguments in the payload, a throwing subscriber not breaking the turn (a broadcast must not cost the answer), zero cost when nothing is listening, and that the gateway actually forwards it under the catalogued name — an emitter nobody forwards is the same defect one layer along.

Mutation-tested both ways: silencing the emit fails 3 tests across two files; misclassifying failure fails 1.

`agent.tool` now comes off both `LISTENED_BUT_NEVER_EMITTED` and `DECLARED_BUT_NEVER_EMITTED` in `event-contract-coverage.test.ts`. The first list is now **empty** — every event a client waits for is one the gateway sends.

## Verification

TypeScript **4924 passed**, 21 skipped; Python **1610 passed**; `parity_harness.py --runtime both` PASS; tsc clean; eslint clean at `--max-warnings 0`.
