### PR TITLE
fix(brainstem): the saved Copilot credential was world-readable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The brainstem saved your Copilot credential world-readable. `_save_token_file`
+  used `Path.write_text`, which takes the process umask, so
+  `~/.openrappter/brainstem/.copilot_token` landed at mode 0644 inside a 0755
+  directory -- every account on the machine could read it. The file holds both
+  `access_token` and the long-lived `refresh_token`, so one read outlives the
+  access token's expiry. Under a permissive umask (0o000, as some container
+  images set) it was 0666: another account could *replace* the credential.
+  Now written 0600 into a 0700 directory, and a token left over from an older
+  build is tightened on the next read rather than waiting for the next login.
+  Two things made this unambiguous: the flight recorder already redacts
+  `.copilot_token` out of captured logs, so the codebase knew the file was
+  sensitive; and the TypeScript runtime already writes the same credential with
+  `mode: 0o600`. Every other secret in the Python tree used the strict pattern
+  too -- this was the one place that did not.
+
+- Saving that credential was not atomic. `write_text` truncates before it
+  writes, so a crash or a full disk part-way through left a half-written token,
+  which reads back as "not logged in" with nothing to explain why. It is now a
+  rename over a fully-written temporary file, so a reader sees either the old
+  credential or the new one, never a fragment. Agent files imported through
+  `/agents/import` go through the same path, so a truncated upload can no
+  longer be loaded as a broken agent, and they are no longer written
+  world-readable either.
+
+- `test_all_core_agents_importable` ended in `assert True`, so it only proved
+  the imports resolved -- renaming `ShellAgent.perform` left it green. It now
+  asserts the contract its name implies.
+
 - `python3 -m nanorappter` did not work. Both the module docstring and the
   CLI's own help text advertise it, but there was no `__main__.py`, so the
   documented command failed with "No module named nanorappter.__main__" -- the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,7 +104,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `test_all_core_agents_importable` ended in `assert True`, so it only proved
   the imports resolved -- renaming `ShellAgent.perform` left it green. It now
-  asserts the contract its name implies.
+  requires each agent to implement `perform` itself. Asserting merely that the
+  attribute exists was not enough: they all subclass `BasicAgent`, which also
+  defines `perform`, so a subclass that lost its own implementation would
+  inherit one and still pass.
 
 - `python3 -m nanorappter` did not work. Both the module docstring and the
   CLI's own help text advertise it, but there was no `__main__.py`, so the

--- a/python/openrappter/brainstem.py
+++ b/python/openrappter/brainstem.py
@@ -189,7 +189,7 @@ class LocalStorageManager:
         return True
 
     def ensure_directory_exists(self, *args, **kwargs):
-        BRAINSTEM_HOME.mkdir(parents=True, exist_ok=True)
+        _secure_dir(BRAINSTEM_HOME)
 
     @classmethod
     def _lock_for(cls, path):
@@ -369,8 +369,70 @@ def _token_file():
     return Path(BRAINSTEM_HOME) / ".copilot_token"
 
 
+#: Everything under `BRAINSTEM_HOME` is private to the account that runs the
+#: brainstem: the saved Copilot credential, and the agent files the server
+#: imports and then executes. `mkdir()` without a mode yields `0o777 & ~umask`,
+#: which is 0755 under the usual umask — every account on the machine can list
+#: the directory and read what is in it. These helpers exist so that no caller
+#: has to remember the mode; `imessage/config.py` already does the same thing.
+def _secure_dir(path):
+    """Create `path` private to this account, tightening it if it already exists."""
+    path = Path(path)
+    path.mkdir(parents=True, exist_ok=True, mode=0o700)
+    try:
+        os.chmod(path, 0o700)
+    except OSError:
+        pass
+    return path
+
+
+def _write_private_file(path, payload):
+    """Write `payload` to `path` atomically and readable only by this account.
+
+    Atomic because the previous `write_text` truncated the file before writing:
+    a crash or a full disk part-way through left a half-written token behind,
+    and `_read_token_file` reads that as "not logged in" with nothing to say
+    why. The replacement is a rename over a fully-written temporary file, so a
+    reader sees either the old credential or the new one, never a fragment.
+    """
+    path = Path(path)
+    _secure_dir(path.parent)
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    try:
+        descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_EXCL, 0o600)
+        with os.fdopen(descriptor, "wb") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            os.unlink(temporary)
+        except OSError:
+            pass
+        raise
+
+
+def _harden_existing(path):
+    """Tighten a file an older build left readable by other accounts.
+
+    Fixing the write path alone would only protect people who log in again;
+    anyone already holding a 0644 token would keep it until it expired.
+    """
+    try:
+        mode = os.stat(path).st_mode & 0o777
+    except OSError:
+        return
+    if mode & 0o077:
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+
+
 def _read_token_file():
     """Kernel format: JSON {access_token, refresh_token?}; legacy plain text supported."""
