### PR TITLE
feat(cli): service status — the gateway has run unsupervised for 13 days and nothing said so

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- `openrappter service status` reports whether launchd actually supervises the gateway that is answering. The two can disagree permanently and nothing said so: on the machine that prompted this, a gateway started outside launchd had held the port for 13 days, so all 29 supervised starts exited 1 with `EADDRINUSE` while `/health` returned 200 and `doctor` reported the same message it reports when supervision is correct.
 - `openrappter audit` runs the security auditor and exits non-zero on high or critical findings. `SecurityAuditor` had five checks and was constructed by nothing but its own test.
 - The gateway now emits `agent.tool` as each tool call finishes, so tool use appears in chat. The chat UI has registered a listener for it since it was written and the event had no emit site anywhere, so the feature had never worked. The payload carries the tool's name, outcome and duration -- never its arguments, which can hold secrets.
 

--- a/typescript/src/__tests__/integration/service-status.test.ts
+++ b/typescript/src/__tests__/integration/service-status.test.ts
@@ -1,0 +1,120 @@
+/**
+ * `service status` exists because launchd and the running gateway can disagree
+ * permanently, and nothing said so.
+ *
+ * On the machine that prompted #144 they had disagreed for thirteen days:
+ *
+ *     launchctl list   ->  -   1   com.openrappter.gateway   (no pid, exit 1)
+ *     curl /health     ->  200
+ *     launchctl print  ->  runs = 29
+ *
+ * A gateway started outside launchd held the port, so all 29 supervised starts
+ * exited 1 with `EADDRINUSE`. Every signal available said "fine": health
+ * answered, and `doctor` reported the same "port is in use (gateway may
+ * already be running)" that it reports when supervision is correct.
+ *
+ * These tests drive the pure functions rather than `launchctl`, so they assert
+ * the *diagnosis* rather than the state of whatever machine runs them.
+ */
+import { describe, it, expect } from 'vitest';
+import { parseLaunchctlRow, describeSupervision, type ServiceStatus } from '../../cli/service-status.js';
+
+const LABEL = 'com.openrappter.gateway';
+
+/** A `launchctl list` sample in the real tab-separated shape. */
+const LISTING = [
+  'PID\tStatus\tLabel',
+  '53830\t-15\tcom.openrappter.keepawake',
+  '-\t1\tcom.openrappter.gateway',
+  '22988\t0\tcom.rapp.infrastructure-city',
+].join('\n');
+
+function status(overrides: Partial<ServiceStatus> = {}): ServiceStatus {
+  return {
+    registered: true,
+    launchdPid: null,
+    lastExit: null,
+    recordedPid: null,
+    recordedAlive: false,
+    ...overrides,
+  };
+}
+
+describe('parseLaunchctlRow', () => {
+  it('reads the failed job the way launchctl prints it', () => {
+    expect(parseLaunchctlRow(LISTING, LABEL)).toEqual({
+      registered: true,
+      pid: null,
+      lastExit: 1,
+    });
+  });
+
+  it('reads a healthy job', () => {
+    expect(parseLaunchctlRow('4242\t0\tcom.openrappter.gateway', LABEL)).toEqual({
+      registered: true,
+      pid: 4242,
+      lastExit: 0,
+    });
+  });
+
+  it('does not match a label that merely contains the name', () => {
+    // `com.openrappter.gateway.helper` is a different job.
+    const other = '99\t0\tcom.openrappter.gateway.helper';
+    expect(parseLaunchctlRow(other, LABEL).registered).toBe(false);
+  });
+
+  it('reports an absent job rather than guessing', () => {
+    expect(parseLaunchctlRow('53830\t-15\tcom.openrappter.keepawake', LABEL)).toEqual({
+      registered: false,
+      pid: null,
+      lastExit: null,
+    });
+  });
+});
+
+describe('describeSupervision', () => {
+  it('stays quiet when launchd owns the running gateway', () => {
+    expect(
+      describeSupervision(status({ launchdPid: 4242, lastExit: 0, recordedPid: 4242, recordedAlive: true })),
+    ).toBeNull();
+  });
+
+  it('names the exact state from #144', () => {
+    // Registered, no supervised pid, and something else alive on the port.
+    const message = describeSupervision(
+      status({ lastExit: 1, recordedPid: 25041, recordedAlive: true }),
+    );
+    expect(message).toContain('NOT started by launchd');
+    expect(message).toContain('25041');
+    expect(message).toContain('unsupervised');
+    // The actionable part: this is what makes every supervised start fail.
+    expect(message).toContain('EADDRINUSE');
+  });
+
+  it('reports a gateway running with no job installed at all', () => {
+    const message = describeSupervision(
+      status({ registered: false, recordedPid: 900, recordedAlive: true }),
+    );
+    expect(message).toContain('no launchd job is installed');
+    expect(message).toContain('openrappter service install');
+  });
+
+  it('stays quiet when nothing is installed and nothing is running', () => {
+    expect(describeSupervision(status({ registered: false }))).toBeNull();
+  });
+
+  it('reports a job that is installed but genuinely stopped', () => {
+    const message = describeSupervision(status({ lastExit: 0, recordedPid: 111, recordedAlive: false }));
+    expect(message).toContain('nothing is running');
+  });
+
+  it('reports a supervised pid that disagrees with the recorded one', () => {
+    // Two gateways: launchd owns one, another wrote the pid file. Whoever
+    // reads that file is talking to a process launchd is not supervising.
+    const message = describeSupervision(
+      status({ launchdPid: 100, recordedPid: 200, recordedAlive: true }),
+    );
+    expect(message).toContain('supervises pid 100');
+    expect(message).toContain('recorded pid 200');
+  });
+});

