### PR TITLE
fix(brainstem): finish the dispatch guard it claimed to have generalised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The brainstem dispatch guard appended a second response when a route failed
+  after it had already begun replying, so the caller received
+  `HTTP/1.0 200 OK ... HTTP/1.0 500 ...` concatenated inside one reply. The
+  guard now detects that bytes are committed and closes the connection instead.
+- `DELETE` was not dispatched through that guard, so a failing `DELETE` still
+  closed the connection with no status line. All three verbs the handler serves
+  now go through it, and a test enumerates them rather than naming them.
+
 - An exception raised while serving a brainstem request closed the connection
   without a status line. `BaseHTTPRequestHandler` dispatches straight into
   `do_GET`/`do_POST`, so anything escaping them unwound into `socketserver`,

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -1200,6 +1200,18 @@ class BrainstemHandler(BaseHTTPRequestHandler):
         pass
 
     # ── GET ──
+    def end_headers(self):
+        """Record that bytes are committed to the wire.
+
+        `_guarded` needs to know whether a reply has already begun. Once a
+        status line and headers are out, a second `send_response` does not
+        replace them -- it appends, and the caller receives two responses
+        concatenated inside one. There is no standard flag for this, so it is
+        set at the one point every reply passes through.
+        """
+        self._response_started = True
+        super().end_headers()
+
     def _guarded(self, route):
         """Run a route so that no request can end without a reply.
 
@@ -1223,6 +1235,15 @@ class BrainstemHandler(BaseHTTPRequestHandler):
             # The detail goes to the operator, not the caller: it is a stack
             # trace of our internals and the caller can do nothing with it.
             traceback.print_exc()
+            if getattr(self, "_response_started", False):
+                # Too late to say anything: the status line and headers are
+                # already on the wire. Sending a second response here appended
+                # `HTTP/1.0 500 ...` to the body of the first, which is a worse
+                # outcome than the dropped connection this guard exists to
+                # prevent -- a truncated reply is at least recognisably broken,
+                # while two concatenated responses are not. Close instead.
+                self.close_connection = True
+                return
             try:
                 if self.path.split("?")[0] == "/chat":
                     self._send(500, {
@@ -1243,6 +1264,9 @@ class BrainstemHandler(BaseHTTPRequestHandler):
 
     def do_POST(self):
         self._guarded(self._route_post)
+
+    def do_DELETE(self):
+        self._guarded(self._route_delete)
 
     def _route_get(self):
         if self.path == "/health":
@@ -1485,7 +1509,7 @@ class BrainstemHandler(BaseHTTPRequestHandler):
         self._send(404, {"error": "Not found"})
 
     # ── DELETE ──
-    def do_DELETE(self):
+    def _route_delete(self):
         if self.path.startswith("/agents/"):
             filename = os.path.basename(self.path[len("/agents/"):])
             target = AGENTS_PATH / filename

--- a/python/tests/test_brainstem_http_framing.py
+++ b/python/tests/test_brainstem_http_framing.py
@@ -23,6 +23,7 @@ one already did.
 not wedge the server; it leaked one thread per request instead, which is a
 slower version of the same thing on a daemon meant to run for weeks.
 """
+import inspect
 import socket
 import urllib.parse
 
@@ -261,3 +262,82 @@ class TestNoRequestEndsWithoutAReply:
         status, body = _raw_get(server, b"/health")
         assert status == 200
         assert b'"status": "ok"' in body
