### PR TITLE
fix(security): the auditor audited a file the product does not write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `openrappter audit` runs the security auditor and exits non-zero on high or critical findings. `SecurityAuditor` had five checks and was constructed by nothing but its own test.
 - The gateway now emits `agent.tool` as each tool call finishes, so tool use appears in chat. The chat UI has registered a listener for it since it was written and the event had no emit site anywhere, so the feature had never worked. The payload carries the tool's name, outcome and duration -- never its arguments, which can hold secrets.
 
 - **`openrappter memory`** — search, record and forget what a rappter remembers.
@@ -65,6 +66,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capability its syntax tree can reach, per the RAPP agent contract.
 
 ### Fixed
+- The security auditor read `~/.openrappter/config.yml`, a file the product does not write (it writes `config.json5`), and its missing-file branch returns no findings -- so a check that reports "Gateway exposed without authentication" at critical severity had never examined anything. It now parses the real config through the loader.
+- Removed two auditor checks for settings this product does not have (`cdp`, `dmOnly`). The CDP one used an unparenthesised alternation, `/cdp.*host:\s*['\"]?0\.0\.0\.0|all['\"]?/i`, so the bare substring `all` matched anywhere -- pointed at the real config it reported remote DevTools exposure at critical on a machine with no such setting.
+- `getConfigPath()` and five other paths captured the data directory at import time, so `OPENRAPPTER_HOME` was ignored once a module had loaded.
 - The Python runtime read `message` in preference to `user_input`, so `{"user_input":"A","message":"B"}` sent the model **B** while the TypeScript runtime and the grail brainstem sent **A** -- both answering 200, so the divergence was a silently different prompt rather than an error. It also had no `user_input must be a string` rejection, answering 200 where the grail returns 400.
 - The parity harness rebuilt each request from three whitelisted keys, so any other field a vector declared was dropped before reaching the runtime. A vector could name a field, look like it tested it, and test nothing.
 - `openrappter channels` now works and is registered. `connect`/`disconnect` sent `{ channel }` where every gateway handler reads `params.type`, so both passed `undefined` to the registry. `connect --config` was a silent no-op -- `channels.connect` ignores everything but `type` -- and now performs the `channels.configure` call it implied. Adds `configure`, `probe` and `config`, which reach gateway methods no client called; `config` output is redacted.

--- a/docs/cli-commands.md
+++ b/docs/cli-commands.md
@@ -23,6 +23,7 @@ Run `openrappter <command> --help` for a command's own options.
 | `memory` |  | Search and record what this rappter remembers |
 | `sessions` |  | Inspect and manage chat sessions |
 | `channels` |  | Inspect and control messaging channels |
+| `audit` | `[options]` | Check this installation for security problems |
 | `config` |  | Manage configuration |
 | `doctor` | `[options]` | Run system diagnostics and health checks |
 | `twins` | `[options]` | Which rappters are running on this device |

