### PR TITLE
fix(brainstem): answer malformed Content-Length instead of dropping the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Python brainstem answered nothing at all to a malformed `Content-Length`.
+  `do_POST` opened with a bare `int(self.headers.get("Content-Length") or 0)`,
+  so `Content-Length: abc` raised `ValueError` out of the handler and the
+  connection closed with no HTTP reply; `Content-Length: -5` did the same. Both
+  are now `400`, in the same error envelope as every other rejection. The
+  TypeScript gateway already answered `400` to both.
+- A `Content-Length` larger than the body sent held a brainstem request thread
+  open indefinitely. `BrainstemHandler` now carries a 30 second socket timeout,
+  so a caller that stops sending is dropped instead of parked forever, and a
+  short body followed by a close is refused with `400`.
+
 - The Python brainstem accepted a `tool` turn in `conversation_history`,
   answered 200, and then dropped it before the model saw it. Validation used
   `_HISTORY_ROLES` (`user`, `assistant`, `tool`) while the line that forwards

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -29,6 +29,7 @@ import importlib.util
 import json
 import os
 import re
+import socket
 import subprocess
 import sys
 import tempfile
@@ -1171,6 +1172,18 @@ def _run_chat_within_trace(
 
 
 class BrainstemHandler(BaseHTTPRequestHandler):
+    #: Seconds a single connection may stall before the socket read gives up.
+    #:
+    #: `do_POST` reads exactly `Content-Length` bytes. A caller may claim any
+    #: number and then send nothing, and without a timeout that read blocks for
+    #: as long as the connection is held open. `ThreadingHTTPServer` gives each
+    #: request its own thread, so the server keeps answering others -- but the
+    #: threads accumulate, one per request, for free.
+    #:
+    #: This bounds the stall without rejecting any request that succeeds today:
+    #: a client still sending data resets the timer. TypeScript is covered by
+    #: node's own `requestTimeout`/`headersTimeout`; this runtime had nothing.
+    timeout = 30
     server_version = f"OpenRappterBrainstem/{__version__}"
 
     def _send(self, code, payload):
@@ -1235,8 +1248,39 @@ class BrainstemHandler(BaseHTTPRequestHandler):
 
     # ── POST ──
     def do_POST(self):
-        length = int(self.headers.get("Content-Length") or 0)
-        raw = self.rfile.read(length) if length else b""
+        # `int(...)` used to run bare here, as the first statement of the
+        # method. `Content-Length: abc` raised ValueError out of do_POST and the
+        # caller got no HTTP response at all -- not a 400, nothing, the
+        # connection simply closed. `Content-Length: -5` did the same. Both are
+        # answered 400 by the TypeScript gateway, which is where these came from:
+        # the same three headers were sent to both runtimes.
+        raw_length = self.headers.get("Content-Length")
+        try:
+            length = int(raw_length) if raw_length is not None else 0
+        except (TypeError, ValueError):
+            return self._send(400, {
+                "schema": "rapp-chat/1.0",
+                "status": "error",
+                "error": "Content-Length must be an integer",
+            })
+        if length < 0:
+            return self._send(400, {
+                "schema": "rapp-chat/1.0",
+                "status": "error",
+                "error": "Content-Length must not be negative",
+            })
+        try:
+            raw = self.rfile.read(length) if length else b""
+        except (TimeoutError, socket.timeout, OSError):
+            # The caller claimed more than it sent and then stopped. Nothing
+            # useful can be parsed, and the socket is already unusable.
+            return
+        if length and len(raw) < length:
+            return self._send(400, {
+                "schema": "rapp-chat/1.0",
+                "status": "error",
+                "error": "Request body shorter than Content-Length",
+            })
 
         if self.path == "/chat":
             try:

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -2,8 +2,11 @@
 
 import json
 import sys
+import threading
 import pytest
 from pathlib import Path
+
+from openrappter import brainstem
 
 #: Mirrors ``requires-python`` in pyproject.toml. Kept in sync by a test.
 MIN_PYTHON = (3, 10)
@@ -133,3 +136,27 @@ def sample_memories(tmp_memory_file):
     }
     tmp_memory_file.write_text(json.dumps(memories, indent=2))
     return tmp_memory_file
+
+
+@pytest.fixture()
+def server(tmp_path, monkeypatch):
+    """A real brainstem on a loopback port, hermetic and torn down after.
+
+    Lives here rather than in `test_openrappter_brainstem.py` because more than
+    one module needs it: `test_brainstem_http_framing.py` drives the same server
+    with hand-built requests. A second copy would be a second thing to keep in
+    step with the fixture it was copied from.
+    """
+    monkeypatch.setattr(brainstem, "BRAINSTEM_HOME", tmp_path)
+    monkeypatch.setattr(brainstem, "AGENTS_PATH", tmp_path / "agents")
+    monkeypatch.setattr(brainstem, "SOUL_PATH", tmp_path / "soul.md")
+    # Keep tests hermetic: never reach for a real GitHub token
+    monkeypatch.setattr(brainstem, "_github_token", lambda: None)
+    (tmp_path / "agents").mkdir()
+
+    httpd = brainstem.serve(port=0)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    base = f"http://127.0.0.1:{httpd.server_address[1]}"
+    yield base
+    httpd.shutdown()