+
+
+def _raw_request(base, verb=b"GET", path=b"/health", timeout=15):
+    """Send a bare request and return the whole reply, framing included."""
+    parts = urllib.parse.urlparse(base)
+    conn = socket.create_connection((parts.hostname, parts.port), timeout=timeout)
+    try:
+        conn.sendall(verb + b" " + path + b" HTTP/1.1\r\nHost: x\r\n\r\n")
+        data = b""
+        while True:
+            chunk = conn.recv(4096)
+            if not chunk:
+                break
+            data += chunk
+    finally:
+        conn.close()
+    return data
+
+
+class TestTheGuardItself:
+    """Two defects in the dispatch guard added by #357, found by auditing it.
+
+    The guard turned a dropped connection into a `500`. Both of these are ways
+    it did not finish the job it claimed to have done generally.
+    """
+
+    def test_a_route_that_already_replied_does_not_get_a_second_response(
+        self, server, monkeypatch
+    ):
+        """The guard must not append a status line to a reply in progress.
+
+        Before this, a route that wrote its headers and then raised produced
+
+            HTTP/1.0 200 OK ... HALF!HTTP/1.0 500 Internal Server Error ...
+
+        -- two responses concatenated inside one, which is a worse failure than
+        the dropped connection the guard exists to prevent. A truncated reply is
+        recognisably broken; this is not.
+        """
+
+        def half_written(self):
+            self.send_response(200)
+            self.send_header("Content-Length", "5")
+            self.end_headers()
+            self.wfile.write(b"HALF!")
+            raise RuntimeError("deliberate failure after the reply began")
+
+        monkeypatch.setattr(brainstem.BrainstemHandler, "_route_get", half_written)
+        reply = _raw_request(server)
+        assert reply.count(b"HTTP/1.0") == 1, "a second status line was appended"
+        assert reply.endswith(b"HALF!")
+
+    def test_delete_is_guarded_too(self, server, monkeypatch):
+        """`do_DELETE` was left out of the guard that was described as general."""
+        monkeypatch.setattr(brainstem, "AGENTS_PATH", None)
+        reply = _raw_request(server, b"DELETE", b"/agents/x.py")
+        assert reply, "a failing DELETE must answer, not close the connection"
+        assert reply.split(b"\r\n")[0].split(b" ")[1] == b"500"
+
+    def test_a_healthy_delete_is_unaffected(self, server):
+        """Anti-vacuity: the guard must not change a DELETE that works."""
+        reply = _raw_request(server, b"DELETE", b"/agents/not-there.py")
+        assert reply.split(b"\r\n")[0].split(b" ")[1] == b"404"
+
+    def test_every_verb_the_handler_serves_is_dispatched_through_the_guard(self):
+        """The gap this class exists for was a verb, so name them all.
+
+        `do_DELETE` existed for the whole life of the guard and was not wrapped,
+        because the fix was written by editing the two methods that were in
+        front of me rather than by asking which methods there were.
+        """
+        verbs = [
+            name for name in dir(brainstem.BrainstemHandler)
+            if name.startswith("do_")
+        ]
+        assert verbs, "expected the handler to serve at least one verb"
+        for verb in verbs:
+            source = inspect.getsource(getattr(brainstem.BrainstemHandler, verb))
+            assert "_guarded(" in source, f"{verb} does not go through _guarded"


### PR DESCRIPTION
## Auditing my own #357, which claimed to have generalised something

#357 argued that fixing dropped connections one handler at a time was the
mistake, and that the guarantee *a request always ends in a status line* belongs
at the dispatch point. That argument was right. The implementation then failed
to apply it at the dispatch point, twice.

## 1. `do_DELETE` was never wrapped

The handler serves **three** verbs. I edited the two that were in front of me.

```
DELETE /agents/x.py, with AGENTS_PATH broken
  before:  <NO RESPONSE>          (traceback names do_DELETE line 1491)
  after:   HTTP/1.0 500
```

So the exact bug #357 was written to remove was reachable the entire time,
through the one verb I did not look at.

The test now enumerates `dir(BrainstemHandler)` for `do_*` and asserts each goes
through the guard, rather than naming the verbs — because naming them is what
produced this.

## 2. The guard corrupted replies it could not rescue

This one is a regression *I introduced*, and in its specific case it is worse
than what it replaced.

`/agents/export/` writes its status line and headers directly, then the body. A
failure after that point left the guard calling `_send(500, ...)`, which does
not replace a reply in progress — **it appends to it**:

```
HTTP/1.0 200 OK
Content-Type: text/plain
Content-Length: 5

HALF!HTTP/1.0 500 Internal Server Error
Server: ...
```

Two responses concatenated inside one. `Content-Length: 5` means the client
reads `HALF!` as the body and then finds a status line where the next reply
should be — on a keep-alive connection that desynchronises the stream.

A dropped connection is at least recognisably broken. This is not.

`end_headers()` now records that bytes are committed, and the guard closes the
connection rather than writing a reply it cannot make valid. That single case
returns to the pre-#357 behaviour, and only where no better option exists.

## Mutation tests

| mutation | result |
|---|---|
| unwrap `do_DELETE` again | **2 failed** |
| drop the committed-bytes check | **FAIL** (concatenation test) |

## Verification

- `test_brainstem_http_framing.py` — 18 passed, stable over 3 runs
- Python suite — **1645 passed**, 6 skipped
- `parity_harness.py --runtime both` — PASS

## Note

Both defects were in a change I made one round earlier, and both are the same
failure of method: I wrote the general claim and then verified only the paths I
had just edited. The verb list and the already-replied case were both visible in
the file at the time.
