### PR TITLE
fix(cli): count audit findings against --fail-on, not a fixed severity set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capability its syntax tree can reach, per the RAPP agent contract.
 
 ### Fixed
+
+- `openrappter audit` printed a blocking-finding count that ignored
+  `--fail-on`. The exit code honoured the flag while the summary counted
+  against a fixed `critical|high` set, so `--fail-on critical` could report
+  "1 at high or critical" and still exit 0, and `--fail-on low` could report
+  "0 at high or critical" while exiting 1. The count now uses the threshold in
+  effect and names it.
 - `agent.tool` omitted `toolCallId`, the field the chat list keys its rows on. Two tools finishing in the same millisecond therefore resolved to the same key, and the second *updated* the first's row instead of adding one -- so a tool vanished from the transcript.
 - The Flight Recorder ledger ignored `OPENRAPPTER_HOME` in **both** runtimes, so relocating an installation moved everything except the database recording it. TypeScript spelled the path across three lines, which is how it escaped the migration that moved the other 46 sites -- and the guard meant to catch stragglers, whose pattern could not match its own formatting.
 - `agent.tool` reported every **successful** tool call as a failure in chat. The event added in the previous change sent `status: 'ok'`, and the chat UI -- which has read this event since before it was emitted -- renders `status === 'success' ? '✓' : '✗'`, so `'ok'` fell to the cross. Emitter and consumer are now pinned to one vocabulary.

--- a/typescript/src/__tests__/integration/audit-fail-on.test.ts
+++ b/typescript/src/__tests__/integration/audit-fail-on.test.ts
@@ -1,0 +1,117 @@
+/**
+ * `openrappter audit --fail-on <severity>`: the number it prints and the exit
+ * code it sets must describe the same threshold.
+ *
+ * They did not. The exit code came from `--fail-on`, but the summary line
+ * counted against a hardcoded `Set(['critical','high'])` and was worded
+ * "N at high or critical". So with a single `high` finding on the machine:
+ *
+ *     $ openrappter audit --fail-on critical
+ *       1 finding, 1 at high or critical.      <- reads as blocking
+ *       $? = 0                                  <- but it passed
+ *
+ * and in the other direction `--fail-on low` reported "0 at high or critical"
+ * while exiting 1 -- a CI gate that fails while printing a reassuring zero.
+ *
+ * The count is the only thing that tells a human *why* the command exited the
+ * way it did, so it is tested against the exit code rather than on its own.
+ */
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { Command } from 'commander';
+import type { AuditFinding } from '../../security/audit.js';
+
+const findings = vi.hoisted(() => ({ current: [] as AuditFinding[] }));
+
+vi.mock('../../security/audit.js', () => ({
+  SecurityAuditor: class {
+    async runAll(): Promise<AuditFinding[]> {
+      return findings.current;
+    }
+  },
+}));
+
+function finding(severity: AuditFinding['severity']): AuditFinding {
+  return {
+    checkId: `check-${severity}`,
+    severity,
+    title: `A ${severity} problem`,
+    detail: 'planted by the test',
+  } as AuditFinding;
+}
+
+async function runAudit(argv: string[]): Promise<{ out: string; code: number }> {
+  const { registerAuditCommand } = await import('../../cli/audit.js');
+  const lines: string[] = [];
+  const log = vi.spyOn(console, 'log').mockImplementation((...a) => {
+    lines.push(a.join(' '));
+  });
+  const err = vi.spyOn(console, 'error').mockImplementation(() => {});
+  const saved = process.exitCode;
+  process.exitCode = 0;
+
+  const program = new Command();
+  program.exitOverride();
+  registerAuditCommand(program);
+  await program.parseAsync(['node', 'openrappter', 'audit', ...argv]);
+
+  const code = Number(process.exitCode ?? 0);
+  process.exitCode = saved;
+  log.mockRestore();
+  err.mockRestore();
+  return { out: lines.join('\n'), code };
+}
+
+/** The count the summary line reports as blocking. */
+function reportedBlocking(out: string): number {
+  const m = /(\d+) at or above/.exec(out);
+  expect(m, `summary should report a blocking count, got:\n${out}`).toBeTruthy();
+  return Number(m![1]);
+}
+
+afterEach(() => {
+  findings.current = [];
+  vi.restoreAllMocks();
+});
+
+describe('audit --fail-on: the printed count and the exit code agree', () => {
+  const levels = ['critical', 'high', 'medium', 'low', 'info'] as const;
+
+  for (const planted of levels) {
+    for (const threshold of levels) {
+      it(`a ${planted} finding under --fail-on ${threshold}`, async () => {
+        findings.current = [finding(planted)];
+        const { out, code } = await runAudit(['--fail-on', threshold]);
+
+        const blocking = reportedBlocking(out);
+        // Whenever the summary claims something is blocking, the command must
+        // have exited non-zero -- and vice versa. This is the invariant the
+        // hardcoded set broke.
+        expect(blocking > 0).toBe(code === 1);
+      });
+    }
+  }
+
+  it('names the threshold the user asked for, not a fixed one', async () => {
+    findings.current = [finding('low')];
+    const { out } = await runAudit(['--fail-on', 'low']);
+    expect(out).toContain('at or above low');
+  });
+
+  it('counts every finding at or above the threshold', async () => {
+    findings.current = [
+      finding('critical'),
+      finding('high'),
+      finding('low'),
+      finding('info'),
+    ];
+    const { out, code } = await runAudit(['--fail-on', 'low']);
+    expect(reportedBlocking(out)).toBe(3);
+    expect(code).toBe(1);
+  });
+
+  it('still rejects a threshold that is not a severity', async () => {
+    findings.current = [finding('critical')];
+    const { code } = await runAudit(['--fail-on', 'catastrophic']);
+    expect(code).toBe(1);
+  });
+});

