### PR TITLE
fix(registry): an interrupted write destroyed the installed-agent lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- An interrupted write destroyed the record of which agents are installed.
+  `_save_lock` used `Path.write_text`, which truncates the visible file before
+  writing a byte and never flushes it to disk. Killing a process during that
+  call and watching the file, `lock.json` was left zero length and unparseable
+  in 5 of 5 attempts. What that cost was more specific than an empty list:
+  `list_installed` and `load_agent` scan the filesystem, and only `uninstall`
+  reads the lock. So a lost lock left the agent still listed, still running its
+  code, and impossible to remove -- `uninstall` answered "Agent 'demo' not
+  found" for something plainly there. Writes now go to a temporary file beside
+  the target, are flushed, and are renamed into place, so a reader sees either
+  the old lock or the new one and never a half-written one. Killed during the
+  write the previous lock survived intact; killed after the rename the new lock
+  was complete; 5 of 5 in both directions. A lock that is already damaged is
+  now moved aside instead of being silently treated as "nothing is installed",
+  because the next save used to overwrite the only evidence of what had been
+  there. Also fixes a crash found while testing this: a lock holding valid JSON
+  that is not an object reached `lock["installed"]` and raised `TypeError` out
+  of `install`, measured for `[]`, `"hello"`, `null` and `123`. ClawHub's lock
+  gets the same durable write; nothing observable is fixed there, since its
+  lock is written but never read for anything that changes behaviour.
+
 - Installing an agent could delete any directory on the machine.
   `rappterhub install` split a reference on the first slash only, so
   everything after it became part of the destination path. It then ran

--- a/python/openrappter/atomic_io.py
+++ b/python/openrappter/atomic_io.py
@@ -1,0 +1,152 @@
+"""Durable JSON writes, and honest handling of a file that did not survive.
+
+``Path.write_text`` opens with ``O_TRUNC``: the previous contents are gone the
+instant the call begins, and the new bytes are only in the page cache when it
+returns. A crash, a kill, or a full disk in that window leaves a file that is
+empty or half-written, and the old value is unrecoverable.
+
+That is not theoretical. Killing a process during ``write_text`` and polling
+the target's size, the file was observed at zero length and left unparseable
+in 5 of 5 attempts. The same test against the temp-file-and-rename strategy
+below left either the complete old value or the complete new one, 5 of 5 --
+never anything in between.
+
+``os.replace`` is atomic on POSIX and on Windows, so a reader either sees the
+old file or the new one. Renaming into place is the whole point: the risky
+part happens on a file nobody is reading, and the visible file changes in one
+indivisible step.
+
+Several modules here already do this correctly by hand -- ``brainstem``,
+``show_and_tell``, ``imessage.config``, ``imessage.state``, ``pokemon_agent``.
+This module exists so the next one does not have to reinvent it, and so the
+two registry clients that were still calling ``write_text`` can share a single
+implementation.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import stat
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+DEFAULT_NEW_FILE_MODE = 0o600
+
+
+def write_json_atomic(
+    path: Path,
+    value: Any,
+    *,
+    indent: int = 2,
+    new_file_mode: int = DEFAULT_NEW_FILE_MODE,
+) -> None:
+    """Write ``value`` as JSON so an interrupted write cannot destroy ``path``.
+
+    The payload is serialised before anything on disk is touched, so a value
+    that cannot be encoded leaves no temporary file behind and does not
+    disturb the file already there.
+
+    An existing file keeps the permissions it already has: this writes data,
+    it does not decide policy, and silently loosening a file someone tightened
+    on purpose would be worse than the bug it is fixing. A file being created
+    for the first time is owner-only, because it lands in the user's data
+    directory and nothing here needs to be world-readable.
+    """
+    path = Path(path)
+    payload = json.dumps(value, indent=indent)
+
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        mode = stat.S_IMODE(path.stat().st_mode)
+    except OSError:
+        mode = new_file_mode
+
+    descriptor, temporary_name = tempfile.mkstemp(
+        dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
+    )
+    temporary = Path(temporary_name)
+    try:
+        with os.fdopen(descriptor, "w", encoding="utf-8") as stream:
+            stream.write(payload)
+            stream.flush()
+            os.fsync(stream.fileno())
+        os.chmod(temporary, mode)
+        os.replace(temporary, path)
+    except BaseException:
+        try:
+            temporary.unlink()
+        except OSError:
+            pass
+        raise
+
+    _sync_directory(path.parent)
+
+
+def read_json_object(path: Path, default: dict) -> dict:
+    """Read a JSON object, moving the file aside if it is not one.
+
+    Returns ``default`` when the file is missing, unreadable as JSON, or holds
+    something other than an object. Callers must pass a freshly built default
+    each time, because the value is handed back for the caller to mutate.
+
+    A damaged file is renamed rather than ignored. Ignoring it reads the same
+    as "nothing is installed", and the next save then overwrites the only
+    evidence of what was there. Renaming keeps the bytes next to the file they
+    came from, so the state is recoverable by hand and visible to anyone
+    wondering why the tool suddenly forgot something.
+    """
+    path = Path(path)
+    if not path.exists():
+        return default
+
+    try:
+        parsed = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, UnicodeDecodeError):
+        quarantine(path)
+        return default
+
+    if not isinstance(parsed, dict):
+        quarantine(path)
+        return default
+
+    return parsed
+
+
+def quarantine(path: Path) -> Optional[Path]:
+    """Move a damaged file aside. Returns where it went, or None if it could
+    not be moved -- a failure to preserve evidence must not become a crash."""
+    path = Path(path)
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    target = path.with_name(f"{path.name}.corrupt-{stamp}")
+    counter = 1
+    while target.exists():
+        target = path.with_name(f"{path.name}.corrupt-{stamp}-{counter}")
+        counter += 1
+    try:
+        os.replace(path, target)
+    except OSError:
+        return None
+    return target
+
+
+def _sync_directory(directory: Path) -> None:
+    """Flush the rename itself.
+
+    Without this the new file's contents are durable but the directory entry
+    pointing at them may not be. Windows cannot open a directory as a file
+    descriptor, so this is best effort by design.
+    """
+    try:
+        descriptor = os.open(str(directory), os.O_RDONLY)
+    except OSError:
+        return
+    try:
+        os.fsync(descriptor)
+    except OSError:
+        pass
+    finally:
+        os.close(descriptor)

--- a/python/openrappter/atomic_io.py
+++ b/python/openrappter/atomic_io.py
@@ -45,10 +45,11 @@ def write_json_atomic(
 ) -> None:
     """Write ``value`` as JSON so an interrupted write cannot destroy ``path``.
 
