### PR TITLE
fix(brainstem): the size of a POST body read was the caller's choice

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The brainstem read a POST body of any size a caller cared to declare. It
+  buffered exactly `Content-Length` bytes with no ceiling, and the existing
+  30-second stall budget did not cover it -- that guard bounds a caller which
+  claims bytes and never sends them, and the dangerous caller is the opposite
+  one, which sends everything it claims as fast as the socket allows. Measured
+  against a real brainstem, with no credential: one 64 MB POST took peak RSS
+  from 33 MB to 180 MB in 0.04s, and six concurrent 16 MB POSTs added 113 MB,
+  because the read is per connection and `ThreadingHTTPServer` gives every
+  request a thread. Now capped at 2 MB with an `OPENRAPPTER_MAX_BODY_BYTES`
+  override, answering 413; both figures are the TypeScript gateway's, whose own
+  comment recorded the gap and asked this runtime to close it. Peak RSS is now
+  flat regardless of what is offered. The oversized body is drained and
+  discarded before the refusal is sent, because answering while the caller is
+  still uploading resets the connection and it gets no readable response.
+
+- The TypeScript gateway answered its `/chat` 413 with a bare `{error}`, the one
+  `/chat` rejection whose shape differed from every other -- its own 401 and 503
+  on that path, and everything the brainstem sends, use the `rapp-chat/1.0`
+  error envelope required by `contracts/rapp-chat-v1.json`. It was written that
+  way deliberately, because at the time the brainstem had no body cap and so no
+  counterpart to agree with. It has one now, so both runtimes answer the same
+  status and the same envelope.
+
 - A field named `cookies` was written to the structured log in the clear, while
   `cookie` was redacted. The same held for `signatures` and `jwts` -- and for
   `sessionCookies` and `setCookies`, which is the shape a `Set-Cookie` header or

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -27,6 +27,7 @@ import glob
 import hashlib
 import importlib.util
 import json
+import math
 import os
 import re
 import socket
@@ -1182,6 +1183,33 @@ def _run_chat_within_trace(
 # ── HTTP server (stdlib — the wire is the contract, not the framework) ───────
 
 
+#: Default ceiling on a POST body. Generous for a chat turn carrying dozens of
+#: turns of history, and far below anything a model API accepts, so it never
+#: bites a request that was going to work.
+DEFAULT_MAX_BODY_BYTES = 2 * 1024 * 1024
+
+
+def _resolve_max_body_bytes():
+    """Read `OPENRAPPTER_MAX_BODY_BYTES`, falling back to the default.
+
+    Parsed as a float so `2.5e6` and `2500000` both work, matching the
+    TypeScript gateway's `Number(...)`. Anything unparseable, infinite or
+    non-positive falls back rather than raising: a bad environment variable
+    should not stop the daemon from starting, and silently removing the cap
+    would be the worst of the available answers.
+    """
+    raw = os.environ.get("OPENRAPPTER_MAX_BODY_BYTES")
+    if raw is None:
+        return DEFAULT_MAX_BODY_BYTES
+    try:
+        value = float(raw)
+    except (TypeError, ValueError):
+        return DEFAULT_MAX_BODY_BYTES
+    if not math.isfinite(value) or value <= 0:
+        return DEFAULT_MAX_BODY_BYTES
+    return int(value)
+
+
 class BrainstemHandler(BaseHTTPRequestHandler):
     #: Seconds a single connection may stall before the socket read gives up.
     #:
@@ -1195,6 +1223,23 @@ class BrainstemHandler(BaseHTTPRequestHandler):
     #: a client still sending data resets the timer. TypeScript is covered by
     #: node's own `requestTimeout`/`headersTimeout`; this runtime had nothing.
     timeout = 30
+    #: Largest POST body this brainstem will buffer, in bytes.
+    #:
+    #: The stall guard above bounds a caller that claims bytes and never sends
+    #: them. It does nothing about the opposite caller -- one that claims a lot
+    #: and sends it as fast as the socket allows -- because that read never
+    #: stalls. Measured against this server before the cap existed:
+    #:
+    #:     one POST /chat of 64 MB   peak RSS 33 MB -> 180 MB in 0.04s
+    #:     six concurrent of 16 MB   peak RSS 33 MB -> 146 MB in 0.34s
+    #:
+    #: `read` is per connection and `ThreadingHTTPServer` gives every request a
+    #: thread, so the cost is per caller and nothing bounded it. No credential
+    #: is needed to spend it.
+    #:
+    #: 2 MB and `OPENRAPPTER_MAX_BODY_BYTES` are the TypeScript gateway's, whose
+    #: own comment records the divergence and asks this runtime to adopt them.
+    max_body_bytes = _resolve_max_body_bytes()
     server_version = f"OpenRappterBrainstem/{__version__}"
 
     def _send(self, code, payload):
@@ -1208,6 +1253,30 @@ class BrainstemHandler(BaseHTTPRequestHandler):
 
     def log_message(self, fmt, *args):  # quiet request logging
         pass
+
+    def _discard_body(self, length):
+        """Read an over-sized body and throw it away, so the 413 is readable.
+
+        Memory stays at one chunk however much was claimed -- discarding is the
+        whole point, and accumulating here would re-create the defect the cap
+        exists to close.
+
+        Bounded rather than unbounded: past `max_body_bytes * 8` this stops
+        reading and answers anyway. A caller that far over the limit has stopped
+        being a request worth being polite to, and draining it in full would
+        hand it the server's time instead of its memory.
+        """
+        remaining = min(length, self.max_body_bytes * 8)
+        try:
+            while remaining > 0:
+                chunk = self.rfile.read(min(65536, remaining))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+        except (TimeoutError, socket.timeout, OSError):
+            # The caller stopped sending. The 413 may not reach it, but the
+            # bytes are already not being buffered, which is what mattered.
+            pass
 
     # ── GET ──
     def flush_headers(self):
@@ -1362,6 +1431,16 @@ class BrainstemHandler(BaseHTTPRequestHandler):
                 "schema": "rapp-chat/1.0",
                 "status": "error",
                 "error": "Content-Length must not be negative",
+            })
+        if length > self.max_body_bytes:
+            # Drain first, answer second. Replying the instant the limit is
+            # known ends the response while the caller is still uploading, and
+            # it gets a connection reset instead of the 413 it needs to read.
+            self._discard_body(length)
+            return self._send(413, {
+                "schema": "rapp-chat/1.0",
+                "status": "error",
+                "error": "Request body too large",
             })
         try:
             raw = self.rfile.read(length) if length else b""

