### PR TITLE
fix(gateway): answer a WebSocket request whose result cannot be serialised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A WebSocket RPC whose result could not be serialised was never answered.
+  `sendFrame` wrapped `ws.send(JSON.stringify(frame))` in a `try`/`catch` that
+  ignored the failure, so the caller waited on an `id` that would never arrive
+  while the connection stayed open and every other call worked. The same method
+  over HTTP answers a JSON-RPC error. It now answers one here too, carrying the
+  caller's `id`; frames with no `id` -- events, which nobody is awaiting -- are
+  still dropped.
+
 - A registered RPC method returning a value `JSON.stringify` refuses -- a cycle,
   a BigInt -- terminated the gateway. `/rpc` serialised the result as the
   argument to `res.end()`, after `res.writeHead()` had committed a status line,

--- a/typescript/src/__tests__/integration/ws-frame-serialisation.test.ts
+++ b/typescript/src/__tests__/integration/ws-frame-serialisation.test.ts
@@ -1,0 +1,135 @@
+/**
+ * A WebSocket reply that cannot be serialised must still be a reply.
+ *
+ * `sendFrame` was `try { ws.send(JSON.stringify(frame)); } catch { }`. A frame
+ * carrying a value `JSON.stringify` refuses -- a cycle, a BigInt -- threw
+ * inside that `try` and was swallowed, so the request was never answered at
+ * all. The socket stayed open and later calls worked, which is what made it
+ * hard to see: nothing looked broken except one request that never came back.
+ *
+ * The same method over HTTP answers a JSON-RPC error (#361). Over this
+ * transport it answered nothing, and a client awaiting `id` cannot tell silence
+ * from a hung server -- it waits for its own timeout, or forever if it has
+ * none.
+ *
+ * Verified against a running gateway before the fix: `plugin.good` replied,
+ * `plugin.bad` produced `<NO REPLY>`, and `plugin.good` replied again.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import WebSocket from 'ws';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+import { RPC_ERROR } from '../../gateway/types.js';
+
+let server: GatewayServer | undefined;
+let socket: WebSocket | undefined;
+
+afterEach(async () => {
+  socket?.close();
+  socket = undefined;
+  await server?.stop();
+  server = undefined;
+});
+
+function cyclic(): Record<string, unknown> {
+  const value: Record<string, unknown> = { ok: true };
+  value.self = value;
+  return value;
+}
+
+interface Frame {
+  id?: string;
+  ok?: boolean;
+  payload?: unknown;
+  error?: { code?: number; message?: string };
+}
+
+/** Resolve with the frame answering `id`, or null if none arrives in time. */
+function call(
+  ws: WebSocket,
+  id: string,
+  method: string,
+  params: unknown = {},
+  timeoutMs = 3000,
+): Promise<Frame | null> {
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      ws.off('message', onMessage);
+      resolve(null);
+    }, timeoutMs);
+    function onMessage(data: WebSocket.RawData): void {
+      const frame = JSON.parse(data.toString()) as Frame;
+      if (frame.id !== id) return;
+      clearTimeout(timer);
+      ws.off('message', onMessage);
+      resolve(frame);
+    }
+    ws.on('message', onMessage);
+    ws.send(JSON.stringify({ type: 'req', id, method, params }));
+  });
+}
+
+async function connect(): Promise<WebSocket> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server.registerMethod('plugin.bad', async () => cyclic());
+  server.registerMethod('plugin.big', async () => ({ big: BigInt(1) }));
+  server.registerMethod('plugin.good', async () => ({ hello: 'world' }));
+  await server.start();
+
+  const ws = new WebSocket(`ws://127.0.0.1:${port}`);
+  await new Promise((resolve) => ws.once('open', resolve));
+  await call(ws, 'handshake', 'connect', {
+    client: { id: 'test', version: '1.0.0', platform: 'node', mode: 'control' },
+  });
+  socket = ws;
+  return ws;
+}
+
+describe('a WebSocket result that cannot be serialised', () => {
+  it('is answered, not silently dropped', async () => {
+    const ws = await connect();
+
+    const frame = await call(ws, 'r1', 'plugin.bad');
+    expect(frame, 'the caller must not be left waiting').not.toBeNull();
+    expect(frame?.ok).toBe(false);
+    expect(frame?.error?.code).toBe(RPC_ERROR.INTERNAL_ERROR);
+  });
+
+  it('answers on the id the caller is waiting for', async () => {
+    // Without the correlator the reply is useless: a client demultiplexes on
+    // `id`, so an error frame that does not carry it is another silent request.
+    const ws = await connect();
+
+    const frame = await call(ws, 'correlate-me', 'plugin.bad');
+    expect(frame?.id).toBe('correlate-me');
+  });
+
+  it('a BigInt fails the same way as a cycle', async () => {
+    const ws = await connect();
+
+    const frame = await call(ws, 'r2', 'plugin.big');
+    expect(frame?.ok).toBe(false);
+    expect(frame?.error?.code).toBe(RPC_ERROR.INTERNAL_ERROR);
+  });
+
+  it('leaves the connection usable', async () => {
+    const ws = await connect();
+
+    await call(ws, 'r3', 'plugin.bad');
+    const after = await call(ws, 'r4', 'plugin.good');
+    expect(after?.ok).toBe(true);
+    expect(after?.payload).toEqual({ hello: 'world' });
+  });
+});
+
+describe('an ordinary WebSocket result', () => {
+  it('is unaffected', async () => {
+    // Anti-vacuity: serialising into a variable must not change the reply.
+    const ws = await connect();
+
+    const frame = await call(ws, 'r5', 'plugin.good');
+    expect(frame?.ok).toBe(true);
+    expect(frame?.payload).toEqual({ hello: 'world' });
+  });
+});

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -2321,7 +2321,32 @@ export class GatewayServer {
       try { ws.close(1013, 'Outbound buffer limit exceeded'); } catch { /* already gone */ }
       return;
     }
