### PR TITLE
fix(brainstem): a failing route could answer 200 with an error body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The brainstem's dispatch guard could deliver a server error to the client as
+  `200 OK`. It recorded that a reply had begun in `end_headers`, but
+  `send_response` does not write -- it buffers the status line, and nothing is
+  flushed until `end_headers`. A route raising in between therefore left a
+  status line buffered while the guard believed nothing had been sent, so the
+  guard appended a second one and both flushed together; a parsing client read
+  the first and took the error body as a success payload. The guard now tracks
+  the flush itself, and withdraws a buffered-but-unsent status line so the
+  error is the only reply.
+
 - `POST /agents/import` ended the gateway process when the injected agent
   importer returned a value `JSON.stringify` refuses. The status line was
   committed before the body was serialised, so the throw arrived with the reply

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -1200,17 +1200,25 @@ class BrainstemHandler(BaseHTTPRequestHandler):
         pass
 
     # ── GET ──
-    def end_headers(self):
-        """Record that bytes are committed to the wire.
+    def flush_headers(self):
+        """Record the point after which a reply can no longer be taken back.
 
-        `_guarded` needs to know whether a reply has already begun. Once a
-        status line and headers are out, a second `send_response` does not
-        replace them -- it appends, and the caller receives two responses
-        concatenated inside one. There is no standard flag for this, so it is
-        set at the one point every reply passes through.
+        `_guarded` needs to know whether a reply has already begun, and the
+        subtlety is *when* that becomes true. `send_response` writes nothing to
+        the socket -- it appends the status line to `_headers_buffer`, and none
+        of it is flushed until here. The flag used to be set in `end_headers`,
+        which left a window: a route raising after `send_response` but before
+        `end_headers` had a status line buffered while the guard believed
+        nothing had been sent, so the guard sent its own. Both flushed together
+        and the client parsed the first -- a 500 delivered as `200 OK` with the
+        error text in the body.
+
+        Recording it here instead makes the flag mean what the guard actually
+        needs to ask: not "has a reply been composed" but "can it still be
+        withdrawn".
         """
-        self._response_started = True
-        super().end_headers()
+        self._response_flushed = True
+        super().flush_headers()
 
     def _guarded(self, route):
         """Run a route so that no request can end without a reply.
@@ -1235,15 +1243,22 @@ class BrainstemHandler(BaseHTTPRequestHandler):
             # The detail goes to the operator, not the caller: it is a stack
             # trace of our internals and the caller can do nothing with it.
             traceback.print_exc()
-            if getattr(self, "_response_started", False):
-                # Too late to say anything: the status line and headers are
-                # already on the wire. Sending a second response here appended
-                # `HTTP/1.0 500 ...` to the body of the first, which is a worse
-                # outcome than the dropped connection this guard exists to
-                # prevent -- a truncated reply is at least recognisably broken,
-                # while two concatenated responses are not. Close instead.
+            if getattr(self, "_response_flushed", False):
+                # Too late to say anything: those bytes are gone. A second
+                # `send_response` appends rather than replaces, so the caller
+                # would receive two responses inside one -- a worse outcome than
+                # the dropped connection this guard exists to prevent, because a
+                # truncated reply is at least recognisably broken while a
+                # concatenated one parses as a success.
                 self.close_connection = True
                 return
