### PR TITLE
fix(gateway): serialisation failures use the RPC error convention, not a new status

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `/rpc` answered HTTP 500 when a result could not be serialised, while every
+  other JSON-RPC-level failure on that endpoint -- method not found, timeout,
+  internal error -- answers HTTP 200 and carries the fault in the `error`
+  member. A client that checks the status before parsing saw one failure mode
+  as a transport error and the rest as RPC errors. It now answers 200 like the
+  others.
+
 - A WebSocket RPC whose result could not be serialised was never answered.
   `sendFrame` wrapped `ws.send(JSON.stringify(frame))` in a `try`/`catch` that
   ignored the failure, so the caller waited on an `id` that would never arrive

--- a/typescript/src/__tests__/integration/rpc-response-safety.test.ts
+++ b/typescript/src/__tests__/integration/rpc-response-safety.test.ts
@@ -58,7 +58,10 @@ describe('an RPC method returning a value that cannot be serialised', () => {
     const port = await startWithMethod(cyclic);
 
     const { status, body } = await callRpc(port, 'plugin.result');
-    expect(status).toBe(500);
+    // HTTP 200, like every other JSON-RPC-level failure on this endpoint. A
+    // client that checks the status before parsing must see this the same way
+    // it sees a timeout, not as a transport error.
+    expect(status).toBe(200);
     const error = body.error as { code?: number; message?: string } | undefined;
     expect(error?.code).toBe(RPC_ERROR.INTERNAL_ERROR);
     // The id is echoed so a caller can still correlate the failure.
@@ -81,7 +84,7 @@ describe('an RPC method returning a value that cannot be serialised', () => {
     const port = await startWithMethod(cyclic);
     for (let i = 0; i < 3; i += 1) {
       const { status } = await callRpc(port, 'plugin.result');
-      expect(status, `call ${i + 1}`).toBe(500);
+      expect(status, `call ${i + 1}`).toBe(200);
     }
   });
 
@@ -89,8 +92,9 @@ describe('an RPC method returning a value that cannot be serialised', () => {
     // A different reason for the same failure, so the fix is not tied to
     // cycles specifically.
     const port = await startWithMethod(() => ({ big: BigInt(1) }));
-    const { status } = await callRpc(port, 'plugin.result');
-    expect(status).toBe(500);
+    const { status, body } = await callRpc(port, 'plugin.result');
+    expect(status).toBe(200);
+    expect((body.error as { code?: number })?.code).toBe(RPC_ERROR.INTERNAL_ERROR);
 
     const live = await fetch(`http://127.0.0.1:${port}/livez`, {
       signal: AbortSignal.timeout(5000),
@@ -107,6 +111,31 @@ describe('an RPC method returning an ordinary value', () => {
     const { status, body } = await callRpc(port, 'plugin.result');
     expect(status).toBe(200);
     expect(body.result).toEqual({ hello: 'world' });
+    expect(body.id).toBe(7);
+  });
+});
+
+describe('every JSON-RPC-level failure answers with the same HTTP status', () => {
+  /**
+   * The endpoint carries RPC faults in the `error` member and keeps HTTP 200
+   * for all of them; 401 is the single exception and it is a transport refusal
+   * rather than an RPC result.
+   *
+   * Tested as a rule over several failures rather than asserted once, because
+   * #361 added a fourth failure mode and gave it a 500 without noticing the
+   * three beside it. A client that checks the status before parsing would have
+   * read that one as a transport error and the rest as RPC errors.
+   */
+  it.each([
+    ['a method that does not exist', 'no.such.method', () => ({ fine: true })],
+    ['a method that throws', 'plugin.result', () => { throw new Error('boom'); }],
+    ['a result that cannot be serialised', 'plugin.result', cyclic],
+  ])('%s answers 200 with an error member', async (_label, method, result) => {
+    const port = await startWithMethod(result);
+
+    const { status, body } = await callRpc(port, method);
+    expect(status).toBe(200);
+    expect(body.error, 'the fault belongs in the error member').toBeTruthy();
     expect(body.id).toBe(7);
   });
 });

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -291,13 +291,14 @@ export function writeJsonResponse(
   body: unknown,
   headers: Record<string, string> = {},
   fallback: unknown = { status: 'error', error: 'Response could not be serialised' },
+  fallbackStatus = 500,
 ): void {
   let payload: string;
   let code = status;
   try {
     payload = JSON.stringify(body);
   } catch {
-    code = 500;
+    code = fallbackStatus;
     payload = JSON.stringify(fallback);
   }
   if (res.headersSent) {
@@ -1626,13 +1627,22 @@ export class GatewayServer {
             try {
               const responseBody = await this.runWithTimeout(responsePromise);
               if (!this.isGenerationActive(requestGeneration)) return;
-              writeJsonResponse(res, 200, responseBody, corsHeaders, {
-                schema: 'rapp-chat/1.0',
-                status: 'error',
-                error: 'Response could not be serialised',
-                session_id: sessionId,
-                sessionId,
-              });
+              writeJsonResponse(
+                res,
+                200,
+                responseBody,
+                corsHeaders,
+                {
+                  schema: 'rapp-chat/1.0',
+                  status: 'error',
+                  error: 'Response could not be serialised',
+                  session_id: sessionId,
+                  sessionId,
+                },
+                // 503, matching this handler's own catch for an internal
+                // failure, rather than a third status for the same situation.
+                503,
+              );
             } catch (error) {
               if (idempotencyKey && !(error instanceof GatewayTimeoutError)) {
                 this.httpChatIdempotency.delete(idempotencyKey);
@@ -1692,14 +1702,28 @@ export class GatewayServer {
               if (!this.isGenerationActive(requestGeneration)) return;
               this.metrics.recordRequest('success');
               logGatewayRequest('gateway', 'rpc.dispatch', { transport: 'http', outcome: 'success', durationMs: Date.now() - dispatchStartedAt });
-              writeJsonResponse(res, 200, { jsonrpc: '2.0', id: parsed.id, result }, corsHeaders, {
-                jsonrpc: '2.0',
-                id: parsed.id,
-                error: {
-                  code: RPC_ERROR.INTERNAL_ERROR,
-                  message: 'Result could not be serialised',
+              writeJsonResponse(
+                res,
+                200,
+                { jsonrpc: '2.0', id: parsed.id, result },
+                corsHeaders,
+                {
+                  jsonrpc: '2.0',
+                  id: parsed.id,
+                  error: {
+                    code: RPC_ERROR.INTERNAL_ERROR,
+                    message: 'Result could not be serialised',
+                  },
                 },
-              });
+                // HTTP 200, like every other JSON-RPC-level failure on this
+                // endpoint: method-not-found, timeout and internal-error all
+                // answer 200 and carry the fault in `error`. 401 is the one
+                // exception and it is a transport refusal, not an RPC result.
+                // #361 shipped this as a 500, so a client that checks the
+                // status before parsing saw a serialisation failure as a
+                // transport error while seeing a timeout as an RPC error.
+                200,
+              );
             } catch (error) {
               if (
                 error instanceof GatewayStoppedError


### PR DESCRIPTION
## Auditing #361, which I merged one round ago

#361 made an unserialisable RPC result answer a well-formed JSON-RPC error
instead of killing the daemon. It gave that reply **HTTP 500**. The endpoint's
other JSON-RPC-level failures do not:

| failure | status | fault carried in |
|---|---|---|
| `METHOD_NOT_FOUND` | 200 | `error` member |
| `TIMEOUT` | 200 | `error` member |
| `INTERNAL_ERROR` | 200 | `error` member |
| `UNAUTHORIZED` | 401 | — (transport refusal, not an RPC result) |
| **serialisation failure (#361)** | **500** | `error` member |

So I added a fourth answer to a question the endpoint had already answered three
times the same way.

## Why it matters

Checking the HTTP status before parsing the body is a common client shape. Under
#361 such a client read a serialisation failure as a **transport** error while
reading a timeout as an **RPC** error — two different code paths for two
instances of the same thing: *the method did not produce a result*.

That is the same class of defect as the runtime-fingerprinting work earlier in
this session: not a wrong answer, an *inconsistent* one, where the inconsistency
is invisible until a caller happens to branch on it.

## Fix

The fallback status is a parameter rather than a constant, so the caller states
it:

- `/rpc` passes **200**, matching its three siblings.
- `/chat` passes **503**, matching its own `catch` for an internal failure,
  rather than introducing a third status there too.

## The test is a rule, not an assertion

```ts
it.each([
  ['a method that does not exist',      ...],
  ['a method that throws',              ...],
  ['a result that cannot be serialised',...],
])('%s answers 200 with an error member', ...)
```

Because the way this got in was adding a fourth failure mode without looking at
the three beside it. A fifth one now has to satisfy the same rule.

## Mutation test

Restoring the 500 fails **4 of 8**.

## Verification

- `rpc-response-safety.test.ts` — 8 passed
- TypeScript suite — **5032 passed**, 21 skipped
- `tsc --noEmit`, `eslint src --max-warnings 0` — clean

Also this round, reported as a negative: the Python brainstem's `_send` calls
`json.dumps` **before** `send_response`, so an unserialisable payload throws with
nothing committed and the dispatch guard turns it into a clean 500 — one status
line, server survives. Python had the ordering right in the one place TypeScript
had it wrong in three. Nothing to fix there.
