### PR TITLE
fix(brainstem): refuse malformed multipart instead of dropping the connection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `POST /agents/import` dropped the connection without a status line when a
+  multipart part carried no blank line after its headers: two unguarded
+  `split(...)[1]` indexes raised `IndexError` out of the handler. Malformed
+  multipart is now `400`.
+- `POST /agents/import` accepted `multipart/form-data` with no `boundary`
+  parameter and wrote the part's closing delimiter into the agent file as
+  source -- the saved bytes were `print(1)\r\n------X--\r\n` -- while
+  answering `200`. A missing boundary is now `400`.
+
 - The Python brainstem answered nothing at all to a malformed `Content-Length`.
   `do_POST` opened with a bare `int(self.headers.get("Content-Length") or 0)`,
   so `Content-Length: abc` raised `ValueError` out of the handler and the

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -1407,11 +1407,27 @@ class BrainstemHandler(BaseHTTPRequestHandler):
             filename = os.path.basename(match.group(1))
             if not filename.endswith(".py"):
                 return self._send(400, {"error": "Only .py files are supported"})
-            # Extract the file part's body (between the first blank line after
-            # the filename header and the closing boundary)
+            # A boundary is what separates the file from the envelope around it.
+            # Without one, `split("boundary=")[-1]` returned the whole
+            # Content-Type, the closing `rsplit` matched nothing, and the part's
+            # trailing delimiter was written into the agent file as source --
+            # verified, the saved bytes were `print(1)\r\n------X--\r\n`. That
+            # answered 200 while storing something that cannot parse.
+            if "boundary=" not in content_type:
+                return self._send(400, {"error": "multipart/form-data requires a boundary"})
             boundary = content_type.split("boundary=")[-1].encode()
-            part = raw.split(b'filename="' + match.group(1).encode() + b'"', 1)[1]
-            body = part.split(b"\r\n\r\n", 1)[1].rsplit(b"\r\n--" + boundary, 1)[0]
+            # Extract the file part's body (between the first blank line after
+            # the filename header and the closing boundary).
+            #
+            # Both indexes below used to run unguarded. A part with no blank line
+            # after its headers raised IndexError out of do_POST, and the caller
+            # got no HTTP response at all -- the connection simply closed. Same
+            # failure the Content-Length parsing had, in the handler next door.
+            try:
+                part = raw.split(b'filename="' + match.group(1).encode() + b'"', 1)[1]
+                body = part.split(b"\r\n\r\n", 1)[1].rsplit(b"\r\n--" + boundary, 1)[0]
+            except IndexError:
+                return self._send(400, {"error": "Malformed multipart body"})
             if not filename.endswith("_agent.py"):
                 filename = filename[:-3] + "_agent.py"
             AGENTS_PATH.mkdir(parents=True, exist_ok=True)

