### PR TITLE
fix(gateway): /agents/import serialisation failure ended the process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `POST /agents/import` ended the gateway process when the injected agent
+  importer returned a value `JSON.stringify` refuses. The status line was
+  committed before the body was serialised, so the throw arrived with the reply
+  already begun and the outer catch wrote a second status line --
+  `ERR_HTTP_HEADERS_SENT`, which node exits on. The caller received no response
+  at all. It now answers 503 with an error envelope.
+- The three catch blocks around the HTTP body handler wrote a status line
+  without checking whether one had already been sent, so any route that threw
+  after answering ended the process rather than the request. They now close an
+  already-committed response instead of re-heading it.
+
 - `/rpc` answered HTTP 500 when a result could not be serialised, while every
   other JSON-RPC-level failure on that endpoint -- method not found, timeout,
   internal error -- answers HTTP 200 and carries the fault in the `error`

--- a/typescript/src/__tests__/integration/agents-import-response-safety.test.ts
+++ b/typescript/src/__tests__/integration/agents-import-response-safety.test.ts
@@ -1,0 +1,123 @@
+/**
+ * The fourth endpoint with one root cause: `JSON.stringify` evaluated after
+ * `res.writeHead` has already committed the reply.
+ *
+ * `/agents/import` answers with whatever `setAgentImporter` returned. That is a
+ * public injection point, so the value is caller-supplied, and a value
+ * `JSON.stringify` refuses threw with the response already begun. The outer
+ * catch around the body handler then wrote a *second* status line, which is
+ * `ERR_HTTP_HEADERS_SENT` inside an async handler -- an unhandled rejection,
+ * which node 20 exits on. Verified against a running gateway before the fix:
+ * the client received no response at all and the daemon left with code 1.
+ *
+ * #359 fixed `/readyz` (`setReadinessProvider`), #361 `/rpc` (`registerMethod`),
+ * #362 the WebSocket frame writer. Each was found by looking for the previous
+ * one's shape somewhere else, and this site was explicitly left alone in #361 as
+ * "not proven reachable" -- so the value here is as much in the second half of
+ * the file as the first: the catches can no longer double-write at all.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { mkdtempSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { GatewayServer } from '../../gateway/server.js';
+import { reserveTestPort } from '../support/test-port.js';
+
+let server: GatewayServer | undefined;
+
+afterEach(async () => {
+  await server?.stop();
+  server = undefined;
+});
+
+/** A value `JSON.stringify` refuses: it contains itself. */
+function cyclic(): Record<string, unknown> {
+  const value: Record<string, unknown> = { status: 'ok' };
+  value.self = value;
+  return value;
+}
+
+async function startWithImporter(result: () => unknown): Promise<number> {
+  const port = await reserveTestPort();
+  server = new GatewayServer({
+    port,
+    bind: 'loopback',
+    auth: { mode: 'none' },
+    dataDir: mkdtempSync(join(tmpdir(), 'import-safety-')),
+  });
+  server.setAgentImporter(async () => result() as never);
+  await server.start();
+  return port;
+}
+
+async function postImport(port: number): Promise<{ status: number; body: Record<string, unknown> }> {
+  const res = await fetch(`http://127.0.0.1:${port}/agents/import`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ filename: 'a.py', contents: 'print(1)' }),
+  });
+  return { status: res.status, body: (await res.json()) as Record<string, unknown> };
+}
+
+describe('an import result that cannot be serialised', () => {
+  it('answers an error envelope rather than killing the daemon', async () => {
+    const port = await startWithImporter(cyclic);
+
+    const { status, body } = await postImport(port);
+
+    // 503, matching this route's own "this daemon cannot install agents": the
+    // importer did not produce a usable answer. Not 400 -- the request was
+    // fine, and 400 is what the outer catch used to report for this.
+    expect(status).toBe(503);
+    expect(body.status).toBe('error');
+    expect(body.error).toBe('Import result could not be serialised');
+  });
+
+  it('leaves the server answering afterwards', async () => {
+    const port = await startWithImporter(cyclic);
+
+    await postImport(port);
+    const health = await fetch(`http://127.0.0.1:${port}/health`);
+
+    // The pre-fix failure was not a bad reply, it was no reply and no process.
+    expect(health.status).toBe(200);
+  });
+
+  it('survives it repeatedly', async () => {
+    const port = await startWithImporter(cyclic);
+
+    for (let i = 0; i < 3; i++) {
+      const { status } = await postImport(port);
+      expect(status, `call ${i + 1}`).toBe(503);
+    }
+  });
+
+  it('refuses a BigInt the same way as a cycle', async () => {
+    const port = await startWithImporter(() => ({ status: 'ok', big: BigInt(1) }));
+
+    const { status, body } = await postImport(port);
+
+    expect(status).toBe(503);
+    expect(body.error).toBe('Import result could not be serialised');
+  });
+
+  it('still returns a serialisable result unchanged', async () => {
+    const port = await startWithImporter(() => ({ status: 'ok', agent: 'a.py' }));
+
+    const { status, body } = await postImport(port);
+
+    // The guard must not have swallowed the normal path.
+    expect(status).toBe(200);
+    expect(body).toEqual({ status: 'ok', agent: 'a.py' });
+  });
+
+  it('reports an importer error with the route status, not the fallback', async () => {
+    const port = await startWithImporter(() => ({ status: 'error', error: 'name taken' }));
+
+    const { status, body } = await postImport(port);
+
+    // A serialisable failure is the importer's own answer and keeps its 400.
+    expect(status).toBe(400);
+    expect(body.error).toBe('name taken');
+  });
+});