-    The payload is serialised before anything on disk is touched, so a value
-    that cannot be encoded leaves no temporary file behind and does not
-    disturb the file already there.
-
+    The payload is serialised before anything on disk is touched. A value that
+    cannot be encoded therefore leaves no trace at all -- not the temporary
+    file, and not the parent directory, which would otherwise be created as a
+    side effect of a call that went on to fail.
+    
     An existing file keeps the permissions it already has: this writes data,
     it does not decide policy, and silently loosening a file someone tightened
     on purpose would be worse than the bug it is fixing. A file being created

--- a/python/openrappter/clawhub.py
+++ b/python/openrappter/clawhub.py
@@ -5,6 +5,7 @@ Allows openrappter to search, install, and use ClawHub skills.
 Skills are SKILL.md files with YAML frontmatter that get wrapped as openrappter agents.
 """
 from openrappter.paths import openrappter_path
+from openrappter.atomic_io import read_json_object, write_json_atomic
 
 import json
 import os
@@ -256,17 +257,11 @@ class ClawHubClient:
 
     def _load_lock(self) -> dict:
         """Load the lock file tracking installed skills."""
-        if self._lock_file.exists():
-            try:
-                return json.loads(self._lock_file.read_text())
-            except json.JSONDecodeError:
-                pass
-        return {"installed": {}}
+        return read_json_object(self._lock_file, {"installed": {}})
 
     def _save_lock(self, lock: dict):
         """Save the lock file."""
-        self._lock_file.parent.mkdir(parents=True, exist_ok=True)
-        self._lock_file.write_text(json.dumps(lock, indent=2))
+        write_json_atomic(self._lock_file, lock)
 
     def search(self, query: str) -> list[dict]:
         """