--- a/python/tests/test_brainstem_http_framing.py
+++ b/python/tests/test_brainstem_http_framing.py
@@ -24,10 +24,13 @@ not wedge the server; it leaked one thread per request instead, which is a
 slower version of the same thing on a daemon meant to run for weeks.
 """
 import inspect
+import json
 import socket
 import urllib.error
 import urllib.parse
 import urllib.request
+
+import pytest
 
 from openrappter import brainstem
 
@@ -122,6 +125,122 @@ class TestStallBudget:
         """
         assert isinstance(brainstem.BrainstemHandler.timeout, (int, float))
         assert 0 < brainstem.BrainstemHandler.timeout <= 120
+
+
+class TestRequestBodyCap:
+    """The body is bounded, so one caller cannot spend the daemon's memory.
+
+    `_route_post` read exactly `Content-Length` bytes into memory with no
+    ceiling. The stall budget above does not touch this: it bounds a caller that
+    claims bytes and never sends them, and the dangerous caller is the opposite
+    one, which sends everything it claims as fast as the socket allows.
+
+    Measured against this server before the cap, as peak RSS of the test
+    process, with no credential of any kind:
+
+        one POST /chat of 64 MB    33 MB -> 180 MB   in 0.04s
+        six concurrent of 16 MB    33 MB -> 146 MB   in 0.34s
+
+    `read` is per connection and `ThreadingHTTPServer` gives every request its
+    own thread, so that cost is per caller. After the cap both are flat at
+    ~39 MB. The limit and the environment variable are the TypeScript gateway's,
+    whose comment asked this runtime to adopt them.
+    """
+
+    CAP = 4096
+
+    @pytest.fixture
+    def cap(self, monkeypatch):
+        """Shrink the cap so the tests need kilobytes, not megabytes."""
+        monkeypatch.setattr(brainstem.BrainstemHandler, "max_body_bytes", self.CAP)
+        return self.CAP
+
+    @staticmethod
+    def _sized(nbytes):
+        """A syntactically valid /chat body of exactly `nbytes` bytes."""
+        prefix, suffix = b'{"user_input": "', b'"}'
+        return prefix + b"x" * (nbytes - len(prefix) - len(suffix)) + suffix
+
+    def test_a_body_over_the_cap_is_refused(self, server, cap):
+        body = self._sized(cap * 4)
+        status, _ = _raw_post(
+            server, f"Content-Length: {len(body)}\r\n".encode(), body=body
+        )
+        assert status == 413
+
+    def test_the_refusal_uses_the_contract_envelope(self, server, cap):
+        """Same shape as every other rejection on this wire, and now the same
+        shape the TypeScript gateway sends -- it had a bare `{error}` here,
+        which was the one /chat rejection whose envelope differed."""
+        body = self._sized(cap * 4)
+        _, raw = _raw_post(
+            server, f"Content-Length: {len(body)}\r\n".encode(), body=body
+        )
+        assert json.loads(raw) == {
+            "schema": "rapp-chat/1.0",
+            "status": "error",
+            "error": "Request body too large",
+        }
+
+    def test_a_body_exactly_at_the_cap_is_still_accepted(self, server, cap):
+        """A ceiling, not a fence one byte inside it."""
+        body = self._sized(cap)
+        status, _ = _raw_post(
+            server, f"Content-Length: {len(body)}\r\n".encode(), body=body
+        )
+        assert status != 413
+
+    def test_a_claimed_gigabyte_is_refused_on_the_claim_alone(self, server, cap):
+        """The claim is judged before the bytes are read, not after.
+
+        This is the whole shape of the fix. Reading first and judging after is
+        what made the size of the read the caller's choice; before the cap this
+        answered 400 `shorter than Content-Length`, having tried to read it.
+        """
+        status, raw = _raw_post(
+            server, b"Content-Length: 1000000000\r\n", body=b"x" * 20, half_close=True
+        )
+        assert status == 413
+        assert b"too large" in raw
+
+    def test_an_ordinary_turn_is_unaffected_by_the_default_cap(self, server):
+        """Anti-vacuity, on the real 2 MB default rather than the shrunken one."""
+        status, _ = _raw_post(server, b"Content-Length: 19\r\n")
+        assert status not in (400, 413, None)
+
+
+class TestBodyCapConfiguration:
+    def test_the_default_is_two_megabytes(self):
+        """The TypeScript gateway's number. Both runtimes answer 413 at the
+        same size, which is the only reason a peer can predict either."""
+        assert brainstem.DEFAULT_MAX_BODY_BYTES == 2 * 1024 * 1024
+        assert brainstem.BrainstemHandler.max_body_bytes > 0
+
+    @pytest.mark.parametrize(
+        "raw,expected",
+        [
+            ("4096", 4096),
+            ("2.5e6", 2500000),
+            ("", brainstem.DEFAULT_MAX_BODY_BYTES),
+            ("nonsense", brainstem.DEFAULT_MAX_BODY_BYTES),
+            ("0", brainstem.DEFAULT_MAX_BODY_BYTES),
+            ("-1", brainstem.DEFAULT_MAX_BODY_BYTES),
+            ("inf", brainstem.DEFAULT_MAX_BODY_BYTES),
+            ("nan", brainstem.DEFAULT_MAX_BODY_BYTES),
+        ],
+    )
+    def test_the_override_falls_back_rather_than_removing_the_cap(
+        self, monkeypatch, raw, expected
+    ):
+        """Every unusable value keeps a cap. `0`, `-1` and `inf` are the ones
+        that matter: read literally they mean "no limit", which is the state
+        this whole class exists to prevent, reachable by typo."""
+        monkeypatch.setenv("OPENRAPPTER_MAX_BODY_BYTES", raw)
+        assert brainstem._resolve_max_body_bytes() == expected
+
+    def test_an_absent_variable_uses_the_default(self, monkeypatch):
+        monkeypatch.delenv("OPENRAPPTER_MAX_BODY_BYTES", raising=False)
+        assert brainstem._resolve_max_body_bytes() == brainstem.DEFAULT_MAX_BODY_BYTES
 
 
 def _multipart_post(base, content_type, body, timeout=15):