--- a/typescript/src/cli/audit.ts
+++ b/typescript/src/cli/audit.ts
@@ -11,14 +11,14 @@
  * missing-file branch returns `[]` -- indistinguishable from a clean bill of
  * health.
  *
- * Exit codes are the point of having this in a terminal: `1` when anything
- * high or critical is found, so it can gate a script.
+ * Exit codes are the point of having this in a terminal: `1` when anything at
+ * or above `--fail-on` is found, so it can gate a script. The printed summary
+ * counts against that same threshold -- an earlier version counted against a
+ * fixed `critical|high` set while exiting on `--fail-on`, so the two disagreed
+ * whenever the flag was not left at its default.
  */
 import type { Command } from 'commander';
 import { SecurityAuditor, type AuditFinding } from '../security/audit.js';
-
-/** Severities that should fail a scripted run. */
-const BLOCKING = new Set(['critical', 'high']);
 
 const ORDER: Record<string, number> = {
   critical: 0,
@@ -64,10 +64,11 @@ export function registerAuditCommand(program: Command): void {
             console.log(`    ${finding.detail}`);
             if (finding.remediation) console.log(`    fix: ${finding.remediation}`);
           }
-          const blocking = findings.filter((f) => BLOCKING.has(f.severity)).length;
+          const level = options.failOn ?? 'high';
+          const blocking = findings.filter((f) => severityRank(f) <= threshold).length;
           console.log(
             `\n  ${findings.length} finding${findings.length === 1 ? '' : 's'}`
-            + `, ${blocking} at high or critical.\n`,
+            + `, ${blocking} at or above ${level}.\n`,
           );
         }
       }


### PR DESCRIPTION
## The number that explains the exit code was measured against a different threshold

`openrappter audit` takes `--fail-on <severity>` and sets its exit code from it.
The summary line, however, counted findings against a hardcoded
`Set(['critical', 'high'])` and was worded *"N at high or critical"*.

So the one piece of output that tells a human *why* the command exited the way
it did was computed from a threshold the user may not have asked for.

Reproduced live against this machine, which has exactly one `high` finding (the
mode-644 config file):

```
$ openrappter audit --fail-on critical

  1 finding, 1 at high or critical.

exit 0
```

The line reads as though the gate tripped. It did not.

The other direction is worse, because it fails quietly in the reassuring
direction: `--fail-on low` prints *"0 at high or critical"* and **exits 1** — a
CI job that fails while displaying a zero. `low` and `info` findings are both
produced by real checks in `security/audit.ts`, so this is reachable, not
hypothetical.

## Fix

The count now filters on the same `severityRank(f) <= threshold` comparison the
exit code uses, and names the level actually in effect:

```
$ openrappter audit --fail-on critical
  1 finding, 0 at or above critical.      exit 0

$ openrappter audit --fail-on high
  1 finding, 1 at or above high.          exit 1

$ openrappter audit --fail-on low
  1 finding, 1 at or above low.           exit 1
```

## The test asserts the invariant, not the number

Pinning the specific strings would have re-encoded the bug. Instead, across all
25 combinations of planted severity × threshold:

```ts
expect(blocking > 0).toBe(code === 1);
```

A non-zero reported count must occur exactly when the command exits 1.
Restoring the hardcoded set fails **8 of the 28** tests.

## Provenance

This is my own defect, from #337 four rounds ago — the same round that wired the
auditor up in the first place. Auditing this session's changes has now produced
six consecutive real findings (#347, #348, #349, #350, #351, this), against nine
clean probes of the pre-existing code.

## Verification

- `audit-fail-on.test.ts` — 28 passed
- TypeScript suite — **5006 passed**, 21 skipped
- `tsc --noEmit`, `eslint src --max-warnings 0` — clean
- Live runs at three thresholds, shown above
