### PR TITLE
fix(imessage): the trusted channel could not remember anyone

### DIFF
--- a/python/openrappter/imessage/service.py
+++ b/python/openrappter/imessage/service.py
@@ -554,7 +554,7 @@ class IMessageService:
         participants.add(sender)
         consent_action = self._consent_action(str(message.get("text") or ""))
         event_id = self.state.transport_event_id(str(message["guid"]))
-        return {
+        context: dict[str, Any] = {
             "trusted": True,
             "channel": "imessage",
             "principal_id": sender,
@@ -590,6 +590,13 @@ class IMessageService:
                 else None
             ),
         }
+        # This recall used to sit after an unconditional `return`, so it never
+        # ran and `context` was not even a defined name here. The brainstem
+        # reads `familiarity` and `authorized_memory_data` off this context, so
+        # every iMessage turn was projected with no memory and an unknown
+        # sender. Recall is best-effort enrichment on the inbound hot path: any
+        # failure degrades to "no memory, not familiar" rather than dropping
+        # the message. ContextMemoryAgent applies the audience filter itself.
         memory_agent = ContextMemoryAgent()
         try:
             recalled = json.loads(
@@ -599,7 +606,7 @@ class IMessageService:
                     _trusted_context=context,
                 )
             )
-        except (TypeError, ValueError, json.JSONDecodeError):
+        except Exception:  # noqa: BLE001 - recall must never drop an inbound message
             recalled = {}
         context["authorized_memory_data"] = (
             recalled.get("memories", []) if isinstance(recalled, Mapping) else []

--- a/python/tests/conftest.py
+++ b/python/tests/conftest.py
@@ -3,6 +3,7 @@
 import json
 import sys
 import threading
+import importlib
 import pytest
 from pathlib import Path
 
@@ -160,3 +161,38 @@ def server(tmp_path, monkeypatch):
     base = f"http://127.0.0.1:{httpd.server_address[1]}"
     yield base
     httpd.shutdown()
+
+
+@pytest.fixture(autouse=True)
+def isolate_agent_memory_store(monkeypatch, tmp_path_factory):
+    """Keep the agent memory store out of the developer's real home directory.
+
+    Both memory agents default `memory_file` to `~/.openrappter/memory.json`.
+    Tests that care point it somewhere else, so this never mattered while the
+    only callers were tests. The iMessage trust context now recalls memory on
+    every inbound message and builds its own agent, so an unpatched test reads
+    whatever the developer happens to have remembered -- making `familiarity`
+    and the projected facts depend on the machine, and reading personal data
+    into a test run. Redirect the default; explicit assignment still wins.
+
+    The store lives outside the test's own `tmp_path` because tests that list a
+    directory count its entries.
+    """
+    store = tmp_path_factory.mktemp("agent-memory") / "memory.json"
+    store.parent.mkdir(parents=True, exist_ok=True)
+    for module, name in (
+        ("openrappter.agents.context_memory_agent", "ContextMemoryAgent"),
+        ("openrappter.agents.manage_memory_agent", "ManageMemoryAgent"),
+    ):
+        try:
+            cls = getattr(importlib.import_module(module), name)
+        except Exception:  # pragma: no cover - module not importable in this env
+            continue
+        original = cls.__init__
+
+        def patched(self, *args, __original=original, **kwargs):
+            __original(self, *args, **kwargs)
+            self.home = store.parent
+            self.memory_file = store
+
+        monkeypatch.setattr(cls, "__init__", patched)

--- a/python/tests/test_imessage_core.py
+++ b/python/tests/test_imessage_core.py
@@ -624,3 +624,116 @@ def test_cross_process_memory_writes_are_serialized(tmp_path):
         process.join(timeout=10)
         assert process.exitcode == 0
     assert len(json.loads(memory_file.read_text())) == 8
+
+
+def _scoped_memory_agents(monkeypatch, tmp_path):
+    """Point every ContextMemoryAgent the service builds at a temp memory file."""
+
+    class _Scoped(ContextMemoryAgent):
+        def __init__(self):
+            super().__init__()
+            self.memory_file = tmp_path / "memory.json"
+
+    monkeypatch.setattr("openrappter.imessage.service.ContextMemoryAgent", _Scoped)
+    manager = ManageMemoryAgent()
+    manager.memory_file = tmp_path / "memory.json"
+    return manager
+
+
+def _capturing_service(tmp_path, seen):
+    def runner(prompt, history, session, trust):
+        seen.append(dict(trust))
+        return {"response": f"reply:{prompt}"}
+
+    return IMessageService(
+        config(tmp_path),
+        supervisor=FakeSupervisor(),
+        chat_runner=runner,
+    )
+
+
+def dm_message(guid="DM-1", rowid=7, text="hello"):
+    return {
+        "id": rowid,
+        "guid": guid,
+        "text": text,
+        "sender": FRIEND,
+        "is_from_me": False,
+        "is_group": False,
+        "service": "iMessage",
+        "chat_id": 9,
+        "chat_guid": f"iMessage;-;{FRIEND}",
+        "participants": [FRIEND],
+    }
+
+
+def test_trust_context_projects_authorized_memory_into_the_turn(monkeypatch, tmp_path):
+    # The brainstem reads `authorized_memory_data` and `familiarity` off the
+    # trust context. Both were unreachable, so iMessage turns had no recall.
+    manager = _scoped_memory_agents(monkeypatch, tmp_path)
+    seen: list[dict] = []
+    service = _capturing_service(tmp_path, seen)
+
+    assert service.process_message(owner_message(guid="U1", rowid=1)) == "replied"
+    owner_trust = seen[0]
+    assert owner_trust["authorized_memory_data"] == []
+    assert owner_trust["familiarity"] is False
+
+    # Store through the very context the service produced, so the audience ids
+    # match what a real turn would carry.
+    manager.perform(content="the garage code is amber", _trusted_context=owner_trust)
+
+    assert service.process_message(owner_message(guid="U2", rowid=2, text="garage")) == "replied"
+    recalled = seen[1]
+    assert [item["message"] for item in recalled["authorized_memory_data"]] == [
+        "the garage code is amber"
+    ]
+    assert recalled["familiarity"] is True
+    # The projection is a summary, never the raw trust envelope.
+    assert all("trust" not in item for item in recalled["authorized_memory_data"])
+
+
+def test_trust_context_withholds_owner_memory_from_another_audience(monkeypatch, tmp_path):
+    manager = _scoped_memory_agents(monkeypatch, tmp_path)
+    seen: list[dict] = []
+    service = _capturing_service(tmp_path, seen)
+
+    assert service.process_message(owner_message(guid="U1", rowid=1)) == "replied"
+    manager.perform(content="the garage code is amber", _trusted_context=seen[0])
+
+    assert service.process_message(dm_message(guid="D1", rowid=5, text="@rappter garage")) == "replied"
+    assert seen[1]["authorized_memory_data"] == []
+    assert seen[1]["familiarity"] is False
+
+    assert service.process_message(group_message(guid="G1", rowid=6, text="@rappter garage")) == "replied"
+    assert seen[2]["authorized_memory_data"] == []
+
+
+def test_trust_context_survives_an_unreadable_memory_store(monkeypatch, tmp_path):
+    # Recall is enrichment on the inbound hot path: an unreadable store must
+    # degrade to "no memory", never drop the message.
+    class _Broken(ContextMemoryAgent):
+        def perform(self, **kwargs):
+            raise OSError("memory.json is not readable")
+
+    monkeypatch.setattr("openrappter.imessage.service.ContextMemoryAgent", _Broken)
+    seen: list[dict] = []
+    service = _capturing_service(tmp_path, seen)
+
+    assert service.process_message(owner_message(guid="U1", rowid=1)) == "replied"
+    assert seen[0]["authorized_memory_data"] == []
+    assert seen[0]["familiarity"] is False
+
+
+def test_trust_context_ignores_non_json_recall(monkeypatch, tmp_path):
+    class _Garbage(ContextMemoryAgent):
+        def perform(self, **kwargs):
+            return "not json at all"
+
+    monkeypatch.setattr("openrappter.imessage.service.ContextMemoryAgent", _Garbage)
+    seen: list[dict] = []
+    service = _capturing_service(tmp_path, seen)
+
+    assert service.process_message(owner_message(guid="U1", rowid=1)) == "replied"
+    assert seen[0]["authorized_memory_data"] == []
+    assert seen[0]["familiarity"] is False


### PR DESCRIPTION
## The bug

`IMessageService._trust_context` builds the dict the brainstem reads. The
brainstem takes two things off it (`brainstem.py:805-821`):

- `familiarity` — whether the model is told it knows the sender
- `authorized_memory_data` — the audience-filtered projection of stored facts

**Neither was ever set.** The code that recalls memory and assigns them sat
after an unconditional `return`, so it was unreachable — and it referenced a
name (`context`) that does not exist in that scope, so it would have raised
`NameError` had it ever run. Dead since the feature landed in `29787fe`.

Every iMessage turn therefore told the model the sender was unknown and
projected no facts at all. The "trusted primary channel" could not remember
anyone.

## Why no test caught it

The consumer is covered — `test_openrappter_brainstem.py:340` hands the
brainstem a context built by hand and asserts it renders `familiarity: known`
and injects the facts. The producer is covered for its other fields. The
**seam between them** was not: both ends were tested, and the middle was never
connected.

Reproduced before fixing — calling `_trust_context` directly returns 14 keys,
and neither of the two the brainstem reads is among them.

## The fix

Assign the dict to a name, run the recall, return the enriched context.

The audience filter is unchanged and still lives in `ContextMemoryAgent`
(`_is_authorized`: owner-only for untrusted memories → public → explicit
`allowed_audiences` → active non-revoked grants → same-principal DM
continuity, else deny). A fact still reaches only the conversations already
entitled to it. Because this PR *enables* a projection path for the first
time, the tests assert the negative directly: a fact stored by the owner stays
out of a DM and out of a group.

Recall now runs on the inbound hot path, so the failure path is widened. The
old handler caught `TypeError`/`ValueError`/`JSONDecodeError` but **not
`OSError`** — which is exactly what an unreadable store raises. An unreadable
store now degrades to "no memory, not familiar" rather than dropping the
message.

## Test isolation

Enabling recall means an unpatched test builds a real `ContextMemoryAgent`,
which defaults to `~/.openrappter/memory.json` — so the suite would read the
developer's actual memories, making `familiarity` depend on the machine. An
autouse fixture redirects the default to a temp directory. It deliberately
lives outside the per-test `tmp_path`, because tests that list a directory
count its entries (that mistake cost one red run here).

## Verification

- Python **1803 passed** / 6 skipped / 51 subtests (baseline 1799, +4 new)
- `parity_harness.py --runtime both` PASS
- No TypeScript change — this path has no TS mirror

Mutations, all caught:

| # | Mutation | Result |
|---|----------|--------|
| M1 | Restore the unconditional `return` (the original bug) | all 4 new tests fail |
| M2 | Make `_is_authorized` always allow | exactly the withholding test fails |
| M3 | Restore the narrow exception tuple | exactly the unreadable-store test fails |

M2 and M3 failing *only* their intended test is the point: the withholding
test really is what stands between a stored fact and the wrong audience, and
the `OSError` case was a genuine gap rather than defensive padding.
