### PR TITLE
fix(nanorappter): one connection could take the whole gateway offline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `python3 -m nanorappter` did not work. Both the module docstring and the
+  CLI's own help text advertise it, but there was no `__main__.py`, so the
+  documented command failed with "No module named nanorappter.__main__" -- the
+  `if __name__ == "__main__"` guard in `__init__.py` only fires for
+  `python3 nanorappter/__init__.py`, which nothing documents. The whole CLI,
+  including `serve`, was unreachable by its own instructions.
+
+- Every malformed request to the nanorappter gateway crashed its handler and
+  returned nothing at all: a non-numeric `Content-Length`, a body that was not
+  JSON, and a body that was valid JSON but not an object (`[1,2]`, `"x"`, `42`,
+  `null` all raise `AttributeError` on `.get()`). Each now gets a 400.
+
+- A single connection could take the whole nanorappter gateway offline. A
+  negative `Content-Length` was passed straight to `rfile.read(-1)`, which
+  means "read until EOF", and the server was a single-threaded `HTTPServer`, so
+  one caller sending `Content-Length: -1` and a single byte -- then simply not
+  closing the socket -- blocked the accept loop and every other caller timed
+  out until it disconnected. Content-Length is now validated, the server is
+  threading so no one caller can stall the rest, and a stalled request cannot
+  hold its thread past the socket timeout. The gateway also now caps request
+  bodies at the same 2 MB the other two runtimes use.
+
+- The brainstem drained an over-sized body before refusing it even when the
+  declared size was far past the cap, so a caller could claim a gigabyte, send
+  nothing, and hold a thread for the full 30-second timeout to receive a refusal
+  it had already earned. Draining exists to make the 413 readable rather than a
+  connection reset, which is only worth doing for a body that is about to
+  arrive; past `8 x` the cap the refusal now goes out immediately.
+
 - The brainstem read a POST body of any size a caller cared to declare. It
   buffered exactly `Content-Length` bytes with no ceiling, and the existing
   30-second stall budget did not cover it -- that guard bounds a caller which

--- a/python/nanorappter/__init__.py
+++ b/python/nanorappter/__init__.py
@@ -30,6 +30,10 @@ import time
 from datetime import datetime, timezone
 from typing import Any
 
