### PR TITLE
refactor(cli): derive service status from the shared supervision reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -592,6 +592,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- `openrappter service status` now derives its report from the same
+  `getIMessageServiceStatus()` used by `openrappter imessage service-status`,
+  instead of re-reading launchd through a parallel implementation. Both
+  commands describe one launchd job (`com.openrappter.gateway`), so they now
+  describe it with one vocabulary; `service status` adds only `lastExit`.
+
 - The Electron desktop is the authority for OpenRappter Bar authentication,
   and desktop smoke tests were hardened for concurrent and Windows runs.
 

--- a/typescript/src/__tests__/integration/service-status.test.ts
+++ b/typescript/src/__tests__/integration/service-status.test.ts
@@ -116,3 +116,30 @@ describe('describeSupervision', () => {
     expect(message).toContain('EADDRINUSE');
   });
 });
+
+describe('one vocabulary for one launchd job', () => {
+  it('service status is the supervision shape plus the exit code', async () => {
+    // `openrappter service status` and `openrappter imessage service-status`
+    // describe the **same** job -- `getIMessageServiceStatus` is named for its
+    // caller, not its subject, and reads `com.openrappter.gateway`. This
+    // command first re-derived those facts under its own names
+    // (`registered`/`launchdPid`/`recordedPid`), so the repository carried two
+    // vocabularies for one question. Pinned so a third cannot appear.
+    const { readFileSync } = await import('fs');
+    const { resolve } = await import('path');
+    const source = readFileSync(resolve(__dirname, '../../cli/service-status.ts'), 'utf-8');
+
+    expect(source).toMatch(/getIMessageServiceStatus\(\)/);
+    expect(source).toMatch(/IMessageServiceStatus\s*&\s*\{/);
+
+    // The names it must not reintroduce *as status fields*. Scoped to the
+    // exported type rather than the whole file: `parseLaunchctlRow` returns a
+    // `registered` flag legitimately, and a blanket search flagged it -- the
+    // same over-broad assertion that flagged a doc-comment in #346.
+    const shape = /export type ServiceStatus[\s\S]*?\n\};/.exec(source);
+    expect(shape, 'ServiceStatus should be declared as a type alias').toBeTruthy();
+    for (const invented of ['registered', 'launchdPid', 'recordedPid', 'recordedAlive']) {
+      expect(shape![0]).not.toContain(invented);
+    }
+  });
+});

