### PR TITLE
fix(security): a field named cookies was logged in the clear

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A field named `cookies` was written to the structured log in the clear, while
+  `cookie` was redacted. The same held for `signatures` and `jwts` -- and for
+  `sessionCookies` and `setCookies`, which is the shape a `Set-Cookie` header or
+  a cookie jar actually arrives in. Plurals looked handled because `tokens`,
+  `secrets` and `credentials` were all caught, but those are caught by the
+  substring fragment pass rather than by being listed as words: a word survived
+  pluralisation only if it happened to also be a fragment. `cookie`, `jwt` and
+  `signature` are words only, so their plurals fell through every branch. Fixed
+  in both runtimes as a rule rather than three more words. The test that pins
+  the two runtimes to each other compares the word tables, which cannot see a
+  rule -- it stayed green through the whole bug, and would have stayed green
+  with one runtime fixed and the other not, so it now pins the rule as well.
+
 - The flight recorder's excluded-path list covered `.env`, `.ssh`, `.aws/credentials`
   and `.pem`/`.key`/`.p12`, but not `.netrc`, `.npmrc`, `.pypirc`, `.pgpass`,
   `.htpasswd`, `.gnupg`, `.docker/config.json`, `.kube/config`, private keys

--- a/python/openrappter/security/secret_keys.py
+++ b/python/openrappter/security/secret_keys.py
@@ -59,10 +59,25 @@ def _split_words(key: str) -> list:
     return [part.lower() for part in _NON_ALNUM.split(spaced) if part]
 
 
+def _is_secret_word(word: str) -> bool:
+    """True when one word makes a field a secret, singular or plural.
+
+    ``cookies`` is exactly as sensitive as ``cookie``. Plurals looked handled
+    because ``tokens``, ``secrets`` and ``credentials`` are all caught — but
+    they are caught by the *fragment* pass, which is substring-based, not by
+    being spelled out above. So a word survived pluralisation only if it also
+    happened to be a fragment. ``cookie``, ``jwt`` and ``signature`` are words
+    only, and their plurals fell through every branch into the clear.
+    """
+    if word in _SECRET_WORDS:
+        return True
+    return word.endswith("s") and word[:-1] in _SECRET_WORDS
+
+
 def is_secret_key(key: str) -> bool:
     """True when a field of this name must never be logged verbatim."""
     words = _split_words(key)
-    if any(word in _SECRET_WORDS for word in words):
+    if any(_is_secret_word(word) for word in words):
         return True
 
     if words and words[-1] in ("key", "keys"):

--- a/python/tests/test_secret_keys.py
+++ b/python/tests/test_secret_keys.py
@@ -30,6 +30,11 @@ SECRET_NAMES = [
     "authToken", "Cookie", "signature",
     # Missed until an outside review checked.
     "jwt", "bearerToken", "privatePem",
+    # Plurals. `tokens`, `secrets` and `credentials` were already caught, but
+    # only because those three are also substring fragments — the plural of a
+    # word that was *only* a word went into the log in the clear.
+    "cookies", "sessionCookies", "setCookies",
+    "signatures", "requestSignatures", "jwts",
     # A trailing `key` with a qualifier that makes it sensitive.
     "accessKey", "encryptionKey", "masterKey", "sshKey", "key", "keys",
 ]
@@ -40,6 +45,11 @@ BENIGN_NAMES = [
     "durationMs", "outcome",
     # Blanked by the previous rule, which counted `key` anywhere in the name.
     "keyCount", "keyId", "publicKey", "keyspace",
+    # Ordinary plurals. Matching `cookies` must not start matching these: the
+    # plural rule strips one trailing `s`, so anything whose stem is not itself
+    # a secret word has to stay readable.
+    "status", "address", "process", "class", "headers", "params", "results",
+    "sessions", "scopes", "permissions", "authors",
 ]
 
 
