### PR TITLE
fix(python): four kinds of credential reached the ledger that TypeScript redacts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -589,6 +589,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   and desktop smoke tests were hardened for concurrent and Windows runs.
 
 ### Security
+- The Python flight recorder wrote four kinds of credential to the ledger verbatim that the TypeScript one redacts: a `?key=` query parameter (the shape the shipped Gemini provider builds), Slack `xox*-` tokens, `sk-` OpenAI/Anthropic keys, and JWTs. The two `SECRET_VALUE_PATTERNS` lists had drifted, in one direction only. Both now read a shared corpus at `contracts/value-redaction-corpus.json`.
 
 - **A client that stopped reading was buffered without limit.** The handshake
   advertised `policy.maxBufferedBytes: 10000000` and `sendFrame` was

--- a/contracts/value-redaction-corpus.json
+++ b/contracts/value-redaction-corpus.json
@@ -1,0 +1,233 @@
+{
+  "_comment": "Values both runtimes' flight recorders must agree on. Read by typescript/src/flight-recorder/value-redaction-parity.test.ts and python/tests/test_value_redaction_parity.py, so a pattern added to one SECRET_VALUE_PATTERNS list cannot silently miss the other -- the drift that let TypeScript redact ?key=, xox*, sk- and JWTs while Python passed all four through.",
+  "_build_comment": "Credentials are DESCRIBED, not stored. Conformance rule R9 forbids the repository containing a credential of its own, and a credential-shaped literal trips it (and any secret scanner) even when obviously fake -- this file failed R9 with 8 findings before it was written this way. Each case is assembled as prefix + fill*count + suffix, by a builder both runtimes implement identically, so they test the same string without either file containing it.",
+  "must_redact": [
+    {
+      "why": "Gemini provider builds this URL",
+      "prefix": "https://api.example.com/v1?key=AIza",
+      "fill": "b",
+      "count": 35,
+      "suffix": ""
+    },
+    {
+      "why": "query-string token",
+      "prefix": "https://api.example.com/v1?token=",
+      "fill": "b",
+      "count": 12,
+      "suffix": ""
+    },
+    {
+      "why": "query-string api_key",
+      "prefix": "https://api.example.com/v1?api_key=",
+      "fill": "b",
+      "count": 12,
+      "suffix": ""
+    },
+    {
+      "why": "query-string signature",
+      "prefix": "https://api.example.com/v1?sig=",
+      "fill": "b",
+      "count": 12,
+      "suffix": ""
+    },
+    {
+      "why": "GitHub personal token",
+      "prefix": "gh",
+      "fill": "p",
+      "count": 1,
+      "suffix": "_bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "why": "GitHub fine-grained token",
+      "prefix": "github_",
+      "fill": "p",
+      "count": 1,
+      "suffix": "at_bbbbbbbbbbbbbbbbbbbb"
+    },
+    {
+      "why": "AWS access key id",
+      "prefix": "AK",
+      "fill": "I",
+      "count": 1,
+      "suffix": "ABBBBBBBBBBBBBBBB"
+    },
+    {
+      "why": "AWS temporary key id",
+      "prefix": "AS",
+      "fill": "I",
+      "count": 1,
+      "suffix": "ABBBBBBBBBBBBBBBB"
+    },
+    {
+      "why": "bearer header",
+      "prefix": "Bearer ",
+      "fill": "b",
+      "count": 16,
+      "suffix": ""
+    },
+    {
+      "why": "credentials in a URL",
+      "prefix": "https://user:",
+      "fill": "b",
+      "count": 8,
+      "suffix": "@host/path"
+    },
+    {
+      "why": "password assignment",
+      "prefix": "password=",
+      "fill": "b",
+      "count": 8,
+      "suffix": ""
+    },
+    {
+      "why": "labelled api key",
+      "prefix": "api_key: ",
+      "fill": "b",
+      "count": 20,
+      "suffix": ""
+    },
+    {
+      "why": "OpenAI key",
+      "prefix": "sk-",
+      "fill": "b",
+      "count": 24,
+      "suffix": ""
+    },
+    {
+      "why": "Anthropic key",
+      "prefix": "sk-ant-",
+      "fill": "b",
+      "count": 24,
+      "suffix": ""
+    },
+    {
+      "why": "Google API key",
+      "prefix": "AIza",
+      "fill": "b",
+      "count": 35,
+      "suffix": ""
+    },
+    {
+      "why": "Slack bot token",
+      "prefix": "xoxb-",
+      "fill": "b",
+      "count": 20,
+      "suffix": ""
+    },
+    {
+      "why": "Slack app-level token",
+      "prefix": "xapp-1-",
+      "fill": "B",
+      "count": 12,
+      "suffix": ""
+    },
+    {
+      "why": "Telegram bot token",
+      "prefix": "123456789:AA",
+      "fill": "b",
+      "count": 33,
+      "suffix": ""
+    },
+    {
+      "why": "Tailscale auth key",
+      "prefix": "tskey-auth-",
+      "fill": "b",
+      "count": 16,
+      "suffix": ""
+    },
+    {
+      "why": "JWT",
+      "prefix": "eyJ",
+      "fill": "b",
+      "count": 12,
+      "suffix": ".eyJbbbbbbbbbbbb.bbbbbbbbbbbbbbbb"
+    },
+    {
+      "why": "RSA private key header",
+      "prefix": "-----BEGIN RSA PRIVATE KEY",
+      "fill": "-",
+      "count": 5,
+      "suffix": ""
+    },
+    {
+      "why": "OpenSSH private key header",
+      "prefix": "-----BEGIN OPENSSH PRIVATE KEY",
+      "fill": "-",
+      "count": 5,
+      "suffix": ""
+    }
+  ],
+  "_must_keep_comment": "Redacting these would be its own failure: a ledger that blanks ordinary values keeps the record and loses the ability to read it. Several are bare prefixes of real credential patterns, so a rule without a length guard blanks them.",
+  "must_keep": [
+    {
+      "why": "ordinary prose",
+      "prefix": "just a normal sentence with no secret",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    },
+    {
+      "why": "readable numbers",
+      "prefix": "port 18790 and a key_count of 7",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    },
+    {
+      "why": "a query key that names a field",
+      "prefix": "https://api.example.com/v1?key=name",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    },
+    {
+      "why": "a log line",
+      "prefix": "GET /health 200 in 4ms",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    },
+    {
+      "why": "bare OpenAI prefix",
+      "prefix": "sk-",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    },
+    {
+      "why": "bare bearer word",
+      "prefix": "Bearer",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    },
+    {
+      "why": "a public key mentioned in prose",
+      "prefix": "the user asked about their public_key",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    },
+    {
+      "why": "a config path",
+      "prefix": "/Users/someone/.openrappter/config.json5",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    },
+    {
+      "why": "bare JWT prefix",
+      "prefix": "eyJ",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    },
+    {
+      "why": "bare AWS prefix",
+      "prefix": "AKIA",
+      "fill": "",
+      "count": 0,
+      "suffix": ""
+    }
+  ]
+}

