### PR TITLE
fix(config): the config type declared 6 of the 21 sections the schema validates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capability its syntax tree can reach, per the RAPP agent contract.
 
 ### Fixed
+- `OpenRappterConfig` was hand-written and declared **6** sections while the schema validating it declared **21**, so fifteen sections -- including `security`, `network`, `voice` and `plugins` -- were parsed and then invisible to every consumer: reading them was a compile error. The type is now derived from the schema, so the two cannot diverge.
 - The security auditor read `~/.openrappter/config.yml`, a file the product does not write (it writes `config.json5`), and its missing-file branch returns no findings -- so a check that reports "Gateway exposed without authentication" at critical severity had never examined anything. It now parses the real config through the loader.
 - Removed two auditor checks for settings this product does not have (`cdp`, `dmOnly`). The CDP one used an unparenthesised alternation, `/cdp.*host:\s*['\"]?0\.0\.0\.0|all['\"]?/i`, so the bare substring `all` matched anywhere -- pointed at the real config it reported remote DevTools exposure at critical on a machine with no such setting.
 - `getConfigPath()` and five other paths captured the data directory at import time, so `OPENRAPPTER_HOME` was ignored once a module had loaded.

--- a/typescript/src/__tests__/integration/config-type-coverage.test.ts
+++ b/typescript/src/__tests__/integration/config-type-coverage.test.ts
@@ -1,0 +1,78 @@
+/**
+ * The config type must cover every section the schema validates.
+ *
+ * `OpenRappterConfig` was hand-written and listed **6** sections while
+ * `openRappterConfigSchema` validated **21**. The loader parses with the
+ * schema and returns this type, so fifteen sections were accepted, validated,
+ * and then invisible to every consumer: reading `config.security` or
+ * `config.network` was a compile error, and the only way to reach one was a
+ * local cast — which `security/audit.ts` had to do to see `config.browser`.
+ *
+ * That is a structural reason `config.security` (#219) and `config.network`
+ * (#235) are read by nothing. A section nothing can name without a cast is not
+ * going to grow a consumer by accident.
+ *
+ * The type is now `z.infer<typeof openRappterConfigSchema>`, so the two cannot
+ * diverge. This file exists because a derived type is easy to un-derive: it
+ * pins the count against `contracts/config-sections.json`, the same file both
+ * runtimes already test against (#312).
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { openRappterConfigSchema } from '../../config/schema.js';
+
+const CONTRACT = resolve(__dirname, '../../../../contracts/config-sections.json');
+
+/** Section names the schema accepts, read from the schema itself. */
+function schemaSections(): string[] {
+  return Object.keys(openRappterConfigSchema.shape).sort();
+}
+
+function contractSections(): string[] {
+  return [...(JSON.parse(readFileSync(CONTRACT, 'utf-8')).sections as string[])].sort();
+}
+
+describe('the config type covers every validated section', () => {
+  it('the schema and the contract agree', () => {
+    // Anti-vacuity: a schema that lost its shape would make everything below
+    // trivially true.
+    expect(schemaSections().length).toBeGreaterThanOrEqual(20);
+    expect(schemaSections()).toEqual(contractSections());
+  });
+
+  it('the type is derived from the schema, not restated', () => {
+    // The mechanism, pinned. A future hand-written interface would compile
+    // fine and silently reintroduce the gap, so assert how it is defined.
+    const source = readFileSync(resolve(__dirname, '../../config/types.ts'), 'utf-8');
+    expect(source).toMatch(
+      /export type OpenRappterConfig = z\.infer<typeof openRappterConfigSchema>/,
+    );
+    expect(source).not.toMatch(/export interface OpenRappterConfig\b/);
+  });
+
+  it('sections that were invisible are reachable without a cast', () => {
+    // These are the ones the hand-written interface omitted. This is a
+    // compile-time assertion: if the type stopped covering them, tsc fails
+    // before the test runs.
+    const sections: Array<keyof import('../../config/types.js').OpenRappterConfig> = [
+      'security',
+      'network',
+      'browser',
+      'voice',
+      'plugins',
+      'logging',
+      'session',
+      'tools',
+      'ui',
+      'hooks',
+      'media',
+      'experimental',
+      'env',
+      'auth',
+    ];
+    for (const name of sections) {
+      expect(schemaSections()).toContain(name as string);
+    }
+  });
+});

--- a/typescript/src/config/types.ts
+++ b/typescript/src/config/types.ts
@@ -1,3 +1,5 @@
+import type { z } from 'zod';
+import type { openRappterConfigSchema } from './schema.js';
 /**
  * Configuration system types
  */