+            # Nothing has reached the socket yet, so a status line left buffered
+            # by a route that failed part-way through composing its reply can
+            # simply be dropped. Discarding it makes the error the only
+            # response rather than a second one appended to a half-written
+            # first, which is what this guard is for: no request ends without a
+            # reply, including the ones that fail in the middle of writing one.
+            self._headers_buffer = []
             try:
                 if self.path.split("?")[0] == "/chat":
                     self._send(500, {

--- a/python/tests/test_brainstem_http_framing.py
+++ b/python/tests/test_brainstem_http_framing.py
@@ -25,7 +25,9 @@ slower version of the same thing on a daemon meant to run for weeks.
 """
 import inspect
 import socket
+import urllib.error
 import urllib.parse
+import urllib.request
 
 from openrappter import brainstem
 
@@ -313,6 +315,63 @@ class TestTheGuardItself:
         reply = _raw_request(server)
         assert reply.count(b"HTTP/1.0") == 1, "a second status line was appended"
         assert reply.endswith(b"HALF!")
+
+    def test_a_route_that_raised_before_flushing_still_gets_a_clean_500(
+        self, server, monkeypatch
+    ):
+        """The window between composing a status line and sending it.
+
+        The test above covers a reply already on the wire. This covers the step
+        before it, which the guard got wrong in the opposite direction:
+        `send_response` does not write, it buffers, and nothing is flushed until
+        `end_headers`. A route raising in between left a status line buffered
+        while the guard believed nothing had been sent, so the guard appended
+        its own and both flushed together.
+
+        The failure was quiet, which is why it outlived the one above: the
+        client did not see two replies and an error, it saw one reply and a
+        success. `urllib` parsed `200 OK` and read `{"error": ...}` as the body.
+        """
+
+        def buffered_then_failed(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            raise RuntimeError("deliberate failure before the reply was flushed")
+
+        monkeypatch.setattr(brainstem.BrainstemHandler, "_route_get", buffered_then_failed)
+        reply = _raw_request(server)
+
+        assert reply.count(b"HTTP/1.0") == 1, "a second status line was appended"
+        # Nothing had reached the socket, so the half-composed reply is
+        # withdrawn rather than merely abandoned: the caller gets the error.
+        assert reply.startswith(b"HTTP/1.0 500"), reply[:60]
+        assert b"Internal error" in reply
+
+    def test_the_withdrawn_status_line_does_not_reach_a_parsing_client(
+        self, server, monkeypatch
+    ):
+        """What the caller's own HTTP client concludes.
+
+        Counting status lines in raw bytes is how the defect was found, but not
+        how it would have been suffered. A client does not count them -- it
+        parses the first and treats the rest as headers, so a server error
+        arrived as a success carrying an error body, which is the shape of bug
+        that survives a long time in production.
+        """
+
+        def buffered_then_failed(self):
+            self.send_response(200)
+            self.send_header("Content-Type", "text/plain")
+            raise RuntimeError("deliberate failure before the reply was flushed")
+
+        monkeypatch.setattr(brainstem.BrainstemHandler, "_route_get", buffered_then_failed)
+        try:
+            with urllib.request.urlopen(server + "/health", timeout=15) as response:
+                parsed = response.status
+        except urllib.error.HTTPError as failure:
+            parsed = failure.code
+
+        assert parsed == 500, "a failure was delivered to the client as a success"
 
     def test_delete_is_guarded_too(self, server, monkeypatch):
         """`do_DELETE` was left out of the guard that was described as general."""


### PR DESCRIPTION
## A guard that produced the failure it was written to prevent

`_guarded` (#357) already knew it must not append a second status line to a
reply in progress. It asked the wrong question about when a reply *begins*:

```python
def end_headers(self):
    self._response_started = True   # too late
```

`send_response` writes nothing. It appends the status line to `_headers_buffer`,
and none of it is flushed until `end_headers`. A route raising **between** the
two left a status line buffered while the guard believed nothing had been sent —
so the guard sent its own, and both flushed together:

```http
HTTP/1.0 200 OK
Content-Type: text/plain
HTTP/1.0 500 Internal Server Error      <- parsed as a header, not a status
Content-Length: 27

{"error": "Internal error"}
```

**`urllib` reports 200. `curl` reports 200.** The server error is delivered as a
success carrying an error body.

## Why this outlived the bug next to it

The existing test covers a route that raises *after* `end_headers`, and that one
was found quickly — it produced visibly mangled output. This one is the step
earlier and is quiet: the client sees one clean, well-formed, entirely wrong
response. It is also *worse than the original defect* #357 fixed, which was a
dropped connection — recognisably broken.

## The fix

The flag now records the **flush** rather than the composition, which is the
question the guard actually needs answered: not *"has a reply been composed"* but
*"can it still be withdrawn"*.

When it can be, it now **is**. The buffered status line is discarded and the
error becomes the only reply, so these requests get a real `500` instead of the
closed socket #357 existed to eliminate:

| route raises | before | after |
|---|---|---|
| after flush | 1 status line, closed | unchanged |
| **before flush** | **`200 OK` + error body** | **`500` + error body** |

## Not present in TypeScript

Node flips `res.headersSent` inside `writeHead`, at composition time, so the
gateway's guard never had this window. Python exposes no equivalent signal — the
only observable moment is the flush. Same guard concept, hole in one runtime
only. Verified both empirically rather than assumed:

```
node: headersSent after writeHead, before end: true
```

## Verification

- Python **1647 passed**, 6 skipped (framing suite 18 → **20**)
- `parity_harness.py --runtime both` — PASS
- **Mutation-tested:** restoring the `end_headers` flag fails **2 of 20**;
  keeping the new flag but not discarding the buffer also fails **2**.