--- a/python/openrappter/flight_recorder.py
+++ b/python/openrappter/flight_recorder.py
@@ -142,6 +142,26 @@ def _cleanup_process_owner_paths() -> None:
 SECRET_VALUE_PATTERNS = (
     re.compile(r"\b(?:gh[pousr]_[A-Za-z0-9]{16,}|github_pat_[A-Za-z0-9_]{16,})\b", re.I | re.ASCII),
     re.compile(r"\b(?:AKIA|ASIA)[A-Z0-9]{16}\b", re.ASCII),
+    # The providers this repository actually reads keys for. Ported from
+    # typescript/src/flight-recorder/redaction.ts, which carried them while
+    # this list did not -- so a bare token in a recorded value reached the
+    # Python ledger verbatim. The key-based rules only fire when the
+    # surrounding field is named something like `api_key`, and a token quoted
+    # inside a longer string has no such field.
+    #
+    # Lengths are deliberately tight: blanking a value that was not a secret
+    # costs the record its usefulness, which is the opposite failure and just
+    # as real.
+    re.compile(r"\bsk-(?:ant-|proj-)?[A-Za-z0-9_-]{20,}\b", re.ASCII),  # OpenAI, Anthropic
+    re.compile(r"\bAIza[A-Za-z0-9_-]{35}\b", re.ASCII),                 # Google
+    re.compile(r"\bxox[abprs]-[A-Za-z0-9-]{10,}\b", re.ASCII),          # Slack bot/user
+    re.compile(r"\bxapp-[0-9]-[A-Za-z0-9-]{10,}\b", re.ASCII),          # Slack app-level
+    re.compile(r"\b[0-9]{8,10}:AA[A-Za-z0-9_-]{33}\b", re.ASCII),       # Telegram bot
+    re.compile(r"\btskey-[a-z]+-[A-Za-z0-9]{10,}\b", re.ASCII),         # Tailscale
+    re.compile(
+        r"\beyJ[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\.[A-Za-z0-9_-]{10,}\b",
+        re.ASCII,
+    ),  # JWT
     re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{8,}", re.I | re.ASCII),
     re.compile(r"\b[a-z][a-z0-9+.-]*://[^/\s:@]*:[^@\s/]+@", re.I | re.ASCII),
     re.compile(r"\b(?:password|pwd)\s*=\s*[^;\s]+", re.I | re.ASCII),
@@ -151,6 +171,12 @@ SECRET_VALUE_PATTERNS = (
         r"[A-Za-z0-9._~+/=-]{8,}",
         re.I | re.ASCII,
     ),
+    # `key` and `sig` are credentials in a query string too, and the first is
+    # not hypothetical: the shipped Gemini provider builds
+    # `...:generateContent?key=<apiKey>`, so a recorded value carrying that URL
+    # wrote the key into the ledger. Guarded by a value length so an ordinary
+    # `?key=name` is left alone.
+    re.compile(r"[?&](?:key|sig|signature)=[A-Za-z0-9._~+/=-]{8,}", re.I | re.ASCII),
     re.compile(
         r"[?&](?:token|secret|password|credential|authorization|"
         r"api[_-]?key|access[_-]?token|refresh[_-]?token|"

--- a/python/tests/test_value_redaction_parity.py
+++ b/python/tests/test_value_redaction_parity.py
@@ -1,0 +1,79 @@
+"""Both runtimes' flight recorders must redact the same values.
+
+`SECRET_VALUE_PATTERNS` exists in two places -- here and in
+`typescript/src/flight-recorder/redaction.ts` -- and they had drifted. Measured
+before this test existed, TypeScript redacted four things Python passed through
+verbatim:
+
+    ?key=AIzaSy...        the shipped Gemini provider builds this URL
+    xoxb-...              Slack bot token
+    sk-...                OpenAI / Anthropic key
+    eyJ........           JWT
+
+All four in the same direction, and none the other way, which is what makes it
+drift rather than a deliberately smaller redactor.
+
+The corpus lives in `contracts/value-redaction-corpus.json` and is read by both
+this file and its TypeScript counterpart, so a pattern added to one list cannot
+silently miss the other. `must_keep` matters as much as `must_redact`: a ledger
+that blanks ordinary values keeps the record and loses the ability to read it.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openrappter.flight_recorder import SECRET_VALUE_PATTERNS
+
+CORPUS = Path(__file__).resolve().parents[2] / "contracts" / "value-redaction-corpus.json"
+
+
+def build(case: dict) -> str:
+    """Assemble a case's value.
+
+    The corpus describes credentials rather than containing them: conformance
+    rule R9 forbids the repository holding a credential of its own, and a
+    credential-shaped literal trips it even when obviously fake. This file
+    failed R9 with 8 findings before the corpus was written this way. The
+    TypeScript counterpart implements the identical builder, so both runtimes
+    test the same string without either file containing it.
+    """
+    return case["prefix"] + case["fill"] * case["count"] + case["suffix"]
+
+
+def load_corpus() -> dict:
+    raw = json.loads(CORPUS.read_text(encoding="utf-8"))
+    return {
+        "must_redact": [build(c) for c in raw["must_redact"]],
+        "must_keep": [build(c) for c in raw["must_keep"]],
+    }
+
+
+def redacts(value: str) -> bool:
+    return any(pattern.search(value) for pattern in SECRET_VALUE_PATTERNS)
+
+
+class TestValueRedactionCorpus:
+    def test_the_corpus_is_substantial(self):
+        """Guard the guard: an empty corpus would make everything below pass."""
+        corpus = load_corpus()
+        assert len(corpus["must_redact"]) >= 20
+        assert len(corpus["must_keep"]) >= 8
+
+    def test_every_secret_is_redacted(self):
+        missed = [v for v in load_corpus()["must_redact"] if not redacts(v)]
+        assert missed == [], f"secrets that would reach the ledger verbatim: {missed}"
+
+    def test_no_ordinary_value_is_redacted(self):
+        # The opposite failure, and just as real. `sk-`, `Bearer`, `eyJ` and
+        # `AKIA` appear alone here on purpose: each is the prefix of a real
+        # credential pattern, and a rule without a length guard would blank
+        # them.
+        blanked = [v for v in load_corpus()["must_keep"] if redacts(v)]
+        assert blanked == [], f"ordinary values a reader needs, blanked: {blanked}"
+
+    def test_a_short_query_key_is_not_a_secret(self):
+        """`?key=name` is a field name; `?key=<40 chars>` is a credential."""
+        assert not redacts("https://example.com/?key=name")
+        assert redacts("https://example.com/?key=AIzaSyD-EXAMPLE-1234567890abcdef")

--- a/typescript/src/__tests__/integration/esm-dirname-shim.test.ts
+++ b/typescript/src/__tests__/integration/esm-dirname-shim.test.ts
@@ -29,7 +29,14 @@ function sourceFiles(dir: string = SRC, out: string[] = []): string[] {
     if (entry.isDirectory()) {
       if (entry.name === '__tests__' || entry.name === 'node_modules') continue;
       sourceFiles(full, out);
-    } else if (entry.name.endsWith('.ts') && !entry.name.endsWith('.d.ts')) {
+    } else if (
+      entry.name.endsWith('.ts')
+      && !entry.name.endsWith('.d.ts')
+      // Tests run under vitest, which provides `__dirname`; the rule is about
+      // shipped ESM. Excluding the `__tests__` directory was not enough --
+      // `.test.ts` files also live beside the code they cover.
+      && !entry.name.endsWith('.test.ts')
+    ) {
       out.push(full);
     }
   }

--- a/typescript/src/flight-recorder/value-redaction-parity.test.ts
+++ b/typescript/src/flight-recorder/value-redaction-parity.test.ts
@@ -1,0 +1,88 @@
+/**
+ * Both runtimes' flight recorders must redact the same values.
+ *
+ * `SECRET_VALUE_PATTERNS` exists here and in `python/openrappter/flight_recorder.py`,
+ * and they had drifted: this runtime redacted `?key=`, `xox*-`, `sk-` and JWTs
+ * while Python passed all four through verbatim (#287). All four in the same
+ * direction, none the other way -- drift, not a deliberately smaller redactor.
+ *
+ * The corpus is `contracts/value-redaction-corpus.json`, read by this file and
+ * by `python/tests/test_value_redaction_parity.py`, so a pattern added to one
+ * list cannot silently miss the other. That is the failure mode that would
+ * otherwise surface a year from now as "the Python side never caught that one".
+ *
+ * `must_keep` carries as much weight as `must_redact`. A ledger that blanks
+ * ordinary values keeps the record and loses the ability to read it, and the
+ * tight length guards in these patterns exist for exactly that reason.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { sanitizeFlightValue } from './redaction.js';
+
+const CORPUS = resolve(__dirname, '../../../contracts/value-redaction-corpus.json');
+
+interface Case {
+  why: string;
+  prefix: string;
+  fill: string;
+  count: number;
+  suffix: string;
+}
+
+/**
+ * Assemble a case's value.
+ *
+ * The corpus *describes* credentials rather than containing them: conformance
+ * rule R9 forbids the repository holding a credential of its own, and a
+ * credential-shaped literal trips it even when obviously fake -- this corpus
+ * failed R9 with 8 findings before it was written this way. The Python
+ * counterpart implements the identical builder, so both runtimes test the same
+ * string without either file containing it.
+ */
+function build(c: Case): string {
+  return c.prefix + c.fill.repeat(c.count) + c.suffix;
+}
+
+function corpus(): { must_redact: string[]; must_keep: string[] } {
+  const raw = JSON.parse(readFileSync(CORPUS, 'utf-8')) as {
+    must_redact: Case[];
+    must_keep: Case[];
+  };
+  return {
+    must_redact: raw.must_redact.map(build),
+    must_keep: raw.must_keep.map(build),
+  };
+}
+
+/** The recorder changed the value, i.e. it found something to hide. */
+function redacts(value: string): boolean {
+  return sanitizeFlightValue(value) !== value;
+}
+
+describe('value redaction agrees with the Python runtime', () => {
+  it('the corpus is substantial', () => {
+    // Guard the guard: an empty corpus would make everything below pass.
+    const { must_redact, must_keep } = corpus();
+    expect(must_redact.length).toBeGreaterThanOrEqual(20);
+    expect(must_keep.length).toBeGreaterThanOrEqual(8);
+  });
+
+  it('every secret is redacted', () => {
+    const missed = corpus().must_redact.filter((v) => !redacts(v));
+    expect(missed).toEqual([]);
+  });
+
+  it('no ordinary value is redacted', () => {
+    // `sk-`, `Bearer`, `eyJ` and `AKIA` appear alone in the corpus on purpose:
+    // each is the prefix of a real credential pattern, and a rule without a
+    // length guard would blank them.
+    const blanked = corpus().must_keep.filter((v) => redacts(v));
+    expect(blanked).toEqual([]);
+  });
+
+  it('a short query key is not a secret', () => {
+    expect(redacts('https://example.com/?key=name')).toBe(false);
+    expect(redacts('https://example.com/?key=AIzaSyD-EXAMPLE-1234567890abcdef')).toBe(true);
+  });
+});


### PR DESCRIPTION
Addresses #287, with a correction to its diagnosis.

The Python flight recorder wrote four kinds of credential to the ledger verbatim that the TypeScript one redacts. Measured, not argued — same corpus through both:

| value | python | typescript |
|---|---|---|
| `…/v1?key=AIzaSyD-EXAMPLE-…` | **passed through** | redacted |
| `xoxb-1234-5678-abcdefghijk` | **passed through** | redacted |
| `sk-abcdefghijklmnopqrstuvwx` | **passed through** | redacted |
| `eyJhbGciOiJIUzI1NiJ9.…` | **passed through** | redacted |

Four divergences, **all in the same direction**, and none the other way. That asymmetry is what settles the question the issue left open.

The `?key=` case is not hypothetical: the TypeScript pattern's own comment records that the shipped Gemini provider builds `…:generateContent?key=<apiKey>`, so any recorded value carrying that URL wrote the key into the ledger.

## Correcting the issue's diagnosis

#287 compares `security/redact.py` against TypeScript's value scanning and concludes Python "redacts one way". That pairs different layers. The actual arrangement:

| layer | typescript | python |
|---|---|---|
| key-based | `security/redact.ts` | `security/redact.py` — **agrees** |
| value-scanning | `flight-recorder/redaction.ts` | `flight_recorder.py` — **drifted** |

Python *does* have `SECRET_VALUE_PATTERNS`; it had 9 where TypeScript had 17. So this is not a missing capability, it is two copies of one list that fell out of step — which also disposes of the issue's "maybe Python is deliberately smaller" hypothesis. So does the file's own docstring:

> Mirrors typescript/src/security/redact.ts. Kept in step by tests/test_redact.py, which runs the same cases through both runtimes.

## Why the existing cross-runtime test could not see it

`test_both_runtimes_redact_the_same_cases` is real — it shells out to `tsx` and compares actual output. Its five cases are `api_key`, nested `api_key`, `api_key` in a list, `api_key` with an object value, and readable keys.

**Every one is key-based.** Not one puts a secret in a value under an innocuous name, so the corpus could not contain the divergence it claims to police. Same shape as the night-watch corpus in #116 and the parity harness in #335: the axis was right, the coverage was not.

## The fix

The eight missing patterns are **ported**, not invented — same regexes, same length guards, same reasoning carried across in the comments. The issue explicitly preferred porting an agreed list to authoring a second one, and I did not add anything TypeScript does not already have.

`contracts/value-redaction-corpus.json` is now read by both `python/tests/test_value_redaction_parity.py` and `typescript/src/flight-recorder/value-redaction-parity.test.ts`, so a pattern added to one list cannot silently miss the other.

`must_keep` carries as much weight as `must_redact`, because over-redaction is the opposite failure and just as real — a ledger that blanks ordinary values keeps the record and loses the ability to read it. It includes `sk-`, `Bearer`, `eyJ` and `AKIA` **alone**: each is the prefix of a real credential pattern, so a rule without a length guard blanks them.

Both mutations verified:

```
removed two patterns  -> secrets that would reach the ledger verbatim:
                         ['…?key=AIza…', '…?sig=…', 'sk-…', 'sk-ant-…']
added /sk-/ unguarded -> ordinary values a reader needs, blanked: ['sk-']
```

## A guard of mine had a gap

The new TypeScript test lives beside the code it covers, and `esm-dirname-shim.test.ts` (#323) failed on it: it excluded the `__tests__` *directory* but not `.test.ts` files elsewhere. Tests run under vitest, which provides `__dirname`; the rule is about shipped ESM. Widened, then re-verified it still catches production code by planting a bare `__dirname` in `config/loader.ts`.

## Verification

Python **1614 passed** (4 new); TypeScript **4950 passed** (4 new); `conformance.py` 8 passed, 0 failed; `parity_harness.py --runtime both` PASS; tsc clean; eslint clean at `--max-warnings 0`.


## Note on this branch

Opened fresh, replacing #340. That PR's first commit stored the fixtures as literals, which failed **conformance R9** ("the repository contains no credential of its own") with 8 findings, and GitGuardian with it. Both were right.

The corpus now *describes* credentials -- `prefix + fill*count + suffix`, assembled by a builder both runtimes implement identically -- so the two sides test the same string without either file containing it. The existing `test_redact.py` had already solved this, and says so: *"Build the value at runtime; a literal would be rewritten by scanning."*

Since history cannot be rewritten here, this branch carries only the corrected state: **0** assembled credentials appear anywhere in its diff, verified by reconstructing every case and searching the diff for it.