+#: Largest POST body the optional HTTP gateway will read, matching the limit
+#: the brainstem and the TypeScript gateway both use.
+MAX_BODY_BYTES = 2 * 1024 * 1024
+
 
 class NanoAgent:
     """Base class for all nanorappter agents.
@@ -178,9 +182,13 @@ class Gateway:
 
 def serve(gateway: Gateway, port: int = 9999) -> None:
     """Optional HTTP server. GET = status, POST = notify or JSON-RPC."""
-    from http.server import HTTPServer, BaseHTTPRequestHandler
+    from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 
     class H(BaseHTTPRequestHandler):
+        # A caller that claims bytes and never sends them would otherwise hold
+        # its thread open forever.
+        timeout = 30
+
         def do_GET(self):
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
@@ -188,17 +196,79 @@ def serve(gateway: Gateway, port: int = 9999) -> None:
             self.end_headers()
             self.wfile.write(json.dumps(gateway.status(), indent=2).encode())
 
+        def _content_length(self) -> int:
+            """Declared body size, or -1 if the header cannot be trusted.
+
+            Anything non-numeric or negative is -1. Negative matters most:
+            rfile.read(-1) means "read until EOF", so a caller could hold the
+            socket open and block indefinitely.
+            """
+            raw = self.headers.get("Content-Length", "")
+            if not raw:
+                return 0
+            try:
+                length = int(raw)
+            except (TypeError, ValueError):
+                return -1
+            return length if length >= 0 else -1
+
+        def _refuse(self, status: int, message: str) -> None:
+            payload = json.dumps({"error": message}).encode()
+            self.send_response(status)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
+            self.send_header("Access-Control-Allow-Origin", "*")
+            self.end_headers()
+            self.wfile.write(payload)
+
+        def _discard_body(self, length: int) -> None:
+            """Read and throw away an oversized body before refusing it.
+
+            Answering the moment the limit is known ends the response while the
+            caller is still uploading, and it gets a connection reset instead of
+            a readable error.
+            """
+            remaining = length
+            while remaining > 0:
+                chunk = self.rfile.read(min(65536, remaining))
+                if not chunk:
+                    break
+                remaining -= len(chunk)
+
         def do_POST(self):
-            body = json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0)))) if int(self.headers.get("Content-Length", 0)) else {}
+            length = self._content_length()
+            if length < 0:
+                self._refuse(400, "invalid Content-Length")
+                return
+            if length > MAX_BODY_BYTES:
+                # Only a body that is about to arrive anyway is worth draining,
+                # and only so the refusal is readable rather than a reset. A
+                # caller claiming far more than the cap is refused at once: it
+                # has already been told no, and reading megabytes to be polite
+                # about it just hands it the time instead of the memory.
+                if length <= MAX_BODY_BYTES * 8:
+                    self._discard_body(length)
+                self._refuse(413, f"request body too large (limit {MAX_BODY_BYTES} bytes)")
+                return
+            try:
+                body = json.loads(self.rfile.read(length)) if length else {}
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                self._refuse(400, "invalid JSON body")
+                return
+            if not isinstance(body, dict):
+                self._refuse(400, "body must be a JSON object")
+                return
             if body.get("jsonrpc"):
                 result = gateway.handle_jsonrpc(body)
             else:
                 result = gateway.notify(body.get("agent_id", ""), body.get("event", ""), body.get("detail", {}))
+            payload = json.dumps(result).encode()
             self.send_response(200)
             self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(payload)))
             self.send_header("Access-Control-Allow-Origin", "*")
             self.end_headers()
-            self.wfile.write(json.dumps(result).encode())
+            self.wfile.write(payload)
 
         def do_OPTIONS(self):
             self.send_response(204)
@@ -209,7 +279,11 @@ def serve(gateway: Gateway, port: int = 9999) -> None:
 
         def log_message(self, *a): pass
 
-    server = HTTPServer(("127.0.0.1", port), H)
+    # Threading, because one caller must not be able to stall every other one:
+    # a single-threaded server blocks its accept loop for the whole of a slow
+    # request.
+    server = ThreadingHTTPServer(("127.0.0.1", port), H)
+    server.daemon_threads = True
     print(f"nanorappter gateway → http://localhost:{port}  ({len(gateway.agents)} agents)")
     server.serve_forever()
 

--- a/python/nanorappter/__main__.py
+++ b/python/nanorappter/__main__.py
@@ -1,0 +1,11 @@
+"""Entry point for `python3 -m nanorappter`.
+
+Both the module docstring and the CLI's own help text advertise
+`python3 -m nanorappter status`. Without this file that command fails with
+"No module named nanorappter.__main__" -- the `if __name__ == "__main__"`
+guard in __init__.py only fires for `python3 nanorappter/__init__.py`, which
+is not what anything documents.
+"""
+from . import _main
+
+_main()

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -1261,12 +1261,10 @@ class BrainstemHandler(BaseHTTPRequestHandler):
         whole point, and accumulating here would re-create the defect the cap
         exists to close.
 
-        Bounded rather than unbounded: past `max_body_bytes * 8` this stops
-        reading and answers anyway. A caller that far over the limit has stopped
-        being a request worth being polite to, and draining it in full would
-        hand it the server's time instead of its memory.
+        The caller decides whether draining is worth it at all; see the call
+        site. This reads exactly what it is asked to.
         """
-        remaining = min(length, self.max_body_bytes * 8)
+        remaining = length
         try:
             while remaining > 0:
                 chunk = self.rfile.read(min(65536, remaining))
@@ -1436,7 +1434,13 @@ class BrainstemHandler(BaseHTTPRequestHandler):
             # Drain first, answer second. Replying the instant the limit is
             # known ends the response while the caller is still uploading, and
             # it gets a connection reset instead of the 413 it needs to read.