+    _harden_existing(_token_file())
     try:
         raw = _token_file().read_text(encoding="utf-8").strip()
     except OSError:
@@ -386,8 +448,7 @@ def _read_token_file():
 
 
 def _save_token_file(data):
-    Path(BRAINSTEM_HOME).mkdir(parents=True, exist_ok=True)
-    _token_file().write_text(json.dumps(data), encoding="utf-8")
+    _write_private_file(_token_file(), json.dumps(data).encode("utf-8"))
 
 
 def _http_form(url, data, timeout=15):
@@ -1608,7 +1669,7 @@ class BrainstemHandler(BaseHTTPRequestHandler):
             if not filename.endswith("_agent.py"):
                 filename = filename[:-3] + "_agent.py"
             AGENTS_PATH.mkdir(parents=True, exist_ok=True)
-            (AGENTS_PATH / filename).write_bytes(body)
+            _write_private_file(AGENTS_PATH / filename, body)
             loaded = _load_agent_from_file(str(AGENTS_PATH / filename))
             if not loaded:
                 return self._send(200, {"error": f"Saved {filename}, but it did not load as an agent — check the file for errors."})
@@ -1642,8 +1703,8 @@ class BrainstemServer(ThreadingHTTPServer):
 
 
 def serve(port=DEFAULT_PORT, host=os.environ.get("OPENRAPPTER_BRAINSTEM_HOST", "127.0.0.1")):
-    BRAINSTEM_HOME.mkdir(parents=True, exist_ok=True)
-    AGENTS_PATH.mkdir(parents=True, exist_ok=True)
+    _secure_dir(BRAINSTEM_HOME)
+    _secure_dir(AGENTS_PATH)
     server = BrainstemServer((host, port), BrainstemHandler)
     agents = load_agents()
     print(f"\n{EMOJI} OpenRappter Brainstem v{__version__} on http://localhost:{server.server_address[1]}")