@@ -49,17 +51,22 @@ export interface MemoryConfig {
   chunkOverlap: number;
 }
 
-export interface OpenRappterConfig {
-  models?: ModelConfig[];
-  agents?: {
-    list?: AgentConfig[];
-    defaults?: Partial<AgentConfig>;
-  };
-  channels?: Record<string, ChannelConfig>;
-  gateway?: GatewayConfig;
-  cron?: { enabled: boolean };
-  memory?: MemoryConfig;
-}
+/**
+ * The shape `loadConfig()` returns — derived from the schema that validates it.
+ *
+ * This was a hand-written interface listing **6** sections while
+ * `openRappterConfigSchema` validated **21**. The loader parses with the
+ * schema and returns this type, so fifteen sections were accepted, validated
+ * and then invisible: reading `config.security` or `config.network` was a type
+ * error, and the only way to reach one was a local cast.
+ *
+ * That is a structural reason those sections are read by nothing (#219, #235),
+ * not a coincidence — and `security/audit.ts` had to cast to see `browser`.
+ *
+ * Deriving it means the two cannot drift again: adding a section to the schema
+ * adds it here.
+ */
+export type OpenRappterConfig = z.infer<typeof openRappterConfigSchema>;
 
 export interface ConfigWatcherOptions {
   path: string;

--- a/typescript/src/security/audit.ts
+++ b/typescript/src/security/audit.ts
@@ -267,12 +267,7 @@ export class SecurityAuditor {
       // config it reported "Chrome DevTools Protocol exposed remotely" at
       // CRITICAL against a machine with no such setting. A check for a
       // setting that cannot exist is not a check.
-      // `OpenRappterConfig` declares 7 sections while the schema validates 21,
-      // so `browser` is invisible to the type even though the loader returns
-      // it. Narrowed here rather than widened globally, which is its own
-      // change -- and part of why config.security and config.network are
-      // unread (#219, #235): nothing can see them without doing this.
-      const config = loadConfig({ path: configPath }) as { browser?: { headless?: boolean } };
+      const config = loadConfig({ path: configPath });
       if (config.browser?.headless === false) {
         findings.push({
           checkId: 'br-002',


### PR DESCRIPTION
A prerequisite for #219 and #235, found while writing the cast that #337 needed to read `config.browser`.

`OpenRappterConfig` was hand-written. Measured against the schema that validates it:

```
contract sections : 21     (contracts/config-sections.json)
zod schema        : 21
TS interface      :  6

in the schema, missing from the interface:
  auth, browser, configVersion, env, experimental, hooks, logging,
  media, network, plugins, security, session, tools, ui, voice
```

`loadConfig()` parses with the schema and returns this type, so those fifteen sections were accepted, validated, and then **invisible**. Reading `config.security` or `config.network` was a compile error, and the only way to reach one was a local cast.

## Why this matters for #219 and #235

Both issues are "this config section is declared and read by nothing". This is a structural reason why, not a coincidence: a section nothing can *name* without a cast is not going to grow a consumer by accident. Whoever wires up `config.security` would have hit this first, and had the choice of widening the type or quietly casting — and #337 shows which one happens under time pressure, because that is what I did.

This does not close either issue. It removes the obstacle in front of them.

## The fix

```ts
export type OpenRappterConfig = z.infer<typeof openRappterConfigSchema>;
```

`tsc --noEmit` is clean across the repo with no other changes, and the cast added in #337 is now unnecessary and removed. Verified the previously-invisible sections are reachable without one:

```ts
export const probe = [c.security, c.network, c.browser, c.voice, c.plugins];  // 0 errors
```

Small blast radius: only four non-test files import the type.

## Tests

`config-type-coverage.test.ts` (3 tests) pins the schema against `contracts/config-sections.json` — the same file both runtimes already test against (#312) — asserts the type is *derived* rather than restated, and lists the fifteen recovered sections as a compile-time assertion, so if the type stops covering them tsc fails before the test runs.

The middle assertion is the one that matters: a future hand-written interface would compile fine and silently reintroduce the whole gap, so the guard checks the mechanism, not just the result.

Mutation-tested by restoring a two-section interface. The guard fails, **and** `tsc` reports an error in `security/audit.ts` — reverting the type immediately breaks a real consumer, which is better evidence than the guard alone.

## Verification

TypeScript **4946 passed**, 21 skipped (3 new); `tsc --noEmit` clean; eslint clean at `--max-warnings 0`.