--- a/python/tests/test_brainstem_http_framing.py
+++ b/python/tests/test_brainstem_http_framing.py
@@ -1,0 +1,121 @@
+"""The brainstem's HTTP entry point, tested on malformed framing.
+
+`do_POST` began with
+
+    length = int(self.headers.get("Content-Length") or 0)
+    raw = self.rfile.read(length) if length else b""
+
+Three things follow from those two lines, all reproduced against the running
+server with a raw socket before anything was changed:
+
+    Content-Length: abc          no HTTP response at all -- ValueError left
+                                 do_POST unhandled and the connection closed
+    Content-Length: -5           no HTTP response
+    Content-Length: 2000000000   blocked forever waiting for bytes that were
+    (19 bytes sent)              never sent
+
+The TypeScript gateway answers the first two `400 Bad Request` and always
+answers something, so the target behaviour here is not invented -- the same
+three headers were sent to both runtimes and this file encodes what the other
+one already did.
+
+`ThreadingHTTPServer` gives each request its own thread, so the third case did
+not wedge the server; it leaked one thread per request instead, which is a
+slower version of the same thing on a daemon meant to run for weeks.
+"""
+import socket
+import urllib.parse
+
+from openrappter import brainstem
+
+
+def _raw_post(base, headers, body=b'{"user_input":"hi"}', timeout=15, half_close=False):
+    """Send a hand-built request so the framing itself can be malformed."""
+    parts = urllib.parse.urlparse(base)
+    conn = socket.create_connection((parts.hostname, parts.port), timeout=timeout)
+    try:
+        conn.sendall(
+            b"POST /chat HTTP/1.1\r\nHost: x\r\nContent-Type: application/json\r\n"
+            + headers
+            + b"\r\n"
+            + body
+        )
+        if half_close:
+            # Signal "that is the whole body" so the server sees EOF instead of
+            # waiting for bytes the caller still might send. Without this the
+            # server is right to wait, and the request is slow rather than
+            # malformed.
+            conn.shutdown(socket.SHUT_WR)
+        # Read to EOF rather than taking one `recv`. The server answers
+        # HTTP/1.0 and closes, but the headers and the body do not have to
+        # arrive in the same segment -- a single recv made this file fail about
+        # one run in three, on the body assertions only.
+        data = b""
+        try:
+            while True:
+                chunk = conn.recv(4096)
+                if not chunk:
+                    break
+                data += chunk
+        except (TimeoutError, socket.timeout):
+            if not data:
+                return None, b""
+    finally:
+        conn.close()
+    if not data:
+        return None, b""
+    head, _, rest = data.partition(b"\r\n\r\n")
+    status = int(head.split(b"\r\n")[0].split(b" ")[1])
+    return status, rest
+
+
+class TestContentLengthFraming:
+    def test_a_non_numeric_content_length_is_a_400_not_a_dropped_connection(self, server):
+        status, body = _raw_post(server, b"Content-Length: abc\r\n")
+        assert status == 400, "a malformed Content-Length must be answered, not dropped"
+        assert b"Content-Length" in body
+
+    def test_a_negative_content_length_is_a_400(self, server):
+        status, body = _raw_post(server, b"Content-Length: -5\r\n")
+        assert status == 400
+        assert b"negative" in body
+
+    def test_the_rejection_uses_the_same_envelope_as_every_other_rejection(self, server):
+        """`contracts/rapp-chat-v1.json` fixes the shape of an error reply."""
+        for header in (b"Content-Length: abc\r\n", b"Content-Length: -5\r\n"):
+            _, body = _raw_post(server, header)
+            assert b'"schema": "rapp-chat/1.0"' in body, header
+            assert b'"status": "error"' in body, header
+
+    def test_a_body_shorter_than_its_content_length_is_refused(self, server):
+        """Claiming 400 bytes, sending 19, then closing, is malformed input.
+
+        The half close is what makes this different from a slow caller: a client
+        that has not finished sending is waited for, and only a client that says
+        "that is all" while owing bytes is refused.
+        """
+        status, body = _raw_post(server, b"Content-Length: 400\r\n", half_close=True)
+        assert status == 400
+        assert b"shorter than" in body
+
+    def test_a_well_formed_request_still_reaches_the_handler(self, server):
+        """Anti-vacuity: the guards above must not reject ordinary traffic.
+
+        Without a model configured this reaches a 503, which is the point --
+        it got past framing and into the chat handler.
+        """
+        status, _ = _raw_post(server, b"Content-Length: 19\r\n")
+        assert status not in (400, None)
+
+
+class TestStallBudget:
+    def test_the_handler_bounds_a_stalled_body_read(self):
+        """A claimed Content-Length the caller never sends must not block forever.
+
+        Asserted on the attribute rather than by stalling a real socket: the
+        behaviour was verified once against the running server (the connection
+        released at 30.0s instead of never), and repeating that in the suite
+        would cost thirty seconds per run to re-learn the same fact.
+        """
+        assert isinstance(brainstem.BrainstemHandler.timeout, (int, float))
+        assert 0 < brainstem.BrainstemHandler.timeout <= 120