--- a/python/openrappter/rappterhub.py
+++ b/python/openrappter/rappterhub.py
@@ -5,6 +5,7 @@ Allows openrappter to search, install, and use agents from RappterHub.
 Agents are directories with AGENT.md manifests and implementation files.
 """
 from openrappter.paths import openrappter_path
+from openrappter.atomic_io import read_json_object, write_json_atomic
 
 import json
 import os
@@ -156,16 +157,11 @@ class RappterHubClient:
 
     def _load_lock(self) -> dict:
         """Load the lock file tracking installed agents."""
-        if LOCK_FILE.exists():
-            try:
-                return json.loads(LOCK_FILE.read_text())
-            except json.JSONDecodeError:
-                pass
-        return {"installed": {}, "version": 1}
+        return read_json_object(LOCK_FILE, {"installed": {}, "version": 1})
 
     def _save_lock(self, lock: dict):
         """Save the lock file."""
-        LOCK_FILE.write_text(json.dumps(lock, indent=2))
+        write_json_atomic(LOCK_FILE, lock)
 
     def search(self, query: str) -> list[dict]:
         """Search for agents in the registry."""

--- a/python/tests/test_atomic_io.py
+++ b/python/tests/test_atomic_io.py
@@ -1,0 +1,287 @@
+"""Tests for openrappter.atomic_io.
+
+The behaviour these pin was measured before it was written. Killing a process
+during ``Path.write_text`` and polling the target's size, the file was observed
+at zero length and left unparseable in 5 of 5 attempts. Against the strategy in
+``atomic_io`` the same test never produced an unreadable file: killed before the
+rename the previous value survived intact, killed after it the complete new
+value was there, 5 of 5 in both directions.
+
+The stray temporary file left by a write that was killed before its rename is
+deliberate and is asserted here, so that nobody "tidies it up" by deleting
+temporaries belonging to another process that is still writing one.
+"""
+from __future__ import annotations
+
+import json
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from openrappter.atomic_io import (
+    quarantine,
+    read_json_object,
+    write_json_atomic,
+)
+
+
+def temporaries(directory: Path) -> list[str]:
+    return sorted(p.name for p in directory.iterdir() if p.name.endswith(".tmp"))
+
+
+def mode_of(path: Path) -> int:
+    return stat.S_IMODE(path.stat().st_mode)
+
+
+class TestWritingSurvivesInterruption:
+    """The rename is the point: the visible file changes in one step."""
+
+    def test_a_value_round_trips(self, tmp_path):
+        target = tmp_path / "lock.json"
+        write_json_atomic(target, {"installed": {"a/b": {"name": "b"}}})
+        assert json.loads(target.read_text()) == {"installed": {"a/b": {"name": "b"}}}
+
+    def test_a_shorter_value_does_not_leave_the_tail_of_a_longer_one(self, tmp_path):
+        target = tmp_path / "lock.json"
+        write_json_atomic(target, {"installed": {str(i): i for i in range(500)}})
+        long_size = target.stat().st_size
+
+        write_json_atomic(target, {"installed": {}})
+
+        assert target.stat().st_size < long_size
+        assert json.loads(target.read_text()) == {"installed": {}}
+
+    def test_the_file_is_replaced_rather_than_written_in_place(self, tmp_path):
+        """A rename produces a new inode. Writing in place does not.
+
+        This is what separates the fix from the bug: ``write_text`` truncates
+        the file everyone can see, while this writes somewhere nobody is
+        looking and swaps it in.
+        """
+        target = tmp_path / "lock.json"
+        write_json_atomic(target, {"installed": {}})
+        first_inode = target.stat().st_ino
+
+        write_json_atomic(target, {"installed": {"a/b": {}}})
+
+        assert target.stat().st_ino != first_inode
+
+    def test_a_successful_write_leaves_no_temporary_behind(self, tmp_path):
+        target = tmp_path / "lock.json"
+        write_json_atomic(target, {"installed": {}})
+        assert temporaries(tmp_path) == []
+
+    def test_missing_parent_directories_are_created(self, tmp_path):
+        target = tmp_path / "deep" / "deeper" / "lock.json"
+        write_json_atomic(target, {"installed": {}})
+        assert json.loads(target.read_text()) == {"installed": {}}
+
+    def test_the_contents_are_flushed_to_disk_before_the_rename(self, tmp_path, monkeypatch):
+        """Without the fsync the rename can land before the bytes do.
+
+        The file would be atomically replaced by something a crash could still
+        leave empty, which is most of the bug over again.
+        """
+        synced = []
+        real_fsync = os.fsync
+
+        def recording_fsync(descriptor):
+            synced.append(descriptor)
+            return real_fsync(descriptor)
+
+        monkeypatch.setattr(os, "fsync", recording_fsync)
+        write_json_atomic(tmp_path / "lock.json", {"installed": {}})
+
+        assert synced, "the payload was never fsynced"
+
+    def test_a_directory_that_cannot_be_synced_is_not_an_error(self, tmp_path, monkeypatch):
+        """Windows cannot open a directory as a descriptor. That must not fail
+        the write, only the extra durability the sync would have added."""
+        real_open = os.open
+
+        def refusing_open(path, flags, *args, **kwargs):
+            if Path(path).is_dir():
+                raise OSError("directories are not openable here")
+            return real_open(path, flags, *args, **kwargs)
+
+        monkeypatch.setattr(os, "open", refusing_open)
+        target = tmp_path / "lock.json"
+        write_json_atomic(target, {"installed": {"a/b": {}}})
+
+        assert json.loads(target.read_text()) == {"installed": {"a/b": {}}}
+
+
+class TestAFailedWriteDoesNotDamageWhatWasThere:
+    def test_an_unserialisable_value_leaves_the_previous_file_untouched(self, tmp_path):
+        target = tmp_path / "lock.json"
+        write_json_atomic(target, {"installed": {"a/b": {"name": "b"}}})
+        before = target.read_text()
+
+        with pytest.raises(TypeError):
+            write_json_atomic(target, {"installed": {"a/b": object()}})
+
+        assert target.read_text() == before
+
+    def test_an_unserialisable_value_leaves_no_temporary_behind(self, tmp_path):
+        target = tmp_path / "lock.json"
+        write_json_atomic(target, {"installed": {}})
+
+        with pytest.raises(TypeError):
+            write_json_atomic(target, {"installed": object()})
+
+        assert temporaries(tmp_path) == []
+
+    def test_a_failure_during_the_write_removes_the_temporary(self, tmp_path, monkeypatch):
+        target = tmp_path / "lock.json"
+        write_json_atomic(target, {"installed": {}})
+
+        def exploding_replace(source, destination):
+            raise OSError("no")
+
+        monkeypatch.setattr(os, "replace", exploding_replace)
+        with pytest.raises(OSError):
+            write_json_atomic(target, {"installed": {"a/b": {}}})
+
+        assert temporaries(tmp_path) == []
+
+
+class TestPermissionsAreNotQuietlyChanged:
+    def test_a_new_file_is_owner_only(self, tmp_path):
+        target = tmp_path / "lock.json"
+        write_json_atomic(target, {"installed": {}})
+        assert mode_of(target) == 0o600
+
+    def test_an_existing_world_readable_file_keeps_its_mode(self, tmp_path):
+        """Writing data is not the place to make policy decisions."""
+        target = tmp_path / "lock.json"
+        target.write_text("{}")
+        os.chmod(target, 0o644)
+
+        write_json_atomic(target, {"installed": {"a/b": {}}})
+
+        assert mode_of(target) == 0o644
+
+    def test_an_existing_private_file_is_not_loosened(self, tmp_path):
+        """The bug this guards against: mkstemp makes 0600 files, so a blanket
+        chmod to 0644 after the rename would widen a file someone tightened."""
+        target = tmp_path / "lock.json"
+        target.write_text("{}")
+        os.chmod(target, 0o600)
+
+        write_json_atomic(target, {"installed": {"a/b": {}}})
+
+        assert mode_of(target) == 0o600
+
+
+class TestReadingAnObject:
+    def test_a_missing_file_gives_the_default(self, tmp_path):
+        default = {"installed": {}}
+        assert read_json_object(tmp_path / "nope.json", default) is default
+
+    def test_a_valid_object_is_returned(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text(json.dumps({"installed": {"a/b": {"name": "b"}}}))
+        assert read_json_object(target, {"installed": {}}) == {
+            "installed": {"a/b": {"name": "b"}}
+        }
+
+    def test_the_default_is_handed_back_for_the_caller_to_mutate(self, tmp_path):
+        default = {"installed": {}}
+        result = read_json_object(tmp_path / "nope.json", default)
+        result["installed"]["a/b"] = {}
+        assert default["installed"] == {"a/b": {}}
+
+
+class TestDamagedFilesArePreservedNotDiscarded:
+    def test_truncated_json_is_moved_aside(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text('{"installed": {"a/b": {"na')
+
+        result = read_json_object(target, {"installed": {}})
+
+        assert result == {"installed": {}}
+        assert not target.exists()
+        kept = [p for p in tmp_path.iterdir() if "corrupt" in p.name]
+        assert len(kept) == 1
+        assert kept[0].read_text() == '{"installed": {"a/b": {"na'
+
+    def test_an_empty_file_is_moved_aside(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text("")
+
+        assert read_json_object(target, {"installed": {}}) == {"installed": {}}
+        assert [p for p in tmp_path.iterdir() if "corrupt" in p.name]
+
+    @pytest.mark.parametrize("payload", ["[]", '"hello"', "null", "123", "true"])
+    def test_valid_json_that_is_not_an_object_is_moved_aside(self, tmp_path, payload):
+        """Measured against the released code: a lock holding any of these
+        reached ``lock["installed"]`` and raised TypeError out of install."""
+        target = tmp_path / "lock.json"
+        target.write_text(payload)
+
+        assert read_json_object(target, {"installed": {}}) == {"installed": {}}
+        assert [p for p in tmp_path.iterdir() if "corrupt" in p.name]
+
+    def test_bytes_that_are_not_utf8_are_moved_aside(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_bytes(b"\xff\xfe\x00rubbish")
+
+        assert read_json_object(target, {"installed": {}}) == {"installed": {}}
+        assert [p for p in tmp_path.iterdir() if "corrupt" in p.name]
+
+    def test_a_second_damaged_file_does_not_overwrite_the_first(self, tmp_path):
+        target = tmp_path / "lock.json"
+
+        target.write_text("first damage")
+        read_json_object(target, {"installed": {}})
+        target.write_text("second damage")
+        read_json_object(target, {"installed": {}})
+
+        kept = sorted(p.read_text() for p in tmp_path.iterdir() if "corrupt" in p.name)
+        assert kept == ["first damage", "second damage"]
+
+    def test_reading_twice_does_not_pile_up_copies(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text("damaged")
+
+        read_json_object(target, {"installed": {}})
+        read_json_object(target, {"installed": {}})
+
+        assert len([p for p in tmp_path.iterdir() if "corrupt" in p.name]) == 1
+
+
+class TestQuarantine:
+    def test_it_reports_where_the_file_went(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text("damaged")
+
+        destination = quarantine(target)
+
+        assert destination is not None
+        assert destination.read_text() == "damaged"
+        assert not target.exists()
+
+    def test_a_file_that_cannot_be_moved_is_not_an_error(self, tmp_path, monkeypatch):
+        """Failing to preserve evidence is a shame, not a crash."""
+        target = tmp_path / "lock.json"
+        target.write_text("damaged")
+
+        def refusing_replace(source, destination):
+            raise OSError("read-only")
+
+        monkeypatch.setattr(os, "replace", refusing_replace)
+        assert quarantine(target) is None
+
+    def test_a_read_still_returns_the_default_when_it_cannot_be_moved(
+        self, tmp_path, monkeypatch
+    ):
+        target = tmp_path / "lock.json"
+        target.write_text("damaged")
+
+        def refusing_replace(source, destination):
+            raise OSError("read-only")
+
+        monkeypatch.setattr(os, "replace", refusing_replace)
+        assert read_json_object(target, {"installed": {}}) == {"installed": {}}

--- a/python/tests/test_atomic_io.py
+++ b/python/tests/test_atomic_io.py
@@ -146,6 +146,21 @@ class TestAFailedWriteDoesNotDamageWhatWasThere:
 
         assert temporaries(tmp_path) == []
 
+    def test_an_unserialisable_value_touches_nothing_on_disk(self, tmp_path):
+        """Serialise first, then touch the filesystem.
+
+        The cleanup handler already removes a temporary file, so it hides
+        whether the ordering is right -- both orders leave no temporary. What
+        it does not hide is the parent directory: serialising late creates the
+        directory tree for a call that was always going to fail.
+        """
+        target = tmp_path / "not-there-yet" / "lock.json"
+
+        with pytest.raises(TypeError):
+            write_json_atomic(target, {"installed": object()})
+
+        assert not target.parent.exists()
+
 
 class TestPermissionsAreNotQuietlyChanged:
     def test_a_new_file_is_owner_only(self, tmp_path):

--- a/python/tests/test_atomic_io.py
+++ b/python/tests/test_atomic_io.py
@@ -83,18 +83,33 @@ class TestWritingSurvivesInterruption:
 
         The file would be atomically replaced by something a crash could still
         leave empty, which is most of the bug over again.
+
+        This has to tell the payload's fsync apart from the directory's. An
+        earlier version of this test only asserted that os.fsync was called at
+        all, and mutation testing showed it passing with the payload sync
+        deleted -- the directory sync was quietly satisfying it.
         """
