### PR TITLE
fix(brainstem): concurrent logins stranded the user on a dead code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Two concurrent `POST /login` calls each started a separate device-code grant,
+  and the second overwrote the first. One caller was left holding a `user_code`
+  that `/login/poll` was no longer polling for, so that user could authorise
+  correctly on GitHub and the brainstem would report `pending` indefinitely with
+  no error to explain it. The device-login state machine is now serialised.
+
 - The brainstem's dispatch guard could deliver a server error to the client as
   `200 OK`. It recorded that a reply had begun in `end_headers`, but
   `send_response` does not write -- it buffers the status line, and nothing is

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -354,6 +354,15 @@ _copilot_cache = {"token": None, "endpoint": None, "expires_at": 0}
 _pending_login = None
 _login_result = {}
 
+#: Device login is one state machine spread across three routes, and
+#: `ThreadingHTTPServer` gives every request its own thread. Both mutators
+#: check `_pending_login` and then act on it, so without this two concurrent
+#: `POST /login` calls each started a *separate* device-code grant and the
+#: second overwrote the first. One caller was then shown a `user_code` that
+#: `/login/poll` was no longer polling for: that user authorises correctly on
+#: GitHub and the login never completes, with no error anywhere to explain it.
+_LOGIN_GUARD = threading.RLock()
+
 
 def _token_file():
     return Path(BRAINSTEM_HOME) / ".copilot_token"
@@ -561,46 +570,47 @@ def start_device_login():
     """Begin the GitHub device-code flow. Returns {user_code, verification_uri}."""
     global _pending_login, _login_result
     import time
+    with _LOGIN_GUARD:
+        if _pending_login and time.time() < _pending_login.get("expires_at", 0):
+            return {"user_code": _pending_login["user_code"],
+                    "verification_uri": _pending_login["verification_uri"]}
 
-    if _pending_login and time.time() < _pending_login.get("expires_at", 0):
-        return {"user_code": _pending_login["user_code"],
-                "verification_uri": _pending_login["verification_uri"]}
-
-    _login_result = {}
-    data = _http_form("https://github.com/login/device/code", {"client_id": COPILOT_CLIENT_ID})
-    _pending_login = {
-        "device_code": data["device_code"],
-        "user_code": data["user_code"],
-        "verification_uri": data["verification_uri"],
-        "interval": data.get("interval", 5),
-        "expires_at": time.time() + data.get("expires_in", 900),
-    }
-    return {"user_code": data["user_code"], "verification_uri": data["verification_uri"]}
+        _login_result = {}
+        data = _http_form("https://github.com/login/device/code", {"client_id": COPILOT_CLIENT_ID})
+        _pending_login = {
+            "device_code": data["device_code"],
+            "user_code": data["user_code"],
+            "verification_uri": data["verification_uri"],
+            "interval": data.get("interval", 5),
+            "expires_at": time.time() + data.get("expires_in", 900),
+        }
+        return {"user_code": data["user_code"], "verification_uri": data["verification_uri"]}
 
 
 def poll_device_login():
     """One poll of the device-code grant. Persists the token on success."""
     global _pending_login, _login_result