--- a/typescript/src/__tests__/parity/cli-commands.test.ts
+++ b/typescript/src/__tests__/parity/cli-commands.test.ts
@@ -238,13 +238,17 @@ describe('CLI Commands', () => {
       }
     });
 
-    it('all register functions should accept program parameter', () => {
+    it('all register functions should accept a Command to attach to', () => {
       const commandFiles = commandModules();
 
       for (const file of commandFiles) {
         const content = readFileSync(join(CLI_DIR, file), 'utf-8');
+        // The rule is that a register function is handed the Command it should
+        // attach to. That is usually the root `program`, but `service-status.ts`
+        // attaches to the `service` subcommand, where naming the parameter
+        // `program` would say something untrue. The type is what matters.
         // `registerHubCommands` registers two, like registerTelephonyCommands does.
-        expect(content).toMatch(/function register\w+Commands?\(\s*program:\s*Command/);
+        expect(content).toMatch(/function register\w+Commands?\(\s*\w+:\s*Command/);
       }
     });
   });

--- a/typescript/src/cli/service-status.ts
+++ b/typescript/src/cli/service-status.ts
@@ -1,0 +1,163 @@
+/**
+ * `openrappter service status` — does launchd supervise the gateway that is
+ * actually answering?
+ *
+ * The two can disagree permanently, and on the machine that prompted this they
+ * had for thirteen days (#144):
+ *
+ *     $ launchctl list | grep com.openrappter.gateway
+ *     -   1   com.openrappter.gateway          <- no pid, last exit 1
+ *     $ curl -s -o /dev/null -w "%{http_code}" http://127.0.0.1:18790/health
+ *     200                                       <- serving fine
+ *     $ launchctl print … | grep runs
+ *     runs = 29                                 <- and failing on every retry
+ *
+ * A gateway started outside launchd holds the port, so every supervised start
+ * exits 1 with `EADDRINUSE`. Health checks pass, `doctor` reports the same
+ * "port is in use (gateway may already be running)" it reports when everything
+ * is correct, and nothing anywhere says the service is unsupervised -- which
+ * is the state that matters, because `KeepAlive` will not restart a process
+ * launchd does not own.
+ *
+ * This command exists to make those two facts comparable in one place.
+ */
+import type { Command } from 'commander';
+import { execFile } from 'child_process';
+import { promisify } from 'util';
+import { readFileSync, existsSync } from 'fs';
+import { defaultGatewayLockFile } from '../infra/gateway-lock.js';
+import { OPENRAPPTER_LAUNCH_AGENT_LABEL } from '../channels/imessage-launchd.js';
+
+const run = promisify(execFile);
+
+export interface ServiceStatus {
+  /** Whether launchd has the job loaded at all. */
+  registered: boolean;
+  /** The pid launchd is supervising, if any. */
+  launchdPid: number | null;
+  /** The exit status launchd last recorded. */
+  lastExit: number | null;
+  /** The pid recorded by whatever gateway is running. */
+  recordedPid: number | null;
+  /** Whether that pid is alive. */
+  recordedAlive: boolean;
+}
+
+/** Parse one `launchctl list` row: `<pid>\t<status>\t<label>`. */
+export function parseLaunchctlRow(stdout: string, label: string): {
+  registered: boolean;
+  pid: number | null;
+  lastExit: number | null;
+} {
+  for (const line of stdout.split('\n')) {
+    const parts = line.split('\t');
+    if (parts.length < 3 || parts[2].trim() !== label) continue;
+    const pid = Number.parseInt(parts[0], 10);
+    const status = Number.parseInt(parts[1], 10);
+    return {
+      registered: true,
+      pid: Number.isFinite(pid) ? pid : null,
+      lastExit: Number.isFinite(status) ? status : null,
+    };
+  }
+  return { registered: false, pid: null, lastExit: null };
+}
+
+function pidIsAlive(pid: number): boolean {
+  try {
+    // Signal 0 tests for existence without touching the process.
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function readServiceStatus(): Promise<ServiceStatus> {
+  let row = { registered: false, pid: null as number | null, lastExit: null as number | null };
+  try {
+    const { stdout } = await run('launchctl', ['list']);
+    row = parseLaunchctlRow(stdout, OPENRAPPTER_LAUNCH_AGENT_LABEL);
+  } catch {
+    // No launchctl (Linux, or a stripped container): everything below still
+    // reports what it can rather than failing.
+  }
+
+  const lockFile = defaultGatewayLockFile();
+  let recordedPid: number | null = null;
+  if (existsSync(lockFile)) {
+    const parsed = Number.parseInt(readFileSync(lockFile, 'utf-8').trim(), 10);
+    if (Number.isFinite(parsed)) recordedPid = parsed;
+  }
+
+  return {
+    registered: row.registered,
+    launchdPid: row.pid,
+    lastExit: row.lastExit,
+    recordedPid,
+    recordedAlive: recordedPid !== null && pidIsAlive(recordedPid),
+  };
+}
+
+/**
+ * The one sentence a reader needs.
+ *
+ * Returns `null` when supervision is correct, so the caller can stay quiet.
+ */
+export function describeSupervision(status: ServiceStatus): string | null {
+  if (!status.registered) {
+    return status.recordedAlive
+      ? `A gateway is running (pid ${status.recordedPid}) but no launchd job is installed, so nothing will restart it.\n  Install it with: openrappter service install`
+      : null;
+  }
+
+  if (status.launchdPid !== null) {
+    if (status.recordedPid !== null && status.recordedPid !== status.launchdPid) {
+      return `launchd supervises pid ${status.launchdPid}, but the running gateway recorded pid ${status.recordedPid}.`;
+    }
+    return null;
+  }
+
+  // Registered, no pid: launchd is not running it. The interesting case is
+  // whether something else is.
+  if (status.recordedAlive) {
+    return (
+      `The gateway answering on this machine (pid ${status.recordedPid}) was NOT started by launchd, `
+      + `which last recorded exit ${status.lastExit ?? 'unknown'}.\n`
+      + `  It is running unsupervised: KeepAlive will not restart it if it crashes.\n`
+      + `  Most likely it holds the port, so every supervised start fails with EADDRINUSE.\n`
+      + `  Stop that process and let launchd own it: kill ${status.recordedPid}`
+    );
+  }
+
+  return `launchd has the job installed but nothing is running (last exit ${status.lastExit ?? 'unknown'}).`;
+}
+
+export function registerServiceStatusCommand(serviceCommand: Command): void {
+  serviceCommand
+    .command('status')
+    .description('Report whether launchd supervises the running gateway')
+    .option('--json', 'Print the raw status')
+    .action(async (options: { json?: boolean }) => {
+      const status = await readServiceStatus();
+
+      if (options.json) {
+        console.log(JSON.stringify(status, null, 2));
+      } else {
+        console.log(`\n  launchd job:   ${status.registered ? 'installed' : 'not installed'}`);
+        console.log(`  supervised pid: ${status.launchdPid ?? '(none)'}`);
+        console.log(`  last exit:      ${status.lastExit ?? '(none)'}`);
+        console.log(`  running pid:    ${status.recordedPid ?? '(none)'}${
+          status.recordedPid !== null && !status.recordedAlive ? ' (stale — not running)' : ''
+        }`);
+      }
+
+      const problem = describeSupervision(status);
+      if (problem) {
+        if (!options.json) console.log(`\n  ${problem}\n`);
+        process.exitCode = 1;
+      } else if (!options.json) {
+        console.log('\n  Supervision is correct.\n');
+      }
+    });
+}

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -23,6 +23,7 @@ import { registerMemoryCommand } from './cli/memory.js';
 import { registerSessionsCommand } from './cli/sessions.js';
 import { registerChannelsCommand } from './cli/channels.js';
 import { registerAuditCommand } from './cli/audit.js';
+import { registerServiceStatusCommand } from './cli/service-status.js';
 import { registerConfigCommand } from './cli/config.js';
 import { registerDoctorCommand } from './cli/doctor.js';
 import { registerRappterCommand } from './cli/rappters.js';
@@ -2110,6 +2111,8 @@ async function installManagedGatewayService(
 const serviceCommand = program
   .command('service')
   .description('Manage the launchd-supervised OpenRappter gateway');
+
+registerServiceStatusCommand(serviceCommand);
 
 serviceCommand
   .command('install')


### PR DESCRIPTION
Addresses #144, **correcting its root cause**. The state it describes is real and still live on `rapptertwo` 13 days later — but `--daemon` is not what causes it.

## The reported cause does not reproduce

#144 attributes this to the double-fork-under-launchd antipattern: *"`--daemon` makes the process fork and detach."* Measured, on a spare port in a temp home:

```
shell's direct child pid: 66746
66746 66568 node dist/index.js --daemon --port 18999     <- PPID is my shell
node  66746 … TCP 127.0.0.1:18999 (LISTEN)               <- and it is the listener
```

The direct child stays in the foreground and serves. `--daemon` does not fork, so dropping it from `ProgramArguments` would have fixed nothing.

## What is actually happening

A gateway started **outside** launchd holds the port, so every supervised start fails:

```
$ node dist/index.js --daemon --port 18790     # the live port
exit code on port conflict: 1
Gateway server error: listen EADDRINUSE: address already in use 127.0.0.1:18790
```

The machine confirms it:

```
$ launchctl print gui/501/com.openrappter.gateway | grep -E 'state|runs|exit'
state = not running
runs = 29
last exit code = 1

$ cat ~/.openrappter/gateway.pid
25041

$ ps -o pid,ppid -p 25041
25041     1        <- reparented because its parent shell exited, not by forking
```

**launchd has tried 29 times and failed every time**, each on `EADDRINUSE` against pid 25041. The reparenting to PID 1 is a consequence of whoever started it by hand exiting, not evidence of a fork.

The consequences #144 lists are all correct and all still true — no supervision, no restart on failure, monitoring reads it as down. Only the cause differs, and it matters, because the suggested fix would have left the machine in exactly this state.

## Why nobody noticed for 13 days

Every signal available said fine:

- `/health` → **200**, because pid 25041 serves correctly.
- `doctor` → `WARN  Port 18790 is in use (gateway may already be running)` — the **same message it prints when supervision is correct**.
- There was no `openrappter service status` at all.

## The fix

`openrappter service status` makes the two facts comparable in one place, and exits non-zero when they disagree. On the affected machine it says exactly what is wrong:

```
  launchd job:    installed
  supervised pid: (none)
  last exit:      1
  running pid:    25041

  The gateway answering on this machine (pid 25041) was NOT started by launchd,
  which last recorded exit 1.
  It is running unsupervised: KeepAlive will not restart it if it crashes.
  Most likely it holds the port, so every supervised start fails with EADDRINUSE.
  Stop that process and let launchd own it: kill 25041
```

`--json` for monitoring. I have **not** run that `kill` — the live daemon is yours to restart, and it is 200+ commits behind, so it wants a deploy rather than a bounce.

## Tests

10 tests against the pure functions rather than `launchctl`, so they assert the diagnosis rather than the state of whichever machine runs them: the exact #144 shape, a healthy job, a gateway running with no job installed, an installed job genuinely stopped, and a supervised pid disagreeing with the recorded one. `parseLaunchctlRow` is checked against the real tab-separated output, including that `com.openrappter.gateway.helper` does not match `com.openrappter.gateway`.

Mutation-tested: making the unsupervised branch stay quiet fails `names the exact state from #144`.

## One guard widened deliberately

`cli-commands.test.ts` required every register function to take a parameter literally named `program`. This one attaches to the `service` subcommand, where that name would say something untrue, so the assertion now checks the *type* (`\w+: Command`). Re-verified it still bites by planting a register function that takes no Command.

## Verification

TypeScript **4960 passed**, 21 skipped (10 new); tsc clean; eslint clean at `--max-warnings 0`. Exercised against the live launchd state, read-only.
