### PR TITLE
fix(chat): make the RAPP/1 chat contract executable, and stop fingerprinting the runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -68,6 +68,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `POST /chat` rejections diverged between the runtimes. TypeScript answered a
+  malformed request with a bare `{error}` while the Python brainstem answered
+  with `{schema, status, error}`, so one malformed body identified which
+  runtime replied -- on four of five bodies tested. The TypeScript comment
+  justifying the bare shape cited a brainstem returning
+  `jsonify({"error": ...}), 400`; no such brainstem is in this repository.
+  Both runtimes now emit the envelope `contracts/rapp-chat-v1.json` fixes, on
+  every rejection path including unparseable JSON.
+
 - `openrappter audit` printed a blocking-finding count that ignored
   `--fail-on`. The exit code honoured the flag while the summary counted
   against a fixed `critical|high` set, so `--fail-on critical` could report
@@ -598,6 +607,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no OpenRappter code reads. It now documents the flow that ships.
 
 ### Changed
+
+- `contracts/rapp-chat-v1.json` is now executable. It was read by one test,
+  which asserted only that `brand` was `RAPP + X™` and hardcoded every other
+  field, so appending a required key nothing emits left the suite green.
+  Both runtimes now drive their assertions from the file. The contract was
+  also corrected to describe verified behaviour: `user_input` is the canonical
+  input and `message` its alias, not the reverse, and the success envelope
+  requires all ten keys both runtimes actually emit.
 
 - `openrappter service status` now derives its report from the same
   `getIMessageServiceStatus()` used by `openrappter imessage service-status`,

--- a/README.md
+++ b/README.md
@@ -201,7 +201,11 @@ reported after real agent-tool evidence and a post-operative verification pass.
 rapplications, Brainstems, and neighborhood peers. Python and TypeScript accept
 the same `rapp-chat/1.0` envelope; UI, TUI, menu bar, and other clients are
 projections over that headless contract, not separate capability paths. See
