### PR TITLE
fix(rappterhub): installing an agent could delete any directory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Installing an agent could delete any directory on the machine.
+  `rappterhub install` split a reference on the first slash only, so
+  everything after it became part of the destination path. It then ran
+  `shutil.rmtree` on that path and cloned into it, which handed a single
+  reference both arbitrary deletion and arbitrary file write. With the agents
+  directory at `~/.openrappter/agents`: `evil/../precious` deleted
+  `~/.openrappter/precious`, `evil//etc/cron.d` resolved to `/etc/cron.d`,
+  `http://host/path/..` resolved to `~/.openrappter` itself -- config, agents,
+  and the Copilot token -- and `x//` resolved to `/`. The absolute-path cases
+  are why this needed an allow-list rather than a check for `..`: joining an
+  absolute path discards the left-hand side entirely, so no amount of traversal
+  filtering would have caught them. Both halves of a reference must now be one
+  ordinary directory segment. `uninstall` is guarded too, since a lock file
+  written by an older build can already record a path outside the agents
+  directory, and nothing that deletes a directory tree should believe a JSON
+  field.
+
 - The brainstem saved your Copilot credential world-readable. `_save_token_file`
   used `Path.write_text`, which takes the process umask, so
   `~/.openrappter/brainstem/.copilot_token` landed at mode 0644 inside a 0755

--- a/python/openrappter/rappterhub.py
+++ b/python/openrappter/rappterhub.py
@@ -38,9 +38,10 @@ def _is_safe_segment(segment: str) -> bool:
     Deliberately an allow-list. Rejecting `..` is not enough: `Path("/a") /
     "/etc"` is `/etc`, because an absolute right-hand operand discards the
     left one entirely, and `Path("/a") / "/"` is `/`.
+
+    Requiring the first character to be alphanumeric is what rejects `.`,
+    `..`, dotfiles, and names that git or a shell would read as a flag.
     """
-    if segment in (".", ".."):
-        return False
     return bool(_SAFE_SEGMENT.fullmatch(segment))
 
 
@@ -48,12 +49,13 @@ def _is_within(base: Path, candidate: Path) -> bool:
     """True if `candidate` is `base` itself or something inside it.
 
     Resolved on both sides so an intermediate symlink cannot smuggle a path