--- a/typescript/src/__tests__/integration/agents-import-response-safety.test.ts
+++ b/typescript/src/__tests__/integration/agents-import-response-safety.test.ts
@@ -20,7 +20,8 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { mkdtempSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { GatewayServer } from '../../gateway/server.js';
+import type { ServerResponse } from 'http';
+import { GatewayServer, writeJsonResponse } from '../../gateway/server.js';
 import { reserveTestPort } from '../support/test-port.js';
 
 let server: GatewayServer | undefined;
@@ -119,5 +120,49 @@ describe('an import result that cannot be serialised', () => {
     // A serialisable failure is the importer's own answer and keeps its 400.
     expect(status).toBe(400);
     expect(body.error).toBe('name taken');
+  });
+});
+
+describe('writeJsonResponse on an already-committed response', () => {
+  /**
+   * The property the three catches around the body handler now depend on.
+   * Before this, the file contained zero `res.headersSent` checks, so a catch
+   * reached after its route had already answered wrote a second status line --
+   * which is the actual mechanism that ended the process, rather than the
+   * serialisation failure that led there.
+   */
+  function fakeResponse(headersSent: boolean): {
+    calls: string[];
+    res: ServerResponse;
+  } {
+    const calls: string[] = [];
+    const res = {
+      headersSent,
+      writeHead(): unknown { calls.push('writeHead'); return res; },
+      end(payload?: unknown): unknown {
+        calls.push(payload === undefined ? 'end()' : 'end(body)');
+        return res;
+      },
+    };
+    return { calls, res: res as unknown as ServerResponse };
+  }
+
+  it('writes head and body when nothing has been sent', () => {
+    const { calls, res } = fakeResponse(false);
+
+    writeJsonResponse(res, 200, { ok: true });
+
+    expect(calls).toEqual(['writeHead', 'end(body)']);
+  });
+
+  it('closes the response without a second head once headers are sent', () => {
+    const { calls, res } = fakeResponse(true);
+
+    writeJsonResponse(res, 500, { error: 'too late' });
+
+    // No second status line: that is ERR_HTTP_HEADERS_SENT, and in an async
+    // handler node 20 exits on it. The response is ended so the socket is not
+    // left open instead.
+    expect(calls).toEqual(['end()']);
   });
 });

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -1379,8 +1379,22 @@ export class GatewayServer {
               return;
             }
             const result = await this.agentImporter(filename, Buffer.from(contents, 'utf-8'));
-            res.writeHead(result.status === 'ok' ? 200 : 400, { 'Content-Type': 'application/json', ...corsHeaders });
-            res.end(JSON.stringify(result));
+            // `agentImporter` is injected through the public `setAgentImporter`,
+            // so its return value is caller-supplied and may not be
+            // serialisable. Writing the head first and serialising second threw
+            // after the response was committed, the outer catch wrote a second
+            // head, and Node ended the process on ERR_HTTP_HEADERS_SENT -- the
+            // same shape as /readyz and /rpc.
+            writeJsonResponse(
+              res,
+              result.status === 'ok' ? 200 : 400,
+              result,
+              corsHeaders,
+              { status: 'error', error: 'Import result could not be serialised' },
+              // 503, matching this route's own "cannot install agents": the
+              // importer did not produce a usable answer.
+              503,
+            );
             return;
           }
 
@@ -1484,9 +1498,12 @@ export class GatewayServer {
                 agentLogs: (result.agentLogs ?? []).join('\n'),
               })));
             } catch (error) {
-              res.writeHead(error instanceof GatewayTimeoutError ? 504 : 503,
-                { 'Content-Type': 'application/json', ...corsHeaders });
-              res.end(JSON.stringify({ error: (error as Error).message }));
+              writeJsonResponse(
+                res,
+                error instanceof GatewayTimeoutError ? 504 : 503,
+                { error: (error as Error).message },
+                corsHeaders,
+              );
             }
             return;
           }