-        synced = []
+        events = []
         real_fsync = os.fsync
+        real_replace = os.replace
 
         def recording_fsync(descriptor):
-            synced.append(descriptor)
+            kind = "dir" if stat.S_ISDIR(os.fstat(descriptor).st_mode) else "file"
+            events.append(f"fsync-{kind}")
             return real_fsync(descriptor)
 
+        def recording_replace(source, destination):
+            events.append("replace")
+            return real_replace(source, destination)
+
         monkeypatch.setattr(os, "fsync", recording_fsync)
+        monkeypatch.setattr(os, "replace", recording_replace)
         write_json_atomic(tmp_path / "lock.json", {"installed": {}})
 
-        assert synced, "the payload was never fsynced"
+        assert "fsync-file" in events, f"the payload was never fsynced: {events}"
+        assert events.index("fsync-file") < events.index("replace"), (
+            f"the rename happened before the bytes were flushed: {events}"
+        )
 
     def test_a_directory_that_cannot_be_synced_is_not_an_error(self, tmp_path, monkeypatch):
         """Windows cannot open a directory as a descriptor. That must not fail

--- a/python/tests/test_registry_lock_durability.py
+++ b/python/tests/test_registry_lock_durability.py
@@ -1,0 +1,218 @@
+"""The registry lock files must survive an interrupted write.
+
+Measured against the released code, killing a process during ``_save_lock``
+left ``lock.json`` zero length and unparseable in 5 of 5 attempts. What that
+cost the user was specific, and worse than "the list is empty":
+
+    list_installed  still showed the agent   (it scans the filesystem)
+    load_agent      still executed its code  (it scans the filesystem)
+    uninstall       said "Agent 'demo' not found"  (it reads the lock)
+
+So the agent stayed visible, kept running, and became impossible to remove
+with the tool. Only ``uninstall`` consults the lock, which is why losing it
+produces an agent that cannot be uninstalled rather than one that disappears.
+
+After the fix, 5 of 5 kills during the real ``_save_lock`` left a lock that
+reloaded with every entry present.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import openrappter.clawhub as ch
+import openrappter.rappterhub as rh
+
+
+@pytest.fixture
+def hub(tmp_path, monkeypatch):
+    """A RappterHub rooted entirely inside tmp_path."""
+    agents = tmp_path / "agents"
+    home = tmp_path / "rappterhub"
+    agents.mkdir(parents=True)
+    home.mkdir(parents=True)
+
+    monkeypatch.setattr(rh, "AGENTS_DIR", agents)
+    monkeypatch.setattr(rh, "RAPPTERHUB_DIR", home)
+    monkeypatch.setattr(rh, "LOCK_FILE", home / "lock.json")
+    monkeypatch.setattr(rh, "REGISTRY_GITHUB", "https://example.invalid/registry")
+    monkeypatch.setattr(rh, "REGISTRY_URL", "https://example.invalid")
+    return rh.RappterHubClient()
+
+
+@pytest.fixture
+def claw(tmp_path, monkeypatch):
+    skills = tmp_path / "skills"
+    monkeypatch.setattr(ch, "SKILLS_DIR", skills)
+    return ch.ClawHubClient(skills_dir=skills)
+
+
+def temporaries(directory):
+    return sorted(p.name for p in directory.iterdir() if p.name.endswith(".tmp"))
+
+
+def corrupt_copies(directory):
+    return sorted(p.name for p in directory.iterdir() if "corrupt" in p.name)
+
+
+class TestTheRappterHubLockSurvivesAWriteThatDoesNotFinish:
+    def test_a_saved_lock_reloads(self, hub):
+        hub._save_lock({"version": 1, "installed": {"a/b": {"name": "b"}}})
+        assert hub._load_lock() == {"version": 1, "installed": {"a/b": {"name": "b"}}}
+
+    def test_saving_replaces_the_file_rather_than_truncating_it(self, hub):
+        """``write_text`` truncates the visible file before writing a byte.
+        A rename never exposes a half-written state, and shows up as a new
+        inode. This is the assertion that fails if anyone puts write_text back.
+        """
+        hub._save_lock({"version": 1, "installed": {}})
+        first_inode = rh.LOCK_FILE.stat().st_ino
+
+        hub._save_lock({"version": 1, "installed": {"a/b": {"name": "b"}}})
+
+        assert rh.LOCK_FILE.stat().st_ino != first_inode
+
+    def test_saving_leaves_no_temporary_file_behind(self, hub):
+        hub._save_lock({"version": 1, "installed": {"a/b": {}}})
+        assert temporaries(rh.RAPPTERHUB_DIR) == []
+
+    def test_the_lock_is_created_owner_only(self, hub):
+        import stat as stat_module
+
+        hub._save_lock({"version": 1, "installed": {}})
+        mode = stat_module.S_IMODE(rh.LOCK_FILE.stat().st_mode)
+        assert mode == 0o600
+
+
+class TestADamagedRappterHubLockIsKeptNotDiscarded:
+    def test_a_half_written_lock_is_moved_aside(self, hub):
+        rh.LOCK_FILE.write_text('{"version": 1, "installed": {"someone/dem')
+
+        result = hub._load_lock()
+
+        assert result == {"installed": {}, "version": 1}
+        assert corrupt_copies(rh.RAPPTERHUB_DIR)
+
+    def test_the_damaged_bytes_are_still_readable_afterwards(self, hub):
+        rh.LOCK_FILE.write_text('{"version": 1, "installed": {"someone/dem')
+        hub._load_lock()
+
+        kept = [p for p in rh.RAPPTERHUB_DIR.iterdir() if "corrupt" in p.name]
+        assert kept[0].read_text() == '{"version": 1, "installed": {"someone/dem'
+
+    def test_a_damaged_lock_is_not_overwritten_by_the_next_save(self, hub):
+        """Without preserving it, the next save destroys the only record of
+        what was installed."""
+        rh.LOCK_FILE.write_text("wreckage")
+        lock = hub._load_lock()
+        hub._save_lock(lock)
+
+        kept = [p for p in rh.RAPPTERHUB_DIR.iterdir() if "corrupt" in p.name]
+        assert kept[0].read_text() == "wreckage"
+
+    @pytest.mark.parametrize("payload", ["[]", '"hello"', "null", "123"])
+    def test_a_lock_that_is_not_an_object_does_not_crash_install(self, hub, monkeypatch, payload):
+        """Measured on the released code, each of these raised TypeError out
+        of install: 'list indices must be integers or slices, not str' and so
+        on, because _load_lock returned whatever json.loads produced and
+        install went straight to lock["installed"].
+        """
+        rh.LOCK_FILE.write_text(payload)
+
+        def refuse(*args, **kwargs):
+            raise AssertionError("install must not reach the network in tests")
+
+        monkeypatch.setattr(rh.subprocess, "run", refuse)
+
+        result = hub.install("someone/thing")
+
+        assert result["status"] == "error"
+        assert "Failed to install" in result["message"]
+
+    def test_a_lock_that_is_not_an_object_still_lets_uninstall_answer(self, hub):
+        rh.LOCK_FILE.write_text("[]")
+        result = hub.uninstall("demo")
+        assert result["status"] == "error"
+        assert "not found" in result["message"]
+
+
+class TestTheAgentThatCouldNotBeUninstalled:
+    def test_losing_the_lock_makes_uninstall_fail_while_the_agent_remains(self, hub):
+        """The symptom the fix exists to prevent, pinned so the cost of a lost
+        lock stays visible. Nothing can recover a lock that is already gone --
+        this documents what that costs, and the durability tests above are what
+        stop it happening.
+        """
+        agent_dir = rh.AGENTS_DIR / "demo"
+        agent_dir.mkdir()
+        (agent_dir / "AGENT.md").write_text(
+            "---\nname: demo\ndescription: d\nversion: 1.0.0\n---\n\n# demo\n"
+        )
+        hub._save_lock({
+            "version": 1,
+            "installed": {"someone/demo": {"name": "demo", "path": str(agent_dir)}},
+        })
+
+        assert hub.uninstall("demo")["status"] == "success"
+        assert not agent_dir.exists()
+
+    def test_with_a_destroyed_lock_the_same_uninstall_cannot_find_it(self, hub):
+        agent_dir = rh.AGENTS_DIR / "demo"
+        agent_dir.mkdir()
+        (agent_dir / "AGENT.md").write_text(
+            "---\nname: demo\ndescription: d\nversion: 1.0.0\n---\n\n# demo\n"
+        )
+        rh.LOCK_FILE.write_text("")
+
+        result = hub.uninstall("demo")
+
+        assert result["status"] == "error"
+        assert "not found" in result["message"]
+        assert agent_dir.exists()
+        assert [a["name"] for a in hub.list_installed()] == ["demo"]
+
+
+class TestTheClawHubLock:
+    """ClawHub's lock is written on install and never read for anything that
+    changes behaviour -- list_installed and load_skill both scan the
+    filesystem, and there is no uninstall. Losing it costs nothing today. It
+    gets the same durable write anyway, because the next reader of that file
+    should not have to rediscover this.
+    """
+
+    def test_a_saved_lock_reloads(self, claw):
+        claw._save_lock({"installed": {"some-skill": {"version": "latest"}}})
+        assert claw._load_lock() == {"installed": {"some-skill": {"version": "latest"}}}
+
+    def test_the_lock_directory_is_created_on_first_save(self, claw):
+        """The explicit mkdir that used to live in _save_lock moved into the
+        shared helper. If it ever stops happening, saving raises here."""
+        assert not claw._lock_file.parent.exists()
+
+        claw._save_lock({"installed": {}})
+
+        assert claw._lock_file.exists()
+
+    def test_saving_replaces_the_file_rather_than_truncating_it(self, claw):
+        claw._save_lock({"installed": {}})
+        first_inode = claw._lock_file.stat().st_ino
+
+        claw._save_lock({"installed": {"some-skill": {}}})
+
+        assert claw._lock_file.stat().st_ino != first_inode
+
+    def test_saving_leaves_no_temporary_file_behind(self, claw):
+        claw._save_lock({"installed": {"some-skill": {}}})
+        assert temporaries(claw._lock_file.parent) == []
+
+    def test_a_damaged_lock_is_moved_aside(self, claw):
+        claw._save_lock({"installed": {}})
+        claw._lock_file.write_text('{"installed": {"some-sk')
+
+        assert claw._load_lock() == {"installed": {}}
+        assert corrupt_copies(claw._lock_file.parent)
+
+    def test_a_missing_lock_reads_as_empty(self, claw):
+        assert claw._load_lock() == {"installed": {}}
+        assert not claw._lock_file.exists()


