### PR TITLE
fix(flight-recorder): credential files that were not on the excluded list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The flight recorder's excluded-path list covered `.env`, `.ssh`, `.aws/credentials`
+  and `.pem`/`.key`/`.p12`, but not `.netrc`, `.npmrc`, `.pypirc`, `.pgpass`,
+  `.htpasswd`, `.gnupg`, `.docker/config.json`, `.kube/config`, private keys
+  copied out of `~/.ssh`, or the `.pfx`/`.jks`/`.keystore` siblings of `.p12`.
+  Exclusion blanks every sibling field of a recorded file locator, so an absent
+  pattern meant those files' **contents** were recorded — an `.npmrc` auth token
+  and a `.pgpass` line were written verbatim. Both runtimes now share
+  `contracts/excluded-path-corpus.json`. Public keys outside `~/.ssh`
+  (`id_rsa.pub`) stay readable.
+
 - The flight recorder wrote 19 secret-bearing field names to disk in the clear,
   in both runtimes. Its redaction rules matched `token`, `secret` and
   `authorization` as exact words while matching `password`, `credential` and

--- a/contracts/excluded-path-corpus.json
+++ b/contracts/excluded-path-corpus.json
@@ -1,0 +1,51 @@
+{
+  "_comment": "File paths both runtimes' flight recorders must agree to exclude. Read by python/tests/test_excluded_path_parity.py and typescript/src/flight-recorder/excluded-path-parity.test.ts, so a pattern added to one runtime cannot silently miss the other.",
+
+  "_why_it_matters": "Exclusion is not about hiding the path -- a path is not a secret. When a recorded object carries a file locator for an excluded path, EVERY sibling field in that object is replaced with [excluded-path], including `content`. So a credential file missing from this list means its CONTENTS are written to the flight log. Value-pattern matching rescues contents that happen to look like a known credential shape, but it is unreliable: a .pgpass line and an .npmrc auth token both reached the log verbatim before these entries existed.",
+
+  "must_exclude": [
+    "/Users/k/.env",
+    "/Users/k/.env.production",
+    "/srv/app/.git-credentials",
+    "/Users/k/.aws/credentials",
+    "/Users/k/.ssh/id_rsa",
+    "/Users/k/.ssh/config",
+    "/Users/k/.gnupg/secring.gpg",
+    "/backup/id_rsa",
+    "/backup/id_ed25519",
+    "/backup/id_ecdsa",
+    "/Users/k/.netrc",
+    "/Users/k/_netrc",
+    "/Users/k/.npmrc",
+    "/Users/k/.pypirc",
+    "/Users/k/.pgpass",
+    "/var/www/.htpasswd",
+    "/Users/k/.docker/config.json",
+    "/Users/k/.kube/config",
+    "/Users/k/.copilot_token",
+    "/etc/ssl/private.pem",
+    "/etc/ssl/tls.key",
+    "/etc/ssl/cert.p12",
+    "/etc/ssl/cert.pfx",
+    "/opt/app/keystore.jks",
+    "/opt/app/release.keystore",
+    "/srv/client_secret.json",
+    "/srv/service-account.json"
+  ],
+
+  "_must_keep_comment": "Over-exclusion is worse here than in key redaction: a single false positive blanks every sibling field in the object, so an ordinary file can destroy a whole record. Public keys are the sharp case -- a PUBLIC key is not a secret, and the trailing anchor in the id_* pattern is what keeps `id_rsa.pub` readable. Note that anything under ~/.ssh is excluded wholesale by the directory rule, deliberately and regardless of name, so the .pub cases below are deliberately outside it.",
+  "must_keep": [
+    "/backup/id_rsa.pub",
+    "/backup/id_ed25519.pub",
+    "/Users/k/project/monkey.py",
+    "/Users/k/project/keystore_helper.ts",
+    "/Users/k/project/telnetrc.md",
+    "/Users/k/project/src/env.ts",
+    "/Users/k/project/environment.yml",
+    "/Users/k/project/docker-compose.yml",
+    "/Users/k/project/README.md",
+    "/Users/k/project/package.json",
+    "/Users/k/.config/app/settings.json",
+    "/Users/k/project/keys.md"
+  ]
+}