--- a/python/tests/test_brainstem_token_permissions.py
+++ b/python/tests/test_brainstem_token_permissions.py
@@ -1,0 +1,178 @@
+"""The brainstem's saved Copilot credential must not be readable by other accounts.
+
+Measured on `main` before this suite existed, by calling `_save_token_file` with
+a real-shaped payload and stat-ing the result:
+
+    token file  ~/.openrappter/brainstem/.copilot_token   mode 0644
+    directory   ~/.openrappter/brainstem                  mode 0755
+
+    umask 0022 -> 0644   readable by group, other
+    umask 0002 -> 0664   readable by group, other
+    umask 0000 -> 0666   readable AND WRITABLE by group, other
+
+The file holds `{"access_token": ..., "refresh_token": ...}`. The refresh token
+is the long-lived one, so an account that reads it once keeps access after the
+access token expires.
+
+Two things made this a clear defect rather than a judgement call:
+
+  * The flight recorder already treats this exact path as a secret --- it
+    redacts `.copilot_token` out of captured logs (`flight_recorder.py:136`).
+    The codebase knew the file was sensitive while writing it world-readable.
+  * The TypeScript runtime writes the same credential correctly, with
+    `{ mode: 0o600 }` (`typescript/src/providers/copilot-token.ts:63`). Same
+    credential, same purpose, two runtimes, one of them wrong.
+
+Every other secret in the Python tree already used the strict pattern
+(`imessage/config.py`, `flight_recorder.py`, `manage_memory_agent.py`,
+`pokemon_agent.py`); `_save_token_file` was the one place that did not.
+"""
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from openrappter import brainstem
+
+
+def _mode(path):
+    return stat.S_IMODE(os.stat(path).st_mode)
+
+
+@pytest.fixture
+def home(tmp_path, monkeypatch):
+    """Point the brainstem at a private directory under tmp_path."""
+    root = tmp_path / ".openrappter" / "brainstem"
+    monkeypatch.setattr(brainstem, "BRAINSTEM_HOME", root)
+    return root
+
+
+class TestTheSavedCredentialIsPrivate:
+    def test_the_token_file_is_not_readable_by_other_accounts(self, home):
+        brainstem._save_token_file({"access_token": "ghu_x", "refresh_token": "ghr_y"})
+        assert _mode(brainstem._token_file()) & 0o077 == 0
+
+    def test_the_token_file_is_exactly_owner_read_write(self, home):
+        brainstem._save_token_file({"access_token": "ghu_x"})
+        assert _mode(brainstem._token_file()) == 0o600
+
+    def test_the_directory_holding_it_is_not_listable_by_other_accounts(self, home):
+        brainstem._save_token_file({"access_token": "ghu_x"})
+        assert _mode(home) & 0o077 == 0
+
+    @pytest.mark.parametrize("umask", [0o022, 0o002, 0o000])
+    def test_no_umask_can_widen_it(self, home, umask):
+        """A permissive umask used to make the file group- and world-writable."""
+        previous = os.umask(umask)
+        try:
+            brainstem._save_token_file({"access_token": "ghu_x"})
+        finally:
+            os.umask(previous)
+        assert _mode(brainstem._token_file()) == 0o600
+
+    def test_the_credential_still_round_trips(self, home):
+        """Locking the file down must not stop the brainstem reading it back."""
+        saved = {"access_token": "ghu_x", "refresh_token": "ghr_y"}
+        brainstem._save_token_file(saved)
+        assert brainstem._read_token_file() == saved
+
+    def test_a_legacy_plain_text_token_still_reads(self, home):
+        home.mkdir(parents=True, exist_ok=True)
+        brainstem._token_file().write_text("ghu_bare", encoding="utf-8")
+        assert brainstem._read_token_file() == {"access_token": "ghu_bare"}
+
+
+class TestExistingInstallsAreRepaired:
+    """Fixing only the write path would leave everyone already logged in exposed."""
+
+    def test_a_token_left_world_readable_is_tightened_on_read(self, home):
+        home.mkdir(parents=True, exist_ok=True)
+        path = brainstem._token_file()
+        path.write_text(json.dumps({"access_token": "ghu_old"}), encoding="utf-8")
+        os.chmod(path, 0o644)
+
+        assert brainstem._read_token_file() == {"access_token": "ghu_old"}
+        assert _mode(path) == 0o600
+
+    def test_repairing_does_not_lose_the_credential(self, home):
+        home.mkdir(parents=True, exist_ok=True)
+        path = brainstem._token_file()
+        payload = {"access_token": "ghu_old", "refresh_token": "ghr_old"}
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        os.chmod(path, 0o666)
+
+        assert brainstem._read_token_file() == payload
+        assert _mode(path) == 0o600
+
+    def test_an_already_private_token_is_left_alone(self, home):
+        home.mkdir(parents=True, exist_ok=True)
+        path = brainstem._token_file()
+        path.write_text(json.dumps({"access_token": "ghu_x"}), encoding="utf-8")
+        os.chmod(path, 0o400)
+
+        brainstem._read_token_file()
+        assert _mode(path) == 0o400
+
+    def test_a_missing_token_is_not_an_error(self, home):
+        assert brainstem._read_token_file() is None
+
+
+class TestTheWriteIsAtomic:
+    """`write_text` truncated first, so a crash mid-write silently logged you out."""
+
+    def test_a_failed_write_leaves_the_previous_credential_intact(self, home, monkeypatch):
+        brainstem._save_token_file({"access_token": "ghu_good"})
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(brainstem.os, "replace", boom)
+        with pytest.raises(OSError):
+            brainstem._save_token_file({"access_token": "ghu_new"})
+
+        assert brainstem._read_token_file() == {"access_token": "ghu_good"}
+
+    def test_a_failed_write_does_not_leave_temporary_files_behind(self, home, monkeypatch):
+        brainstem._save_token_file({"access_token": "ghu_good"})
+
+        def boom(*args, **kwargs):
+            raise OSError("disk full")
+
+        monkeypatch.setattr(brainstem.os, "replace", boom)
+        with pytest.raises(OSError):
+            brainstem._save_token_file({"access_token": "ghu_new"})
+
+        leftovers = [p.name for p in home.iterdir() if p.name != ".copilot_token"]
+        assert leftovers == []
+
+    def test_overwriting_keeps_the_file_private(self, home):
+        brainstem._save_token_file({"access_token": "ghu_first"})
+        brainstem._save_token_file({"access_token": "ghu_second"})
+        assert brainstem._read_token_file() == {"access_token": "ghu_second"}
+        assert _mode(brainstem._token_file()) == 0o600
+
+
+class TestImportedAgentsArePrivate:
+    """`AGENTS_PATH` holds code the server imports and then executes."""
+
+    def test_a_secured_directory_is_tightened_even_if_it_already_exists(self, tmp_path):
+        existing = tmp_path / "agents"
+        existing.mkdir(mode=0o755)
+        assert _mode(existing) == 0o755
+
+        brainstem._secure_dir(existing)
+        assert _mode(existing) == 0o700
+
+    def test_a_written_agent_file_is_not_readable_by_other_accounts(self, tmp_path):
+        target = tmp_path / "agents" / "demo_agent.py"
+        brainstem._write_private_file(target, b"# agent code\n")
+        assert _mode(target) == 0o600
+        assert target.read_bytes() == b"# agent code\n"
+
+    def test_the_directory_is_created_private(self, tmp_path):
+        target = tmp_path / "fresh" / "demo_agent.py"
+        brainstem._write_private_file(target, b"x")
+        assert _mode(target.parent) == 0o700

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -43,7 +43,20 @@ class TestAgentDiscovery:
         from openrappter.agents.manage_memory_agent import ManageMemoryAgent
         from openrappter.agents.context_memory_agent import ContextMemoryAgent
         from openrappter.agents.learn_new_agent import LearnNewAgent