### PR DESCRIPTION
## What

`rappterhub`'s lock file is written with `Path.write_text`, which truncates the
file everyone can see before writing a byte, and never flushes it. A crash, a
kill, or a full disk in that window leaves it empty or half-written, and the
previous contents are gone.

```python
def _save_lock(self, lock: dict):
    LOCK_FILE.write_text(json.dumps(lock, indent=2))   # O_TRUNC, no fsync
```

## Measured

Killing a real process during `_save_lock` and polling the target's size:

| write strategy | outcome |
| --- | --- |
| `write_text` | zero length, unparseable, **5 of 5** |
| temp file + fsync + rename | old value or new value, never in between, **5 of 5** |

## What losing it actually costs

Not "the list is empty". Only `uninstall` reads the lock — `list_installed` and
`load_agent` both scan the filesystem. Measured on a real install with the lock
corrupted:

| | healthy lock | destroyed lock |
| --- | --- | --- |
| `list_installed` | shows `demo` | **still shows `demo`** |
| `load_agent` runs its code | yes | **still yes** |
| `uninstall` | success | **"Agent 'demo' not found"** |
| directory afterwards | removed | **still there** |

So the agent stays visible, keeps executing, and can no longer be removed with
the tool. The user is told it does not exist while looking at it in the list.