-[`contracts/rapp-chat-v1.json`](contracts/rapp-chat-v1.json).
+[`contracts/rapp-chat-v1.json`](contracts/rapp-chat-v1.json), which both
+runtimes are tested against -- its `required` arrays drive the assertions in
+`python/tests/test_openrappter_brainstem.py` and
+`typescript/src/__tests__/integration/rapp-chat-contract.test.ts`, so a key
+added there fails both suites until both runtimes emit it.
 
 ```bash
 # Install and go

--- a/contracts/rapp-chat-v1.json
+++ b/contracts/rapp-chat-v1.json
@@ -2,21 +2,35 @@
   "schema": "rapp-chat-contract/1.0",
   "brand": "RAPP + X™",
   "principle": "UI is optional. Humans, AIs, twins, rapplications, Brainstems, and neighborhood peers use the same /chat capability surface.",
+  "enforced_by": [
+    "python/tests/test_openrappter_brainstem.py",
+    "typescript/src/__tests__/integration/rapp-chat-contract.test.ts"
+  ],
   "endpoint": {
     "method": "POST",
     "path": "/chat"
   },
   "request": {
-    "required": ["message"],
+    "canonical_input": "user_input",
+    "required_one_of": ["user_input", "message"],
+    "precedence": [
+      "`user_input` is the spec key and wins whenever it is present, even when",
+      "it is present and invalid -- a caller sending the documented field gets",
+      "the documented behaviour, including its errors. `message` is a PARITY §3",
+      "extra axis consulted only when `user_input` is absent entirely.",
+      "Both runtimes were aligned on this in #335; the earlier version of this",
+      "file described the reverse and was never executed, so it never noticed."
+    ],
     "properties": {
       "schema": "rapp-chat/1.0",
-      "message": "string",
+      "user_input": "string",
+      "message": "string?",
       "session_id": "string?",
       "idempotency_key": "string?",
       "conversation_history": "array?"
     },
-    "legacy_aliases": {
-      "user_input": "message",
+    "aliases": {
+      "message": "user_input",
       "sessionId": "session_id",
       "history": "conversation_history"
     }
@@ -28,7 +42,12 @@
         "status",
         "response",
         "content",
-        "session_id"
+        "session_id",
+        "sessionId",
+        "agent_logs",
+        "voice_mode",
+        "model",
+        "requested_model"
       ],
       "properties": {
         "schema": "rapp-chat/1.0",
@@ -38,6 +57,10 @@
         "session_id": "string",
         "sessionId": "string",
         "agent_logs": "string",
+        "voice_mode": "boolean",
+        "model": "string",
+        "requested_model": "string",
+        "voice_response": "string?",
         "idempotency_key": "string?"
       }
     },

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -1236,7 +1236,14 @@ class BrainstemHandler(BaseHTTPRequestHandler):
             except ValueError:
                 data = None
             if not isinstance(data, dict):
-                return self._send(400, {"error": "Request body must be a JSON object"})
+                # Same envelope as every other rejection on this wire; a bare
+                # `{error}` here was the one malformed body whose reply differed
+                # in shape from the rest. contracts/rapp-chat-v1.json fixes it.
+                return self._send(400, {
+                    "schema": "rapp-chat/1.0",
+                    "status": "error",
+                    "error": "Request body must be a JSON object",
+                })
             # `user_input` is authoritative, exactly as the grail and the
             # TypeScript runtime have it. This used to prefer `message`
             # whenever it was a string, so `{"user_input":"A","message":"B"}`

--- a/python/tests/test_openrappter_brainstem.py
+++ b/python/tests/test_openrappter_brainstem.py
@@ -158,29 +158,108 @@ def test_chat_validates_input_like_the_kernel(server):
     assert body["error"] == "user_input is required"
 
 
+CONTRACT = json.loads(
+    (Path(__file__).parents[2] / "contracts" / "rapp-chat-v1.json").read_text()
+)
+
+
+def _fixed_values(properties):
+    """Keys whose literal value the contract pins, e.g. status -> "success"."""
+    return {
+        key: spec
+        for key, spec in properties.items()
+        if spec not in ("string", "boolean", "array") and not spec.endswith("?")
+    }
+
+
 def test_rapp_chat_v1_contract(server, monkeypatch):
-    contract = json.loads(
-        (Path(__file__).parents[2] / "contracts" / "rapp-chat-v1.json").read_text()
-    )
-    assert contract["brand"] == "RAPP + X™"
+    """Every assertion is driven by the contract file, not by a literal here.
+
+    This test used to load the contract and check one thing -- that
+    ``brand`` was ``RAPP + X"`` -- while asserting hardcoded field names for
+    everything else. Appending a required key named ``a_field_nothing_emits``
+    to the success response left it green, so the ``required`` arrays
+    constrained nothing on either runtime.
+    """
+    assert CONTRACT["brand"] == "RAPP + X\u2122"
     monkeypatch.setattr(
         brainstem,
         "llm_chat",
         lambda _messages, _tools: ({"role": "assistant", "content": "canonical"}, "gpt-4o"),
     )
+    canonical = CONTRACT["request"]["canonical_input"]
     status, body = post_json(f"{server}/chat", {
         "schema": "rapp-chat/1.0",
-        "message": "hello",
+        canonical: "hello",
         "session_id": "shared-session",
         "idempotency_key": "shared-idempotency",
         "conversation_history": [],
     })
     assert status == 200
-    assert body["schema"] == "rapp-chat/1.0"
-    assert body["status"] == "success"
+
+    missing = [k for k in CONTRACT["response"]["success"]["required"] if k not in body]
+    assert not missing, f"contract requires these and /chat omitted them: {missing}"
+
+    for key, value in _fixed_values(CONTRACT["response"]["success"]["properties"]).items():
+        assert body[key] == value, f"{key} is fixed by the contract"
+
     assert body["response"] == body["content"] == "canonical"
     assert body["session_id"] == body["sessionId"] == "shared-session"
     assert body["idempotency_key"] == "shared-idempotency"
+
+
+def test_rapp_chat_v1_error_envelope(server):
+    """A rejection carries exactly the keys the contract fixes."""
+    canonical = CONTRACT["request"]["canonical_input"]
+    required = CONTRACT["response"]["error"]["required"]
+    declared = set(CONTRACT["response"]["error"]["properties"])
+
+    for payload in (
+        [],
+        {canonical: 123},
+        {canonical: "   "},
+        {canonical: "hi", "conversation_history": "nope"},
+    ):
+        status, body = post_json(f"{server}/chat", payload)
+        assert status == 400, payload
+        missing = [k for k in required if k not in body]
+        assert not missing, f"{payload}: contract requires {missing}"
+        undeclared = [k for k in body if k not in declared]
+        assert not undeclared, f"{payload}: undeclared keys {undeclared}"
+
+    for key, value in _fixed_values(CONTRACT["response"]["error"]["properties"]).items():
+        status, body = post_json(f"{server}/chat", {canonical: "   "})
+        assert body[key] == value, f"{key} is fixed by the contract"
+
+
+def test_rapp_chat_v1_request_aliases(server, monkeypatch):
+    """Each alias the contract declares is accepted, and loses to the spec key."""
+    monkeypatch.setattr(
+        brainstem,
+        "llm_chat",
+        lambda messages, _tools: (
+            {"role": "assistant", "content": messages[-1]["content"]},
+            "gpt-4o",
+        ),
+    )
+    canonical = CONTRACT["request"]["canonical_input"]
+
+    for key in CONTRACT["request"]["required_one_of"]:
+        status, _ = post_json(f"{server}/chat", {key: "hello"})
+        assert status == 200, f"{key} alone should be accepted"
+
+    alias_for_input = next(
+        alias for alias, target in CONTRACT["request"]["aliases"].items()
+        if target == canonical
+    )
+    status, body = post_json(f"{server}/chat", {
+        canonical: "from-spec-key",
+        alias_for_input: "from-alias",
+    })
+    assert status == 200
+    # The precedence the contract records, and the divergence #335 closed.
+    assert "from-spec-key" in body["response"]
+    assert "from-alias" not in body["response"]
 
 
 def test_rapp_chat_idempotency_prevents_duplicate_execution(server, monkeypatch):

--- a/typescript/src/__tests__/integration/rapp-chat-contract.test.ts
+++ b/typescript/src/__tests__/integration/rapp-chat-contract.test.ts
@@ -1,0 +1,198 @@
+/**
+ * `contracts/rapp-chat-v1.json`, executed against the TypeScript `/chat`.
+ *
+ * The contract is the shared RAPP/1 chat surface, and until now it was read by
+ * exactly one file -- `python/tests/test_openrappter_brainstem.py` -- which
+ * loaded it and asserted a single thing:
+ *
+ *     assert contract["brand"] == "RAPP + X™"
+ *
+ * Every other assertion in that test was a hardcoded literal, so the `required`
+ * arrays -- the actual contract -- constrained nothing. Appending a required
+ * key named `a_field_nothing_emits` to the success response left the suite
+ * green. TypeScript did not read the file at all.
+ *
+ * So the tests here drive every assertion off the parsed contract. Adding a key
+ * to `required` must fail this file until the gateway emits it, and removing
+ * one must stop it being checked. Nothing below names a response field except
+ * where the contract fixes its literal value.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const CONTRACT = resolve(__dirname, '../../../../contracts/rapp-chat-v1.json');
+
+interface ChatContract {
+  brand: string;
+  endpoint: { method: string; path: string };
+  request: {
+    canonical_input: string;
+    required_one_of: string[];
+    aliases: Record<string, string>;
+  };
+  response: {
+    success: { required: string[]; properties: Record<string, string> };
+    error: { required: string[]; properties: Record<string, string> };
+  };
+}
+
+const contract: ChatContract = JSON.parse(readFileSync(CONTRACT, 'utf-8'));
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+/** Start a gateway whose agent echoes the prompt it was handed. */
+async function startGateway(): Promise<number> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server.setAgentHandler(async (request) => ({
+    // `sessionId` is required by AgentResponse; the gateway echoes whatever the
+    // handler returns, so a stub that omits it is not a conforming handler.
+    sessionId: request.sessionId ?? '',
+    content: `echo:${request.message}`,
+    agentLogs: [],
+  }));
+  await server.start();
+  return port;
+}
+
+async function postChat(
+  port: number,
+  body: unknown,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`http://127.0.0.1:${port}${contract.endpoint.path}`, {
+    method: contract.endpoint.method,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body),
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+/** Literal values the contract fixes, e.g. `"status": "success"`. */
+function fixedValues(properties: Record<string, string>): [string, string][] {
+  return Object.entries(properties).filter(
+    ([, spec]) => spec !== 'string' && spec !== 'boolean' && !spec.endsWith('?'),
+  );
+}
+
+describe('rapp-chat-v1: the success envelope', () => {
+  it('carries every key the contract requires', async () => {
+    const port = await startGateway();
+    const { status, body } = await postChat(port, {
+      [contract.request.canonical_input]: 'hello',
+      session_id: 'contract-session',
+    });
+
+    expect(status).toBe(200);
+    const missing = contract.response.success.required.filter((k) => !(k in body));
+    expect(missing, `contract requires these and /chat omitted them`).toEqual([]);
+  });
+
+  it('uses the literal values the contract fixes', async () => {
+    const port = await startGateway();
+    const { body } = await postChat(port, {
+      [contract.request.canonical_input]: 'hello',
+      session_id: 'contract-session',
+    });
+
+    for (const [key, value] of fixedValues(contract.response.success.properties)) {
+      expect(body[key], `${key} is fixed by the contract`).toBe(value);
+    }
+  });
+
+  it('echoes the session id back under both spellings', async () => {
+    const port = await startGateway();
+    const { body } = await postChat(port, {
+      [contract.request.canonical_input]: 'hello',
+      session_id: 'contract-session',
+    });
+    expect(body.session_id).toBe('contract-session');
+    expect(body.sessionId).toBe(body.session_id);
+  });
+});
+
+describe('rapp-chat-v1: the error envelope', () => {
+  it('carries every key the contract requires', async () => {
+    const port = await startGateway();
+    // Empty input is a documented 400.
+    const { status, body } = await postChat(port, {
+      [contract.request.canonical_input]: '   ',
+    });
+
+    expect(status).toBe(400);
+    const missing = contract.response.error.required.filter((k) => !(k in body));
+    expect(missing, `contract requires these on error and /chat omitted them`).toEqual([]);
+  });
+
+  it('uses the literal values the contract fixes', async () => {
+    const port = await startGateway();
+    const { body } = await postChat(port, { [contract.request.canonical_input]: '   ' });
+    for (const [key, value] of fixedValues(contract.response.error.properties)) {
+      expect(body[key], `${key} is fixed by the contract`).toBe(value);
+    }
+  });
+});
+
+describe('rapp-chat-v1: request aliases', () => {
+  it('accepts each alias the contract declares', async () => {
+    const port = await startGateway();
+    const canonical = await postChat(port, {
+      [contract.request.canonical_input]: 'hello',
+      session_id: 's',
+      conversation_history: [],
+    });
+
+    for (const [alias, target] of Object.entries(contract.request.aliases)) {
+      const payload: Record<string, unknown> = {
+        [contract.request.canonical_input]: 'hello',
+        session_id: 's',
+        conversation_history: [],
+      };
+      // Move the value from the spec key onto its alias.
+      payload[alias] = payload[target];
+      delete payload[target];
+      if (target === contract.request.canonical_input) {
+        delete payload[contract.request.canonical_input];
+        payload[alias] = 'hello';
+      }
+
+      const aliased = await postChat(port, payload);
+      expect(aliased.status, `alias ${alias} -> ${target}`).toBe(200);
+      expect(aliased.body.response, `alias ${alias} -> ${target}`).toBe(
+        canonical.body.response,
+      );
+    }
+  });
+
+  it('accepts a request carrying only an alias for the input', async () => {
+    const port = await startGateway();
+    for (const key of contract.request.required_one_of) {
+      const { status } = await postChat(port, { [key]: 'hello' });
+      expect(status, `${key} alone should be accepted`).toBe(200);
+    }
+  });
+
+  it('prefers the canonical key over its alias when both are sent', async () => {
+    const port = await startGateway();
+    const aliasForInput = Object.entries(contract.request.aliases)
+      .find(([, target]) => target === contract.request.canonical_input)?.[0];
+    expect(aliasForInput, 'contract should declare an alias for the input').toBeTruthy();
+
+    const { body } = await postChat(port, {
+      [contract.request.canonical_input]: 'from-spec-key',
+      [aliasForInput!]: 'from-alias',
+    });
+    // The precedence recorded in the contract, and the divergence #335 closed.
+    expect(body.response).toContain('from-spec-key');
+    expect(body.response).not.toContain('from-alias');
+  });
+});

