### PR TITLE
fix(gateway): a plugin's unserialisable result no longer kills the daemon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A registered RPC method returning a value `JSON.stringify` refuses -- a cycle,
+  a BigInt -- terminated the gateway. `/rpc` serialised the result as the
+  argument to `res.end()`, after `res.writeHead()` had committed a status line,
+  so the throw landed mid-reply and the surrounding `catch` wrote a second
+  status line: `ERR_HTTP_HEADERS_SENT`, an unhandled rejection, process exit.
+  `registerMethod` is the extension point plugins use, so this was reachable by
+  design. The call now answers a JSON-RPC `INTERNAL_ERROR` and the daemon stays
+  up.
+
 - `GET /readyz` could terminate the gateway. The handler serialised its report
   as the argument to `res.end()`, after `res.writeHead()` had already committed
   a status line, so a report that could not be serialised threw mid-reply and

--- a/typescript/src/__tests__/integration/rpc-response-safety.test.ts
+++ b/typescript/src/__tests__/integration/rpc-response-safety.test.ts
@@ -1,0 +1,112 @@
+/**
+ * A response body that cannot be serialised must not end the process.
+ *
+ * `res.end(JSON.stringify(x))` evaluates `JSON.stringify` *after*
+ * `res.writeHead` has committed a status line. A value it refuses -- a cycle, a
+ * BigInt -- therefore throws with the reply already begun, and every such site
+ * sits in a `try` whose `catch` writes a second status line onto the same
+ * response. That is `ERR_HTTP_HEADERS_SENT` in an async handler, which node 20
+ * turns into an unhandled rejection and exits on.
+ *
+ * #359 fixed `/readyz`, where the bad value came from `setReadinessProvider`.
+ * This covers `/rpc`, where it comes from `registerMethod` -- the extension
+ * point plugins use, so the input is not contrived. Verified against a running
+ * gateway before the fix: the probe never reached the line after the request.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+import { RPC_ERROR } from '../../gateway/types.js';
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+/** A value `JSON.stringify` refuses: it contains itself. */
+function cyclic(): Record<string, unknown> {
+  const value: Record<string, unknown> = { ok: true };
+  value.self = value;
+  return value;
+}
+
+async function startWithMethod(result: () => unknown): Promise<number> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server.registerMethod('plugin.result', async () => result());
+  await server.start();
+  return port;
+}
+
+async function callRpc(port: number, method: string): Promise<{
+  status: number;
+  body: Record<string, unknown>;
+}> {
+  const res = await fetch(`http://127.0.0.1:${port}/rpc`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 7, method, params: {} }),
+    signal: AbortSignal.timeout(5000),
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe('an RPC method returning a value that cannot be serialised', () => {
+  it('answers a JSON-RPC error rather than writing a second status line', async () => {
+    const port = await startWithMethod(cyclic);
+
+    const { status, body } = await callRpc(port, 'plugin.result');
+    expect(status).toBe(500);
+    const error = body.error as { code?: number; message?: string } | undefined;
+    expect(error?.code).toBe(RPC_ERROR.INTERNAL_ERROR);
+    // The id is echoed so a caller can still correlate the failure.
+    expect(body.id).toBe(7);
+  });
+
+  it('leaves the gateway serving afterwards', async () => {
+    const port = await startWithMethod(cyclic);
+    await callRpc(port, 'plugin.result').catch(() => undefined);
+
+    // THE POINT: before the fix the process was gone, so this had nothing to
+    // talk to.
+    const live = await fetch(`http://127.0.0.1:${port}/livez`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(live.status).toBe(200);
+  });
+
+  it('survives it repeatedly', async () => {
+    const port = await startWithMethod(cyclic);
+    for (let i = 0; i < 3; i += 1) {
+      const { status } = await callRpc(port, 'plugin.result');
+      expect(status, `call ${i + 1}`).toBe(500);
+    }
+  });
+
+  it('a BigInt is refused the same way as a cycle', async () => {
+    // A different reason for the same failure, so the fix is not tied to
+    // cycles specifically.
+    const port = await startWithMethod(() => ({ big: BigInt(1) }));
+    const { status } = await callRpc(port, 'plugin.result');
+    expect(status).toBe(500);
+
+    const live = await fetch(`http://127.0.0.1:${port}/livez`, {
+      signal: AbortSignal.timeout(5000),
+    });
+    expect(live.status).toBe(200);
+  });
+});
+
+describe('an RPC method returning an ordinary value', () => {
+  it('still answers 200 with the result', async () => {
+    // Anti-vacuity: serialising before the write must not change the answer.
+    const port = await startWithMethod(() => ({ hello: 'world' }));
+
+    const { status, body } = await callRpc(port, 'plugin.result');
+    expect(status).toBe(200);
+    expect(body.result).toEqual({ hello: 'world' });
+    expect(body.id).toBe(7);
+  });
+});

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -266,6 +266,50 @@ interface ConfigWriteParams {
   config?: string;
   baseHash?: string;
 }
+/**
+ * Write a JSON response so that serialising it cannot take the process down.
+ *
+ * The order matters and used to be wrong in several places:
+ *
+ *     res.writeHead(200, ...);                 // status line committed
+ *     res.end(JSON.stringify(result));         // throws HERE
+ *
+ * `JSON.stringify` runs as the argument to `res.end()`, so a value it refuses
+ * -- a cycle, a BigInt -- throws with the reply already begun. Every one of
+ * those sites sits inside a `try`, and the `catch` then writes a second status
+ * line onto the same response: `ERR_HTTP_HEADERS_SENT`, raised in an async
+ * handler, which node 20 turns into an unhandled rejection and exits on. #359
+ * fixed one such path in `/readyz`; `/rpc` was reachable the same way through
+ * any registered method, which is public API.
+ *
+ * Serialising first means a bad value produces a clean 500 instead, and the
+ * `headersSent` check means nothing here can ever append to a reply in flight.
+ */
+export function writeJsonResponse(
+  res: ServerResponse,
+  status: number,
+  body: unknown,
+  headers: Record<string, string> = {},
+  fallback: unknown = { status: 'error', error: 'Response could not be serialised' },
+): void {
+  let payload: string;
+  let code = status;
+  try {
+    payload = JSON.stringify(body);
+  } catch {
+    code = 500;
+    payload = JSON.stringify(fallback);
+  }
+  if (res.headersSent) {
+    // Nothing valid is left to say and a second status line would
+    // desynchronise the connection. End what is already out there.
+    res.end();
+    return;
+  }
+  res.writeHead(code, { 'Content-Type': 'application/json', ...headers });
+  res.end(payload);
+}
+
 export interface GatewayReadiness {
   ready: boolean;
   status: 'ready' | 'degraded';
@@ -1582,8 +1626,13 @@ export class GatewayServer {
             try {
               const responseBody = await this.runWithTimeout(responsePromise);
               if (!this.isGenerationActive(requestGeneration)) return;
-              res.writeHead(200, { 'Content-Type': 'application/json', ...corsHeaders });
-              res.end(JSON.stringify(responseBody));
+              writeJsonResponse(res, 200, responseBody, corsHeaders, {
+                schema: 'rapp-chat/1.0',
+                status: 'error',
+                error: 'Response could not be serialised',
+                session_id: sessionId,
+                sessionId,
+              });
             } catch (error) {
               if (idempotencyKey && !(error instanceof GatewayTimeoutError)) {
                 this.httpChatIdempotency.delete(idempotencyKey);
@@ -1643,8 +1692,14 @@ export class GatewayServer {
               if (!this.isGenerationActive(requestGeneration)) return;
               this.metrics.recordRequest('success');
               logGatewayRequest('gateway', 'rpc.dispatch', { transport: 'http', outcome: 'success', durationMs: Date.now() - dispatchStartedAt });
-              res.writeHead(200, { 'Content-Type': 'application/json', ...corsHeaders });
-              res.end(JSON.stringify({ jsonrpc: '2.0', id: parsed.id, result }));
+              writeJsonResponse(res, 200, { jsonrpc: '2.0', id: parsed.id, result }, corsHeaders, {
+                jsonrpc: '2.0',
+                id: parsed.id,
+                error: {
+                  code: RPC_ERROR.INTERNAL_ERROR,
+                  message: 'Result could not be serialised',
+                },
+              });
             } catch (error) {
               if (
                 error instanceof GatewayStoppedError


### PR DESCRIPTION
## The sweep #359 implied, and it found a live one

#359 fixed `/readyz`, where an unserialisable value came from
`setReadinessProvider`. That fix was for one path. This is the sweep.

`/rpc` has the identical shape, and there the value comes from
`registerMethod` — the extension point plugins use. So the bad input is
whatever a plugin returns, not something contrived for a test.

```ts
res.writeHead(200, { ...corsHeaders });                 // status line committed
res.end(JSON.stringify({ jsonrpc, id, result }));       // throws HERE
} catch (error) {
  res.writeHead(200, { ...corsHeaders });               // ERR_HTTP_HEADERS_SENT
```

Verified against a running gateway before the fix — one `POST /rpc` to a method
returning a self-referencing object:

```
before:  RPC started
         Error [ERR_HTTP_HEADERS_SENT]: Cannot write headers after they are sent
         <process gone — probe never reached its next line>

after:   RPC -> 500 {"jsonrpc":"2.0","id":1,
                     "error":{"code":-32603,"message":"Result could not be serialised"}}
         gateway SURVIVED: 200
```

## Fix

`writeJsonResponse()` serialises **before** writing anything, and refuses to
write when `res.headersSent`. Both halves of the failure are closed: a bad value
becomes a clean error reply, and nothing here can append to a reply in flight.

The caller supplies the fallback body, so `/rpc` still answers a well-formed
JSON-RPC error with the original `id` — a caller can correlate the failure
rather than just seeing a 500.

## Reported accurately: `/chat` was not vulnerable

The same helper is now used for the `/chat` 200, and I want to be clear that
**this is hardening, not a repair**. I initially suspected it and tested it:

- the envelope is built from strings inside `executeChat`, before any byte is
  written;
- the `JSON.stringify(result.toolCalls)` that could throw is unreachable
  whenever `agentLogs` is present, because `??` does not fall back on an empty
  array.

A probe returning a circular `toolCalls` answered **200** and the gateway
survived, on the unfixed code. No live bug there.

## Scope

There are **40** `writeHead` / `res.end(JSON.stringify(...))` pairs in
`server.ts`. 29 serialise object literals of strings and numbers, which cannot
throw. The two migrated here are the ones carrying values from public extension
points. I have not mass-migrated the rest: it would be a 40-site mechanical diff
whose risk is not justified by a hazard that does not exist at those sites.

## Mutation test

Restoring the old ordering on `/rpc`:

```
⎯ Unhandled Rejection ⎯
Serialized Error: { code: 'ERR_HTTP_HEADERS_SENT' }
```

## Verification

- `rpc-response-safety.test.ts` — 5 passed (cycle, BigInt, repeat, survival, and
  an ordinary result still returning 200)
- TypeScript suite — **5024 passed**, 21 skipped
- `tsc --noEmit`, `eslint src --max-warnings 0` — clean

Related: #360 (no process-level `unhandledRejection` policy — the reason these
are fatal rather than merely wrong).