--- a/python/tests/test_openrappter_brainstem.py
+++ b/python/tests/test_openrappter_brainstem.py
@@ -70,23 +70,6 @@ def post_multipart(url, filename, content):
     return status, json.loads(resp)
 
 
-@pytest.fixture()
-def server(tmp_path, monkeypatch):
-    monkeypatch.setattr(brainstem, "BRAINSTEM_HOME", tmp_path)
-    monkeypatch.setattr(brainstem, "AGENTS_PATH", tmp_path / "agents")
-    monkeypatch.setattr(brainstem, "SOUL_PATH", tmp_path / "soul.md")
-    # Keep tests hermetic: never reach for a real GitHub token
-    monkeypatch.setattr(brainstem, "_github_token", lambda: None)
-    (tmp_path / "agents").mkdir()
-
-    httpd = brainstem.serve(port=0)
-    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
-    thread.start()
-    base = f"http://127.0.0.1:{httpd.server_address[1]}"
-    yield base
-    httpd.shutdown()
-
-
 def test_health_envelope_matches_kernel_shape(server):
     status, health = get_json(f"{server}/health")
     assert status == 200


### PR DESCRIPTION
## Auditing my own claim from #353 found a worse bug underneath it

In #353 I left the TypeScript 413 body-cap rejection emitting a bare `{error}`,
with a comment saying *"413 has no brainstem counterpart — it has no body cap"*.

That is exactly the kind of statement #353 was about: the bug there was a
comment describing the other runtime that had never been checked against it. So
I posted large bodies to the brainstem instead of trusting my own note.

**The claim held** — 1 MB, 3 MB and 8 MB were all accepted; the brainstem has no
HTTP body cap. But the framing underneath it does not survive contact:

| header sent | Python brainstem | TypeScript gateway |
|---|---|---|
| `Content-Length: abc` | **no HTTP response at all** | `400 Bad Request` |
| `Content-Length: -5` | **no HTTP response** | `400 Bad Request` |
| `Content-Length: 2000000000`, 19 bytes sent | **blocked forever** | responds |

`do_POST` opened with this as its first statement, outside any `try`:

```python
length = int(self.headers.get("Content-Length") or 0)
raw = self.rfile.read(length) if length else b""
```

`int("abc")` raises `ValueError` straight out of the handler, so the caller gets
a closed connection rather than a status. `int("-5")` is accepted and passed to
`read(-5)`. And a caller may claim any length and then send nothing, which
parked the read with no timeout.

`ThreadingHTTPServer` means that last one did not wedge the server — it leaked
**one thread per request** instead, which is the same problem slowed down, on a
daemon meant to run for weeks.

## Fix

- `Content-Length` is parsed defensively; non-numeric and negative are `400`, in
  the same envelope `contracts/rapp-chat-v1.json` fixes for every other
  rejection.
- `BrainstemHandler.timeout = 30` bounds a stalled body read. Verified against
  the running server: the connection now releases at **30.0s** where it
  previously never returned. This rejects nothing that succeeds today — a client
  still sending resets the timer.
- A body shorter than its `Content-Length` **followed by a close** is `400`. A
  client that simply has not finished sending is still waited for; the half
  close is what separates malformed from slow.

The target behaviour is not invented — the same three headers were sent to the
TypeScript gateway and this encodes what it already did.

## Two mistakes of mine, both in the tests

Worth stating, because both would have shipped something that looked fine.

1. My first short-body test asserted `400` while holding the socket open. The
   server is **right** to wait there — the body may still be coming. The test
   was wrong, not the guard; it now half-closes.
2. My second version failed **about one run in three**. It took a single
   `recv(4096)`, and the headers and body need not share a TCP segment, so the
   body assertions intermittently saw nothing. It reads to EOF now and passed
   five consecutive runs.

I broke CI with a flaky test earlier this session (#328). Not shipping another.

## Mutation tests

| mutation | result |
|---|---|
| restore the bare `int(...)` | **3 failed** |
| drop `timeout = 30` | **FAIL** |
| drop the short-body check | **FAIL** |

## Also

The `server` fixture moved from `test_openrappter_brainstem.py` to
`conftest.py`, because a second module needs it now and a copy would be a second
thing to keep in step.

## Verification

- New `test_brainstem_http_framing.py` — 6 passed, stable over 5 runs
- Python suite — **1633 passed**, 6 skipped
- `parity_harness.py --runtime both` — PASS