--- a/typescript/src/gateway/__tests__/chat-body-cap.test.ts
+++ b/typescript/src/gateway/__tests__/chat-body-cap.test.ts
@@ -13,9 +13,13 @@
  * The accumulation was `body += chunk.toString()` with no limit, on a gateway
  * meant to face peers on a shared wire — where untrusted is the normal case.
  *
- * This is a DELIBERATE divergence from the brainstem, which has no cap.
+ * This was a DELIBERATE divergence from the brainstem, which had no cap.
  * Everywhere else on /chat the rule is to match it exactly; here, matching it
- * would mean copying a hole.
+ * would have meant copying a hole.
+ *
+ * The brainstem has since adopted the same 2 MB limit and the same
+ * OPENRAPPTER_MAX_BODY_BYTES override, so there is now a counterpart to
+ * compare against and /chat answers the rapp-chat error envelope in both.
  */
 
 import { describe, it, expect, beforeAll, afterAll } from 'vitest';
@@ -28,6 +32,13 @@ import type { AgentRequest } from '../types.js';
 const PORT = 19812;
 const BASE = `http://127.0.0.1:${PORT}`;
 const CAP = 2 * 1024 * 1024;
+/** What /chat answers when the body is refused -- the contract envelope, the
+ *  same one the brainstem sends and the same one /chat's 401 and 503 use. */
+const CHAT_TOO_LARGE = {
+  schema: 'rapp-chat/1.0',
+  status: 'error',
+  error: 'Request body too large',
+};
 
 let server: GatewayServer;
 let dataDir: string;
