### PR TITLE
fix(gateway): two tools finishing together showed as one, and one disappeared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capability its syntax tree can reach, per the RAPP agent contract.
 
 ### Fixed
+- `agent.tool` omitted `toolCallId`, the field the chat list keys its rows on. Two tools finishing in the same millisecond therefore resolved to the same key, and the second *updated* the first's row instead of adding one -- so a tool vanished from the transcript.
 - The Flight Recorder ledger ignored `OPENRAPPTER_HOME` in **both** runtimes, so relocating an installation moved everything except the database recording it. TypeScript spelled the path across three lines, which is how it escaped the migration that moved the other 46 sites -- and the guard meant to catch stragglers, whose pattern could not match its own formatting.
 - `agent.tool` reported every **successful** tool call as a failure in chat. The event added in the previous change sent `status: 'ok'`, and the chat UI -- which has read this event since before it was emitted -- renders `status === 'success' ? '✓' : '✗'`, so `'ok'` fell to the cross. Emitter and consumer are now pinned to one vocabulary.
 - The dormant `send` CLI sent `{ channel, message, target }` where `channels.send` reads `{ channelId, conversationId, content }`, so every field arrived `undefined` at the channel registry. `--metadata` is removed (no such field exists, so it was accepted and discarded) and `--all` now refuses instead of calling `channels.broadcast`, which no gateway registers. The command remains unregistered.