-            self._discard_body(length)
+            #
+            # Only a body that is about to arrive anyway is worth draining. Past
+            # `max_body_bytes * 8` the refusal goes out immediately: the caller
+            # has already been told no, and waiting on bytes it may never send
+            # would hand it a thread for the whole timeout instead of memory.
+            if length <= self.max_body_bytes * 8:
+                self._discard_body(length)
             return self._send(413, {
                 "schema": "rapp-chat/1.0",
                 "status": "error",

--- a/python/tests/test_brainstem_http_framing.py
+++ b/python/tests/test_brainstem_http_framing.py
@@ -26,6 +26,7 @@ slower version of the same thing on a daemon meant to run for weeks.
 import inspect
 import json
 import socket
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -202,6 +203,24 @@ class TestRequestBodyCap:
         )
         assert status == 413
         assert b"too large" in raw
+
+    def test_a_claim_far_over_the_cap_is_answered_without_waiting_for_it(self, server, cap):
+        """No half-close: the caller claims a gigabyte and then just stops.
+
+        Draining exists so the 413 is readable rather than a reset, but it is
+        only worth doing for a body that is about to arrive. Past `cap * 8` the
+        refusal goes out at once -- otherwise this request holds a thread for
+        the full 30s timeout waiting on bytes that were never coming, which is
+        a cheaper thing to ask of the server than the memory ever was.
+        """
+        started = time.monotonic()
+        status, raw = _raw_post(
+            server, b"Content-Length: 1000000000\r\n", body=b"x" * 20, timeout=10
+        )
+        elapsed = time.monotonic() - started
+        assert status == 413
+        assert b"too large" in raw
+        assert elapsed < 5, f"took {elapsed:.1f}s -- it waited for the body"
 
     def test_an_ordinary_turn_is_unaffected_by_the_default_cap(self, server):
         """Anti-vacuity, on the real 2 MB default rather than the shrunken one."""

--- a/python/tests/test_nanorappter_gateway.py
+++ b/python/tests/test_nanorappter_gateway.py
@@ -1,0 +1,232 @@
+"""The nanorappter gateway's HTTP surface.
+
+This module had no tests at all. It also had no __main__.py, so the
+`python3 -m nanorappter ...` command that its own docstring and help text
+advertise could not run -- which is the likeliest reason nobody noticed that
+every malformed request crashed the handler and returned nothing, or that a
+single connection could take the whole gateway offline.
+
+Measured against the real server before the fix:
+
+    Content-Length: -1, one byte, socket held open
+        -> every other caller times out until the attacker disconnects
+    Content-Length: abc          -> no response, traceback, connection closed
+    body `not json`              -> no response, traceback, connection closed
+    body `[1,2]` (valid JSON)    -> no response, AttributeError on .get()
+
+The -1 case is the sharp one: rfile.read(-1) means "read until EOF", and the
+server was single-threaded, so one held socket blocked the accept loop.
+"""
+from __future__ import annotations
+
+import json
+import socket
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from nanorappter import MAX_BODY_BYTES, Gateway, NanoAgent, serve  # noqa: E402
+
+
+class Echo(NanoAgent):
+    def perform(self, event, detail):
+        return {"reply": event}
+
+
+@pytest.fixture(scope="module")
+def gateway_port():
+    """A real nanorappter gateway on an ephemeral port.
+
+    Both server classes are patched, not just the threading one, so that a
+    change of server class shows up as a failing assertion about behaviour
+    rather than as a fixture that could not bind.
+    """
+    import http.server
+
+    gw = Gateway()
+    gw.register("bot", Echo("bot", "echoes"))
+
+    holder: dict[str, int] = {}
+    originals = {
+        name: getattr(http.server, name)
+        for name in ("HTTPServer", "ThreadingHTTPServer")
+    }
+
+    def ephemeral(base):
+        class Ephemeral(base):  # type: ignore[misc, valid-type]
+            def __init__(self, addr, handler):
+                super().__init__((addr[0], 0), handler)
+                holder["port"] = self.server_address[1]
+
+        return Ephemeral
+
+    for name, base in originals.items():
+        setattr(http.server, name, ephemeral(base))
+    try:
+        threading.Thread(target=lambda: serve(gw, 0), daemon=True).start()
+        deadline = time.time() + 5
+        while "port" not in holder and time.time() < deadline:
+            time.sleep(0.02)
+        assert "port" in holder, "gateway did not start"
+        yield holder["port"]
+    finally:
+        for name, base in originals.items():
+            setattr(http.server, name, base)
+
+
+def _request(port: int, payload: bytes, timeout: float = 5.0) -> bytes:
+    """Send raw bytes, read the whole response. b'' means nothing came back."""
+    sock = socket.create_connection(("127.0.0.1", port), timeout=timeout)
+    sock.settimeout(timeout)
+    try:
+        sock.sendall(payload)
+        chunks = []
+        while True:
+            block = sock.recv(65536)
+            if not block:
+                break
+            chunks.append(block)
+        return b"".join(chunks)
+    except (socket.timeout, ConnectionError):
+        return b""
+    finally:
+        sock.close()
+
+
+def _post(body: bytes, content_length: object | None = None) -> bytes:
+    declared = len(body) if content_length is None else content_length
+    return (
+        b"POST / HTTP/1.1\r\nHost: t\r\nConnection: close\r\n"
+        b"Content-Type: application/json\r\n"
+        b"Content-Length: " + str(declared).encode() + b"\r\n\r\n" + body
+    )
+
+
+def _status(response: bytes) -> int:
+    assert response, "the server sent nothing at all"
+    return int(response.split(b"\r\n", 1)[0].split(b" ")[1])
+
+
+def _body(response: bytes) -> dict:
+    return json.loads(response.split(b"\r\n\r\n", 1)[1])
+
+
+class TestTheDocumentedCommandRuns:
+    """`python3 -m nanorappter` is what the docstring and help text promise."""
+
+    def test_the_module_can_be_executed_as_documented(self):
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-m", "nanorappter", "status"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(Path(__file__).resolve().parents[1]),
+        )
+        assert result.returncode == 0, result.stderr
+        assert json.loads(result.stdout)["runtime"] == "nanorappter"
+
+    def test_help_is_reachable_the_same_way(self):
+        import subprocess
+
+        result = subprocess.run(
+            [sys.executable, "-m", "nanorappter", "help"],
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(Path(__file__).resolve().parents[1]),
+        )
+        assert result.returncode == 0, result.stderr
+        assert "python3 -m nanorappter" in result.stdout
+
+
+class TestMalformedRequestsAreAnswered:
+    """Every one of these used to crash the handler and answer nothing."""
+
+    def test_a_well_formed_request_still_works(self, gateway_port):
+        response = _request(gateway_port, _post(b'{"agent_id":"bot","event":"hi"}'))
+        assert _status(response) == 200
+        assert _body(response)["reply"] == "hi"
+
+    def test_a_non_numeric_content_length_is_refused(self, gateway_port):
+        response = _request(gateway_port, _post(b"", content_length="abc"))
+        assert _status(response) == 400
+        assert "Content-Length" in _body(response)["error"]
+
+    def test_a_negative_content_length_is_refused(self, gateway_port):
+        response = _request(gateway_port, _post(b"", content_length=-1))
+        assert _status(response) == 400
+
+    def test_a_body_that_is_not_json_is_refused(self, gateway_port):
+        response = _request(gateway_port, _post(b"not json at all"))
+        assert _status(response) == 400
+        assert "JSON" in _body(response)["error"]
+
+    @pytest.mark.parametrize("payload", [b"[1,2]", b'"hello"', b"42", b"null"])
+    def test_json_that_is_not_an_object_is_refused(self, gateway_port, payload):
+        """Valid JSON, but .get() does not exist on it."""
+        response = _request(gateway_port, _post(payload))
+        assert _status(response) == 400
+        assert "object" in _body(response)["error"]
+
+    def test_an_empty_body_is_still_accepted(self, gateway_port):
+        """Length 0 has always meant "{}" and must keep meaning it."""
+        response = _request(gateway_port, _post(b""))
+        assert _status(response) == 200
+
+
+class TestOneCallerCannotStallTheRest:
+    """The whole gateway used to stop while one socket was held open."""
+
+    def test_a_held_negative_length_request_does_not_block_other_callers(self, gateway_port):
+        attacker = socket.create_connection(("127.0.0.1", gateway_port), timeout=5)
+        try:
+            attacker.sendall(
+                b"POST / HTTP/1.1\r\nHost: t\r\nContent-Length: -1\r\n\r\nA"
+            )
+            time.sleep(0.3)
+            response = _request(gateway_port, b"GET / HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n", timeout=4)
+            assert _status(response) == 200, "one held socket stalled the gateway"
+        finally:
+            attacker.close()
+
+    def test_a_stalled_upload_does_not_block_other_callers(self, gateway_port):
+        """Claims a legitimate size, sends nothing, never closes."""
+        attacker = socket.create_connection(("127.0.0.1", gateway_port), timeout=5)
+        try:
+            attacker.sendall(b"POST / HTTP/1.1\r\nHost: t\r\nContent-Length: 1000\r\n\r\n")
+            time.sleep(0.3)
+            response = _request(gateway_port, b"GET / HTTP/1.1\r\nHost: t\r\nConnection: close\r\n\r\n", timeout=4)
+            assert _status(response) == 200
+        finally:
+            attacker.close()
+
+
+class TestTheBodyCap:
+    def test_the_cap_is_the_same_two_megabytes_the_other_runtimes_use(self):
+        assert MAX_BODY_BYTES == 2 * 1024 * 1024
+
+    def test_a_claimed_gigabyte_is_refused_on_the_claim_alone(self, gateway_port):
+        response = _request(gateway_port, _post(b"{}", content_length=1024**3))
+        assert _status(response) == 413
+
+    def test_a_body_exactly_at_the_cap_is_not_refused_for_being_too_large(self, gateway_port):
+        """A ceiling, not a fence somewhere inside it. Pins > rather than >=.
+
+        The payload is built to be exactly MAX_BODY_BYTES. An approximate size
+        here lets an off-by-one through: a body merely *near* the cap passes
+        under both > and >=, so the test would prove nothing about which one
+        the server uses.
+        """
+        prefix = b'{"agent_id":"bot","event":"x","pad":"'
+        suffix = b'"}'
+        payload = prefix + b"a" * (MAX_BODY_BYTES - len(prefix) - len(suffix)) + suffix
+        assert len(payload) == MAX_BODY_BYTES
+        response = _request(gateway_port, _post(payload), timeout=15)
+        assert _status(response) != 413


