### PR TITLE
fix(brainstem): guarantee every request gets a reply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An exception raised while serving a brainstem request closed the connection
+  without a status line. `BaseHTTPRequestHandler` dispatches straight into
+  `do_GET`/`do_POST`, so anything escaping them unwound into `socketserver`,
+  which logs a traceback and drops the socket -- to the caller, indistinguishable
+  from the server going away. `GET /health` did this whenever agent loading
+  failed. Both verbs are now dispatched through a guard that answers `500`,
+  using the `contracts/rapp-chat-v1.json` envelope on `/chat`, and the traceback
+  goes to the operator rather than the caller.
+
 - `POST /agents/import` dropped the connection without a status line when a
   multipart part carried no blank line after its headers: two unguarded
   `split(...)[1]` indexes raised `IndexError` out of the handler. Malformed

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -34,6 +34,7 @@ import subprocess
 import sys
 import tempfile
 import threading
+import traceback
 import time
 import types
 import urllib.error
@@ -1199,7 +1200,51 @@ class BrainstemHandler(BaseHTTPRequestHandler):
         pass
 
     # ── GET ──
+    def _guarded(self, route):
+        """Run a route so that no request can end without a reply.
+
+        `BaseHTTPRequestHandler` dispatches straight into `do_GET`/`do_POST`, and
+        an exception that escapes them unwinds into `socketserver`, which logs a
+        traceback and closes the socket. The caller sees a connection drop, not a
+        status -- indistinguishable from the server having gone away.
+
+        That was not hypothetical. Three handlers had already been fixed for it
+        one at a time: a non-numeric `Content-Length` (#355), a multipart part
+        with no blank line (#356), and before this change any exception raised
+        while serving `/health` did the same. Fixing them individually leaves the
+        next one to be found the same way, so the guarantee belongs here.
+
+        The per-route `except Exception` blocks stay: they can say something
+        specific about a failure this one can only call internal.
+        """
+        try:
+            route()
+        except Exception:
+            # The detail goes to the operator, not the caller: it is a stack
+            # trace of our internals and the caller can do nothing with it.
+            traceback.print_exc()
+            try:
+                if self.path.split("?")[0] == "/chat":
+                    self._send(500, {
+                        "schema": "rapp-chat/1.0",
+                        "status": "error",
+                        "error": "Internal error",
+                    })
+                else:
+                    self._send(500, {"error": "Internal error"})
+            except Exception:
+                # The response was already partly written, or the socket is
+                # gone. Nothing further can be delivered; do not mask the
+                # original failure with a second one.
+                pass
+
     def do_GET(self):
