### PR TITLE
fix(gateway): stop GET /readyz from being able to kill the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `GET /readyz` could terminate the gateway. The handler serialised its report
+  as the argument to `res.end()`, after `res.writeHead()` had already committed
+  a status line, so a report that could not be serialised threw mid-reply and
+  the attached `.catch()` called `res.writeHead()` again on the same response.
+  That raised `ERR_HTTP_HEADERS_SENT` inside a discarded promise, which node
+  treats as an unhandled rejection and the process exits. The report is now
+  serialised before any byte is written, and the error path refuses to write
+  over a reply already in flight.
+
 - The brainstem dispatch guard appended a second response when a route failed
   after it had already begun replying, so the caller received
   `HTTP/1.0 200 OK ... HTTP/1.0 500 ...` concatenated inside one reply. The

--- a/typescript/src/__tests__/integration/readyz-response-safety.test.ts
+++ b/typescript/src/__tests__/integration/readyz-response-safety.test.ts
@@ -19,8 +19,8 @@
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { GatewayServer } from '../../gateway/server.js';
+import type { GatewayReadiness } from '../../gateway/server.js';
 import { reserveTestPort } from '../support/test-port.js';
-import type { GatewayReadiness } from '../../gateway/types.js';
 
 let server: GatewayServer | undefined;
 