-    if not _pending_login:
-        return {"status": "idle"}
-    data = _http_form("https://github.com/login/oauth/access_token", {
-        "client_id": COPILOT_CLIENT_ID,
-        "device_code": _pending_login["device_code"],
-        "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
-    })
-    if data.get("access_token"):
-        _save_token_file({"access_token": data["access_token"],
-                          "refresh_token": data.get("refresh_token", "")})
+    with _LOGIN_GUARD:
+        if not _pending_login:
+            return {"status": "idle"}
+        data = _http_form("https://github.com/login/oauth/access_token", {
+            "client_id": COPILOT_CLIENT_ID,
+            "device_code": _pending_login["device_code"],
+            "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+        })
+        if data.get("access_token"):
+            _save_token_file({"access_token": data["access_token"],
+                              "refresh_token": data.get("refresh_token", "")})
+            _pending_login = None
+            _login_result = {"status": "success"}
+            _copilot_cache["token"] = None  # force fresh exchange with the new token
+            return _login_result
+        error = data.get("error", "authorization_pending")
+        if error in ("authorization_pending", "slow_down"):
+            return {"status": "pending"}
         _pending_login = None
-        _login_result = {"status": "success"}
-        _copilot_cache["token"] = None  # force fresh exchange with the new token
+        _login_result = {"status": "error", "error": error}
         return _login_result
-    error = data.get("error", "authorization_pending")
-    if error in ("authorization_pending", "slow_down"):
-        return {"status": "pending"}
-    _pending_login = None
-    _login_result = {"status": "error", "error": error}
-    return _login_result
 
 
 def login_status():

--- a/python/tests/test_device_login_concurrency.py
+++ b/python/tests/test_device_login_concurrency.py
@@ -1,0 +1,149 @@
+"""The device-code login is one state machine shared by three routes.
+
+`POST /login`, `POST /login/poll` and `GET /login/status` all read and write the
+same two module globals, and `ThreadingHTTPServer` gives every request its own
+thread. Both mutators check `_pending_login` and then act on it, which is only
+safe if nothing can interleave between the check and the write.
+
+Nothing covered any of this before these tests: no test in the suite referenced
+`start_device_login` or `poll_device_login` at all.
+"""
+
+import threading
+import time
+
+import pytest
+
+from openrappter import brainstem
+
+
+@pytest.fixture
+def clean_login(monkeypatch):
+    """Isolate the login globals, and make sure no test can write a real token."""
+    monkeypatch.setattr(brainstem, "_pending_login", None, raising=False)
+    monkeypatch.setattr(brainstem, "_login_result", {}, raising=False)
+    monkeypatch.setattr(brainstem, "_save_token_file", lambda *_a, **_k: None)
+
+
+def _grant_source(delay=0.15):
+    """A stand-in for GitHub that issues a distinct grant per call.
+
+    The delay stands for the network round-trip in `_http_form`, which is the
+    window the two callers used to interleave in.
+    """
+    issued = []
+    guard = threading.Lock()
+
+    def fake_http_form(_url, _data, timeout=15):
+        with guard:
+            n = len(issued)
+            issued.append(n)
+        time.sleep(delay)
+        return {
+            "device_code": f"DEV{n}",
+            "user_code": f"USER{n}",
+            "verification_uri": "https://github.com/login/device",
+            "interval": 5,
+            "expires_in": 900,
+        }
+
+    return fake_http_form, issued
+
+
+def _start_concurrently(count=2):
+    shown = {}
+    ready = threading.Barrier(count)
+
+    def caller(tag):
+        ready.wait()
+        shown[tag] = brainstem.start_device_login()["user_code"]
+
+    threads = [threading.Thread(target=caller, args=(i,)) for i in range(count)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    return shown
+
+
+class TestConcurrentLoginStart:
+    def test_every_caller_is_shown_the_same_code(self, clean_login, monkeypatch):
+        """Two `POST /login` calls must not each start their own grant.
+
+        They did. Each thread found no pending login, each asked GitHub for a
+        device code, and the second overwrote the first.
+        """
+        fake, _ = _grant_source()
+        monkeypatch.setattr(brainstem, "_http_form", fake)
+
+        shown = _start_concurrently()
+
+        assert len(set(shown.values())) == 1, f"callers disagreed: {shown}"
+
+    def test_the_code_shown_is_the_one_being_polled_for(self, clean_login, monkeypatch):
+        """The invariant the user actually experiences.
+
+        This is why the race mattered. The losing caller was shown `USER0` while
+        `_pending_login` held `DEV1`, so `/login/poll` asked GitHub about a grant
+        that user never touched. They authorise correctly, GitHub is happy, and
+        the brainstem waits forever -- reporting `pending`, with no error
+        anywhere to suggest the code on screen was already dead.
+        """
+        fake, _ = _grant_source()
+        monkeypatch.setattr(brainstem, "_http_form", fake)
+
+        shown = _start_concurrently()
+        polled_for = brainstem._pending_login
+
+        stranded = [c for c in shown.values() if c != polled_for["user_code"]]
+        assert not stranded, (
+            f"shown a code that can never succeed: {stranded}; "
+            f"poll will authorise {polled_for['device_code']}"
+        )
+
+    def test_only_one_grant_is_requested(self, clean_login, monkeypatch):
+        """The stronger property: the second caller reuses, it does not re-ask.
+
+        Asserting the codes agree would also pass if both callers somehow
+        converged on the same answer after two round-trips. They should not be
+        making two.
+        """
+        fake, issued = _grant_source()
+        monkeypatch.setattr(brainstem, "_http_form", fake)
+
+        _start_concurrently()
+
+        assert len(issued) == 1, f"{len(issued)} device-code grants started"
+
+
+class TestTheStateMachineStillMoves:
+    """A lock that serialises this correctly could also freeze it. It must not."""
+
+    def test_a_single_login_still_returns_a_code(self, clean_login, monkeypatch):
+        fake, _ = _grant_source(delay=0)
+        monkeypatch.setattr(brainstem, "_http_form", fake)
+
+        assert brainstem.start_device_login()["user_code"] == "USER0"
+
+    def test_a_second_call_reuses_the_live_grant(self, clean_login, monkeypatch):
+        fake, issued = _grant_source(delay=0)
+        monkeypatch.setattr(brainstem, "_http_form", fake)
+
+        first = brainstem.start_device_login()["user_code"]
+        second = brainstem.start_device_login()["user_code"]
+
+        assert first == second == "USER0"
+        assert len(issued) == 1
+
+    def test_an_expired_grant_is_replaced_rather_than_reused(self, clean_login, monkeypatch):
+        """Dedup must not outlive the code it is deduplicating."""
+        fake, _ = _grant_source(delay=0)
+        monkeypatch.setattr(brainstem, "_http_form", fake)
+
+        brainstem.start_device_login()
+        brainstem._pending_login["expires_at"] = time.time() - 1
+
+        assert brainstem.start_device_login()["user_code"] == "USER1"
+
+    def test_polling_with_nothing_pending_is_idle(self, clean_login):
+        assert brainstem.poll_device_login() == {"status": "idle"}


### PR DESCRIPTION
## A login that can never complete, and never says so

`start_device_login` checks `_pending_login` and then overwrites it, with no
lock, on a `ThreadingHTTPServer` where every request runs in its own thread. Two
concurrent `POST /login` calls both find nothing pending, both ask GitHub for a
device code, and the second wins:

```
codes shown to callers                     : ['USER0', 'USER1']
device_code that /login/poll will authorise: DEV1
callers shown a code that can never succeed: ['USER0']
```

The caller shown `USER0` does everything right. They enter the code, GitHub
accepts it, the grant is authorised. But the brainstem is polling `DEV1` — which
nobody has touched — so `/login/poll` answers `pending` forever.

**Nothing reports an error**, because from the server's point of view nothing has
gone wrong: it is simply still waiting. The failure is indistinguishable from the
user not having finished yet, which makes it close to undiagnosable from either
end.

## The fix

The state machine is serialised behind one lock, held across the round-trip so
the second caller **reuses** the first grant rather than racing it. `_http_form`
has a 15s timeout, so the lock cannot be held indefinitely.

| | before | after |
|---|---|---|
| grants started by 2 concurrent calls | 2 | **1** |
| codes shown | `USER0`, `USER1` | `USER0`, `USER0` |
| shown code matches the polled grant | **no** | yes |

## Why it survived

No test in the suite referenced `start_device_login` or `poll_device_login` —
the entire device-login state machine was uncovered. There are now **seven**,
including that dedup must not outlive the code it deduplicates (an expired grant
is still replaced), so the lock cannot freeze the flow it protects.

## Verification

- Python **1654 passed**, 6 skipped
- `parity_harness.py --runtime both` — PASS
- **Mutation-tested:** removing the lock fails **3 of 7**; locking only the write
  and not the check — the half-fix that looks right — also fails **3**.