## The fix

A small shared `atomic_io` module: serialise, write to a temporary file in the
same directory, `fsync`, `os.replace` into place, then flush the directory
entry. `os.replace` is atomic on POSIX and Windows, so a reader gets one whole
version or the other.

Five modules here already did this by hand — `brainstem`, `show_and_tell`,
`imessage.config`, `imessage.state`, `pokemon_agent`. The two registry clients
were the only durable JSON writers still calling `write_text`. This gives them
one implementation to share rather than a sixth hand-rolled copy.

Two details worth flagging for review:

- **Permissions are preserved, not imposed.** `mkstemp` creates 0600 files, so
  chmodding to a fixed 0644 after the rename would *widen* a lock that a user
  with a strict umask had tighter. An existing file keeps exactly the mode it
  had; only a brand new one is owner-only.
- **A damaged lock is moved aside**, not silently ignored. Ignoring it reads as
  "nothing is installed", and the next save then overwrote the only record of
  what had been there. It is renamed to `lock.json.corrupt-<timestamp>`.

## A crash found while testing this

`_load_lock` returned whatever `json.loads` produced. A lock holding valid JSON
that is not an object went straight to `lock["installed"]`. Measured against
the released code in a clean worktree:

```
lock contains []       -> TypeError: list indices must be integers or slices, not str
lock contains "hello"  -> TypeError: string indices must be integers, not 'str'
lock contains null     -> TypeError: 'NoneType' object is not subscriptable
lock contains 123      -> TypeError: 'int' object is not subscriptable
```