--- a/typescript/src/gateway/__tests__/chat-body-cap.test.ts
+++ b/typescript/src/gateway/__tests__/chat-body-cap.test.ts
@@ -74,7 +74,8 @@ describe('an oversized body is refused at the door', () => {
     const got = await postRaw('/chat', huge);
 
     expect(got.status).toBe(413);
-    // Bare {error}, like every other rejection on this wire.
+    // 413 has no brainstem counterpart -- it has no body cap -- so nothing
+    // can be compared here and the bare shape stays.
     expect(got.body).toEqual({ error: 'Request body too large' });
     // THE POINT: the agent — and behind it a paid API — was never invoked.
     expect(handlerCalls).toBe(before);
@@ -139,6 +140,6 @@ describe('the cap never bites a real request', () => {
   it('still rejects a malformed body on its own terms, not as oversize', async () => {
     const got = await postRaw('/chat', '{"user_input":123}');
     expect(got.status).toBe(400);
-    expect(got.body).toEqual({ error: 'user_input must be a string' });
+    expect(got.body).toEqual({ schema: 'rapp-chat/1.0', status: 'error', error: 'user_input must be a string' });
   });
 });

--- a/typescript/src/gateway/__tests__/chat-indistinguishability.test.ts
+++ b/typescript/src/gateway/__tests__/chat-indistinguishability.test.ts
@@ -15,17 +15,35 @@
  * the actual bytes off an actual socket, and the negative control is part of the
  * job — a test that cannot fail on the old code is decoration.
  *
- * Ground truth is `brainstem.py`, whose rejection is
- * `return jsonify({"error": ...}), 400` — one key, nothing else.
+ * Ground truth WAS STATED HERE INCORRECTLY, and the correction is the reason
+ * this header is long.
+ *
+ * It read: "Ground truth is `brainstem.py`, whose rejection is
+ * `return jsonify({"error": ...}), 400` — one key, nothing else."
+ *
+ * No such brainstem is in this repository. `python/openrappter/brainstem.py`
+ * imports no Flask, contains no `jsonify`, and answers through `_send`; its
+ * rejections carry `schema`, `status` and `error`. That was checked by posting
+ * every body below to the running brainstem and reading the keys back, which is
+ * the check the sentence above replaced.
+ *
+ * So this file asserted a one-key body to avoid a fingerprint and thereby
+ * created one: four of five malformed requests separated the runtimes.
+ *
+ * Ground truth is now `contracts/rapp-chat-v1.json`, which both runtimes are
+ * tested against -- here and in `python/tests/test_openrappter_brainstem.py` --
+ * so neither can be adjusted toward a belief about the other again.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, rmSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { GatewayServer } from '../server.js';
 import type { AgentRequest } from '../types.js';
 
+const __dirname = dirname(fileURLToPath(import.meta.url));
 const PORT = 19811;
 const BASE = `http://127.0.0.1:${PORT}`;
 
@@ -70,8 +88,22 @@ async function post(target: string, raw: string): Promise<{ status: number; body
   return { status: res.status, body, text };
 }
 
-/** Exactly what brainstem.py writes for a rejected request. */
-const brainstemRejects = (error: string) => ({ status: 400, body: { error } });
+interface ErrorContract {
+  response: { error: { required: string[]; properties: Record<string, string> } };
+}
+const CONTRACT: ErrorContract = JSON.parse(
+  readFileSync(resolve(__dirname, '../../../../contracts/rapp-chat-v1.json'), 'utf-8'),
+);
+
+/** The rejection body the contract fixes, with `error` filled in. */
+function contractRejects(error: string): { status: number; body: Record<string, unknown> } {
+  const body: Record<string, unknown> = {};
+  for (const key of CONTRACT.response.error.required) {
+    const spec = CONTRACT.response.error.properties[key];
+    body[key] = key === 'error' ? error : spec;
+  }
+  return { status: 400, body };
+}
 
 const REJECTIONS: Array<[label: string, raw: string, error: string]> = [
   ['a non-object body', '[]', 'Request body must be a JSON object'],
@@ -93,15 +125,22 @@ describe('a rejection carries nothing that names the runtime', () => {
       const got = await post('/chat', raw);
       // The assertion the old instrument could not make: the WHOLE body.
       // Comparing only `.error` passed while `schema` and `status` sat beside it.
-      expect({ status: got.status, body: got.body }).toEqual(brainstemRejects(error));
-      expect(Object.keys(got.body as object)).toEqual(['error']);
+      expect({ status: got.status, body: got.body }).toEqual(contractRejects(error));
+      expect(Object.keys(got.body as object).sort())
+        .toEqual([...CONTRACT.response.error.required].sort());
     });
   }
 
   it('leaks no fingerprint key on any rejection', async () => {
     for (const [, raw] of REJECTIONS) {
       const got = await post('/chat', raw);
-      for (const tell of ['schema', 'status', 'content', 'sessionId', 'session_id']) {
+      // Anything the contract does not declare is a tell: it is a key one
+      // runtime emits and the other has no reason to.
+      const declared = new Set(Object.keys(CONTRACT.response.error.properties));
+      for (const key of Object.keys(got.body as object)) {
+        expect(declared.has(key), `undeclared key ${key} for body ${raw}`).toBe(true);
+      }
+      for (const tell of ['content', 'response', 'model', 'agent_logs']) {
         expect(got.body, `${tell} present for body ${raw}`).not.toHaveProperty(tell);
       }
     }
@@ -116,7 +155,7 @@ describe('a query string does not change which endpoint this is', () => {
     it(`validates ${target} exactly as /chat`, async () => {
       const got = await post(target, '{"user_input":"hi","conversation_history":"nope"}');
       expect({ status: got.status, body: got.body })
-        .toEqual(brainstemRejects('conversation_history must be an array'));
+        .toEqual(contractRejects('conversation_history must be an array'));
       // The old fallthrough is unmistakable in the bytes.
       expect(got.text).not.toContain('Received:');
     });

--- a/typescript/src/gateway/__tests__/unknown-path-404.test.ts
+++ b/typescript/src/gateway/__tests__/unknown-path-404.test.ts
@@ -102,12 +102,12 @@ describe('the paths it does implement are unaffected', () => {
   it('still validates /chat rather than 404-ing it', async () => {
     const got = await post('/chat', '{"user_input":123}');
     expect(got.status).toBe(400);
-    expect(got.body).toEqual({ error: 'user_input must be a string' });
+    expect(got.body).toEqual({ schema: 'rapp-chat/1.0', status: 'error', error: 'user_input must be a string' });
   });
 
   it('still treats /chat with a query string as /chat', async () => {
     const got = await post('/chat?x=1', '{"user_input":"hi","conversation_history":"nope"}');
     expect(got.status).toBe(400);
-    expect(got.body).toEqual({ error: 'conversation_history must be an array' });
+    expect(got.body).toEqual({ schema: 'rapp-chat/1.0', status: 'error', error: 'conversation_history must be an array' });
   });
 });

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -1457,16 +1457,25 @@ export class GatewayServer {
             // the transcript.
             const parsedRequest = parseChatRequest(parsed);
             if (!parsedRequest.ok) {
-              // Bare `{error}`, exactly as the brainstem writes it. PARITY §3
-              // permits extra axes, but the goal on this wire is stronger than
-              // §3: a peer must not be able to tell which runtime answered. A
-              // single malformed request was enough to fingerprint us, because
-              // ours carried `schema` and `status` and the brainstem's does not.
-              // Those keys survive on the paths the brainstem has no
-              // counterpart for (401 auth, 503, 409, 504) — nothing can be
-              // compared there, so nothing diverges.
+              // The same three keys `brainstem.py` writes -- verified by posting
+              // each malformed body to both runtimes, not by reading either.
+              //
+              // This used to send a bare `{error}` to avoid fingerprinting,
+              // citing a brainstem that replies `jsonify({"error": ...}), 400`.
+              // No such brainstem is in this repository: `brainstem.py` has no
+              // Flask and no `jsonify`, it answers through `_send`, and its
+              // rejections carry `schema` and `status`. Stripping them here
+              // therefore produced the divergence the change set out to remove
+              // -- one malformed request separated the runtimes on four of five
+              // bodies. `contracts/rapp-chat-v1.json` fixes the shape and both
+              // runtimes are now tested against the file rather than against a
+              // belief about each other.
               res.writeHead(400, { 'Content-Type': 'application/json', ...corsHeaders });
-              res.end(JSON.stringify({ error: parsedRequest.error }));
+              res.end(JSON.stringify({
+                schema: 'rapp-chat/1.0',
+                status: 'error',
+                error: parsedRequest.error,
+              }));
               return;
             }
             const message = parsedRequest.value.userInput;
@@ -1670,13 +1679,19 @@ export class GatewayServer {
           }
         } catch {
           // The brainstem answers malformed JSON with the same sentence it uses
-          // for a non-object body — `get_json(silent=True)` yields None and
-          // falls into the same branch. A `/chat` caller must not be able to
-          // tell the two runtimes apart by their parse errors either.
+          // for a non-object body, and in the same envelope. (The `get_json`
+          // this comment used to cite is Flask; the brainstem here catches
+          // `json.loads` and replies through `_send` -- verified by posting
+          // `not json at all` to it.) A `/chat` caller must not be able to tell
+          // the two runtimes apart by their parse errors either.
           res.writeHead(400, { 'Content-Type': 'application/json', ...corsHeaders });
           res.end(JSON.stringify(
             pathOnly === '/chat'
-              ? { error: 'Request body must be a JSON object' }
+              ? {
+                schema: 'rapp-chat/1.0',
+                status: 'error',
+                error: 'Request body must be a JSON object',
+              }
               : { error: 'Invalid JSON' },
           ));
         }


### PR DESCRIPTION
## The RAPP/1 chat contract was never executed, so both runtimes drifted from it

`contracts/rapp-chat-v1.json` is the shared `/chat` surface — the thing that
makes "UI is optional" true rather than aspirational. It was read by exactly one
file, `python/tests/test_openrappter_brainstem.py`, which used it for a single
assertion:

```python
assert contract["brand"] == "RAPP + X™"
```

Every other assertion in that test was a hardcoded literal. **TypeScript did not
read the file at all.**

Proof it constrained nothing — append a required key that no runtime emits:

```diff
   "success": {
     "required": [
-      "schema", "status", "response", "content", "session_id"
+      "schema", "status", "response", "content", "session_id",
+      "a_field_nothing_emits"
     ],
```

```
2 passed, 21 deselected
```

Green. Both runtimes now drive their assertions off the `required` arrays, and
that same edit fails **both** suites.

## A single malformed request identified which runtime answered

Found while making the contract executable — the error envelope tests failed,
and the reason was not the contract.

`server.ts` answered a validation failure with a bare `{error}`, with this
justification:

> Bare `{error}`, exactly as the brainstem writes it. […] a peer must not be
> able to tell which runtime answered. A single malformed request was enough to
> fingerprint us, because ours carried `schema` and `status` and the
> brainstem's does not.

and `chat-indistinguishability.test.ts` pinned it:

> Ground truth is `brainstem.py`, whose rejection is
> `return jsonify({"error": ...}), 400` — one key, nothing else.

**No such brainstem is in this repository.** `python/openrappter/brainstem.py`
imports no Flask, contains no `jsonify` (`grep -c` → `0`), and replies through
`_send`. I posted every malformed body to both running servers rather than
reading either:

| body | Python brainstem | TypeScript gateway |
|---|---|---|
| `{"user_input":123}` | `{error, schema, status}` | `{error}` |
| `{"user_input":"   "}` | `{error, schema, status}` | `{error}` |
| `{"user_input":"hi","conversation_history":"nope"}` | `{error, schema, status}` | `{error}` |
| bad history role | `{error, schema, status}` | `{error}` |
| `[]` | `{error}` | `{error}` |
| `not json at all` | `{error, schema, status}` | `{error}` |

The change that set out to remove a fingerprint **created** one, on five of six
bodies, and the test written to prevent that asserted the mistake.

## Fix

TypeScript emits the contract envelope on every `/chat` rejection, including the
unparseable-JSON path (whose comment cited Flask's `get_json(silent=True)` —
also not in this repository). Python's non-object branch, the one row that was
bare on both sides, was brought into the same envelope. All six bodies now match
across runtimes and satisfy the contract.

`chat-indistinguishability.test.ts` keeps its real strength — it boots a server
and reads bytes off a socket — but its ground truth is now the contract file
instead of a recollection of the other runtime, so it cannot rot the same way.

## The contract was corrected where it contradicted both implementations

- `request.required: ["message"]` with `user_input` as a *legacy alias* is
  backwards. Both runtimes treat `user_input` as canonical and consult
  `message` only when it is absent — deliberately aligned in #335. Now recorded
  as `canonical_input`, with the precedence written down.
- `response.success.required` listed 5 keys; both runtimes emit the same 10.
  Verified by calling both envelope builders, not by reading them.

Two independently-verified implementations agreeing is stronger evidence than an
unenforced JSON file, so the file changed.

## A false alarm, reported

I first read a missing `session_id` as a third defect. It was my stub omitting
`sessionId`, which `AgentResponse` declares required. No product bug — and the
same stub bug had made three alias assertions pass vacuously until I fixed it.

## Verification

- New `rapp-chat-contract.test.ts` — 8 passed; 3 new Python contract tests
- Mutation: the `a_field_nothing_emits` edit now fails **both** runtimes
- TypeScript suite — **5014 passed**, 21 skipped
- Python suite — **1627 passed**; `test_brainstem_compliance.py` 23 passed
- `tsc --noEmit`, `eslint src --max-warnings 0` — clean

Refs #335.