-    back out of `base`.
+    back out of `base`. A path that cannot be resolved at all -- an embedded
+    null byte raises ValueError, not OSError -- is not within anything.
     """
     try:
         base_resolved = base.resolve()
         candidate_resolved = candidate.resolve()
-    except OSError:
+    except (OSError, ValueError):
         return False
     return (
         candidate_resolved == base_resolved

--- a/python/openrappter/rappterhub.py
+++ b/python/openrappter/rappterhub.py
@@ -25,6 +25,41 @@ REGISTRY_URL = "https://api.rappterhub.dev"
 REGISTRY_GITHUB = "https://github.com/rappterhub/registry"
 LOCK_FILE = RAPPTERHUB_DIR / "lock.json"
 
+# An agent reference is `author/name`, and each half names one directory
+# segment. Anything else -- a separator, `..`, a leading `/` -- would let the
+# installed path land outside the agents directory, where install() deletes
+# whatever it finds and git clone writes whatever a remote repository sends.
+_SAFE_SEGMENT = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+
+
+def _is_safe_segment(segment: str) -> bool:
+    """True if `segment` names exactly one directory inside its parent.
+
+    Deliberately an allow-list. Rejecting `..` is not enough: `Path("/a") /
+    "/etc"` is `/etc`, because an absolute right-hand operand discards the
+    left one entirely, and `Path("/a") / "/"` is `/`.
+    """
+    if segment in (".", ".."):
+        return False
+    return bool(_SAFE_SEGMENT.fullmatch(segment))
+
+
+def _is_within(base: Path, candidate: Path) -> bool:
+    """True if `candidate` is `base` itself or something inside it.
+
+    Resolved on both sides so an intermediate symlink cannot smuggle a path
+    back out of `base`.
+    """
+    try:
+        base_resolved = base.resolve()
+        candidate_resolved = candidate.resolve()
+    except OSError:
+        return False
+    return (
+        candidate_resolved == base_resolved
+        or base_resolved in candidate_resolved.parents
+    )
+
 
 @dataclass
 class RappterAgent:
@@ -152,10 +187,20 @@ class RappterHubClient:
         # Parse agent reference
         if "/" in agent_ref and not agent_ref.startswith("http"):
             author, name = agent_ref.split("/", 1)
+            if not _is_safe_segment(author) or not _is_safe_segment(name):
+                return {
+                    "status": "error",
+                    "message": f"Invalid agent reference: {agent_ref}. Use format: author/name"
+                }
             source = f"{REGISTRY_GITHUB}/raw/main/agents/{author}/{name}"
         elif agent_ref.startswith("http"):
             source = agent_ref
             name = agent_ref.rstrip("/").split("/")[-1]
+            if not _is_safe_segment(name):
+                return {
+                    "status": "error",
+                    "message": f"Cannot derive a safe agent name from URL: {agent_ref}"
+                }
             author = "unknown"
         else:
             return {
@@ -172,6 +217,14 @@ class RappterHubClient:
             }
 
         target_dir = self.agents_dir / name
+
+        # Belt and braces: the name is already validated, but nothing that
+        # deletes a directory tree should trust a single check.
+        if not _is_within(self.agents_dir, target_dir):
+            return {
+                "status": "error",
+                "message": f"Refusing to install outside the agents directory: {target_dir}"
+            }
 
         try:
             if target_dir.exists():
@@ -313,6 +366,18 @@ class RappterHubClient:
 
         info = lock["installed"][found_ref]
         agent_path = Path(info.get("path", ""))
+
+        # The lock file is just a file on disk, and an install from before
+        # this path was validated could have recorded somewhere arbitrary.
+        # Never delete a tree because a JSON field said so.
+        if not _is_within(self.agents_dir, agent_path):
+            return {
+                "status": "error",
+                "message": (
+                    f"Refusing to remove '{agent_path}': it is outside the agents "
+                    f"directory. Delete it by hand if you trust it."
+                )
+            }
 
         if agent_path.exists():
             shutil.rmtree(agent_path)

--- a/python/tests/test_rappterhub_install_paths.py
+++ b/python/tests/test_rappterhub_install_paths.py
@@ -1,0 +1,246 @@
+"""Installing an agent must not touch anything outside the agents directory.
+
+Measured before the fix, with the agents directory at ~/.openrappter/agents:
+
+    install("evil/../precious")      -> shutil.rmtree deleted .../precious
+    install("evil//etc/cron.d")      -> target_dir was /etc/cron.d
+    install("x//")                   -> target_dir was /
+    install("http://h/path/..")      -> target_dir was ~/.openrappter itself
+
+`install` deletes target_dir and then runs `git clone` into it, so the same
+two lines gave a remote repository both arbitrary deletion and arbitrary
+file write. Only the first slash was consumed by the split, so everything
+after it -- separators, `..`, a leading `/` -- became part of the path.
+"""
+import json
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from openrappter import rappterhub as rh
+
+
+@pytest.fixture
+def hub(tmp_path, monkeypatch):
+    """A client rooted entirely inside tmp_path, never the real home."""
+    agents = tmp_path / "home" / ".openrappter" / "agents"
+    agents.mkdir(parents=True)
+    hub_dir = tmp_path / "home" / ".rappterhub"
+    hub_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(rh, "AGENTS_DIR", agents)
+    monkeypatch.setattr(rh, "RAPPTERHUB_DIR", hub_dir)
+    monkeypatch.setattr(rh, "LOCK_FILE", hub_dir / "lock.json")
+    monkeypatch.setattr(rh, "REGISTRY_GITHUB", "http://127.0.0.1:1/registry")
+    monkeypatch.setattr(rh, "REGISTRY_URL", "http://127.0.0.1:1")
+
+    client = rh.RappterHubClient()
+    client.root = tmp_path
+    return client
+
+
+@pytest.fixture
+def victim(tmp_path):
+    """A directory outside the agents tree that must survive every test."""
+    directory = tmp_path / "home" / "precious"
+    directory.mkdir(parents=True)
+    (directory / "important.txt").write_text("irreplaceable")
+    return directory
+
+
+def _no_network(monkeypatch):
+    """Fail any clone or download instantly instead of reaching the network."""
+    def refuse(*args, **kwargs):
+        raise AssertionError("test attempted a real network call")
+
+    monkeypatch.setattr(subprocess, "run", refuse)
+
+
+class TestReferencesCannotEscapeTheAgentsDirectory:
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            "evil/../precious",
+            "evil/../../precious",
+            "evil/../../../../etc",
+            "evil//etc/cron.d",
+            "evil//",
+            "x//",
+            "evil/sub/dir",
+            "evil/.",
+            "evil/..",
+            "evil/.ssh",
+            "evil/-rf",
+            "evil/na\x00me",
+            "evil/na me",
+            "../evil",
+        ],
+    )
+    def test_a_traversing_reference_is_rejected(self, hub, monkeypatch, ref):
+        _no_network(monkeypatch)
+        result = hub.install(ref)
+        assert result["status"] == "error"
+
+    @pytest.mark.parametrize(
+        "ref",
+        [
+            "evil/../precious",
+            "evil/../../precious",
+        ],
+    )
+    def test_the_directory_outside_survives(self, hub, victim, monkeypatch, ref):
+        _no_network(monkeypatch)
+        hub.install(ref)
+        assert victim.exists()
+        assert (victim / "important.txt").read_text() == "irreplaceable"
+
+    def test_an_absolute_reference_cannot_target_another_directory(
+        self, hub, victim, monkeypatch
+    ):
+        _no_network(monkeypatch)
+        result = hub.install(f"evil/{victim}")
+        assert result["status"] == "error"
+        assert (victim / "important.txt").exists()
+
+    def test_a_url_ending_in_dotdot_cannot_target_the_openrappter_home(
+        self, hub, monkeypatch
+    ):
+        _no_network(monkeypatch)
+        home = hub.agents_dir.parent
+        marker = home / "config.json5"
+        marker.write_text("{}")
+
+        result = hub.install("http://127.0.0.1:1/path/..")
+
+        assert result["status"] == "error"
+        assert marker.exists()
+        assert home.exists()
+
+
+class TestLegitimateInstallsStillWork:
+    """The validator must not be so tight that it rejects real agents."""
+
+    @pytest.mark.parametrize(
+        "segment", ["agent", "my-agent", "my_agent", "agent.v2", "Agent2", "a"]
+    )
+    def test_ordinary_names_are_accepted(self, segment):
+        assert rh._is_safe_segment(segment)
+
+    @pytest.mark.parametrize(
+        "segment", ["", ".", "..", "/", "a/b", "../a", "/etc", ".hidden", "-flag", "a\x00b"]
+    )
+    def test_dangerous_names_are_refused(self, segment):
+        assert not rh._is_safe_segment(segment)
+
+    def test_a_valid_reference_reaches_the_install_body(self, hub, monkeypatch):
+        """Proves validation lets a good ref through, without any network."""
+        created = {}
+
+        def fake_clone(argv, **kwargs):
+            Path(argv[-1]).mkdir(parents=True, exist_ok=True)
+            created["target"] = Path(argv[-1])
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+        monkeypatch.setattr(subprocess, "run", fake_clone)
+
+        result = hub.install("someauthor/someagent")
+
+        assert created["target"] == hub.agents_dir / "someagent"
+        # Got past validation and cloning, and stopped on the manifest check.
+        assert "AGENT.md" in result["message"]
+
+    def test_reinstalling_still_replaces_an_existing_agent(self, hub, monkeypatch):
+        stale = hub.agents_dir / "someagent"
+        stale.mkdir()
+        (stale / "old.txt").write_text("stale")
+
+        def fake_clone(argv, **kwargs):
+            Path(argv[-1]).mkdir(parents=True, exist_ok=True)
+            return subprocess.CompletedProcess(argv, 0, "", "")
+
+        monkeypatch.setattr(subprocess, "run", fake_clone)
+
+        hub.install("someauthor/someagent")
+
+        assert not (stale / "old.txt").exists()
+
+
+class TestContainment:
+    def test_a_path_inside_is_accepted(self, tmp_path):
+        assert rh._is_within(tmp_path, tmp_path / "a" / "b")
+
+    def test_the_base_itself_is_accepted(self, tmp_path):
+        assert rh._is_within(tmp_path, tmp_path)
+
+    def test_a_sibling_is_rejected(self, tmp_path):
+        base = tmp_path / "base"
+        base.mkdir()
+        assert not rh._is_within(base, tmp_path / "other")
+
+    def test_a_parent_is_rejected(self, tmp_path):
+        base = tmp_path / "base"
+        base.mkdir()
+        assert not rh._is_within(base, tmp_path)
+
+    def test_a_symlink_out_of_the_base_is_rejected(self, tmp_path):
+        base = tmp_path / "base"
+        base.mkdir()
+        outside = tmp_path / "outside"
+        outside.mkdir()
+        link = base / "link"
+        link.symlink_to(outside, target_is_directory=True)
+
+        assert not rh._is_within(base, link / "file")
+
+
+class TestUninstallWillNotFollowAPoisonedLockFile:
+    def test_a_lock_entry_pointing_outside_is_refused(self, hub, victim):
+        rh.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        rh.LOCK_FILE.write_text(
+            json.dumps(
+                {
+                    "installed": {
+                        "evil/agent": {
+                            "name": "evil",
+                            "version": "1",
+                            "path": str(victim),
+                            "author": "evil",
+                        }
+                    },
+                    "version": 1,
+                }
+            )
+        )
+
+        result = hub.uninstall("evil")
+
+        assert result["status"] == "error"
+        assert (victim / "important.txt").read_text() == "irreplaceable"
+
+    def test_an_agent_inside_the_directory_is_still_removed(self, hub):
+        installed = hub.agents_dir / "good"
+        installed.mkdir()
+        (installed / "agent.py").write_text("# code")
+        rh.LOCK_FILE.parent.mkdir(parents=True, exist_ok=True)
+        rh.LOCK_FILE.write_text(
+            json.dumps(
+                {
+                    "installed": {
+                        "someauthor/good": {
+                            "name": "good",
+                            "version": "1",
+                            "path": str(installed),
+                            "author": "someauthor",
+                        }
+                    },
+                    "version": 1,
+                }
+            )
+        )
+
+        result = hub.uninstall("good")
+
+        assert result["status"] == "success"
+        assert not installed.exists()

--- a/python/tests/test_rappterhub_install_paths.py
+++ b/python/tests/test_rappterhub_install_paths.py
@@ -167,6 +167,48 @@ class TestLegitimateInstallsStillWork:
         assert not (stale / "old.txt").exists()
 
 
+class TestEachGuardIsPinnedIndependently:
+    """The guards overlap, so outcome-only tests let any single one rot.
+
+    Each test below asserts on the message of the layer it targets, so
+    removing that layer changes the answer even though a later layer would
+    still keep the user safe.
+    """
+
+    @pytest.mark.parametrize("ref", ["evil/../precious", "evil//etc", "evil/sub/dir"])
+    def test_the_reference_validator_is_what_rejects_a_bad_name(
+        self, hub, monkeypatch, ref
+    ):
+        _no_network(monkeypatch)
+        result = hub.install(ref)
+        assert "Invalid agent reference" in result["message"]
+
+    def test_the_url_validator_is_what_rejects_a_bad_url(self, hub, monkeypatch):
+        _no_network(monkeypatch)
+        result = hub.install("http://127.0.0.1:1/path/..")
+        assert "Cannot derive a safe agent name from URL" in result["message"]
+
+    def test_the_containment_check_catches_a_symlinked_target(
+        self, hub, victim, monkeypatch
+    ):
+        """A valid name whose directory is a symlink pointing outside.
+
+        This passes the reference validator, so only the containment check
+        can stop it.
+        """
+        _no_network(monkeypatch)
+        (hub.agents_dir / "someagent").symlink_to(victim, target_is_directory=True)
+
+        result = hub.install("someauthor/someagent")
+
+        assert "Refusing to install outside" in result["message"]
+        assert (victim / "important.txt").read_text() == "irreplaceable"
+
+    def test_a_null_byte_is_answered_not_raised(self, tmp_path):
+        """resolve() raises ValueError, not OSError, on an embedded null."""
+        assert rh._is_within(tmp_path, Path("/tmp/na\x00me")) is False
+
+
 class TestContainment:
     def test_a_path_inside_is_accepted(self, tmp_path):
         assert rh._is_within(tmp_path, tmp_path / "a" / "b")


### PR DESCRIPTION
## What

`rappterhub install <ref>` could delete any directory on the machine, and let a
remote repository write files anywhere.

Two lines did it:

```python
author, name = agent_ref.split("/", 1)   # first slash only
...
target_dir = self.agents_dir / name
if target_dir.exists():
    shutil.rmtree(target_dir)            # <-- arbitrary path
subprocess.run(["git", "clone", "--depth", "1", source, str(target_dir)])
```

`split("/", 1)` consumes only the first slash, so everything after it — more
separators, `..`, or a leading `/` — became part of the destination path.

## Measured, before the fix

With the agents directory at `~/.openrappter/agents`:

| reference | `target_dir` became |
| --- | --- |
| `evil/../precious` | `~/.openrappter/precious` — **deleted, live-confirmed** |
| `evil//etc/cron.d` | `/etc/cron.d` — **deleted, live-confirmed** |
| `http://host/path/..` | `~/.openrappter` — config, agents, and the Copilot token |
| `x//` | `/` |

Both "live-confirmed" rows were reproduced end to end in a sandbox: a file
outside the agents directory existed before the call and was gone after it.

It is not only deletion. `git clone` runs into that same path, and a clone
writes whatever filenames the remote repository contains — so a malicious or
compromised registry entry gets arbitrary file write at any path the user can
write, which on most machines means code execution at next login.

## Why an allow-list, not a check for `..`

The absolute-path rows are the reason. Rejecting `..` would not have caught
either of them, because joining an absolute path discards the left-hand side:

```python
>>> Path("/home/u/.openrappter/agents") / "/etc/cron.d"
PosixPath('/etc/cron.d')
>>> Path("/home/u/.openrappter/agents") / "/"
PosixPath('/')
```

So both halves of a reference must now match one ordinary directory segment,
`[A-Za-z0-9][A-Za-z0-9._-]*`. Requiring a leading alphanumeric is also what
rejects `.`, `..`, dotfiles, and anything git or a shell would read as a flag.

Every `rmtree` is additionally guarded by a containment check that resolves
both sides, so an intermediate symlink cannot smuggle a path back out.

`uninstall` is guarded too. It deletes whatever path the lock file records, and
a lock file written by the current released build can already contain a path
outside the agents directory. Users who ran the old code are protected without
having to notice.

## Tests

49 new tests in `python/tests/test_rappterhub_install_paths.py`. There were no
tests for this module at all before.

Nine mutations, each applied against committed code and each caught by exactly
the matching test:

| mutation | caught by |
| --- | --- |
| allow-list accepts everything | validator + both message tests |
| `fullmatch` → `match` | `a/b`, `a\x00b`, `evil/sub/dir` |
| install stops validating `author`/`name` | `test_the_reference_validator_is_what_rejects_a_bad_name` |
| install stops validating the URL-derived name | `test_the_url_validator_is_what_rejects_a_bad_url` |
| install containment check always passes | `test_the_containment_check_catches_a_symlinked_target` |
| uninstall containment check always passes | `test_a_lock_entry_pointing_outside_is_refused` |
| `_is_within` always true | four containment tests |
| `_is_within` stops resolving | both symlink tests |
| `ValueError` no longer caught | `test_a_null_byte_is_answered_not_raised` |

The second commit exists because the first round of mutation testing found the
guards were shadowing each other: deleting the reference validator outright
left every escape test green, because the containment check caught the same
cases. Safe for users, but it meant neither guard was pinned and either could
have been deleted later without a failure. Each guard now has a test that
asserts on its own refusal message.

That same exercise turned up two smaller things. The explicit `"." / ".."`
check was dead — the allow-list requires a leading alphanumeric, so neither
value could ever reach it — and it is removed rather than left looking
load-bearing. And `Path.resolve` raises `ValueError`, not `OSError`, on an
embedded null byte, so a null in a name escaped `_is_within` as an unhandled
exception out of `install`; it is caught now.

## Verification

- Full Python suite: **1920 passed**, 6 skipped (baseline 1871, +49)
- `parity_harness.py --runtime both`: **PASS**
- Both original reproduction probes now report the outside directory intact
- Legitimate installs still work: `someauthor/someagent` reaches the clone and
  lands in `agents/someagent`, and reinstalling still replaces an existing
  agent — both asserted, without touching the network

## Not addressed here

- `_save_lock` writes `lock.json` with `write_text`, which truncates before
  writing. A crash mid-write leaves invalid JSON, and `_load_lock` swallows
  `JSONDecodeError` and returns an empty dict — silently forgetting every
  installed agent. Same atomicity fix as #378, different file; left out to keep
  this focused on the path escape.
- The agents directory is created without `mode=0o700`, unlike the brainstem,
  iMessage, and flight-recorder directories. It holds Python that `load_agent`
  passes to `exec_module`. Integrity rather than confidentiality, and
  tightening an existing directory is more intrusive than this PR's scope.
- The TypeScript `rappterhub.ts` is a 19-line stub returning "Not implemented",
  so there is no parity change to make.