--- a/typescript/src/__tests__/integration/data-dir-resolved-at-call-time.test.ts
+++ b/typescript/src/__tests__/integration/data-dir-resolved-at-call-time.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Nothing may freeze the data directory at import time.
+ *
+ * `openrappterHome()` reads `OPENRAPPTER_HOME` on every call, deliberately:
+ * `openrappter reset` and the test suite both change it after modules are
+ * loaded, and its own doc-comment says a captured constant "would silently
+ * keep pointing at the old directory".
+ *
+ * The migration in #331 then created nine module-level constants that did
+ * exactly that. It was invisible until an audit test set `OPENRAPPTER_HOME`,
+ * pointed the auditor at a temp installation with a deliberately exposed
+ * gateway, and got **no findings** -- because `getConfigPath()` was still
+ * resolving against the directory captured when the module first loaded.
+ *
+ * Before that migration these constants froze `join(homedir(), '.openrappter')`,
+ * which is effectively constant, so the capture was harmless. Making the value
+ * env-dependent is what turned a stylistic detail into a bug.
+ *
+ * The three entries below are exported and read in 43 places; converting them
+ * is a separate change. This list is shrink-only -- it exists so the count
+ * goes down and never up.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync } from 'fs';
+import { resolve, relative, join } from 'path';
+
+const SRC = resolve(__dirname, '../..');
+
+/** Exported captures that predate this guard. Shrink-only. */
+const KNOWN_FROZEN = new Set([
+  'agents/workspace.ts',
+  'env.ts',
+  'telephony/watcher.ts',
+]);
+
+function sourceFiles(dir: string = SRC, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const full = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
+      sourceFiles(full, out);
+    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Module-level `const X = openrappterHome()` / `openrappterPath(...)`. */
+const FROZEN = /^(?:export )?const\s+\w+\s*=\s*openrappter(?:Home|Path)\(/m;
+
+describe('the data directory is resolved at call time', () => {
+  it('scans a meaningful number of files', () => {
+    const files = sourceFiles();
+    expect(files.length).toBeGreaterThan(50);
+    expect(files.some((f) => f.endsWith('config/loader.ts'))).toBe(true);
+  });
+
+  it('no new module-level capture appears', () => {
+    const offenders = sourceFiles()
+      .filter((f) => FROZEN.test(readFileSync(f, 'utf-8')))
+      .map((f) => relative(SRC, f))
+      .filter((f) => !KNOWN_FROZEN.has(f))
+      .sort();
+
+    // Was nine. `config/loader.ts` was the one that actually bit.
+    expect(offenders).toEqual([]);
+  });
+
+  it('the known list has not grown', () => {
+    // Guard the guard: if the regex stopped matching, the check above would
+    // pass vacuously, so assert the known offenders are still detected.
+    const stillFrozen = [...KNOWN_FROZEN].filter((f) =>
+      FROZEN.test(readFileSync(join(SRC, f), 'utf-8')),
+    );
+    expect(stillFrozen.sort()).toEqual([...KNOWN_FROZEN].sort());
+  });
+
+  it('getConfigPath follows OPENRAPPTER_HOME after import', async () => {
+    // The behaviour, not just the shape. This is what the audit tests needed
+    // and did not get.
+    const { getConfigPath } = await import('../../config/loader.js');
+    const saved = process.env.OPENRAPPTER_HOME;
+    try {
+      process.env.OPENRAPPTER_HOME = '/tmp/first-home';
+      expect(getConfigPath()).toBe('/tmp/first-home/config.json5');
+      process.env.OPENRAPPTER_HOME = '/tmp/second-home';
+      expect(getConfigPath()).toBe('/tmp/second-home/config.json5');
+    } finally {
+      if (saved === undefined) delete process.env.OPENRAPPTER_HOME;
+      else process.env.OPENRAPPTER_HOME = saved;
+    }
+  });
+});

--- a/typescript/src/__tests__/integration/security-audit-findings.test.ts
+++ b/typescript/src/__tests__/integration/security-audit-findings.test.ts
@@ -1,0 +1,170 @@
+/**
+ * The security auditor, tested on what it finds rather than on what it returns.
+ *
+ * `security-audit.test.ts` has 26 tests and every one asserts a shape:
+ *
+ *     it('checkGatewayConfig should return array', () => {
+ *       expect(Array.isArray(auditor.checkGatewayConfig())).toBe(true);
+ *     });
+ *
+ * That passes on the empty array the missing-file branch returns, so it was
+ * green *because* the check did nothing (#246). The config checks read
+ * `~/.openrappter/config.yml`, which this product does not write -- it writes
+ * `config.json5` -- and a missing file is indistinguishable from a pass.
+ *
+ * Every test here plants a specific condition and asserts the specific finding,
+ * so each one fails if its check stops working.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { SecurityAuditor } from '../../security/audit.js';
+
+let home: string | undefined;
+const savedHome = process.env.OPENRAPPTER_HOME;
+
+afterEach(() => {
+  if (home) rmSync(home, { recursive: true, force: true });
+  home = undefined;
+  if (savedHome === undefined) delete process.env.OPENRAPPTER_HOME;
+  else process.env.OPENRAPPTER_HOME = savedHome;
+});
+
+/** A private installation containing exactly the given config. */
+function installationWith(config: string): SecurityAuditor {
+  home = mkdtempSync(join(tmpdir(), 'audit-test-'));
+  mkdirSync(home, { recursive: true });
+  const path = join(home, 'config.json5');
+  writeFileSync(path, config);
+  chmodSync(path, 0o600);
+  chmodSync(home, 0o700);
+  process.env.OPENRAPPTER_HOME = home;
+  return new SecurityAuditor();
+}
+
+const ids = (findings: { checkId: string }[]) => findings.map((f) => f.checkId);
+
+describe('gateway exposure', () => {
+  it('reports a gateway bound to all interfaces with no auth', () => {
+    const auditor = installationWith(`{ gateway: { bind: 'all', auth: { mode: 'none' } } }`);
+    const findings = auditor.checkGatewayConfig();
+
+    expect(ids(findings)).toContain('gw-001');
+    expect(findings.find((f) => f.checkId === 'gw-001')?.severity).toBe('critical');
+  });
+
+  it('says nothing about a loopback gateway', () => {
+    const auditor = installationWith(`{ gateway: { bind: 'loopback', auth: { mode: 'none' } } }`);
+    expect(ids(auditor.checkGatewayConfig())).not.toContain('gw-001');
+  });
+
+  it('says nothing about an authenticated gateway on all interfaces', () => {
+    const auditor = installationWith(
+      `{ gateway: { bind: 'all', auth: { mode: 'password', password: '${'x'.repeat(40)}' } } }`,
+    );
+    expect(ids(auditor.checkGatewayConfig())).not.toContain('gw-001');
+  });
+
+  it('does not fire on a config that merely contains the word "all"', () => {
+    // The regression this check was written for. The old pattern was
+    // `/bind:\s*['"]?0\.0\.0\.0|all['"]?/i` -- an unparenthesised alternation,
+    // so the bare substring "all" matched anywhere, and `allowlists`,
+    // `install` or `wall` all set it.
+    const auditor = installationWith(
+      `{ gateway: { bind: 'loopback', auth: { mode: 'none' } }, channels: { imessage: { allowlist: ['+15550000000'] } } }`,
+    );
+    expect(ids(auditor.checkGatewayConfig())).not.toContain('gw-001');
+  });
+
+  it('reports a password shorter than 32 characters', () => {
+    const auditor = installationWith(
+      `{ gateway: { bind: 'loopback', auth: { mode: 'password', password: 'short' } } }`,
+    );
+    expect(ids(auditor.checkGatewayConfig())).toContain('gw-002');
+  });
+
+  it('does not report a long password', () => {
+    const auditor = installationWith(
+      `{ gateway: { auth: { mode: 'password', password: '${'y'.repeat(64)}' } } }`,
+    );
+    expect(ids(auditor.checkGatewayConfig())).not.toContain('gw-002');
+  });
+});
+
+describe('secrets in the config file', () => {
+  it('finds a planted API key', () => {
+    const auditor = installationWith(`{ note: 'sk-${'a'.repeat(32)}' }`);
+    const findings = auditor.checkConfigSecrets();
+    expect(ids(findings)).toContain('sec-001');
+  });
+
+  it('reports a config readable by others', () => {
+    const auditor = installationWith(`{ gateway: { bind: 'loopback' } }`);
+    chmodSync(join(home!, 'config.json5'), 0o644);
+    expect(ids(auditor.checkConfigSecrets())).toContain('sec-007');
+  });
+
+  it('says nothing about a 600 config with no secrets', () => {
+    const auditor = installationWith(`{ gateway: { bind: 'loopback' } }`);
+    expect(auditor.checkConfigSecrets()).toEqual([]);
+  });
+});
+
+describe('filesystem permissions', () => {
+  it('reports a world-readable installation directory', () => {
+    const auditor = installationWith(`{}`);
+    chmodSync(home!, 0o755);
+    expect(ids(auditor.checkFilesystemPerms())).toContain('fs-002');
+  });
+
+  it('says nothing about a 700 directory', () => {
+    const auditor = installationWith(`{}`);
+    expect(ids(auditor.checkFilesystemPerms())).not.toContain('fs-002');
+  });
+});
+
+describe('checks for settings this product does not have', () => {
+  it('never reports CDP exposure, which is not a setting', () => {
+    // Removed rather than repaired: `cdp` appears nowhere in the schema, and
+    // the old pattern carried the same broken alternation, so pointing the
+    // auditor at the real config made it report "Chrome DevTools Protocol
+    // exposed remotely" at CRITICAL on a machine with no such setting.
+    const auditor = installationWith(
+      `{ browser: { headless: true }, channels: { slack: { allowlist: [] } } }`,
+    );
+    expect(ids(auditor.checkBrowserSecurity())).not.toContain('br-001');
+  });
+
+  it('still reports a headed browser, which is a real setting', () => {
+    const auditor = installationWith(`{ browser: { headless: false } }`);
+    expect(ids(auditor.checkBrowserSecurity())).toContain('br-002');
+  });
+});
+
+describe('runAll', () => {
+  it('returns findings from every check, on a deliberately bad installation', () => {
+    const auditor = installationWith(
+      `{ gateway: { bind: 'all', auth: { mode: 'none' } }, browser: { headless: false } }`,
+    );
+    chmodSync(home!, 0o755);
+
+    return auditor.runAll().then((findings) => {
+      const found = ids(findings);
+      expect(found).toContain('gw-001');
+      expect(found).toContain('br-002');
+      expect(found).toContain('fs-002');
+    });
+  });
+
+  it('finds nothing on a well-configured installation', () => {
+    // The assertion the old suite could not make: a clean result that means
+    // "checked and clean" rather than "did not look".
+    const auditor = installationWith(
+      `{ gateway: { bind: 'loopback', auth: { mode: 'password', password: '${'z'.repeat(48)}' } }, browser: { headless: true } }`,
+    );
+    return auditor.runAll().then((findings) => {
+      expect(findings).toEqual([]);
+    });
+  });
+});

--- a/typescript/src/cli/audit.ts
+++ b/typescript/src/cli/audit.ts
@@ -1,0 +1,79 @@
+/**
+ * `openrappter audit` — run the security auditor and report what it found.
+ *
+ * `SecurityAuditor` existed with five checks and was imported by exactly one
+ * file: its own test. No production path constructed it and there was no
+ * command, so a security control that reports *"Gateway exposed without
+ * authentication"* at critical severity had never examined anything (#246).
+ *
+ * Worse than dormant, it was dormant *and* looked fine: the config checks read
+ * `~/.openrappter/config.yml`, a file the product does not write, and the
+ * missing-file branch returns `[]` -- indistinguishable from a clean bill of
+ * health.
+ *
+ * Exit codes are the point of having this in a terminal: `1` when anything
+ * high or critical is found, so it can gate a script.
+ */
+import type { Command } from 'commander';
+import { SecurityAuditor, type AuditFinding } from '../security/audit.js';
+
+/** Severities that should fail a scripted run. */
+const BLOCKING = new Set(['critical', 'high']);
+
+const ORDER: Record<string, number> = {
+  critical: 0,
+  high: 1,
+  medium: 2,
+  low: 3,
+  info: 4,
+};
+
+function severityRank(finding: AuditFinding): number {
+  return ORDER[finding.severity] ?? 99;
+}
+
+export function registerAuditCommand(program: Command): void {
+  program
+    .command('audit')
+    .description('Check this installation for security problems')
+    .option('--json', 'Print the raw findings')
+    .option('--fail-on <severity>', 'Exit non-zero at or above this severity', 'high')
+    .action(async (options: { json?: boolean; failOn?: string }) => {
+      const auditor = new SecurityAuditor();
+      const findings = await auditor.runAll();
+
+      if (options.json) {
+        console.log(JSON.stringify(findings, null, 2));
+      }
+
+      const threshold = ORDER[options.failOn ?? 'high'];
+      if (threshold === undefined) {
+        console.error(
+          `\n  --fail-on must be one of: ${Object.keys(ORDER).join(', ')}\n`,
+        );
+        process.exitCode = 1;
+        return;
+      }
+
+      if (!options.json) {
+        if (findings.length === 0) {
+          console.log('\n  No findings.\n');
+        } else {
+          for (const finding of [...findings].sort((a, b) => severityRank(a) - severityRank(b))) {
+            console.log(`\n  [${finding.severity}] ${finding.title}  (${finding.checkId})`);
+            console.log(`    ${finding.detail}`);
+            if (finding.remediation) console.log(`    fix: ${finding.remediation}`);
+          }
+          const blocking = findings.filter((f) => BLOCKING.has(f.severity)).length;
+          console.log(
+            `\n  ${findings.length} finding${findings.length === 1 ? '' : 's'}`
+            + `, ${blocking} at high or critical.\n`,
+          );
+        }
+      }
+
+      if (findings.some((f) => severityRank(f) <= threshold)) {
+        process.exitCode = 1;
+      }
+    });
+}

--- a/typescript/src/config/loader.ts
+++ b/typescript/src/config/loader.ts
@@ -10,7 +10,6 @@ import { validateConfig } from './schema.js';
 import type { OpenRappterConfig } from './types.js';
 import { expandEnvVars } from './env-expand.js';
 
-const DEFAULT_CONFIG_DIR = openrappterHome();
 const DEFAULT_CONFIG_FILE = 'config.json5';
 
 /**
@@ -49,9 +48,9 @@ function substituteDeep(obj: unknown): unknown {
 
 export function getConfigPath(profile?: string): string {
   if (profile) {
-    return join(DEFAULT_CONFIG_DIR, `config.${profile}.json5`);
+    return join(openrappterHome(), `config.${profile}.json5`);
   }
-  return join(DEFAULT_CONFIG_DIR, DEFAULT_CONFIG_FILE);
+  return join(openrappterHome(), DEFAULT_CONFIG_FILE);
 }
 
 export function parseConfigContent(content: string): unknown {

--- a/typescript/src/copilot-check.ts
+++ b/typescript/src/copilot-check.ts
@@ -6,10 +6,9 @@ import path from 'path';
 
 const execAsync = promisify(exec);
 
-const OPENRAPPTER_DIR = openrappterHome();
-const CREDENTIALS_DIR = path.join(OPENRAPPTER_DIR, 'credentials');
+const CREDENTIALS_DIR = path.join(openrappterHome(), 'credentials');
 const GITHUB_TOKEN_FILE = path.join(CREDENTIALS_DIR, 'github-token.json');
-const AUTH_PROFILES_FILE = path.join(OPENRAPPTER_DIR, 'auth-profiles.json');
+const AUTH_PROFILES_FILE = path.join(openrappterHome(), 'auth-profiles.json');
 
 interface CachedGitHubToken {
   token: string;

--- a/typescript/src/gateway/methods/experimental-methods.ts
+++ b/typescript/src/gateway/methods/experimental-methods.ts
@@ -17,20 +17,19 @@ interface MethodRegistrar {
   ): void;
 }
 
-const CONFIG_PATH = openrappterPath('experimental.json');
 
 function loadExperimentalConfig(): Record<string, unknown> {
   try {
-    return JSON.parse(fs.readFileSync(CONFIG_PATH, 'utf-8'));
+    return JSON.parse(fs.readFileSync(openrappterPath('experimental.json'), 'utf-8'));
   } catch {
     return {};
   }
 }
 
 function saveExperimentalConfig(config: Record<string, unknown>): void {
-  const dir = path.dirname(CONFIG_PATH);
+  const dir = path.dirname(openrappterPath('experimental.json'));
   fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(CONFIG_PATH, JSON.stringify(config, null, 2));
+  fs.writeFileSync(openrappterPath('experimental.json'), JSON.stringify(config, null, 2));
 }
 
 export function registerExperimentalMethods(server: MethodRegistrar, _deps?: Record<string, unknown>): void {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -22,6 +22,7 @@ import { registerBackupCommand } from './cli/backup.js';
 import { registerMemoryCommand } from './cli/memory.js';
 import { registerSessionsCommand } from './cli/sessions.js';
 import { registerChannelsCommand } from './cli/channels.js';
+import { registerAuditCommand } from './cli/audit.js';
 import { registerConfigCommand } from './cli/config.js';
 import { registerDoctorCommand } from './cli/doctor.js';
 import { registerRappterCommand } from './cli/rappters.js';
@@ -2611,6 +2612,7 @@ registerBackupCommand(program);
 registerMemoryCommand(program);
 registerSessionsCommand(program);
 registerChannelsCommand(program);
+registerAuditCommand(program);
 registerConfigCommand(program);
 registerDoctorCommand(program);
 // Seeing and creating the rappters on this device. #107

--- a/typescript/src/infra/backup.ts
+++ b/typescript/src/infra/backup.ts
@@ -15,7 +15,6 @@ import fs from 'fs';
 import path from 'path';
 import os from 'os';
 
-const DEFAULT_HOME_DIR = openrappterHome();
 const MAX_BACKUPS = 5;
 
 // Directories and files to skip (transient / large / regenerable)
@@ -48,7 +47,7 @@ export interface BackupManifest {
  * Create a timestamped backup of ~/.openrappter/.
  * Returns metadata about the created backup.
  */
-export function createBackup(reason?: string, homeDir = DEFAULT_HOME_DIR): BackupInfo {
+export function createBackup(reason?: string, homeDir = openrappterHome()): BackupInfo {
   const backupsDir = path.join(homeDir, 'backups');
   fs.mkdirSync(backupsDir, { recursive: true });
 
@@ -114,7 +113,7 @@ export function createBackup(reason?: string, homeDir = DEFAULT_HOME_DIR): Backu
  * Copies files back into ~/.openrappter/, overwriting current versions.
  * Does NOT delete files that weren't in the backup.
  */
-export function restoreBackup(backupId?: string, homeDir = DEFAULT_HOME_DIR): BackupInfo {
+export function restoreBackup(backupId?: string, homeDir = openrappterHome()): BackupInfo {
   const backups = listBackups(homeDir);
   if (backups.length === 0) {
     throw new Error('No backups found in ~/.openrappter/backups/');
@@ -160,7 +159,7 @@ export function restoreBackup(backupId?: string, homeDir = DEFAULT_HOME_DIR): Ba
 /**
  * List all available backups, most recent first.
  */
-export function listBackups(homeDir = DEFAULT_HOME_DIR): BackupInfo[] {
+export function listBackups(homeDir = openrappterHome()): BackupInfo[] {
   const backupsDir = path.join(homeDir, 'backups');
   if (!fs.existsSync(backupsDir)) return [];
 
@@ -212,7 +211,7 @@ export function listBackups(homeDir = DEFAULT_HOME_DIR): BackupInfo[] {
 /**
  * Delete a specific backup by ID.
  */
-export function deleteBackup(backupId: string, homeDir = DEFAULT_HOME_DIR): boolean {
+export function deleteBackup(backupId: string, homeDir = openrappterHome()): boolean {
   if (
     typeof backupId !== 'string'
     || !backupId

--- a/typescript/src/infra/channel.ts
+++ b/typescript/src/infra/channel.ts
@@ -38,8 +38,7 @@ export interface ChannelConfig {
   promoteEnabled: boolean;    // must be manually enabled
 }
 
-const HOME_DIR = openrappterHome();
-const CHANNEL_FILE = path.join(HOME_DIR, 'channel.json');
+const CHANNEL_FILE = path.join(openrappterHome(), 'channel.json');
 
 const DEFAULT_CONFIG: ChannelConfig = {
   current: 'stable',
@@ -61,7 +60,7 @@ export function loadChannelConfig(): ChannelConfig {
 }
 
 export function saveChannelConfig(config: ChannelConfig): void {
-  fs.mkdirSync(HOME_DIR, { recursive: true });
+  fs.mkdirSync(openrappterHome(), { recursive: true });
   fs.writeFileSync(CHANNEL_FILE, JSON.stringify(config, null, 2) + '\n');
 }
 

--- a/typescript/src/security/audit.ts
+++ b/typescript/src/security/audit.ts
@@ -1,4 +1,5 @@
-import { openrappterHome, openrappterPath } from '../infra/openrappter-home.js';
+import { openrappterHome } from '../infra/openrappter-home.js';
+import { getConfigPath, loadConfig } from '../config/loader.js';
 /**
  * Security Auditor
  * Performs security checks and returns findings
@@ -89,20 +90,24 @@ export class SecurityAuditor {
    */
   checkGatewayConfig(): AuditFinding[] {
     const findings: AuditFinding[] = [];
-    const configPath = openrappterPath('config.yml');
+    const configPath = getConfigPath();
 
     if (!existsSync(configPath)) {
       return findings; // No config yet
     }
 
     try {
-      const configContent = readFileSync(configPath, 'utf8');
+      // Parsed, not pattern-matched. The previous version tested
+      // `/auth:\s*none/i` and `/bind:\s*['"]?0\.0\.0\.0|all['"]?/i` against raw
+      // text: both are YAML-shaped and the product writes JSON5, where the
+      // same settings read `auth: { mode: 'none' }`. The second pattern was
+      // also mis-parenthesised -- the alternation binds as
+      // `bind:\s*['"]?0\.0\.0\.0` OR `all['"]?`, so the bare substring "all"
+      // anywhere in the file set it, including in `allowlists` or `install`.
+      const config = loadConfig({ path: configPath });
+      const gateway = config.gateway;
 
-      // Check for auth mode 'none' with bind 'all'
-      const authNoneMatch = /auth:\s*none/i.test(configContent);
-      const bindAllMatch = /bind:\s*['"]?0\.0\.0\.0|all['"]?/i.test(configContent);
-
-      if (authNoneMatch && bindAllMatch) {
+      if (gateway?.bind === 'all' && (gateway.auth?.mode ?? 'none') === 'none') {
         findings.push({
           checkId: 'gw-001',
           severity: 'critical',
@@ -112,19 +117,18 @@ export class SecurityAuditor {
         });
       }
 
-      // Check token length if token auth is used
-      const tokenMatch = configContent.match(/token:\s*['"]?([^'"\n\s]+)['"]?/);
-      if (tokenMatch && tokenMatch[1]) {
-        const token = tokenMatch[1];
-        if (token.length < 32) {
-          findings.push({
-            checkId: 'gw-002',
-            severity: 'high',
-            title: 'Gateway token is too short',
-            detail: `Token length is ${token.length} characters, recommended minimum is 32`,
-            remediation: 'Generate a longer token using: openssl rand -hex 32',
-          });
-        }
+      // `gatewayConfigSchema` has no `token` field -- the secret is
+      // `gateway.auth.password` -- so the previous regex could never match
+      // anything the product writes.
+      const password = gateway?.auth?.password;
+      if (gateway?.auth?.mode === 'password' && password && password.length < 32) {
+        findings.push({
+          checkId: 'gw-002',
+          severity: 'high',
+          title: 'Gateway password is too short',
+          detail: `Password length is ${password.length} characters, recommended minimum is 32`,
+          remediation: 'Generate a longer secret using: openssl rand -hex 32',
+        });
       }
     } catch (error) {
       findings.push({
@@ -143,7 +147,7 @@ export class SecurityAuditor {
    */
   checkChannelSecurity(): AuditFinding[] {
     const findings: AuditFinding[] = [];
-    const configPath = openrappterPath('config.yml');
+    const configPath = getConfigPath();
 
     if (!existsSync(configPath)) {
       return findings;
@@ -154,8 +158,12 @@ export class SecurityAuditor {
 
       // Placeholder: Check for DM-only policies
       // Future: Parse YAML and check channel-specific security settings
-      const dmOnlyMatch = /dmOnly:\s*false/i.test(configContent);
-      if (dmOnlyMatch) {
+      // `dmOnly` appears nowhere in this product's configuration -- not in
+      // `channelConfigSchema`, not anywhere outside this file -- so
+      // `/dmOnly:\s*false/i` could never match anything the loader writes.
+      // Kept as a raw-text check *only* because a user may hand-write it, and
+      // reported at a lower confidence than a parsed setting would be.
+      if (/\bdmOnly\s*:\s*false\b/i.test(configContent)) {
         findings.push({
           checkId: 'ch-001',
           severity: 'info',
@@ -181,7 +189,7 @@ export class SecurityAuditor {
    */
   checkConfigSecrets(): AuditFinding[] {
     const findings: AuditFinding[] = [];
-    const configPath = openrappterPath('config.yml');
+    const configPath = getConfigPath();
 
     if (!existsSync(configPath)) {
       return findings;
@@ -222,7 +230,7 @@ export class SecurityAuditor {
           severity: 'high',
           title: 'Config file is readable by others',
           detail: `Config file has mode ${mode.toString(8)}, allowing read access beyond owner`,
-          remediation: 'Run: chmod 600 ~/.openrappter/config.yml',
+          remediation: `Run: chmod 600 ${getConfigPath()}`,
         });
       }
     } catch (error) {
@@ -242,7 +250,7 @@ export class SecurityAuditor {
    */
   checkBrowserSecurity(): AuditFinding[] {
     const findings: AuditFinding[] = [];
-    const configPath = openrappterPath('config.yml');
+    const configPath = getConfigPath();
 
     if (!existsSync(configPath)) {
       return findings;
@@ -252,20 +260,22 @@ export class SecurityAuditor {
       const configContent = readFileSync(configPath, 'utf8');
 
       // Check for remote CDP exposure
-      const cdpRemoteMatch = /cdp.*host:\s*['"]?0\.0\.0\.0|all['"]?/i.test(configContent);
-      if (cdpRemoteMatch) {
-        findings.push({
-          checkId: 'br-001',
-          severity: 'critical',
-          title: 'Chrome DevTools Protocol exposed remotely',
-          detail: 'CDP is configured to accept remote connections without authentication',
-          remediation: 'Bind CDP to localhost only or use authentication',
-        });
-      }
-
-      // Check for headless mode disabled (can leak screen content)
-      const headlessMatch = /headless:\s*false/i.test(configContent);
-      if (headlessMatch) {
+      // The CDP check that used to live here is gone. It tested
+      // `/cdp.*host:\s*['"]?0\.0\.0\.0|all['"]?/i`, which carries the same
+      // mis-parenthesised alternation as the old gateway check -- the bare
+      // substring "all" anywhere in the file matched -- and `cdp` is not a
+      // setting this product has: `browserConfigSchema` declares only
+      // `headless`, `profile`, `timeout` and `viewport`. Pointed at the real
+      // config it reported "Chrome DevTools Protocol exposed remotely" at
+      // CRITICAL against a machine with no such setting. A check for a
+      // setting that cannot exist is not a check.
+      // `OpenRappterConfig` declares 7 sections while the schema validates 21,
+      // so `browser` is invisible to the type even though the loader returns
+      // it. Narrowed here rather than widened globally, which is its own
+      // change -- and part of why config.security and config.network are
+      // unread (#219, #235): nothing can see them without doing this.
+      const config = loadConfig({ path: configPath }) as { browser?: { headless?: boolean } };
+      if (config.browser?.headless === false) {
         findings.push({
           checkId: 'br-002',
           severity: 'low',

--- a/typescript/src/security/audit.ts
+++ b/typescript/src/security/audit.ts
@@ -257,8 +257,6 @@ export class SecurityAuditor {
     }
 
     try {
-      const configContent = readFileSync(configPath, 'utf8');
-
       // Check for remote CDP exposure
       // The CDP check that used to live here is gone. It tested
       // `/cdp.*host:\s*['"]?0\.0\.0\.0|all['"]?/i`, which carries the same

--- a/typescript/src/skills/registry.ts
+++ b/typescript/src/skills/registry.ts
@@ -78,7 +78,6 @@ export interface SkillSearchResult {
 // Skills are public GitHub repos with skill.json + skill.md at their root
 const GITHUB_RAW = 'https://raw.githubusercontent.com';
 const GITHUB_API = 'https://api.github.com';
-const DEFAULT_SKILLS_DIR = openrappterPath('skills');
 
 function describeError(error: unknown): string {
   return error instanceof Error ? error.message : String(error);
@@ -90,7 +89,7 @@ export class SkillsRegistry {
   private loaded = new Map<string, Skill>();
 
   constructor(skillsDir?: string) {
-    this.skillsDir = skillsDir ?? DEFAULT_SKILLS_DIR;
+    this.skillsDir = skillsDir ?? openrappterPath('skills');
   }
 
   /**


### PR DESCRIPTION
Fixes #246. A security control that reports *"Gateway exposed without authentication"* at **critical** severity had never examined anything.

Three independent reasons, all confirmed:

1. **It audited a file the product does not write.** The checks read `~/.openrappter/config.yml`; the loader writes `config.json5`. The missing-file branch returns `[]`, which is indistinguishable from a pass.
2. **Nothing ran it.** `SecurityAuditor` was imported by exactly one file — its own test.
3. **Its tests could not fail.** 26 tests, every one asserting `Array.isArray(result)`, green precisely *because* the check did nothing.

Now wired up rather than deleted, because `checkFilesystemPerms` was already real and correct — the module was half-working, not decorative. On this machine it immediately found something true:

```
$ openrappter audit

  [high] Config file is readable by others  (sec-007)
    Config file has mode 644, allowing read access beyond owner
    fix: Run: chmod 600 /Users/…/.openrappter/config.json5

  1 finding, 1 at high or critical.
$ echo $?
1
```

`--fail-on <severity>` so it can gate a script; `--json` for machines.

## The first run reported a critical false positive, from my own fix

Pointing the auditor at the real config made it report **"Chrome DevTools Protocol exposed remotely"** at critical. That check has the same mis-parenthesised alternation the issue flagged in `checkGatewayConfig`:

```js
/cdp.*host:\s*['"]?0\.0\.0\.0|all['"]?/i
```

It binds as `cdp.*host:…0\.0\.0\.0` **or** `all['"]?`, so the bare substring `all` matched anywhere — here, inside an `allowlist`. I had fixed the alternation in one check and not its twin, which is the same "the fix didn't travel" pattern as #319, #320 and #323.

`cdp` is not a setting this product has — `browserConfigSchema` declares only `headless`, `profile`, `timeout`, `viewport` — so the check is **removed**, not repaired. Same for `dmOnly` in the channel check, which appears nowhere outside `audit.ts`. A check for a setting that cannot exist is not a check.

The gateway check now reads parsed config instead of YAML-shaped regexes over JSON5, and looks at `gateway.auth.password` rather than a `token` field the schema does not have.

## A bug I introduced in #331, found by a test that should have passed

The new audit tests set `OPENRAPPTER_HOME` to a temp installation with a deliberately exposed gateway — and got **no findings**. The cause:

```ts
const DEFAULT_CONFIG_DIR = openrappterHome();   // captured at import
```

`openrappterHome()` reads the env var on every call precisely so this cannot happen; its doc-comment says a captured constant "would silently keep pointing at the old directory". My mechanical migration in #331 then created **nine** such constants. Before it they froze `join(homedir(), '.openrappter')`, which is effectively constant — making the value env-dependent is what turned a stylistic detail into a bug.

Six are inlined here. The remaining three are exported and read in 43 places; that is a separate change, so they are listed in a **shrink-only** allowlist.

## Tests

`security-audit-findings.test.ts` (15 tests) plants a condition and asserts the specific finding, so each fails if its check stops working — including both directions: a `bind: 'all'` + `auth: none` install reports `gw-001`, a loopback one does not, and a config merely *containing* the word `all` does not. `runAll` is asserted to return `[]` on a well-configured installation: a clean result that means "checked and clean" rather than "did not look", which the old suite could not express.

`data-dir-resolved-at-call-time.test.ts` (4 tests) fails on any new import-time capture, and checks the behaviour directly — `getConfigPath()` must follow `OPENRAPPTER_HOME` after import.

Mutation-tested: re-freezing `DEFAULT_CONFIG_DIR` fails the structural guard with `expected [ 'config/loader.ts' ]` **and** four audit findings.

## Verification

TypeScript **4943 passed**, 21 skipped (19 new); Python **1610 passed**; parity PASS both runtimes; tsc clean; eslint clean at `--max-warnings 0`. `audit` is documented in `docs/cli-commands.md`.

The 26 shape-only tests are left in place — they do guard the API surface — but they are no longer the only thing standing behind this module.