Those now quarantine and carry on.

## Tests

50 new tests. Twelve mutations, each caught by the matching test:

| mutation | caught by |
| --- | --- |
| write in place again | `replaces_the_file_rather_than_truncating_it` (+10) |
| never fsync the payload | `flushed_to_disk_before_the_rename` |
| silently discard damaged json | `truncated_json_is_moved_aside` (+8) |
| accept a lock that is not an object | `valid_json_that_is_not_an_object_is_moved_aside` (+9) |
| let quarantine collide | `second_damaged_file_does_not_overwrite_the_first` |
| chmod everything 0644 | `existing_private_file_is_not_loosened` (+2) |
| stop preserving an existing mode | `existing_world_readable_file_keeps_its_mode` |
| leave the temporary after a failure | `failure_during_the_write_removes_the_temporary` |
| serialise after creating the temp | `unserialisable_value_touches_nothing_on_disk` |
| let an unopenable directory raise | `directory_that_cannot_be_synced_is_not_an_error` |
| clawhub writes in place again | `TestTheClawHubLock::…truncating_it` |
| rappterhub reads without handling damage | `half_written_lock_is_moved_aside` (+8) |

Two of those started as survivors, and both were real holes rather than
equivalent mutants:

- **The fsync test was passing without the fsync.** It asserted only that
  `os.fsync` had been called during the write, and the best-effort *directory*
  sync satisfied that by itself. The durability guarantee this PR exists to
  provide was pinned by nothing. It now distinguishes the two with `fstat` and
  asserts the payload is flushed before the rename.