@@ -84,6 +94,14 @@ class TestGatewayLogRedaction:
 
 
 class TestRuntimeAgreement:
+    @staticmethod
+    def _typescript_source() -> str:
+        ts_path = (
+            Path(__file__).resolve().parents[2]
+            / "typescript" / "src" / "security" / "secret-keys.ts"
+        )
+        return ts_path.read_text(encoding="utf-8")
+
     def test_the_typescript_answer_lists_the_same_words(self):
         """The bug was two runtimes disagreeing, so pin them to each other.
 
@@ -109,3 +127,22 @@ class TestRuntimeAgreement:
             assert f"'{word}'" in source, f"TypeScript is missing the word {word!r}"
         for fragment in _SECRET_FRAGMENTS:
             assert f"'{fragment}'" in source, f"TypeScript is missing the fragment {fragment!r}"
+
+    def test_the_typescript_answer_applies_the_same_plural_rule(self):
+        """Agreeing on the words is not the same as agreeing on the answer.
+
+        `cookies` leaked because of a missing rule, not a missing word: every
+        table above was already correct while the plural went into the log in
+        the clear. A comparison of tables stays green through that bug, and
+        stays green if one runtime is fixed and the other is not — which is the
+        drift this class exists to catch.
+        """
+        source = self._typescript_source()
+
+        assert "function isSecretWord" in source, (
+            "TypeScript is missing the plural rule, so `cookies`, `signatures` "
+            "and `jwts` leak there while Python redacts them."
+        )
+        assert "word.slice(0, -1)" in source, (
+            "TypeScript's plural rule no longer strips one trailing 's'."
+        )

--- a/typescript/src/security/secret-keys.test.ts
+++ b/typescript/src/security/secret-keys.test.ts
@@ -27,6 +27,11 @@ describe('isSecretKey', () => {
     'api-key', 'Cookie', 'signature',
     // Missed until an outside review checked: no jwt, bearer or pem.
     'jwt', 'bearerToken', 'privatePem',
+    // Plurals. `tokens`, `secrets` and `credentials` were already caught, but
+    // only because those three are also substring fragments — the plural of a
+    // word that was *only* a word went into the log in the clear.
+    'cookies', 'sessionCookies', 'setCookies',
+    'signatures', 'requestSignatures', 'jwts',
     // A trailing `key` with a qualifier that makes it sensitive.
     'accessKey', 'encryptionKey', 'masterKey', 'sshKey', 'key', 'keys',
   ])('treats %s as secret', (key) => {
@@ -43,6 +48,11 @@ describe('isSecretKey', () => {
     // `key` counted as a whole word anywhere in the name. An outside review
     // caught the claim; these are the names it blanked.
     'keyCount', 'keyId', 'publicKey', 'keyspace',
+    // Ordinary plurals. Matching `cookies` must not start matching these: the
+    // plural rule strips one trailing `s`, so anything whose stem is not
+    // itself a secret word has to stay readable.
+    'status', 'address', 'process', 'class', 'headers', 'params', 'results',
+    'sessions', 'scopes', 'permissions', 'authors',
   ])('does not treat %s as secret', (key) => {
     expect(isSecretKey(key)).toBe(false);
   });

--- a/typescript/src/security/secret-keys.ts
+++ b/typescript/src/security/secret-keys.ts
@@ -57,9 +57,24 @@ function splitWords(key: string): string[] {
     .filter(Boolean);
 }
 
+/**
+ * True when one word makes a field a secret, singular or plural.
+ *
+ * `cookies` is exactly as sensitive as `cookie`. Plurals looked handled
+ * because `tokens`, `secrets` and `credentials` are all caught — but they are
+ * caught by the *fragment* pass, which is substring-based, not by being
+ * spelled out above. So a word survived pluralisation only if it also happened
+ * to be a fragment. `cookie`, `jwt` and `signature` are words only, and their
+ * plurals fell through every branch into the clear.
+ */
+function isSecretWord(word: string): boolean {
+  if (SECRET_WORDS.has(word)) return true;
+  return word.endsWith('s') && SECRET_WORDS.has(word.slice(0, -1));
+}
+
 export function isSecretKey(key: string): boolean {
   const words = splitWords(key);
-  if (words.some(word => SECRET_WORDS.has(word))) return true;
+  if (words.some(word => isSecretWord(word))) return true;
 
   const last = words[words.length - 1];
   if (last === 'key' || last === 'keys') {


### PR DESCRIPTION
## The bug

`is_secret_key` / `isSecretKey` is the single canonical answer to "must this
field name be kept out of the log?" It redacted `cookie` and leaked `cookies`.

Measured against `main`:

| field name | before | after |
|---|---|---|
| `cookie`, `sessionCookie`, `set_cookie` | redacted | redacted |
| `cookies`, `sessionCookies`, `setCookies` | **in the clear** | redacted |
| `signature` | redacted | redacted |
| `signatures`, `requestSignatures` | **in the clear** | redacted |
| `jwt` | redacted | redacted |
| `jwts` | **in the clear** | redacted |

`sessionCookies` and `setCookies` are the shapes that actually turn up — a
`Set-Cookie` header, or a cookie jar on a request object.

## Why it survived review

Plurals *looked* handled. `tokens`, `secrets` and `credentials` are all caught,
and two of them are even spelled out in the word table next to their singulars,
which reads like the plural case was considered and covered.

They are caught by a different pass. After the word check there is a substring
fragment check, and `token`, `secret`, `credential`, `password`, `passphrase`,
`apikey` and `authorization` are all fragments — so their plurals match on the
substring regardless of what the word table says.

That means a word survived pluralisation **only if it also happened to be a
fragment**. Exactly three entries are words but not fragments:

    cookie    jwt    signature

and those are exactly the three whose plurals leaked. The two mechanisms
overlapped so heavily that the gap was only visible in the three cases where
they didn't.

## The fix

A rule, not three more words — otherwise the next word added to the table
inherits the same trap:

```python
if word in _SECRET_WORDS:
    return True
return word.endswith("s") and word[:-1] in _SECRET_WORDS
```

Same change in `typescript/src/security/secret-keys.ts`.

## Not blanking things that matter

This module exists to be *narrow*: its own comments record that an earlier
version blanked `keyCount`, `keyId` and `publicKey`, and that this cost real
debuggability. Stripping a trailing `s` is exactly the kind of change that
re-creates that.

So the benign table is extended alongside the secret one, with the plurals most
likely to collide: `status`, `address`, `process`, `class`, `headers`, `params`,
`results`, `sessions`, `scopes`, `permissions`, `authors`. All 54 benign names
checked stay readable.

## The runtime-agreement test was blind to this

The whole point of this module is that there used to be two answers that
drifted. A test pins the runtimes together — but it compares the **word
tables**, and this was a missing **rule**. Every table was already correct while
the plural went into the log in the clear.

So that test stayed green through the entire bug, and would have stayed green
with one runtime fixed and the other not. It now pins the rule too.

Mutation M3 below is the proof: with the rule removed from TypeScript only, the
existing table-comparison test still passes and only the new one fails.

## Verification

- Python `1821 passed` / 6 skipped / 51 subtests (was 1803; +18 new cases)
- TypeScript `5202 passed` / 21 skipped across 324 files
- `parity_harness.py --runtime both` → PASS (15/15)

Mutations, each caught precisely:

| # | mutation | result |
|---|---|---|
| M1 | drop the plural rule in Python | exactly the 6 plural names fail |
| M2 | let the rule also consult the `key` qualifiers | exactly `sessions` fails — the readability guard is load-bearing |
| M3 | drop the plural rule in **TypeScript only** | the 6 TS plural names fail, **and** the new agreement test fails while the old table test still passes |