### PR DESCRIPTION
## One connection, offline gateway

`do_POST` passed `Content-Length` straight into `rfile.read()` with no validation:

```python
body = json.loads(self.rfile.read(int(self.headers.get("Content-Length", 0)))) if int(self.headers.get("Content-Length", 0)) else {}
```

`int("-1")` is `-1`, which is truthy, so it takes the read branch — and `read(-1)`
means *read until EOF*. The server was a single-threaded `HTTPServer`, so that
blocked read holds the accept loop.

One connection. One byte. No credential. Just don't close the socket:

| | before | after |
|---|---|---|
| baseline `GET /` | 200 in 0.9ms | 200 in 1.0ms |
| while `-1` is held | **TimeoutError after 4.0s** | 200 in **1.7ms** |
| again | **TimeoutError after 4.0s** | 200 in 0.6ms |
| after attacker disconnects | 200 in 0.8ms | 200 in 1.6ms |

## Everything malformed returned nothing at all

Not an error — *nothing*. The handler raised, `socketserver` logged a traceback
to stderr, the connection closed empty.

| request | before | after |
|---|---|---|
| `Content-Length: abc` | no response | 400 |
| `Content-Length: -1` | no response (after reading to EOF) | 400 |
| body `not json` | no response | 400 |
| body `[1,2]`, `"x"`, `42`, `null` | no response | 400 |