@@ -1648,17 +1665,18 @@ export class GatewayServer {
                 this.httpChatIdempotency.delete(idempotencyKey);
               }
               if (!this.isGenerationActive(requestGeneration)) return;
-              res.writeHead(
+              writeJsonResponse(
+                res,
                 error instanceof GatewayTimeoutError ? 504 : 503,
-                { 'Content-Type': 'application/json', ...corsHeaders }
+                {
+                  schema: 'rapp-chat/1.0',
+                  status: 'error',
+                  error: (error as Error).message,
+                  session_id: sessionId,
+                  sessionId,
+                },
+                corsHeaders,
               );
-              res.end(JSON.stringify({
-                schema: 'rapp-chat/1.0',
-                status: 'error',
-                error: (error as Error).message,
-                session_id: sessionId,
-                sessionId,
-              }));
             }
             return;
           }
@@ -1779,8 +1797,14 @@ export class GatewayServer {
           // `json.loads` and replies through `_send` -- verified by posting
           // `not json at all` to it.) A `/chat` caller must not be able to tell
           // the two runtimes apart by their parse errors either.
-          res.writeHead(400, { 'Content-Type': 'application/json', ...corsHeaders });
-          res.end(JSON.stringify(
+          // This is the last catch around the whole body handler, so it sees
+          // more than a malformed request: anything a route throws after it has
+          // already answered arrives here too. Writing a second head in that
+          // case is what ends the process, so it goes through the helper, which
+          // closes an already-committed response instead of re-heading it.
+          writeJsonResponse(
+            res,
+            400,
             pathOnly === '/chat'
               ? {
                 schema: 'rapp-chat/1.0',
@@ -1788,7 +1812,8 @@ export class GatewayServer {
                 error: 'Request body must be a JSON object',
               }
               : { error: 'Invalid JSON' },
-          ));
+            corsHeaders,
+          );
         }
       });
       return;


### PR DESCRIPTION
## The fourth endpoint with one root cause — and the one I'd already looked at

```ts
const result = await this.agentImporter(filename, ...);
res.writeHead(result.status === 'ok' ? 200 : 400, {...});   // committed
res.end(JSON.stringify(result));                            // then throws
```

`setAgentImporter` is public, so the return value is caller-supplied. A cycle or
a `BigInt` throws with the reply already begun, the outer catch writes a **second**
status line, and that is `ERR_HTTP_HEADERS_SENT` inside an async handler — an
unhandled rejection, which node 20 exits on.

Verified against a running gateway:

| | before | after |
|---|---|---|
| client receives | *nothing* | `503 {"status":"error","error":"Import result could not be serialised"}` |
| `/health` after | connection refused | `200` |
| process exit code | **1** | 0 |

## I had this site in my hands and let it go

When #361 fixed `/rpc` I wrote that the remaining `JSON.stringify` sites were
"not proven reachable yet, so verify before changing" and listed this one. It was
reachable, through the same kind of public injection point `/rpc` was reachable
through. Flagging it was right; not spending ten minutes on it was not.

## So this fixes the mechanism, not just the site

The serialisation failure is only how you *get* there. What ends the process is
the second status line — and the file contained **zero** `res.headersSent` checks
outside the helper #359 added, while three catches around the body handler wrote
a status line unconditionally:

| catch | route | previously |
|---|---|---|
| `/twin` | 504 / 503 | unconditional `writeHead` |
| `/chat` | 504 / 503 | unconditional `writeHead` |
| outer body handler | 400 `Invalid JSON` | unconditional `writeHead` |

Any route throwing after it had answered ended the process, not just this one.
All three now go through `writeJsonResponse`, which closes an already-committed
response rather than re-heading it.

The third one is also why the fallback here is **503** and not 400: the outer
catch used to report a serialisation failure as `Invalid JSON`, but the request
was never malformed. 503 matches this route's own *"this daemon cannot install
agents"* — the importer did not produce a usable answer.

## Tests

Eight, including the normal path and a *serialisable* importer error (still 400,
so the guard didn't swallow the route's own answer), plus a direct unit test of
the `headersSent` no-op the three catches now depend on — a property nothing
tested before.

**Mutation-tested:** restoring `writeHead`-then-`stringify` fails **4 of 8**;
removing the `headersSent` guard fails the unit test that pins it.

## Verification

- TypeScript **5040 passed**, 21 skipped
- Python **1645 passed**, 6 skipped
- `parity_harness.py --runtime both` — PASS
- `tsc --noEmit`, `eslint src --max-warnings 0` — clean