-        assert True
+
+        # `assert True` used to stand here, so the test only proved the imports
+        # resolved: renaming `ShellAgent.perform` left it green. Assert the
+        # contract the name implies instead.
+        for agent in (
+            BasicAgent,
+            ShellAgent,
+            ManageMemoryAgent,
+            ContextMemoryAgent,
+            LearnNewAgent,
+        ):
+            assert callable(getattr(agent, "perform", None)), (
+                f"{agent.__name__} does not expose perform()"
+            )
 
     def test_core_agents_instantiate(self):
         from openrappter.agents.shell_agent import ShellAgent

--- a/python/tests/test_cli.py
+++ b/python/tests/test_cli.py
@@ -45,8 +45,10 @@ class TestAgentDiscovery:
         from openrappter.agents.learn_new_agent import LearnNewAgent
 
         # `assert True` used to stand here, so the test only proved the imports
-        # resolved: renaming `ShellAgent.perform` left it green. Assert the
-        # contract the name implies instead.
+        # resolved. Checking `getattr` is not enough either: every one of these
+        # subclasses BasicAgent, which also defines `perform`, so a subclass
+        # that lost its own implementation would still inherit one and pass.
+        # Each agent is required to implement `perform` itself.
         for agent in (
             BasicAgent,
             ShellAgent,
@@ -54,8 +56,8 @@ class TestAgentDiscovery:
             ContextMemoryAgent,
             LearnNewAgent,
         ):