--- a/typescript/src/__tests__/integration/agent-tool-event.test.ts
+++ b/typescript/src/__tests__/integration/agent-tool-event.test.ts
@@ -90,6 +90,7 @@ describe('agent.tool is emitted for each finished tool call', () => {
     expect(seen).toHaveLength(1);
     expect(seen[0]).toMatchObject({
       sessionId: 'session-a',
+      toolCallId: 'call_1',
       name: 'secret_tool',
       status: 'success',
     });
@@ -137,7 +138,24 @@ describe('agent.tool is emitted for each finished tool call', () => {
     // without any named property looking wrong.
     expect(JSON.stringify(seen)).not.toContain('hunter2');
     expect(JSON.stringify(seen)).not.toContain('password');
-    expect(Object.keys(seen[0]).sort()).toEqual(['durationMs', 'name', 'sessionId', 'status']);
+    expect(Object.keys(seen[0]).sort()).toEqual([
+      'durationMs', 'name', 'sessionId', 'status', 'toolCallId',
+    ]);
+  });
+
+  it('carries the model call id so two tools cannot collide', async () => {
+    // The chat UI keys its list on `toolCallId ?? `tool_${Date.now()}``, so
+    // without this two tools finishing in the same millisecond rendered as one
+    // row and the second name was lost. Reproduced against the UI's own
+    // keying logic before this field was added.
+    const assistant = assistantWithScriptedTool('ok');
+    const seen: AgentToolEvent[] = [];
+    assistant.onToolEvent = (event) => seen.push(event);
+
+    await assistant.getResponse('do the thing', undefined, undefined, 'session-g');
+
+    expect(seen[0].toolCallId).toBe('call_1');
+    expect(seen[0].toolCallId).toBeTruthy();
   });
 
   it('a throwing subscriber does not break the turn', async () => {

--- a/typescript/src/__tests__/integration/chat-tool-event-contract.test.ts
+++ b/typescript/src/__tests__/integration/chat-tool-event-contract.test.ts
@@ -74,4 +74,17 @@ describe('agent.tool status vocabulary', () => {
     const success: AgentToolEvent['status'] = 'success';
     expect(source).toContain(`tool.status === '${success}'`);
   });
+
+  it('the emitter sends the field the UI keys its list on', () => {
+    // `chat.ts` does `const id = data.toolCallId ?? \`tool_\${Date.now()}\``.
+    // Without `toolCallId`, two tools finishing in the same millisecond
+    // resolve to the same key and the second *updates* the first's row rather
+    // than adding one -- so a tool silently disappears from the transcript.
+    const ui = readFileSync(CHAT_UI, 'utf-8');
+    expect(ui).toMatch(/data\.toolCallId/);
+
+    const assistant = readFileSync(ASSISTANT, 'utf-8');
+    expect(assistant).toMatch(/toolCallId: string;/);
+    expect(assistant).toMatch(/onToolEvent\(\{[^}]*toolCallId/);
+  });
 });

--- a/typescript/src/agents/Assistant.ts
+++ b/typescript/src/agents/Assistant.ts
@@ -140,6 +140,16 @@ export interface AssistantConversationMessage {
  * subscribed client, which is a wider audience than a local trace file.
  */
 export interface AgentToolEvent {
+  /**
+   * The model's own id for this call.
+   *
+   * The chat UI keys its list on `toolCallId ?? \`tool_${Date.now()}\``, so
+   * omitting it made two tools that finished in the same millisecond collide:
+   * the second *updated* the first's row instead of adding one, and its name
+   * was never shown. Sending the id the model already assigned removes the
+   * guess.
+   */
+  toolCallId: string;
   /** Conversation this ran in. */
   sessionId: string;
   /** The tool the model asked for. */
@@ -307,6 +317,7 @@ export class Assistant {
    */
   private emitToolEvent(
     sessionId: string,
+    toolCallId: string,
     name: string,
     status: 'success' | 'error',
     /** A `performance.now()` reading, matching the Flight Recorder's clock. */
@@ -315,7 +326,7 @@ export class Assistant {
     if (!this.onToolEvent) return;
     try {
       const durationMs = Math.max(0, Math.round(performance.now() - startedAt));
-      this.onToolEvent({ sessionId, name, status, durationMs });
+      this.onToolEvent({ sessionId, toolCallId, name, status, durationMs });
     } catch {
       // Intentionally ignored; see the note above.
     }
@@ -1040,7 +1051,7 @@ export class Assistant {
       // product disagreeing on the wire is the failure PARITY §0 is about.
       if (!agent) {
         const msg = `Agent '${agentName}' not found.`;
-        this.emitToolEvent(conversationKey, agentName, 'error', started);
+        this.emitToolEvent(conversationKey, tc.id, agentName, 'error', started);
         agentLogs.push(formatFlightAgentLog(agentName, msg));
         await recorder.record({
           kind: "tool.call.failed",
@@ -1072,7 +1083,7 @@ export class Assistant {
         // often as by throwing (#134), so the absence of an exception proves
         // nothing on its own.
         const failed = agentResultIsError(resultStr);
-        this.emitToolEvent(conversationKey, agentName, failed ? 'error' : 'success', started);
+        this.emitToolEvent(conversationKey, tc.id, agentName, failed ? 'error' : 'success', started);
         let structuredResult: unknown = sanitizeFlightValue(resultStr);
         try {
           structuredResult = sanitizeFlightValue(JSON.parse(resultStr));
@@ -1103,7 +1114,7 @@ export class Assistant {
         return resultStr;
       } catch (err) {
         const message = (err as Error).message;
-        this.emitToolEvent(conversationKey, agentName, 'error', started);
+        this.emitToolEvent(conversationKey, tc.id, agentName, 'error', started);
         agentLogs.push(formatFlightAgentLog(agentName, message, true));
         const result = `Error: ${message}`;
         await recorder.record({


### PR DESCRIPTION
The second half of the same contract #347 fixed. That PR corrected the status vocabulary; this one supplies the field the UI uses for **identity**.

`ui/src/components/chat.ts:1303`:

```js
const id = data.toolCallId ?? `tool_${Date.now()}`;
const idx = this.toolCalls.findIndex((t) => t.id === id);
if (idx >= 0) { /* update the existing row */ }
```

The emitter did not send `toolCallId`. Two tools finishing in the same millisecond therefore resolved to the **same key**, and the second *updated* the first's row instead of adding one. Reproduced against the UI's own keying logic:

```
before:  entries shown: 1 ["weather"]          <- "calendar" vanished
after:   entries shown: 2 ["weather","calendar"]
```

That is not a hypothetical window. Local tools — a memory read, a file stat — routinely complete inside the same millisecond.

## The fix

Emit the id the model already assigned. `tc.id` was in scope at all three emit sites; nothing had to be invented, which is the same reason `'success'` rather than `'ok'` was the right call in #347: the consumer had already decided.

## Why this keeps happening

Three defects now in one small event: wrong status vocabulary (#347), and here a missing identity field. Each was invisible because the emitter's tests asserted what the emitter sends and the UI's tests asserted what the UI does with a hand-written payload.

`chat-tool-event-contract.test.ts` reads both sides, and now covers identity as well as status. Its new assertion is deliberately specific — it checks the UI *reads* `data.toolCallId` and the emitter *sends* it, so deleting either half fails.

Mutation-tested by dropping the field from the emitted object: **4 tests fail** across both files.

## Verification

TypeScript **4978 passed**, 21 skipped (1 new); dashboard UI **130 passed**; tsc clean; eslint clean at `--max-warnings 0`.

Worth noting what did **not** turn out to be a problem, since I checked before assuming: the UI does not filter tool events by `runId`, and clears `toolCalls` on session change rather than per run — so the absent `runId` costs nothing today.