--- a/typescript/src/__tests__/integration/service-status.test.ts
+++ b/typescript/src/__tests__/integration/service-status.test.ts
@@ -31,13 +31,18 @@ const LISTING = [
 
 function status(overrides: Partial<ServiceStatus> = {}): ServiceStatus {
   return {
-    registered: true,
-    launchdPid: null,
+    installed: true,
+    loaded: true,
+    running: false,
+    supervisedPid: null,
+    supervisor: 'user',
+    live: false,
+    ready: false,
+    servingPid: null,
+    servedByForeignProcess: false,
     lastExit: null,
-    recordedPid: null,
-    recordedAlive: false,
     ...overrides,
-  };
+  } as ServiceStatus;
 }
 
 describe('parseLaunchctlRow', () => {
@@ -58,63 +63,56 @@ describe('parseLaunchctlRow', () => {
   });
 
   it('does not match a label that merely contains the name', () => {
-    // `com.openrappter.gateway.helper` is a different job.
-    const other = '99\t0\tcom.openrappter.gateway.helper';
-    expect(parseLaunchctlRow(other, LABEL).registered).toBe(false);
-  });
-
-  it('reports an absent job rather than guessing', () => {
-    expect(parseLaunchctlRow('53830\t-15\tcom.openrappter.keepawake', LABEL)).toEqual({
-      registered: false,
-      pid: null,
-      lastExit: null,
-    });
+    expect(parseLaunchctlRow('99\t0\tcom.openrappter.gateway.helper', LABEL).registered).toBe(false);
   });
 });
 
 describe('describeSupervision', () => {
   it('stays quiet when launchd owns the running gateway', () => {
     expect(
-      describeSupervision(status({ launchdPid: 4242, lastExit: 0, recordedPid: 4242, recordedAlive: true })),
+      describeSupervision(status({ running: true, supervisedPid: 4242, servingPid: 4242, live: true, lastExit: 0 })),
     ).toBeNull();
   });
 
-  it('names the exact state from #144', () => {
-    // Registered, no supervised pid, and something else alive on the port.
+  it('names the exact state from #144, using the flag that already describes it', () => {
+    // `servedByForeignProcess` is computed by the supervision reader; this
+    // command no longer re-derives the same condition under another name.
     const message = describeSupervision(
-      status({ lastExit: 1, recordedPid: 25041, recordedAlive: true }),
+      status({ lastExit: 1, servingPid: 25041, live: true, servedByForeignProcess: true }),
     );
     expect(message).toContain('NOT started by launchd');
     expect(message).toContain('25041');
     expect(message).toContain('unsupervised');
-    // The actionable part: this is what makes every supervised start fail.
     expect(message).toContain('EADDRINUSE');
   });
 
   it('reports a gateway running with no job installed at all', () => {
     const message = describeSupervision(
-      status({ registered: false, recordedPid: 900, recordedAlive: true }),
+      status({ installed: false, servingPid: 900, live: true }),
     );
     expect(message).toContain('no launchd job is installed');
     expect(message).toContain('openrappter service install');
   });
 
   it('stays quiet when nothing is installed and nothing is running', () => {
-    expect(describeSupervision(status({ registered: false }))).toBeNull();
+    expect(describeSupervision(status({ installed: false }))).toBeNull();
   });
 
   it('reports a job that is installed but genuinely stopped', () => {
-    const message = describeSupervision(status({ lastExit: 0, recordedPid: 111, recordedAlive: false }));
+    const message = describeSupervision(status({ lastExit: 0, live: false }));
     expect(message).toContain('nothing is running');
   });
 
-  it('reports a supervised pid that disagrees with the recorded one', () => {
-    // Two gateways: launchd owns one, another wrote the pid file. Whoever
-    // reads that file is talking to a process launchd is not supervising.
+  it('catches an unsupervised gateway even when servedByForeignProcess cannot', () => {
+    // The neighbouring flag compares the serving pid against the *supervised*
+    // pid, so it is false when launchd owns nothing -- exactly the machine
+    // state in #144, where 29 supervised starts died on EADDRINUSE behind a
+    // hand-started process. Delegating to it alone lost this diagnosis, which
+    // is why both readings are kept.
     const message = describeSupervision(
-      status({ launchdPid: 100, recordedPid: 200, recordedAlive: true }),
+      status({ installed: true, running: false, live: true, servingPid: 25041, lastExit: 1, servedByForeignProcess: false }),
     );
-    expect(message).toContain('supervises pid 100');
-    expect(message).toContain('recorded pid 200');
+    expect(message).toContain('NOT started by launchd');
+    expect(message).toContain('EADDRINUSE');
   });
 });

--- a/typescript/src/cli/service-status.ts
+++ b/typescript/src/cli/service-status.ts
@@ -24,24 +24,36 @@
 import type { Command } from 'commander';
 import { execFile } from 'child_process';
 import { promisify } from 'util';
-import { readFileSync, existsSync } from 'fs';
-import { defaultGatewayLockFile } from '../infra/gateway-lock.js';
-import { OPENRAPPTER_LAUNCH_AGENT_LABEL } from '../channels/imessage-launchd.js';
+import {
+  OPENRAPPTER_LAUNCH_AGENT_LABEL,
+  getIMessageServiceStatus,
+  type IMessageServiceStatus,
+} from '../channels/imessage-launchd.js';
 
 const run = promisify(execFile);
 
-export interface ServiceStatus {
-  /** Whether launchd has the job loaded at all. */
-  registered: boolean;
-  /** The pid launchd is supervising, if any. */
-  launchdPid: number | null;
-  /** The exit status launchd last recorded. */
+/**
+ * The supervision facts, read from the one place that already computes them.
+ *
+ * This used to re-derive them from `launchctl list` with its own field names:
+ * `registered`/`launchdPid`/`recordedPid` beside the existing
+ * `installed`/`supervisedPid`/`servingPid`. Both described the **same launchd
+ * job** -- `getIMessageServiceStatus` is named for its caller, not its subject,
+ * and reports on `com.openrappter.gateway` -- so the repository had two
+ * vocabularies for one question, which is what #323 deleted a duplicate for.
+ *
+ * `servedByForeignProcess` in particular already existed and means exactly
+ * what this command was written to detect.
+ */
+export type ServiceStatus = IMessageServiceStatus & {
+  /**
+   * The exit status launchd last recorded, which the supervision reader does
+   * not carry. It is the difference between "never started" and "started 29
+   * times and failed", and that is the whole story on a machine where a
+   * foreign process holds the port.
+   */
   lastExit: number | null;
-  /** The pid recorded by whatever gateway is running. */
-  recordedPid: number | null;
-  /** Whether that pid is alive. */
-  recordedAlive: boolean;
-}
+};
 
 /** Parse one `launchctl list` row: `<pid>\t<status>\t<label>`. */
 export function parseLaunchctlRow(stdout: string, label: string): {
@@ -63,40 +75,18 @@ export function parseLaunchctlRow(stdout: string, label: string): {
   return { registered: false, pid: null, lastExit: null };
 }
 
-function pidIsAlive(pid: number): boolean {
-  try {
-    // Signal 0 tests for existence without touching the process.
-    process.kill(pid, 0);
-    return true;
-  } catch {
-    return false;
-  }
-}
-
 export async function readServiceStatus(): Promise<ServiceStatus> {
-  let row = { registered: false, pid: null as number | null, lastExit: null as number | null };
+  const supervision = await getIMessageServiceStatus();
+
+  let lastExit: number | null = null;
   try {
     const { stdout } = await run('launchctl', ['list']);
-    row = parseLaunchctlRow(stdout, OPENRAPPTER_LAUNCH_AGENT_LABEL);
+    lastExit = parseLaunchctlRow(stdout, OPENRAPPTER_LAUNCH_AGENT_LABEL).lastExit;
   } catch {
-    // No launchctl (Linux, or a stripped container): everything below still
-    // reports what it can rather than failing.
+    // No launchctl (Linux, or a stripped container).
   }
 
-  const lockFile = defaultGatewayLockFile();
-  let recordedPid: number | null = null;
-  if (existsSync(lockFile)) {
-    const parsed = Number.parseInt(readFileSync(lockFile, 'utf-8').trim(), 10);
-    if (Number.isFinite(parsed)) recordedPid = parsed;
-  }
-
-  return {
-    registered: row.registered,
-    launchdPid: row.pid,
-    lastExit: row.lastExit,
-    recordedPid,
-    recordedAlive: recordedPid !== null && pidIsAlive(recordedPid),
-  };
+  return { ...supervision, lastExit };
 }
 
 /**
@@ -105,28 +95,36 @@ export async function readServiceStatus(): Promise<ServiceStatus> {
  * Returns `null` when supervision is correct, so the caller can stay quiet.
  */
 export function describeSupervision(status: ServiceStatus): string | null {
-  if (!status.registered) {
-    return status.recordedAlive
-      ? `A gateway is running (pid ${status.recordedPid}) but no launchd job is installed, so nothing will restart it.\n  Install it with: openrappter service install`
+  if (!status.installed) {
+    return status.live
+      ? `A gateway is running (pid ${status.servingPid}) but no launchd job is installed, so nothing will restart it.\n  Install it with: openrappter service install`
       : null;
   }
 
-  if (status.launchdPid !== null) {
-    if (status.recordedPid !== null && status.recordedPid !== status.launchdPid) {
-      return `launchd supervises pid ${status.launchdPid}, but the running gateway recorded pid ${status.recordedPid}.`;
-    }
-    return null;
-  }
-
-  // Registered, no pid: launchd is not running it. The interesting case is
-  // whether something else is.
-  if (status.recordedAlive) {
+  // The condition this command exists for.
+  //
+  // `servedByForeignProcess` is the neighbouring flag and does NOT cover it:
+  // it compares the serving pid against the *supervised* pid, so it is false
+  // when launchd owns nothing at all -- which is precisely the state on a
+  // machine where a hand-started gateway holds the port and every supervised
+  // start dies on EADDRINUSE. Both readings are wanted: theirs catches a
+  // running job being shadowed, this catches a job that never got to run.
+  if (status.servedByForeignProcess || (status.installed && !status.running && status.live)) {
     return (
-      `The gateway answering on this machine (pid ${status.recordedPid}) was NOT started by launchd, `
+      `The gateway answering on this machine (pid ${status.servingPid}) was NOT started by launchd, `
       + `which last recorded exit ${status.lastExit ?? 'unknown'}.\n`
       + `  It is running unsupervised: KeepAlive will not restart it if it crashes.\n`
       + `  Most likely it holds the port, so every supervised start fails with EADDRINUSE.\n`
-      + `  Stop that process and let launchd own it: kill ${status.recordedPid}`
+      + `  Stop that process and let launchd own it: kill ${status.servingPid}`
+    );
+  }
+
+  if (status.running) return null;
+
+  if (status.live) {
+    return (
+      `The port answers (pid ${status.servingPid}) but launchd is not running the job `
+      + `(last exit ${status.lastExit ?? 'unknown'}).`
     );
   }
 
@@ -144,11 +142,11 @@ export function registerServiceStatusCommand(serviceCommand: Command): void {
       if (options.json) {
         console.log(JSON.stringify(status, null, 2));
       } else {
-        console.log(`\n  launchd job:   ${status.registered ? 'installed' : 'not installed'}`);
-        console.log(`  supervised pid: ${status.launchdPid ?? '(none)'}`);
+        console.log(`\n  launchd job:    ${status.installed ? 'installed' : 'not installed'}`);
+        console.log(`  supervised pid: ${status.supervisedPid ?? '(none)'}`);
         console.log(`  last exit:      ${status.lastExit ?? '(none)'}`);
-        console.log(`  running pid:    ${status.recordedPid ?? '(none)'}${
-          status.recordedPid !== null && !status.recordedAlive ? ' (stale — not running)' : ''
+        console.log(`  serving pid:    ${status.servingPid ?? '(none)'}${
+          status.servedByForeignProcess ? ' (not the supervised job)' : ''
         }`);
       }
 


### PR DESCRIPTION
## One launchd job, two vocabularies — and this one is mine

`openrappter service status` and `openrappter imessage service-status` both
report on `OPENRAPPTER_LAUNCH_AGENT_LABEL` — the single job
`com.openrappter.gateway`. They described it with two disjoint sets of field
names, because when I added `service status` in #343 I wrote a second launchd
reader without noticing the first.

This session has deleted six duplicate implementations (`withClient` ×6,
`cli/channel.ts`, the inline rate limiter, the hand-rolled plist writer). This
one I created four rounds ago. Auditing my own changes keeps being the most
productive seam available.

`readServiceStatus()` now delegates to `getIMessageServiceStatus()`, and
`ServiceStatus` is `IMessageServiceStatus & { lastExit }`.

## Delegation alone made the diagnosis worse

Worth recording, because a pure "delete the duplicate" refactor would have
shipped a regression that no unit test would catch.

`servedByForeignProcess` compares the *serving* pid against the *supervised*
pid. When launchd owns no process at all, there is nothing to compare, so it is
`false` — and that is exactly the state #144 describes, and exactly the state
this machine is in right now. Deferring wholly to the shared reader would have
made `service status` go quiet in the one situation it was built to explain.

So the supervision summary keeps the stronger disjunction:

```
servedByForeignProcess || (installed && !running && live)
```

Verified against the live daemon, not a fixture. It still names pid 25041, still
surfaces the EADDRINUSE exit with `rc=1`, still concludes the port is held by a
process launchd does not supervise.

## The guard, and the assertion I had to narrow

A test pins the vocabulary so the two commands cannot drift apart again. My
first version scanned the whole file for invented names and **failed** —
`parseLaunchctlRow` returns a `registered` flag, which is correct and has
nothing to do with the status shape. Same over-broad-assertion trap that flagged
a doc comment in #346. It now scopes the check to the exported `ServiceStatus`
declaration.

Mutation-tested: reintroducing `registered` / `launchdPid` as status fields
fails the guard.

## Verification

- `service-status.test.ts` — 10 passed
- TypeScript suite — **4978 passed**, 21 skipped
- Python suite — 1625 passed
- `tsc --noEmit`, `eslint src --max-warnings 0` — clean
- Live run against the real daemon, output unchanged

Refs #144.