+        self._guarded(self._route_get)
+
+    def do_POST(self):
+        self._guarded(self._route_post)
+
+    def _route_get(self):
         if self.path == "/health":
             agents = load_agents()
             self._send(200, {
@@ -1247,7 +1292,7 @@ class BrainstemHandler(BaseHTTPRequestHandler):
             self._send(404, {"error": "Not found"})
 
     # ── POST ──
-    def do_POST(self):
+    def _route_post(self):
         # `int(...)` used to run bare here, as the first statement of the
         # method. `Content-Length: abc` raised ValueError out of do_POST and the
         # caller got no HTTP response at all -- not a 400, nothing, the

--- a/python/tests/test_brainstem_http_framing.py
+++ b/python/tests/test_brainstem_http_framing.py
@@ -195,3 +195,69 @@ class TestAgentImportFraming:
         saved = brainstem.AGENTS_PATH / "a_agent.py"
         assert saved.exists()
         assert saved.read_bytes() == b"print(1)"
+
+
+def _raw_get(base, path=b"/health", timeout=15):
+    parts = urllib.parse.urlparse(base)
+    conn = socket.create_connection((parts.hostname, parts.port), timeout=timeout)
+    try:
+        conn.sendall(b"GET " + path + b" HTTP/1.1\r\nHost: x\r\n\r\n")
+        data = b""
+        while True:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    finally:
+        conn.close()
+    if not data:
+        return None, b""
+    head, _, rest = data.partition(b"\r\n\r\n")
+    return int(head.split(b"\r\n")[0].split(b" ")[1]), rest
+
+
+def _raising(*_args, **_kwargs):
+    raise RuntimeError("deliberate failure planted by the test")
+
+
+class TestNoRequestEndsWithoutAReply:
+    """An exception inside a route must become a status, never a closed socket.
+
+    Three separate handlers were fixed for this one at a time -- `Content-Length`
+    parsing (#355), multipart framing (#356), and any failure while serving
+    `/health`, which returned nothing at all until the guard was added. The
+    point of testing it here is that the next unguarded line, wherever it is,
+    is already covered.
+    """
+
+    def test_a_failing_get_route_answers_500_rather_than_dropping(self, server, monkeypatch):
+        monkeypatch.setattr(brainstem, "load_agents", _raising)
+        status, body = _raw_get(server, b"/health")
+        assert status == 500, "a failing route must answer, not close the connection"
+        assert b"Internal error" in body
+
+    def test_a_failing_chat_route_answers_in_the_contract_envelope(self, server, monkeypatch):
+        """`/chat` replies are fixed by `contracts/rapp-chat-v1.json`.
+
+        `_validate_conversation_history` runs before the handler's own
+        `except Exception`, so raising there reaches the dispatch guard.
+        """
+        monkeypatch.setattr(brainstem, "_validate_conversation_history", _raising)
+        status, body = _raw_post(server, b"Content-Length: 19\r\n")
+        assert status == 500
+        assert b'"schema": "rapp-chat/1.0"' in body
+        assert b'"status": "error"' in body
+
+    def test_the_caller_is_not_handed_our_stack_trace(self, server, monkeypatch):
+        """The operator gets the traceback; the caller gets a sentence."""
+        monkeypatch.setattr(brainstem, "load_agents", _raising)
+        _, body = _raw_get(server, b"/health")
+        assert b"Traceback" not in body
+        assert b"deliberate failure planted by the test" not in body
+        assert b"brainstem.py" not in body
+
+    def test_healthy_requests_are_unaffected(self, server):
+        """Anti-vacuity: the guard must not change a request that works."""
+        status, body = _raw_get(server, b"/health")
+        assert status == 200
+        assert b'"status": "ok"' in body


### PR DESCRIPTION
## Fixing this one handler at a time was the mistake

Three handlers have now been fixed for the same failure:

| | trigger | result |
|---|---|---|
| #355 | `Content-Length: abc` | `ValueError` out of `do_POST` → **no response** |
| #356 | multipart part with no blank line | `IndexError` out of `do_POST` → **no response** |
| here | `GET /health` while agent loading fails | **no response** |

Each fix was correct. Each also left the next instance to be found the same
way — by someone noticing a dropped connection and going looking. After the
third, the pattern is the finding.

The guarantee *a request always ends in a status line* belongs at the dispatch
point, not in whichever handler happened to be audited that day.

## Why a dropped connection is the worst available failure

`BaseHTTPRequestHandler` calls `do_GET`/`do_POST` directly. Anything escaping
them unwinds into `socketserver`, which prints a traceback and closes the
socket. The caller cannot distinguish that from the server having gone away —
which invites a retry against a server that is perfectly healthy, and sends
whoever debugs it looking at the network.

## Fix

`do_GET`/`do_POST` are now thin wrappers over `_route_get`/`_route_post`,
dispatched through `_guarded()`:

```
GET /health, load_agents raising
  before:  <NO RESPONSE>
  after:   HTTP/1.0 500 ... {"error": "Internal error"}

GET /health, healthy
  before:  200        after: 200
```

On `/chat` the reply is the envelope `contracts/rapp-chat-v1.json` fixes;
elsewhere it is the plain `{"error"}` shape those routes already use.

**The traceback goes to the operator, not the caller.** It describes our
internals and the caller can do nothing with it. A test asserts the reply
contains no `Traceback`, no exception text, and no file name — and fails if the
guard is changed to echo `format_exc()`.

## What I did not do

The per-route `except Exception` blocks in `/chat`, `/login` and `/login/poll`
stay. They can say something specific about a failure that this guard can only
call *internal*, and collapsing them into the backstop would trade real
diagnostics for tidiness.

## Mutation tests

| mutation | result |
|---|---|
| remove the dispatch guard | **2 failed** |
| leak `traceback.format_exc()` to the caller | **FAIL** |

## Verification

- `test_brainstem_http_framing.py` — 14 passed, stable over 3 runs
- Python suite — **1641 passed**, 6 skipped
- `parity_harness.py --runtime both` — PASS