-            assert callable(getattr(agent, "perform", None)), (
-                f"{agent.__name__} does not expose perform()"
+            assert callable(agent.__dict__.get("perform")), (
+                f"{agent.__name__} does not implement perform() itself"
             )
 
     def test_core_agents_instantiate(self):


### PR DESCRIPTION
## A world-readable Copilot credential

`_save_token_file` used `Path.write_text`, which takes the process umask:

```python
Path(BRAINSTEM_HOME).mkdir(parents=True, exist_ok=True)
_token_file().write_text(json.dumps(data), encoding="utf-8")
```

Measured by calling it with a real-shaped payload and stat-ing the result:

| | before | after |
|---|---|---|
| `~/.openrappter/brainstem/.copilot_token` | **0644** | 0600 |
| `~/.openrappter/brainstem/` | **0755** | 0700 |
| under `umask 0022` | 0644 — group, other can read | 0600 |
| under `umask 0002` | 0664 — group, other can read | 0600 |
| under `umask 0000` | **0666 — group, other can WRITE** | 0600 |

The file holds `{"access_token": ..., "refresh_token": ...}`. The refresh token
is the long-lived one, so an account that reads it once keeps access well after
the access token expires. At `umask 0000` — which some container images set —
another account could *replace* the credential rather than merely read it.

## Why this is unambiguous rather than a judgement call

Two independent places in this repository already treat the file as a secret:

- The flight recorder **redacts `.copilot_token` out of captured logs**
  (`flight_recorder.py:136`, and the same rule in `redaction.ts:63`). The
  codebase scrubs the path from logs while writing the file world-readable.
- The **TypeScript runtime writes the same credential correctly**:
  `fs.writeFileSync(cachePath, ..., { mode: 0o600 })`
  (`providers/copilot-token.ts:63`).

Same credential, same purpose, two runtimes, one of them wrong. Every other
secret in the Python tree already used the strict pattern — `imessage/config.py`,
`flight_recorder.py`, `manage_memory_agent.py`, `pokemon_agent.py` all use
`os.open(..., 0o600)` with a `0o700` parent. `_save_token_file` was the single
place that did not.

## Existing installs, not just new ones

Fixing the write path alone would only protect people who log in again; anyone
already holding a 0644 token would keep it until it expired. The token is now
tightened on read, so an install that is already logged in is covered without
needing a re-login.

## The write was also not atomic

`write_text` truncates before it writes. A crash or a full disk part-way through
left a half-written token, and `_read_token_file` reads that as `None` — you are
silently logged out with nothing to explain why. It is now a rename over a
fully-written temporary file, so a reader sees either the old credential or the
new one, never a fragment.

Agent files imported through `/agents/import` had the same two problems and go
through the same helper now. That path writes code the server then **executes**,
so a truncated upload could previously be loaded as a broken agent, and the file
was left readable by every account on the machine.

## Also: a near-inert test, and a correction to my own first fix

`test_all_core_agents_importable` ended in `assert True` — it only proved the
imports resolved.

My first attempt asserted `getattr(agent, "perform")`. **Mutation testing showed
that was still wrong**: every one of these agents subclasses `BasicAgent`, which
also defines `perform`, so renaming a subclass's own implementation still
resolved through inheritance and the test stayed green. It now asserts on the
class's own `__dict__`. That is the second commit on this branch, and the reason
it exists.

## Verification

- Python `1871 passed` / 6 skipped (was 1853; +18)
- `parity_harness.py --runtime both` → PASS (15/15 both runtimes)
- No TypeScript changed — the TS side was already correct, which is how the bug
  was found

Mutations, each confirmed to have actually applied before trusting the result:

| # | mutation | result |
|---|---|---|
| M1 | file mode `0o600` → `0o644` | 6 fail: all the file-permission and umask tests, plus the agent-file one |
| M2 | `_secure_dir` → plain `mkdir`, no chmod | 3 fail: exactly the directory tests |
| M3 | drop the repair call on read | 2 fail: exactly the existing-install tests |
| M4 | write in place instead of temp + rename | 2 fail: exactly the atomicity tests |
| M5 | drop the temp-file cleanup on failure | 1 fail: exactly the leftover-files test |
| M6 | `_harden_existing` never fires | 2 fail: exactly the repair tests |
| M7 | rename `ShellAgent.perform` | fails the strengthened test — it did **not** before the correction above |

M5 first reported as "did not apply" when it had. My check grepped for
`os.unlink(temporary)`, and there are three of those in the file, so an
unrelated one matched. A mutation check has to be unique to the mutation site
or it is no check at all; the matrix above uses `git diff` instead, which cannot
be fooled that way.

## Not addressed here

`pokemon_agent.py:2006` has `min(int(Content-Length), 4096)`, and `min(-1, 4096)`
is `-1`, so `rfile.read(-1)` reads to EOF and parks a thread. I checked and did
not fix it: that endpoint requires a `secrets.token_urlsafe(32)` cookie compared
with `compare_digest`, checks Origin and Host, binds to 127.0.0.1, and the
server is threaded — so it is a latent smell rather than something reachable.
Worth tidying, but not under cover of this PR.