The last row is the easy one to miss: those are all *valid JSON*. They fail later,
on `body.get(...)`, because `.get` does not exist on a list, str, int or None.

## The reason nobody noticed

The module docstring and the CLI's own help text both advertise this:

```
python3 -m nanorappter status       # gateway health
python3 -m nanorappter serve [PORT]  # HTTP + JSON-RPC server
```

It could not run. There was no `__main__.py`:

```
$ python3 -m nanorappter status
No module named nanorappter.__main__; 'nanorappter' is a package and cannot be directly executed
```

The `if __name__ == "__main__": _main()` guard at the bottom of `__init__.py`
only fires for `python3 nanorappter/__init__.py`, which nothing documents. So the
entire CLI, `serve` included, was unreachable by its own instructions — and the
module has no tests, no packaging entry and no mention in any doc.

Added `__main__.py`, and the first tests this module has ever had.

## Changes

- `__main__.py`, so the documented command runs
- `Content-Length` validated: non-numeric or negative → 400
- `ThreadingHTTPServer` + `daemon_threads`, so one caller cannot stall the rest
- `timeout = 30`, so a stalled caller cannot hold its thread indefinitely
- Malformed and non-object JSON → 400 instead of an unhandled exception
- Bodies capped at 2 MB, matching the brainstem and the TypeScript gateway
- Explicit `Content-Length` on responses

