### PR TITLE
test: record the snippet divergence #68 asked to have written down

### DIFF
--- a/contracts/snippet-divergence.json
+++ b/contracts/snippet-divergence.json
@@ -1,0 +1,93 @@
+{
+  "_comment": "generateSnippet (TypeScript) and generate_snippet (Python) do not agree. This file records exactly how, so the divergence cannot widen unnoticed and nobody has to re-derive it -- #68 asked for it to be written down rather than resolved by whoever diffs it next.",
+  "_status": "UNRESOLVED. Neither side is agreed canonical. Choosing belongs to whoever owns what a memory snippet should look like: TypeScript trims to word boundaries and reads better; Python backfills so the snippet uses the max_length the caller asked for. Changing either is a deliberate act that changes output for every existing caller.",
+  "_differences": [
+    "Which match wins: python takes the first query TERM that matches; typescript takes the earliest POSITION across all terms.",
+    "Window: python backfills to always reach max_length when content allows; typescript uses match +/- half and never backfills.",
+    "Boundaries: typescript trims to spaces; python does not.",
+    "Degenerate input: python returns content[:max_length]; typescript falls through to position 0 then trims."
+  ],
+  "max_length": 40,
+  "cases": [
+    {
+      "label": "no match",
+      "content": "the quick brown fox jumps over the lazy dog and keeps running far away into the woods",
+      "query": "zzz",
+      "python": "the quick brown fox jumps over the lazy ",
+      "typescript": "the quick brown fox...",
+      "agree": false
+    },
+    {
+      "label": "match mid",
+      "content": "the quick brown fox jumps over the lazy dog and keeps running far away into the woods",
+      "query": "fox jumps",
+      "python": "the quick brown fox jumps over the lazy ...",
+      "typescript": "the quick brown fox jumps over the...",
+      "agree": false
+    },
+    {
+      "label": "multi-term order",
+      "content": "alpha beta gamma delta epsilon zeta",
+      "query": "zeta alpha",
+      "python": "alpha beta gamma delta epsilon zeta",
+      "typescript": "alpha beta gamma...",
+      "agree": false
+    },
+    {
+      "label": "short terms only",
+      "content": "the quick brown fox",
+      "query": "a i",
+      "python": "the quick brown fox",
+      "typescript": "the quick brown fox",
+      "agree": true
+    },
+    {
+      "label": "empty query",
+      "content": "the quick brown fox",
+      "query": "",
+      "python": "the quick brown fox",
+      "typescript": "the quick brown fox",
+      "agree": true
+    },
+    {
+      "label": "empty content",
+      "content": "",
+      "query": "anything",
+      "python": "",
+      "typescript": "",
+      "agree": true
+    },
+    {
+      "label": "match at start",
+      "content": "fox jumps over the lazy dog and keeps running far away into the woods for a while",
+      "query": "fox",
+      "python": "fox jumps over the lazy dog and keeps ru...",
+      "typescript": "fox jumps over the...",
+      "agree": false
+    },
+    {
+      "label": "match at end",
+      "content": "the lazy dog and keeps running far away into the woods with the clever fox runs",
+      "query": "clever fox runs",
+      "python": "... into the woods with the clever fox runs",
+      "typescript": "...the woods with the clever fox runs",
+      "agree": false
+    },
+    {
+      "label": "content shorter than max",
+      "content": "tiny",
+      "query": "tiny",
+      "python": "tiny",
+      "typescript": "tiny",
+      "agree": true
+    },
+    {
+      "label": "case insensitive",
+      "content": "the quick Brown FOX jumps over the lazy dog and keeps going onward",
+      "query": "brown fox",
+      "python": "the quick Brown FOX jumps over the lazy ...",
+      "typescript": "the quick Brown FOX jumps over...",
+      "agree": false
+    }
+  ]
+}