@@ -74,9 +85,9 @@ describe('an oversized body is refused at the door', () => {
     const got = await postRaw('/chat', huge);
 
     expect(got.status).toBe(413);
-    // 413 has no brainstem counterpart -- it has no body cap -- so nothing
-    // can be compared here and the bare shape stays.
-    expect(got.body).toEqual({ error: 'Request body too large' });
+    // The brainstem answers this exact envelope now; a bare {error} here was
+    // the one /chat rejection in this file whose shape differed from the rest.
+    expect(got.body).toEqual(CHAT_TOO_LARGE);
     // THE POINT: the agent — and behind it a paid API — was never invoked.
     expect(handlerCalls).toBe(before);
   });
@@ -96,7 +107,7 @@ describe('an oversized body is refused at the door', () => {
     const got = await postRaw('/chat', enormous);
 
     expect(got.status).toBe(413);
-    expect(got.body).toEqual({ error: 'Request body too large' });
+    expect(got.body).toEqual(CHAT_TOO_LARGE);
     expect(handlerCalls).toBe(before);
   });
 
@@ -104,7 +115,7 @@ describe('an oversized body is refused at the door', () => {
     const huge = JSON.stringify({ user_input: 'x'.repeat(CAP + 1024) });
     const got = await postRaw('/chat?x=1', huge);
     expect(got.status).toBe(413);
-    expect(got.body).toEqual({ error: 'Request body too large' });
+    expect(got.body).toEqual(CHAT_TOO_LARGE);
   });
 
   it('names the limit on non-chat POSTs, which have no parity obligation', async () => {

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -1269,10 +1269,11 @@ export class GatewayServer {
        * openrappter 503). Rejecting at the door costs nothing and is the same
        * answer every time.
        *
-       * This is a DELIBERATE divergence from the brainstem, which has no cap.
-       * Everywhere else on /chat the rule is to match it exactly; here matching
-       * it would mean copying a hole. The brainstem should adopt the same cap —
-       * it is a different repository and not mine to change.
+       * This was a DELIBERATE divergence from the brainstem, which had no cap:
+       * everywhere else on /chat the rule is to match it exactly, and here
+       * matching it would have meant copying a hole. The brainstem has since
+       * adopted the same limit and the same environment variable, so /chat now
+       * answers the same status AND the same envelope in both runtimes.
        */
       req.on('data', (chunk: Buffer) => {
         if (bodyTooLarge) {
@@ -1309,7 +1310,7 @@ export class GatewayServer {
           if (!res.writableEnded) {
             res.writeHead(413, { 'Content-Type': 'application/json', ...corsHeaders });
             res.end(JSON.stringify(isChat
-              ? { error: 'Request body too large' }
+              ? { schema: 'rapp-chat/1.0', status: 'error', error: 'Request body too large' }
               : { error: 'Request body too large', limit_bytes: this.maxHttpBodyBytes }));
           }
           return;


### PR DESCRIPTION
## The defect

`_route_post` read exactly `Content-Length` bytes into memory, with no ceiling.
How much the brainstem allocates per request was the caller's choice.

The 30-second stall budget added earlier does not cover this. That guard bounds
a caller which *claims* bytes and never sends them. The dangerous caller is the
opposite one: it sends everything it claims, as fast as the socket allows, and
never stalls at all.

Measured against a real brainstem on this machine, as peak RSS of the process,
with no credential of any kind:

| offered | before | after |
|---|---|---|
| one POST `/chat` of 64 MB | 33 MB → **180 MB** in 0.04s | 33 MB → 39 MB |
| six concurrent of 16 MB | 33 MB → **146 MB** in 0.34s | 33 MB → 35 MB |

0.04 seconds is the point about the timeout: nothing was ever close to stalling.

The read is per connection and `ThreadingHTTPServer` gives every request its own
thread, so the cost is per caller and nothing bounded the total. The default
bind is loopback, but `OPENRAPPTER_BRAINSTEM_HOST` exists and `/chat` takes no
credential.

## This was already known

`typescript/src/gateway/server.ts` capped its own body reads and left a note:

> This is a DELIBERATE divergence from the brainstem, which has no cap.
> Everywhere else on /chat the rule is to match it exactly; here matching it
> would mean copying a hole. **The brainstem should adopt the same cap — it is a
> different repository and not mine to change.**

It is this repository. Adopting it, with the gateway's own numbers: 2 MB,
overridable by `OPENRAPPTER_MAX_BODY_BYTES`, answering 413.

Both runtimes now refuse at the same size, which is the only reason a peer can
predict either.

## Two details that are not obvious

**Drain before refusing.** Replying the instant the limit is known ends the
response while the caller is still uploading, and it gets a connection reset
instead of a readable 413. The oversized body is read and discarded — one 64 KB
chunk at a time, never accumulated — and the refusal is sent after. The
TypeScript side learned this the same way and its comment says so.

The drain is bounded at `8 x` the cap, matching the gateway's `req.destroy()`
threshold. Past that the caller does get a reset; a request that far over the
limit has stopped being one worth being polite to, and draining it in full would
hand it the server's time instead of its memory. Both are reproduced below.

**A bad override must not remove the cap.** `0`, `-1` and `inf` read literally
mean "no limit", which is the state this change exists to prevent, reachable by
typo. Every unparseable or non-positive value falls back to 2 MB rather than
raising, because a bad environment variable should not stop the daemon booting.

## The envelope, which this change made wrong

Adding the counterpart exposed a shape problem. The gateway answered its `/chat`
413 with a bare `{error}`, and its test said why:

> 413 has no brainstem counterpart -- it has no body cap -- so nothing can be
> compared here and the bare shape stays.

That reasoning was sound and is now expired. Meanwhile the gateway's own `/chat`
401 and 503 both use the `rapp-chat/1.0` error envelope that
`contracts/rapp-chat-v1.json` requires, so its 413 was the single `/chat`
rejection whose shape differed from its neighbours.

Both runtimes now answer `{schema, status, error}`. Non-chat POSTs keep
`limit_bytes`, which the gateway's test calls out as having no parity obligation.

## Behaviour at the boundary

Cap at the 2 MB default, body sent in full:

| body | before | after |
|---|---|---|
| 1 MB | read, 400 on content | unchanged |
| 2 MB (exactly at cap) | read, 400 on content | unchanged — a ceiling, not a fence inside it |
| 3 MB | read, 400 on content | **413** |
| 16 MB | read, 400 on content | **413** |
| 64 MB | read, RSS 180 MB | connection reset, RSS flat (past the `8 x` drain bound) |

## Verification

- Python `1836 passed` / 6 skipped (was 1821; +15 new cases)
- TypeScript `5202 passed` / 21 skipped across 324 files (unchanged — assertions
  updated, no tests added)
- `parity_harness.py --runtime both` → PASS (15/15)

Mutations, each caught precisely:

| # | mutation | result |
|---|---|---|
| M1 | remove the cap check | exactly the 3 refusal tests fail |
| M2 | `>=` instead of `>` | exactly the at-the-cap test fails |
| M3 | make the drain a no-op | exactly the 2 tests that send a real body without half-closing fail — the half-closed one still passes, correctly, since it has nothing to drain |
| M4 | drop the non-positive guard on the override | exactly `0`, `-1`, `inf`, `nan` fail |