-    try { ws.send(JSON.stringify(frame)); } catch { /* ignore */ }
+    let payload: string;
+    try {
+      payload = JSON.stringify(frame);
+    } catch {
+      // A frame that cannot be serialised used to be swallowed by the `catch`
+      // below, so the caller was never answered at all. Over HTTP the same
+      // method returns a JSON-RPC error (#361); over this transport it returned
+      // silence, which a client awaiting `id` cannot distinguish from a hung
+      // server -- it waits for its own timeout, or forever if it has none.
+      //
+      // Only a frame carrying an `id` has someone waiting on it. An event has
+      // no correlator and no awaiting caller, so there is nothing to answer and
+      // it is dropped as before.
+      const id = typeof frame.id === 'string' ? frame.id : '';
+      if (!id) return;
+      payload = JSON.stringify({
+        type: 'res',
+        id,
+        ok: false,
+        error: {
+          code: RPC_ERROR.INTERNAL_ERROR,
+          message: 'Result could not be serialised',
+        },
+      });
+    }
+    try { ws.send(payload); } catch { /* ignore */ }
   }
 
   private checkRateLimit(connId: string): boolean {


### PR DESCRIPTION
## The third transport, and the only one that stayed quiet about it

`/readyz` (#359) and `/rpc` (#361) both **died** on a value `JSON.stringify`
refuses. The WebSocket path does not die — which is exactly why it was still
there after two rounds of looking.

```ts
try { ws.send(JSON.stringify(frame)); } catch { /* ignore */ }
```

The `stringify` sits inside the `try`, so a cycle or a BigInt is swallowed
alongside the send errors that `catch` was written for. Nothing crashes.
Nothing is logged. **The request is simply never answered.**

## Measured, one connection, three calls

```
plugin.good  ->  {"type":"res","id":"c1","ok":true,"payload":{"hello":"world"}}
plugin.bad   ->  <NO REPLY>
plugin.good  ->  {"type":"res","id":"c3","ok":true,"payload":{"hello":"world"}}
```

The socket stays open and everything else keeps working, so there is no symptom
to notice except one request that never comes back. A client awaiting `id`
cannot tell that from a hung server: it waits for its own timeout, or forever if
it has none.

And after #361, the *same method* over HTTP returns `INTERNAL_ERROR`. The two
transports disagreed about whether a request had failed at all.

## Fix

`sendFrame` serialises into a variable first and, on failure, sends a
well-formed error frame **carrying the caller's `id`** — without the correlator
the reply is useless, because a client demultiplexes on it, and an error frame
with no `id` is just another unanswered request.

A frame with no `id` is an event that nobody is awaiting, so that case is still
dropped rather than answered with an invented correlator.

## Mutation test

Restoring the swallowing version fails **3 of 5** tests, each by timing out
waiting for a reply — the bug stated exactly:

```
× is answered, not silently dropped                  3023ms
× answers on the id the caller is waiting for        3009ms
× a BigInt fails the same way as a cycle             3008ms
```

## Verification

- `ws-frame-serialisation.test.ts` — 5 passed
- TypeScript suite — **5029 passed**, 21 skipped
- `tsc --noEmit`, `eslint src --max-warnings 0` — clean

## Pattern

Three transports, one root cause: `JSON.stringify` evaluated at the point of
sending rather than before it. Two turned it into a dead process, one into a
dead request. Related: #360, which is why the first two were fatal.