--- a/python/tests/test_snippet_divergence.py
+++ b/python/tests/test_snippet_divergence.py
@@ -1,0 +1,69 @@
+"""`generate_snippet` and its TypeScript twin do not agree, and that is recorded.
+
+#68 measured the two implementations disagreeing on most inputs and deliberately
+did **not** pick a winner: TypeScript trims to word boundaries and reads better,
+Python backfills so the snippet uses the `max_length` the caller asked for, and
+choosing changes output for every existing caller. That is a product decision
+about what a memory snippet should look like.
+
+What the issue asked for instead was that it be *written down*, because
+`SPEC.md` says nothing about it and "the next person to diff these will file
+this issue again".
+
+So `contracts/snippet-divergence.json` records every case with **both** answers,
+and this test asserts the Python column. Its TypeScript counterpart asserts the
+other one. Neither endorses its side; together they mean:
+
+  * the divergence cannot widen without a test failing,
+  * whoever resolves it can see exactly what changes, and
+  * nobody has to re-derive the table by hand.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from openrappter.memory.chunker import generate_snippet
+
+CONTRACT = Path(__file__).resolve().parents[2] / "contracts" / "snippet-divergence.json"
+
+
+def load() -> dict:
+    return json.loads(CONTRACT.read_text(encoding="utf-8"))
+
+
+class TestSnippetDivergence:
+    def test_the_record_is_substantial(self):
+        """Guard the guard: an empty table would make everything below pass."""
+        data = load()
+        assert len(data["cases"]) >= 10
+        assert data["max_length"] > 0
+
+    def test_it_still_records_a_real_disagreement(self):
+        """If these ever agree, the record is stale and should be deleted.
+
+        Asserted so the file cannot outlive the problem it documents: a
+        contract describing a divergence that no longer exists is worse than
+        no contract, because it teaches the next reader something false.
+        """
+        data = load()
+        disagreements = [c for c in data["cases"] if not c["agree"]]
+        assert disagreements, (
+            "the two runtimes now agree — resolve #68 and delete "
+            "contracts/snippet-divergence.json"
+        )
+
+    def test_python_still_answers_what_the_record_says(self):
+        data = load()
+        max_length = data["max_length"]
+        drifted = []
+        for case in data["cases"]:
+            got = generate_snippet(case["content"], case["query"], max_length)
+            if got != case["python"]:
+                drifted.append((case["label"], case["python"], got))
+
+        assert drifted == [], (
+            "Python's snippet output changed. If that was deliberate, update "
+            f"contracts/snippet-divergence.json: {drifted}"
+        )

--- a/typescript/src/__tests__/integration/snippet-divergence.test.ts
+++ b/typescript/src/__tests__/integration/snippet-divergence.test.ts
@@ -1,0 +1,69 @@
+/**
+ * `generateSnippet` and its Python twin do not agree, and that is recorded.
+ *
+ * #68 measured the two implementations disagreeing on most inputs and
+ * deliberately did **not** pick a winner: this side trims to word boundaries
+ * and reads better, Python backfills so the snippet uses the `maxLength` the
+ * caller asked for, and choosing changes output for every existing caller.
+ *
+ * What the issue asked for instead was that it be *written down*, because
+ * `SPEC.md` says nothing about it and "the next person to diff these will file
+ * this issue again".
+ *
+ * `contracts/snippet-divergence.json` records every case with **both** answers.
+ * This test asserts the TypeScript column; `python/tests/test_snippet_divergence.py`
+ * asserts the other. Neither endorses its side; together they mean the
+ * divergence cannot widen without a test failing, and whoever resolves it can
+ * see exactly what changes.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { generateSnippet } from '../../memory/chunker.js';
+
+const CONTRACT = resolve(__dirname, '../../../../contracts/snippet-divergence.json');
+
+interface Case {
+  label: string;
+  content: string;
+  query: string;
+  python: string;
+  typescript: string;
+  agree: boolean;
+}
+
+function load(): { max_length: number; cases: Case[] } {
+  return JSON.parse(readFileSync(CONTRACT, 'utf-8')) as { max_length: number; cases: Case[] };
+}
+
+describe('snippet divergence is recorded, not resolved', () => {
+  it('the record is substantial', () => {
+    // Guard the guard: an empty table would make everything below pass.
+    const { cases, max_length } = load();
+    expect(cases.length).toBeGreaterThanOrEqual(10);
+    expect(max_length).toBeGreaterThan(0);
+  });
+
+  it('still records a real disagreement', () => {
+    // If these ever agree, the record is stale. A contract describing a
+    // divergence that no longer exists teaches the next reader something
+    // false, so it should fail rather than sit there.
+    const disagreements = load().cases.filter((c) => !c.agree);
+    expect(
+      disagreements.length,
+      'the two runtimes now agree — resolve #68 and delete contracts/snippet-divergence.json',
+    ).toBeGreaterThan(0);
+  });
+
+  it('TypeScript still answers what the record says', () => {
+    const { cases, max_length } = load();
+    const drifted = cases
+      .map((c) => ({ label: c.label, want: c.typescript, got: generateSnippet(c.content, c.query, max_length) }))
+      .filter((r) => r.want !== r.got);
+
+    expect(
+      drifted,
+      'TypeScript snippet output changed. If deliberate, update contracts/snippet-divergence.json',
+    ).toEqual([]);
+  });
+});


### PR DESCRIPTION
#68 measured `generateSnippet` and `generate_snippet` disagreeing and deliberately did not pick a winner, because choosing changes output for every existing caller and belongs to whoever owns what a memory snippet should look like. This PR does not pick one either.

It does the other thing that issue asked for:

> If the answer is "this is an extra axis and drift here is acceptable", that is a fine answer too, but it is worth writing down, because `SPEC.md` currently says nothing about it and **the next person to diff these will file this issue again.**

## Still true, measured today

At `max_length = 40`, **6 of 10** cases disagree:

```
0: py='the quick brown fox jumps over the lazy ' ts='the quick brown fox...'
1: py='the quick brown fox jumps over the lazy ...' ts='the quick brown fox jumps over the...'
2: py='alpha beta gamma delta epsilon zeta'      ts='alpha beta gamma...'
6: py='fox jumps over the lazy dog and keeps ru...' ts='fox jumps over the...'
7: py='... into the woods with the clever fox runs' ts='...the woods with the clever fox runs'
9: py='the quick Brown FOX jumps over the lazy ...' ts='the quick Brown FOX jumps over...'
```

(The issue reported 8 of 10 at its own `max_length`; the four behavioural differences it identified all reproduce.)

## What this adds

`contracts/snippet-divergence.json` records every case with **both** answers, the four behavioural differences, and an explicit `_status: UNRESOLVED` naming the trade-off. Each runtime has a test asserting **its own** column.

Neither test endorses its side. Together they mean:

- the divergence cannot widen without a test failing,
- whoever resolves #68 can see exactly what changes and for which inputs, and
- nobody has to re-derive the table by hand — which is what the issue predicted would happen.

Both suites also assert the record still describes a **real** disagreement, and fail with *"the two runtimes now agree — resolve #68 and delete this file"* if they ever converge. A contract describing a divergence that no longer exists teaches the next reader something false, so it should not be able to outlive the problem.

Mutation-tested by shortening Python's window: the Python test fails and names all five affected cases with old and new values.

## Verification

TypeScript **4967 passed**, 21 skipped (3 new); Python **1617 passed** (3 new); tsc clean; eslint clean at `--max-warnings 0`.