- **The cleanup handler hid the serialisation order.** Moving `json.dumps`
  inside the `try` survived, because `except BaseException` removes the
  temporary either way. The property the ordering actually buys is that a value
  that cannot be encoded does not create the parent directory on its way to
  failing; that is now asserted, and the docstring says that rather than the
  weaker claim.

I also missed the fsync survivor on the first matrix run, because I read the
output through `tail` and the early cases had scrolled off. The re-run is
untruncated.

## Verification

- Full Python suite: **1970 passed**, 6 skipped (baseline 1920, +50)
- `parity_harness.py --runtime both`: **PASS**
- Kill-during-`_save_lock` against the real client: 5 of 5 reload with every
  entry present
- No TypeScript change: `rappterhub.ts` is a stub and there is no ClawHub port

## Known and deliberate

- **A write killed before its rename leaves a temporary file behind.** Measured:
  5 of 5, named `.lock.json.<random>.tmp`. They are hidden, inert, and only
  appear after a crash. Sweeping them on the next write would risk deleting a
  temporary belonging to a different process that is still writing one, so they
  are left alone.
- Nothing can recover a lock that was already destroyed before this change. The
  un-removable-agent symptom is pinned as a test so the cost stays visible, but
  the fix is preventing it, not undoing it.
- The five existing hand-rolled atomic writers are not migrated to the shared
  helper here. That is a mechanical change across five modules with its own
  risk, and it does not belong in a bug fix.