## Also: a refinement to last round's brainstem drain

#375 added a drain-before-refusing so an over-sized body gets a readable 413
instead of a connection reset. It drained up to `8 x` the cap *whatever* was
claimed — so a caller could claim a gigabyte, send nothing, and hold a thread for
the full 30-second timeout to collect a refusal it had already earned.

Draining is only worth doing for a body that is about to arrive. Past `8 x` the
cap the refusal now goes out immediately. My change last round, so it belongs here
rather than in someone else's backlog. The nanorappter cap does the same thing, so
the two agree.

## Deliberately not fixed

`Access-Control-Allow-Origin: *` with a preflight that permits `Content-Type`,
on an endpoint that *executes agents* — so any page in the user's browser can
drive the local gateway. Unlike everything above, that has a plausible intentional
rationale (a local dashboard or browser demo), so it is a design decision rather
than a bug. Filed separately with the measurement rather than decided here.

## Verification

- Python `1853 passed` / 6 skipped (was 1836; +16 nanorappter, +1 brainstem)
- `parity_harness.py --runtime both` → PASS (15/15)
- No TypeScript files touched

Mutations. Two of these initially **survived**, which is the point of running them:

| # | mutation | result |
|---|---|---|
| M1 | revert to single-threaded `HTTPServer` | exactly the stalled-upload test fails — and the `-1` test correctly still passes, since validation alone fixes that one |
| M2 | remove the negative-length guard | exactly the two Content-Length tests fail |
| M3 | drop the `isinstance(body, dict)` check | exactly the four non-object cases fail |
| M4 | drop the JSON error handling | exactly the not-JSON test fails |
| M5 | remove the cap check | exactly the claimed-gigabyte test fails |
| M6 | delete `__main__.py` | exactly the two CLI tests fail |
| M7 | `>=` instead of `>` | exactly the at-the-cap test fails |

M7 and M2 survived on the first attempt. M7 because my "at the cap" body was
merely *near* the cap — a size that passes under both `>` and `>=`, proving
nothing about which one the server used; it is now built to be exactly
`MAX_BODY_BYTES`. M2 because my first mutation removed a redundant normalisation
rather than the guard that actually does the work. Both tests were weaker than
they looked, and only mutating them showed it.
