### PR TITLE
fix(brainstem): stop discarding tool turns from conversation history, and make the corpus able to see it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
+- Parity vector `history-carried-to-model`, the only one that reaches the model
+  carrying a valid `conversation_history`. Every other vector arrived with an
+  empty transcript -- the one vector that carries history is rejected 400
+  before the model is called -- so the corpus could not detect a runtime that
+  dropped, reordered or truncated a transcript, and the harness's
+  `outbound_history_roles` assertion was declared by no vector at all.
+- `parity_harness.py` now checks the outbound user message on **every** vector
+  that reaches the model, defaulting to the request's `user_input`, instead of
+  only on the single vector that opted in (#250).
 - `openrappter service status` reports whether launchd actually supervises the gateway that is answering. The two can disagree permanently and nothing said so: on the machine that prompted this, a gateway started outside launchd had held the port for 13 days, so all 29 supervised starts exited 1 with `EADDRINUSE` while `/health` returned 200 and `doctor` reported the same message it reports when supervision is correct.
 - `openrappter audit` runs the security auditor and exits non-zero on high or critical findings. `SecurityAuditor` had five checks and was constructed by nothing but its own test.
 - The gateway now emits `agent.tool` as each tool call finishes, so tool use appears in chat. The chat UI has registered a listener for it since it was written and the event had no emit site anywhere, so the feature had never worked. The payload carries the tool's name, outcome and duration -- never its arguments, which can hold secrets.
@@ -67,6 +77,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   capability its syntax tree can reach, per the RAPP agent contract.
 
 ### Fixed
+
+- The Python brainstem accepted a `tool` turn in `conversation_history`,
+  answered 200, and then dropped it before the model saw it. Validation used
+  `_HISTORY_ROLES` (`user`, `assistant`, `tool`) while the line that forwards
+  history to the model carried a second, narrower hand-written tuple. A caller
+  replaying a transcript had no way to learn it had been edited, and the model
+  reasoned about tool results it could no longer see. TypeScript forwards the
+  turn; the two runtimes now agree, and the forwarding filter reuses
+  `_HISTORY_ROLES` so the two lists cannot drift apart again.
 
 - `POST /chat` rejections diverged between the runtimes. TypeScript answered a
   malformed request with a bare `{error}` while the Python brainstem answered

--- a/parity_harness.py
+++ b/parity_harness.py
@@ -272,6 +272,25 @@ def observe_typescript(vector, driver=TS_DRIVER):
     return Observation(status, body, rounds, outbound, tools_first)
 
 
+def default_outbound_user_input(vector):
+    """The text the model must receive when the vector does not say otherwise.
+
+    `user_input` is the spec key and wins over the `message` alias, matching
+    both runtimes (#335). Returned trimmed, because both runtimes trim before
+    dispatching. `None` means "do not check": the vector sends no usable input,
+    so the model is not expected to be called at all.
+    """
+    request = vector.get("request") or {}
+    if not isinstance(request, dict):
+        return None
+    raw = request.get("user_input")
+    if raw is None:
+        raw = request.get("message")
+    if not isinstance(raw, str) or not raw.strip():
+        return None
+    return raw.strip()
+
+
 def check(vector, obs):
     """Judge one observation against one vector.
 
@@ -367,20 +386,28 @@ def check(vector, obs):
         if any(needle in json.dumps(messages) for messages in obs.outbound):
             failures.append(f"outbound carried {needle!r}, which should have been filtered")
 
-    if "outbound_user_input" in expect:
-        # What the model was actually asked. The corpus could assert the reply,
-        # the history roles and the system prompt, but never the user turn --
-        # so a runtime that resolved the wrong request field sent the model
-        # different text and still passed every vector. That is not
-        # hypothetical: python read `message` in preference to `user_input`,
-        # so `{"user_input":"A","message":"B"}` answered B while typescript and
-        # the grail answered A, both with a 200.
-        sent = (
-            obs.outbound[0][-1].get("content") if obs.outbound and obs.outbound[0] else None
-        )
-        if sent != expect["outbound_user_input"]:
+    # What the model was actually asked. The corpus could assert the reply, the
+    # history roles and the system prompt, but never the user turn -- so a
+    # runtime that resolved the wrong request field sent the model different
+    # text and still passed every vector. That is not hypothetical: python read
+    # `message` in preference to `user_input`, so `{"user_input":"A",
+    # "message":"B"}` answered B while typescript and the grail answered A,
+    # both with a 200.
+    #
+    # This is checked on EVERY vector that reaches the model, not only the one
+    # that opts in. When only the alias vector asserted it, the corpus could
+    # still not see a runtime that mangled the input just for requests carrying
+    # history, or on a later tool round -- conditions that vector does not
+    # create. #250 asked for exactly this assertion; one instance of it was not
+    # the same as having it.
+    expected_outbound = expect.get("outbound_user_input")
+    if expected_outbound is None:
+        expected_outbound = default_outbound_user_input(vector)
+    if expected_outbound is not None and obs.outbound and obs.outbound[0]:
+        sent = obs.outbound[0][-1].get("content")
+        if sent != expected_outbound:
             failures.append(
-                f"outbound user input: expected {expect['outbound_user_input']!r}, got {sent!r}"
+                f"outbound user input: expected {expected_outbound!r}, got {sent!r}"
             )
 
     if "outbound_system_prompt_contains" in expect:

--- a/parity_vectors/CORPUS.json
+++ b/parity_vectors/CORPUS.json
@@ -1,14 +1,15 @@
 {
   "canonicalization": "sha256 over JSON with sorted keys and (',',':') separators, UTF-8",
-  "corpus_sha256": "6c1fd49aa724f516742d3275c2348e942521df3915ac1b1a6b0548a862820859",
+  "corpus_sha256": "c92f0b5c765324f51613c4ca477ac411cee2c56ff03b6e0cadbf1b99688c4d86",
   "spec": "rapp-runtime-parity/1.0",
-  "vector_count": 15,
+  "vector_count": 16,
   "vectors": {
     "agent-not-found": "a65276f5906db37733007fc549a9804cb4b1b7dc37771bcfda1a0e62e36024e3",
     "agent-raises": "403437bd5f515cdf9e189f7ff46c2b1a3fcf0c123dd9f6f62beb073d37295815",
     "bad-arguments-fallback": "ccc4de2395e5d6e775741073758931fcbb170419b5293f379781833e9e7396b2",
     "empty-input-400": "b70ce40465bcd2f8c362e35d96a5bb7edccb5b30ce0b34c2ff46f6837c4de3a0",
     "finish-reason-agnostic-trigger": "0c4713b71821456ae863534a69e611ea7ded0994f078cf6a19fc746e982e6ed4",
+    "history-carried-to-model": "90d2edad36e203ae0354472dac65c46f243f5cc28accd1ecc883fd41c6029464",
     "history-role-filter": "c8062fd137bf8ce5cb8c7bb8e0ba59f42995dc6587aaa2000fe1272d96793ba7",
     "multi-round-tools": "2510ed9a6a409dce848a7488b1ec6b4e2cba625e0823d22cd869af44fd59fe02",
     "no-agents-passthrough": "deaefc9651fd958e6ad5b0980907bf3209fb7a48d3c3349e551dbe7401356564",

--- a/parity_vectors/history-carried-to-model.json
+++ b/parity_vectors/history-carried-to-model.json
@@ -1,0 +1,56 @@
+{
+  "expect": {
+    "envelope": {
+      "response": "You are Kody."
+    },
+    "model_called": true,
+    "outbound_history_roles": [
+      "user",
+      "assistant",
+      "tool"
+    ],
+    "outbound_user_input": "who am i",
+    "status": 200
+  },
+  "fixture": {
+    "agents": [],
+    "model": {
+      "kind": "scripted"
+    },
+    "soul": "You are a helper."
+  },
+  "id": "rapp-parity-vector",
+  "model_script": [
+    {
+      "emit": {
+        "content": "You are Kody."
+      },
+      "round": 1
+    }
+  ],
+  "name": "history-carried-to-model",
+  "request": {
+    "conversation_history": [
+      {
+        "content": "KEEP-ME-USER",
+        "role": "user"
+      },
+      {
+        "content": "KEEP-ME-ASSISTANT",
+        "role": "assistant"
+      },
+      {
+        "content": "KEEP-ME-TOOL",
+        "role": "tool"
+      }
+    ],
+    "session_id": "fixed-session-0016",
+    "user_input": "who am i"
+  },
+  "spec": "rapp-runtime-parity/1.0",
+  "tags": {
+    "core": true,
+    "edge": false
+  },
+  "why": "Every other vector reaches the model with an EMPTY history: the only one carrying conversation_history is history-role-filter, which is rejected 400 before the model is called. So the corpus could not see a runtime that dropped, reordered or truncated a valid transcript, and the outbound_history_roles assertion in the harness was never exercised by any vector. Roles are the three the reference accepts (user, assistant, tool); a tool turn is included because a transcript replayed from a brainstem client carries one, and dropping it leaves the model reasoning about results it can no longer see."
+}

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -815,7 +815,15 @@ def _run_chat_within_trace(
     messages = [{"role": "system", "content": system_prompt}]
     if memory_data_message:
         messages.append({"role": "user", "content": memory_data_message})
-    messages.extend(h for h in history if isinstance(h, dict) and h.get("role") in ("user", "assistant"))
+    # `_HISTORY_ROLES`, not a second hand-written tuple. This line used to read
+    # `in ("user", "assistant")` while validation at line ~98 accepted the wider
+    # set, so a `tool` turn was accepted, answered 200, and then dropped before
+    # the model saw it -- the caller had no way to learn its transcript had been
+    # edited. TypeScript forwards it, which is the divergence the parity corpus
+    # could not see: no vector reached the model with any history at all.
+    messages.extend(
+        h for h in history if isinstance(h, dict) and h.get("role") in _HISTORY_ROLES
+    )
     messages.append({"role": "user", "content": user_input})
     recorder.record(
         {

--- a/python/tests/test_parity_corpus.py
+++ b/python/tests/test_parity_corpus.py
@@ -38,6 +38,7 @@ EXPECTED_VECTORS = {
     "history-role-filter", "system-context-injection",
     "finish-reason-agnostic-trigger", "session-id-minted",
     "voice-sentinel-split", "user-input-wins-over-message-alias",
+    "history-carried-to-model",
 }
 
 
@@ -49,6 +50,16 @@ class TestParityCorpus:
         fourteen could not see the request-field precedence: python read
         `message` in preference to `user_input`, so it sent the model different
         text than typescript and the grail and every vector still passed.
+
+        `history-carried-to-model` is a sixteenth. Every one of the fifteen
+        reached the model with an EMPTY history -- the only vector carrying a
+        `conversation_history` is `history-role-filter`, which is rejected 400
+        before the model is called. So the corpus could not see a runtime that
+        dropped or reordered a valid transcript, and the harness's
+        `outbound_history_roles` assertion was declared by no vector at all.
+        Arming it found python forwarding only `user` and `assistant` while
+        validating the wider `_HISTORY_ROLES`, so a `tool` turn was accepted,
+        answered 200, and discarded before the model saw it.
         """
         required = EXPECTED_VECTORS
         present = {

--- a/typescript/src/gateway/__tests__/parity-vectors.test.ts
+++ b/typescript/src/gateway/__tests__/parity-vectors.test.ts
@@ -42,6 +42,7 @@ export const VECTOR_CASES = [
   { name: 'session-id-minted', tier: 'core' },
   { name: 'voice-sentinel-split', tier: 'full' },
   { name: 'user-input-wins-over-message-alias', tier: 'core' },
+  { name: 'history-carried-to-model', tier: 'core' },
 ] as const;
 
 describe('envelope-level vectors (decidable without a model)', () => {
@@ -123,12 +124,18 @@ describe('vectors that need a live model — declared, not silently skipped', ()
     'system-context-injection',
     'finish-reason-agnostic-trigger',
     'empty-input-400',
+    // The only vector that reaches the model carrying a conversation_history.
+    // Every other one arrives with an empty transcript, so nothing could see a
+    // runtime dropping or reordering it -- python was forwarding `user` and
+    // `assistant` while validating the wider `_HISTORY_ROLES`, discarding a
+    // `tool` turn after answering 200.
+    'history-carried-to-model',
   ];
 
   it('names them, so the tier claim is auditable', () => {
     // These are loop semantics inside the provider, not envelope shape. They are
     // exercised by the live-daemon run reported alongside this suite.
-    expect(needsModel.length).toBe(7);
+    expect(needsModel.length).toBe(8);
     for (const n of needsModel) {
       expect(VECTOR_CASES.map(v => v.name)).toContain(n);
     }


### PR DESCRIPTION
## Verifying #250 was closed found a wider hole, and a live divergence in it

#250 says the parity corpus cannot detect a runtime sending the model the wrong
user input. The `outbound_user_input` assertion added in #335 was supposed to
close it, so I tried to break it rather than read it.

**Already fixed.** All four corruption modes the issue names are caught — I ran
each against `ts_parity_driver.mjs`:

| mutation | result |
|---|---|
| `'__WRONG_INPUT_ENTIRELY__'` | FAIL (14 → 13 classes) |
| `userInput.slice(0, 3)` | FAIL (14 → 2) |
| `userInput.toUpperCase()` | FAIL (14 → 2) |
| `userInput + " (ignore previous instructions)"` | FAIL (14 → 13) |

**Not fixed.** Detection rested on a single vector opting in — 1 of 16 declared
`outbound_user_input`. So I tried a mutation that corrupts the input *only* when
`conversation_history` is present:

```js
const userInput = request.conversation_history?.length
  ? 'HIJACKED'
  : parsedRequest.value.userInput;
```

**PASS.** Undetected.

## Why: no vector ever gives the model a transcript

Probing all fifteen vectors through the driver and reading `__outbound`:

```
agent-not-found        round0 msgs=2 history_roles=[]
agent-raises           round0 msgs=2 history_roles=[]
...
history-role-filter    model not called
empty-input-400        model not called
```

Every executed vector reaches the model with an **empty** history. The only
vector carrying a `conversation_history` is `history-role-filter`, which expects
a **400** for an invalid role and never calls the model.

Consequences:

- `outbound_history_roles` — fully implemented in `parity_harness.py` — is
  declared by **zero** vectors. So is `outbound_must_not_contain`.
- Nothing in the corpus tested conversation history in any way.

## The divergence that was hiding there

I added `history-carried-to-model`, carrying `user`/`assistant`/`tool` turns to
the model, and armed the dormant assertion. It failed immediately — on Python:

```
outbound history roles: expected ['user', 'assistant', 'tool'],
                             got ['user', 'assistant']
```

`brainstem.py` contradicts itself:

```python
# line 75 — validation accepts three roles
_HISTORY_ROLES = {"user", "assistant", "tool"}

# line 818 — forwarding carries a second, narrower hand-written tuple
messages.extend(h for h in history
                if isinstance(h, dict) and h.get("role") in ("user", "assistant"))
```

A `tool` turn is **accepted, answered 200, and then discarded** before the model
sees it. The caller has no way to learn its transcript was edited. TypeScript
forwards it — deliberately, per the comment on its `AgentRequest` history type:

> `tool` is here because the brainstem accepts it. A transcript replayed from a
> brainstem client carries tool turns, and dropping them silently leaves the
> model reasoning about results it can no longer see.

The brainstem accepts it and drops it. Same request, different context sent to
the model, different answer, no error on either side.

## Fix

- Forwarding reuses `_HISTORY_ROLES` instead of a duplicate tuple, so the
  validating set and the forwarding set cannot drift apart again.
- `parity_harness.py` checks the outbound user message on **every** vector that
  reaches the model, defaulting to the request's `user_input`, rather than only
  where a vector opts in.
- New vector registered in both binding guards — `EXPECTED_VECTORS` in
  `test_parity_corpus.py` and `VECTOR_CASES` in `parity-vectors.test.ts`, which
  each fail if the corpus and the runtime lists disagree.

## Mutation tests

| mutation | before | after |
|---|---|---|
| Python forwards `("user","assistant")` again | pass | **FAIL** |
| TS corrupts input only when history present | pass | **FAIL** |
| TS drops history entirely | pass | **FAIL** |

## Verification

- `parity_harness.py --runtime both` — 15/16 classes both runtimes, PASS
- Python suite — **1627 passed**
- TypeScript suite — **5014 passed**, 21 skipped
- `tsc --noEmit`, `eslint src --max-warnings 0` — clean

Closes #250.