--- a/python/tests/test_brainstem_http_framing.py
+++ b/python/tests/test_brainstem_http_framing.py
@@ -119,3 +119,79 @@ class TestStallBudget:
         """
         assert isinstance(brainstem.BrainstemHandler.timeout, (int, float))
         assert 0 < brainstem.BrainstemHandler.timeout <= 120
+
+
+def _multipart_post(base, content_type, body, timeout=15):
+    """POST to /agents/import with hand-built multipart framing."""
+    parts = urllib.parse.urlparse(base)
+    conn = socket.create_connection((parts.hostname, parts.port), timeout=timeout)
+    try:
+        conn.sendall(
+            b"POST /agents/import HTTP/1.1\r\nHost: x\r\nContent-Type: "
+            + content_type
+            + b"\r\nContent-Length: "
+            + str(len(body)).encode()
+            + b"\r\n\r\n"
+            + body
+        )
+        conn.shutdown(socket.SHUT_WR)
+        data = b""
+        while True:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    finally:
+        conn.close()
+    if not data:
+        return None, b""
+    head, _, rest = data.partition(b"\r\n\r\n")
+    return int(head.split(b"\r\n")[0].split(b" ")[1]), rest
+
+
+BOUNDARY = b"multipart/form-data; boundary=----X"
+WELL_FORMED = (
+    b'------X\r\nContent-Disposition: form-data; name="f"; filename="a.py"'
+    b"\r\n\r\nprint(1)\r\n------X--\r\n"
+)
+
+
+class TestAgentImportFraming:
+    """`/agents/import` parses multipart by hand, and hand-rolled parsers fall over.
+
+    This is the same defect as `Content-Length` one handler above: an unguarded
+    index raised out of `do_POST`, so a malformed upload closed the connection
+    without ever sending a status line.
+    """
+
+    def test_a_part_with_no_blank_line_is_a_400_not_a_dropped_connection(self, server):
+        body = (
+            b'------X\r\nContent-Disposition: form-data; name="f"; filename="a.py"'
+            b"\r\n------X--\r\n"
+        )
+        status, payload = _multipart_post(server, BOUNDARY, body)
+        assert status == 400, "a malformed part must be answered, not dropped"
+        assert b"Malformed multipart" in payload
+
+    def test_a_missing_boundary_is_refused_rather_than_silently_corrupting(self, server):
+        """Without a boundary the delimiter was written into the agent as source.
+
+        The saved bytes were `print(1)\\r\\n------X--\\r\\n` and the endpoint
+        answered 200, so the caller was told the import succeeded while the file
+        on disk could not parse.
+        """
+        status, payload = _multipart_post(server, b"multipart/form-data", WELL_FORMED)
+        assert status == 400
+        assert b"boundary" in payload
+
+    def test_a_well_formed_upload_still_imports(self, server):
+        """Anti-vacuity: the guards must not reject a real upload."""
+        status, _ = _multipart_post(server, BOUNDARY, WELL_FORMED)
+        assert status == 200
+
+    def test_the_saved_agent_is_exactly_the_uploaded_source(self, server):
+        """The bytes on disk are the file, with no envelope left in them."""
+        _multipart_post(server, BOUNDARY, WELL_FORMED)
+        saved = brainstem.AGENTS_PATH / "a_agent.py"
+        assert saved.exists()
+        assert saved.read_bytes() == b"print(1)"


### PR DESCRIPTION
## The same defect, one handler along

#355 fixed `Content-Length` parsing at the top of `do_POST`, which covers every
POST route. But `/agents/import` parses multipart **by hand** below that, and
repeats the same mistake in a different shape.

Probed with raw sockets, before any change:

| request | before | after |
|---|---|---|
| part with no blank line after its headers | **no HTTP response** | `400` |
| `multipart/form-data` with no `boundary=` | `200`, **corrupt file on disk** | `400` |
| well-formed upload | `200` | `200` |

## Two unguarded indexes

```python
part = raw.split(b'filename="' + match.group(1).encode() + b'"', 1)[1]
body = part.split(b"\r\n\r\n", 1)[1].rsplit(b"\r\n--" + boundary, 1)[0]
```

A part whose headers are not followed by a blank line has no second element, so
`IndexError` left `do_POST` and the caller got a closed socket rather than a
status line — exactly the failure #355 fixed for `Content-Length`.

## The missing-boundary case is the interesting one, because it reported success

Without a `boundary` parameter, `content_type.split("boundary=")[-1]` returns
the *whole* Content-Type, so the closing `rsplit` matches nothing and the part's
trailing delimiter stays in the extracted bytes.

I did not assume that — I wrote the file and read it back:

```
WROTE: b'print(1)\r\n------X--\r\n'
```

That is stored as agent source. It cannot parse. The endpoint answered **200**,
and the caller was told the import succeeded.

A test now asserts the saved bytes are **exactly** the uploaded source, so an
envelope leaking into a stored agent fails at the point it happens rather than
turning up later as a mysterious unloadable agent.

## Not changed, and why

`/agents/import` writes a `.py` file and immediately executes it via
`_load_agent_from_file`, with no authentication. That is by design for a
loopback daemon — `serve()` binds `127.0.0.1` by default — and the auth model is
already tracked in #133. Widening or gating it is a product decision, not a
refactor, so I have left it alone and am noting it here rather than quietly
changing the security posture.

## Mutation tests

| mutation | result |
|---|---|
| remove the `IndexError` guard | **FAIL** (no-blank-line test) |
| remove the boundary guard | **FAIL** (corruption test) |

## Verification

- `test_brainstem_http_framing.py` — 10 passed, stable over 3 runs
- Python suite — **1637 passed**, 6 skipped