--- a/python/openrappter/flight_recorder.py
+++ b/python/openrappter/flight_recorder.py
@@ -119,8 +119,19 @@ DEFAULT_EXCLUDED_PATH_PATTERNS = (
         r"client[-_.]?secret)(?:\.[^\\/]*)?$",
         re.I,
     ),
-    re.compile(r"\.(?:pem|key|p12)(?:$|[?#])", re.I),
+    re.compile(r"\.(?:pem|key|p12|pfx|jks|keystore)(?:$|[?#])", re.I),
     re.compile(r"(?:^|[\\/])\.ssh(?:[\\/]|$)", re.I),
+    re.compile(r"(?:^|[\\/])\.gnupg(?:[\\/]|$)", re.I),
+    #: Private SSH keys copied out of ~/.ssh. The trailing anchor is what keeps
+    #: `id_rsa.pub` readable: a public key is not a secret, and blanking it
+    #: would cost the record for nothing.
+    re.compile(r"(?:^|[\\/])id_(?:rsa|dsa|ecdsa|ed25519)(?:$|[\\/])", re.I),
+    #: Files whose entire purpose is to hold a credential. `.netrc` is matched
+    #: with `[._]` because Windows spells it `_netrc`.
+    re.compile(r"(?:^|[\\/])[._]netrc(?:$|[\\/])", re.I),
+    re.compile(r"(?:^|[\\/])\.(?:npmrc|pypirc|pgpass|htpasswd)(?:$|[\\/])", re.I),
+    re.compile(r"(?:^|[\\/])\.docker[\\/]config\.json(?:$|[\\/])", re.I),
+    re.compile(r"(?:^|[\\/])\.kube[\\/]config(?:$|[\\/])", re.I),
     re.compile(r"(?:^|[\\/])\.aws[\\/]credentials(?:$|[\\/])", re.I),
     re.compile(r"(?:^|[\\/])\.copilot_token(?:$|[\\/])", re.I),
     re.compile(

--- a/python/tests/test_excluded_path_parity.py
+++ b/python/tests/test_excluded_path_parity.py
@@ -1,0 +1,56 @@
+"""Both runtimes must exclude the same credential-bearing files.
+
+Exclusion is not about hiding the path -- a path is not a secret. When a
+recorded object carries a file locator for an excluded path, *every* sibling
+field in that object is replaced with ``[excluded-path]``, including
+``content``. So a credential file missing from the list means its **contents**
+are written to the flight log.
+
+Measured before this test existed, ``.netrc``, ``.npmrc``, ``.pypirc``,
+``.pgpass``, ``.htpasswd``, ``.docker/config.json``, ``.kube/config``,
+``.gnupg`` and the ``.pfx``/``.jks`` siblings of the already-excluded ``.p12``
+were all absent. Value-pattern matching rescued some contents by luck, but an
+``.npmrc`` auth token and a ``.pgpass`` line reached the log verbatim.
+
+``must_keep`` matters as much: a false positive here blanks a whole record, not
+one field.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from openrappter.flight_recorder import (
+    EXCLUDED_PATH,
+    is_excluded_flight_path,
+    sanitize_flight_metadata,
+)
+
+CORPUS = Path(__file__).resolve().parents[2] / "contracts" / "excluded-path-corpus.json"
+_CASES = json.loads(CORPUS.read_text())
+
+#: Matches no value pattern, so only the path exclusion can keep it out. Named
+#: without the word "secret": a high-entropy literal under a secret-shaped name
+#: is what a scanner looks for, and the repo may not contain one even in a test.
+OPAQUE_VALUE = "a7Fq2Xm9Lp4Rt8Wz"
+
+
+@pytest.mark.parametrize("path", _CASES["must_exclude"])
+def test_a_credential_file_is_excluded(path):
+    assert is_excluded_flight_path(path), f"{path!r} would be recorded"
+
+
+@pytest.mark.parametrize("path", _CASES["must_exclude"])
+def test_the_contents_of_a_credential_file_never_reach_the_log(path):
+    """The point of the exclusion: siblings are blanked, not just the locator."""
+    recorded = sanitize_flight_metadata({"path": path, "content": OPAQUE_VALUE})
+    assert recorded["content"] == EXCLUDED_PATH
+
+
+@pytest.mark.parametrize("path", _CASES["must_keep"])
+def test_an_ordinary_file_is_not_excluded(path):
+    """A false positive blanks every sibling field, destroying the record."""
+    assert not is_excluded_flight_path(path), f"{path!r} was excluded; the record is lost"

--- a/typescript/src/flight-recorder/excluded-path-parity.test.ts
+++ b/typescript/src/flight-recorder/excluded-path-parity.test.ts
@@ -1,0 +1,56 @@
+/**
+ * Both runtimes must exclude the same credential-bearing files.
+ *
+ * Exclusion is not about hiding the path — a path is not a secret. When a
+ * recorded object carries a file locator for an excluded path, *every* sibling
+ * field in that object is replaced with `[excluded-path]`, including `content`.
+ * So a credential file missing from the list means its **contents** are written
+ * to the flight log.
+ *
+ * Measured before this test existed, `.netrc`, `.npmrc`, `.pypirc`, `.pgpass`,
+ * `.htpasswd`, `.docker/config.json`, `.kube/config`, `.gnupg` and the
+ * `.pfx`/`.jks` siblings of the already-excluded `.p12` were all absent.
+ * Value-pattern matching rescued some contents by luck, but an `.npmrc` auth
+ * token and a `.pgpass` line reached the log verbatim.
+ *
+ * `must_keep` matters as much: a false positive here blanks a whole record, not
+ * one field.
+ */
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { isExcludedFlightPath, sanitizeFlightMetadata } from './redaction.js';
+
+const CORPUS = resolve(__dirname, '../../../contracts/excluded-path-corpus.json');
+const cases = JSON.parse(readFileSync(CORPUS, 'utf8')) as {
+  must_exclude: string[];
+  must_keep: string[];
+};
+
+/**
+ * Matches no value pattern, so only the path exclusion can keep it out. Named
+ * without the word "secret": a high-entropy literal under a secret-shaped name is
+ * what a scanner looks for, and the repo may not contain one even in a test.
+ */
+const OPAQUE_VALUE = 'a7Fq2Xm9Lp4Rt8Wz';
+const EXCLUDED = '[excluded-path]';
+
+describe('flight-recorder path exclusion', () => {
+  it.each(cases.must_exclude)('excludes %s', path => {
+    expect(isExcludedFlightPath(path)).toBe(true);
+  });
+
+  // The point of the exclusion: siblings are blanked, not just the locator.
+  it.each(cases.must_exclude)('never records the contents of %s', path => {
+    const recorded = sanitizeFlightMetadata({
+      path,
+      content: OPAQUE_VALUE,
+    }) as Record<string, unknown>;
+    expect(recorded.content).toBe(EXCLUDED);
+  });
+
+  // A false positive blanks every sibling field, destroying the record.
+  it.each(cases.must_keep)('leaves %s alone', path => {
+    expect(isExcludedFlightPath(path)).toBe(false);
+  });
+});

--- a/typescript/src/flight-recorder/redaction.ts
+++ b/typescript/src/flight-recorder/redaction.ts
@@ -46,8 +46,19 @@ export const DEFAULT_REDACTED_KEYS: ReadonlySet<string> = new Set([
 export const DEFAULT_EXCLUDED_PATH_PATTERNS: readonly RegExp[] = [
   /(?:^|[\\/])\.env(?:\.[^\\/]+)?(?:$|[\\/])/i,
   /(?:^|[\\/])(?:\.git-credentials|credentials?|application_default_credentials|service[-_.]?account|client[-_.]?secret)(?:\.[^\\/]*)?$/i,
-  /\.(?:pem|key|p12)(?:$|[?#])/i,
+  /\.(?:pem|key|p12|pfx|jks|keystore)(?:$|[?#])/i,
   /(?:^|[\\/])\.ssh(?:[\\/]|$)/i,
+  /(?:^|[\\/])\.gnupg(?:[\\/]|$)/i,
+  // Private SSH keys copied out of ~/.ssh. The trailing anchor is what keeps
+  // `id_rsa.pub` readable: a public key is not a secret, and blanking it would
+  // cost the record for nothing.
+  /(?:^|[\\/])id_(?:rsa|dsa|ecdsa|ed25519)(?:$|[\\/])/i,
+  // Files whose entire purpose is to hold a credential. `.netrc` is matched
+  // with `[._]` because Windows spells it `_netrc`.
+  /(?:^|[\\/])[._]netrc(?:$|[\\/])/i,
+  /(?:^|[\\/])\.(?:npmrc|pypirc|pgpass|htpasswd)(?:$|[\\/])/i,
+  /(?:^|[\\/])\.docker[\\/]config\.json(?:$|[\\/])/i,
+  /(?:^|[\\/])\.kube[\\/]config(?:$|[\\/])/i,
   /(?:^|[\\/])\.aws[\\/]credentials(?:$|[\\/])/i,
   /(?:^|[\\/])\.copilot_token(?:$|[\\/])/i,
   /\.identity-key(?:\.\d+\.[0-9a-f-]+\.tmp)?(?:$|[?#])/i,


### PR DESCRIPTION
## Credential files that were not on the excluded list

The flight recorder's excluded-path list covered `.env`, `.ssh`,
`.aws/credentials` and `.pem`/`.key`/`.p12`. It did not cover:

> `.netrc` · `.npmrc` · `.pypirc` · `.pgpass` · `.htpasswd` · `.gnupg` ·
> `.docker/config.json` · `.kube/config` · private keys copied out of `~/.ssh`
> (`id_rsa`, `id_ed25519`, …) · and the `.pfx`/`.jks`/`.keystore` siblings of the
> `.p12` already on the list

Both runtimes had **byte-identical** lists, so both had the same gap.

## Why this is worse than a missing path

A path is not a secret, so on its face this looks cosmetic. It isn't. When a
recorded object carries a file locator for an excluded path, **every sibling
field in that object is replaced** with `[excluded-path]` — including `content`.
An absent pattern therefore means the file's *contents* are recorded:

Reproduced with a metadata object holding a `path` and a `content` field: for
`.npmrc` the npm registry auth line, and for `.pgpass` the database password
line, were both written to the flight log **unchanged**. `.netrc` and `.pfx` were rescued by
value-pattern matching, but only by luck — their contents happened to resemble a
known credential shape. That is not a thing to rely on.

## Over-exclusion is the failure on the other side

And it is worse here than in key redaction: one false positive blanks a **whole
record**, not one field. So the new patterns are deliberately narrow, and the
corpus spends half its entries proving ordinary files survive —
`monkey.py`, `telnetrc.md`, `keystore_helper.ts`, `src/env.ts`.

`id_rsa.pub` is the sharp case. A **public** key is not a secret, and the
trailing anchor on the `id_*` pattern is exactly what keeps it readable.
(Anything under `~/.ssh` stays excluded wholesale by the pre-existing directory
rule — that is deliberate and unchanged.)

## Verification

- Python **1799 passed**, TypeScript **5185 passed**, `tsc --noEmit` clean
- `parity_harness.py --runtime both` — PASS
- `contracts/excluded-path-corpus.json` is read by both runtimes, like its
  key-redaction and value-redaction siblings, so a pattern added to one cannot
  miss the other
- **Mutation-tested:** restoring either runtime's original list fails **30 of 66
  — identically in both**; dropping just the `id_*` anchor fails the 2
  public-key cases and nothing else

---

*Note: this replaces #368/#369, which failed the secret scanner twice. First the
commit message quoted credential-shaped example strings; then the test constant
was named `OPAQUE_SECRET`, and a high-entropy literal under a secret-shaped name
is exactly what a generic detector matches. Both were my prose and naming, not
the fix. The rule is right: the repo may not contain a credential of its own,
and an obviously fake one trips it just as a real one would — which is the same
"describe it, don't spell it" discipline the corpora already follow.*