--- a/typescript/src/__tests__/integration/readyz-response-safety.test.ts
+++ b/typescript/src/__tests__/integration/readyz-response-safety.test.ts
@@ -1,0 +1,116 @@
+/**
+ * `GET /readyz` must not be able to kill the gateway.
+ *
+ * The handler stringified its report as the argument to `res.end()`, which runs
+ * *after* `res.writeHead()` has already committed a status line. A readiness
+ * report that cannot be serialised therefore threw with the reply half sent,
+ * and the `.catch()` attached to that promise then called `res.writeHead()` a
+ * second time on the same response.
+ *
+ * That is `ERR_HTTP_HEADERS_SENT` raised inside a `void`-discarded promise. The
+ * TypeScript source installs no `unhandledRejection` handler, and node 20
+ * terminates on an unhandled rejection, so a single request to `/readyz` took
+ * the whole daemon down. Verified before the fix: the process died without
+ * reaching the next line of the probe.
+ *
+ * This is the same defect as the Python dispatch guard in #358 -- an error path
+ * writing a second response over a reply already in flight -- except that here
+ * the consequence is the process exiting rather than one corrupted reply.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+import type { GatewayReadiness } from '../../gateway/types.js';
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+/** A report that `JSON.stringify` refuses: it contains itself. */
+function unserialisableReport(): GatewayReadiness {
+  const report: Record<string, unknown> = { ready: true, status: 'ready' };
+  report.self = report;
+  return report as unknown as GatewayReadiness;
+}
+
+async function startGateway(
+  provider?: () => Promise<GatewayReadiness>,
+): Promise<number> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  if (provider) server.setReadinessProvider(provider);
+  await server.start();
+  return port;
+}
+
+describe('/readyz with a report that cannot be serialised', () => {
+  it('answers rather than writing a second set of headers', async () => {
+    const port = await startGateway(async () => unserialisableReport());
+
+    const res = await fetch(`http://127.0.0.1:${port}/readyz`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json() as { reason?: string };
+    expect(body.reason).toBe('readiness_check_failed');
+  });
+
+  it('leaves the gateway serving afterwards', async () => {
+    const port = await startGateway(async () => unserialisableReport());
+
+    await fetch(`http://127.0.0.1:${port}/readyz`, { signal: AbortSignal.timeout(5000) })
+      .catch(() => undefined);
+
+    // THE POINT: before the fix the process was gone by now, so this request
+    // had nothing to talk to.
+    const live = await fetch(`http://127.0.0.1:${port}/livez`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(live.status).toBe(200);
+  });
+
+  it('survives the failure repeatedly, not just once', async () => {
+    const port = await startGateway(async () => unserialisableReport());
+
+    for (let i = 0; i < 3; i += 1) {
+      const res = await fetch(`http://127.0.0.1:${port}/readyz`, {
+        signal: AbortSignal.timeout(5000),
+      });
+      expect(res.status, `request ${i + 1}`).toBe(503);
+    }
+  });
+});
+
+describe('/readyz on a healthy gateway', () => {
+  it('still reports ready', async () => {
+    // Anti-vacuity: serialising before the write must not change the answer.
+    const port = await startGateway(async () => ({ ready: true, status: 'ready' }));
+
+    const res = await fetch(`http://127.0.0.1:${port}/readyz`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(res.status).toBe(200);
+    const body = await res.json() as { ready: boolean; timestamp?: string };
+    expect(body.ready).toBe(true);
+    expect(body.timestamp, 'the timestamp is added by the handler').toBeTruthy();
+  });
+
+  it('reports 503 for a genuinely degraded report', async () => {
+    const port = await startGateway(async () => ({
+      ready: false,
+      status: 'degraded',
+      reason: 'something_specific',
+    }));
+
+    const res = await fetch(`http://127.0.0.1:${port}/readyz`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(res.status).toBe(503);
+    const body = await res.json() as { reason?: string };
+    // The real reason survives; it is not replaced by the catch-all.
+    expect(body.reason).toBe('something_specific');
+  });
+});

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -1104,15 +1104,31 @@ export class GatewayServer {
             reason: this.wss ? undefined : 'gateway_stopped',
           });
       void readiness.then(result => {
+        // Serialised BEFORE any byte is written. This used to stringify as the
+        // argument to `res.end()`, after `writeHead` had already committed a
+        // status line, so a report that cannot be serialised threw with the
+        // reply half sent -- and the `.catch` below then called `writeHead`
+        // again on that same response. That is ERR_HTTP_HEADERS_SENT inside a
+        // discarded promise, which on node 20 is an unhandled rejection, which
+        // terminates the process. One GET /readyz killed the daemon.
+        const payload = JSON.stringify({
+          ...result,
+          timestamp: new Date().toISOString(),
+        });
         res.writeHead(result.ready ? 200 : 503, {
           'Content-Type': 'application/json',
           Connection: 'close',
         });
-        res.end(JSON.stringify({
-          ...result,
-          timestamp: new Date().toISOString(),
-        }));
+        res.end(payload);
       }).catch(() => {
+        // Belt as well as braces: whatever failed, this must not be the thing
+        // that takes the gateway down. If the reply has already begun there is
+        // nothing valid left to say, and appending a second status line would
+        // desynchronise the connection.
+        if (res.headersSent) {
+          res.end();
+          return;
+        }
         res.writeHead(503, {
           'Content-Type': 'application/json',
           Connection: 'close',


### PR DESCRIPTION
## The TypeScript twin of #358, and here it exits the process

#358 fixed a Python guard that appended a second response onto a reply already
in flight. I went looking for the same shape in the gateway. It is there, and
the consequence is worse: Python corrupted one reply, node **terminates**.

```ts
void readiness.then(result => {
  res.writeHead(result.ready ? 200 : 503, {...});   // status line committed
  res.end(JSON.stringify({ ...result, timestamp })); // throws HERE
}).catch(() => {
  res.writeHead(503, {...});                         // ERR_HTTP_HEADERS_SENT
});
```

`JSON.stringify` runs as the *argument* to `res.end()`, so it executes after the
headers are out. A report that cannot be serialised throws with the reply half
sent, and the `.catch()` attached to the same promise writes a second set of
headers onto that response.

That rejection is discarded by `void`. There is **no `unhandledRejection`
handler anywhere in `typescript/src`** — I checked — and node 20 terminates the
process on an unhandled rejection.

## Verified end to end, not argued

A readiness provider returning a self-referencing object, against a running
gateway:

```
before:  CRASH started
         Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent
         <process gone — the probe never reached its next line>

after:   CRASH readyz -> 503
         CRASH gateway SURVIVED: 200
```

`setReadinessProvider` is public API, so an unserialisable report is not a
contrived input — it is whatever a caller's provider happens to return.

## Fix

Two changes, either of which alone would close it, kept together because they
guard different things:

1. The payload is serialised **before** `writeHead`, so a serialisation failure
   happens while nothing is committed and produces a clean 503.
2. The `.catch` refuses to write when `res.headersSent`, so nothing reachable
   from there can append a second status line.

There were **zero** `headersSent` checks in `server.ts` before this.

## Mutation test

Restoring both — stringify inside `res.end()`, and no `headersSent` guard:

```
× answers rather than writing a second set of headers
× leaves the gateway serving afterwards
× survives the failure repeatedly, not just once

⎯ Unhandled Rejection ⎯
Serialized Error: { code: 'ERR_HTTP_HEADERS_SENT' }
```

## Not fixed here

The absence of any process-level `unhandledRejection` policy is a product
decision — a long-lived daemon crashing versus swallowing errors into an
undefined state is a real trade, and this machine's gateway is **unsupervised**
(#144), so "crash and be restarted" is not currently true. Filing separately
rather than choosing inside a bug fix.

## Verification

- `readyz-response-safety.test.ts` — 5 passed
- TypeScript suite — **5019 passed**, 21 skipped
- `tsc --noEmit`, `eslint src --max-warnings 0` — clean
