### PR TITLE
fix(exec-safety): the command history grew without limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The command-safety engine's history grew without limit. `ExecSafety` records
+  every command it inspects and dropped none of it, in a process-wide singleton
+  shared by `ShellAgent` and the gateway, so the history lived as long as the
+  server. Two things made it worse than a slow leak: refusing a command cost
+  exactly as much as allowing one, so a caller who was only ever refused could
+  still drive it; and the size of each record was the sender's to choose,
+  because the whole command string was kept. Measured on the released build,
+  20,000 refused commands kept 20,000 entries and 8.3 MB, 2,000 refused 100 KB
+  commands retained 191.5 MB, 20,000 fully-used approval tokens were all still
+  held, and `exec.history` returned a 40.1 MB response after 5,000 refused 8 KB
+  commands. The log now holds a bounded number of entries and reports how many
+  it dropped, since a capped history that looks complete would send someone
+  investigating an incident to the wrong conclusion. Stored commands are
+  shortened, and say so in the text rather than only in a flag. Truncation
+  applies to what is stored and never to what is checked — the injection
+  patterns still run against the whole command, or padding would be all it took
+  to hide a second command behind a semicolon. Finished approval tokens are
+  released, while pending and approved-but-unspent ones are never evicted,
+  because dropping either would turn a decision a human already made into a
+  silent refusal. After: refusals cost 0.5 MB, a 100 KB command costs the same
+  as a 10 KB one, and `exec.history` returns 2.1 MB.
+
 - An interrupted write destroyed the record of which agents are installed.
   `_save_lock` used `Path.write_text`, which truncates the visible file before
   writing a byte and never flushes it to disk. Killing a process during that

--- a/typescript/src/security/__tests__/exec-safety-bounds.test.ts
+++ b/typescript/src/security/__tests__/exec-safety-bounds.test.ts
@@ -1,0 +1,293 @@
+/**
+ * ExecSafety keeps a history, and nothing was bounding it.
+ *
+ * The engine is a process-wide singleton (`getSharedExecSafety`) shared by
+ * ShellAgent and the gateway, so whatever it retains is retained for the life
+ * of the server. Measured against the released build:
+ *
+ *   20,000 refused commands        ->  20,000 entries kept,   8.3 MB
+ *   2,000 refused 100 KB commands  ->  191.5 MB
+ *   20,000 fully-used tokens       ->  all 20,000 still held
+ *   5,000 refused 8 KB commands    ->  exec.history returned 40.1 MB
+ *
+ * Two things stand out and both are pinned below: refusing a command cost the
+ * same as allowing one, and the size of each record was chosen by whoever sent
+ * the command.
+ */
+import { describe, it, expect } from 'vitest';
+import { execFileSync } from 'child_process';
+import { existsSync } from 'fs';
+import { fileURLToPath } from 'url';
+
+import {
+  ExecSafety,
+  DEFAULT_MAX_AUDIT_ENTRIES,
+  DEFAULT_MAX_AUDIT_COMMAND_CHARS,
+  DEFAULT_MAX_APPROVAL_TOKENS,
+} from '../exec-safety.js';
+
+describe('the audit log stops growing', () => {
+  it('keeps no more than the ceiling', () => {
+    const safety = new ExecSafety(undefined, { maxAuditEntries: 100 });
+
+    for (let i = 0; i < 5000; i++) safety.checkCommand(`ls /path/${i}`);
+
+    expect(safety.getAuditLog()).toHaveLength(100);
+  });
+
+  it('refusing a command is not free either', () => {
+    // The engine records blocked commands too, so a caller who only ever gets
+    // refused could still grow the log without limit.
+    const safety = new ExecSafety(undefined, { maxAuditEntries: 50 });
+
+    for (let i = 0; i < 1000; i++) {
+      const verdict = safety.checkCommand(`no-such-binary-${i} --flag`);
+      expect(verdict.safe).toBe(false);
+    }
+
+    expect(safety.getAuditLog()).toHaveLength(50);
+    expect(safety.getAuditDroppedCount()).toBe(950);
+  });
+
+  it('says how much history it threw away', () => {
+    // A capped log that looks complete is worse than a short one that admits
+    // it: someone investigating would conclude the entry was never written.
+    const safety = new ExecSafety(undefined, { maxAuditEntries: 10 });
+
+    for (let i = 0; i < 25; i++) safety.checkCommand(`ls /path/${i}`);
+
+    expect(safety.getAuditDroppedCount()).toBe(15);
+  });
+
+  it('drops the oldest and keeps what just happened', () => {
+    const safety = new ExecSafety(undefined, { maxAuditEntries: 3 });
+
+    for (let i = 0; i < 6; i++) safety.checkCommand(`ls /path/${i}`);
+
+    expect(safety.getAuditLog().map((e) => e.cmd)).toEqual([
+      'ls /path/3',
+      'ls /path/4',
+      'ls /path/5',
+    ]);
+  });
+
+  it('bounds the approval-token entries as well', () => {
+    const safety = new ExecSafety(undefined, { maxAuditEntries: 5 });
+
+    for (let i = 0; i < 50; i++) safety.issueApprovalToken(`curl http://host/${i}`);
+
+    expect(safety.getAuditLog()).toHaveLength(5);
+  });
+
+  it('reports nothing lost once the log is deliberately emptied', () => {
+    const safety = new ExecSafety(undefined, { maxAuditEntries: 2 });
+    for (let i = 0; i < 10; i++) safety.checkCommand(`ls /path/${i}`);
+    expect(safety.getAuditDroppedCount()).toBeGreaterThan(0);
+
+    safety.clearAuditLog();
+
+    expect(safety.getAuditLog()).toHaveLength(0);
+    expect(safety.getAuditDroppedCount()).toBe(0);
+  });
+
+  it('has a ceiling without being asked', () => {
+    const safety = new ExecSafety();
+    for (let i = 0; i < DEFAULT_MAX_AUDIT_ENTRIES + 500; i++) {
+      safety.checkCommand(`ls /path/${i}`);
+    }
+    expect(safety.getAuditLog()).toHaveLength(DEFAULT_MAX_AUDIT_ENTRIES);
+  });
+});
+
+describe('the sender does not decide how much is stored', () => {
+  it('keeps only the head of an oversized command', () => {
+    const safety = new ExecSafety(undefined, { maxAuditCommandChars: 100 });
+
+    safety.checkCommand('ls ' + 'A'.repeat(50_000));
+
+    const [entry] = safety.getAuditLog();
+    expect(entry.cmd.length).toBeLessThan(200);
+    expect(entry.truncated).toBe(true);
+  });
+
+  it('says so in the text, not just in a flag', () => {
+    // Whoever reads the history has to be able to tell the whole command from
+    // the beginning of one.
+    const safety = new ExecSafety(undefined, { maxAuditCommandChars: 20 });
+
+    safety.checkCommand('ls ' + 'A'.repeat(5000));
+
+    expect(safety.getAuditLog()[0].cmd).toContain('[truncated, 5003 chars total]');
+  });
+
+  it('leaves an ordinary command exactly as it was', () => {
+    const safety = new ExecSafety(undefined, { maxAuditCommandChars: 2000 });
+
+    safety.checkCommand('ls -la /tmp');
+
+    const [entry] = safety.getAuditLog();
+    expect(entry.cmd).toBe('ls -la /tmp');
+    expect(entry.truncated).toBeUndefined();
+  });
+
+  it('truncates the record without ever truncating the decision', () => {
+    // The dangerous part of a command can sit past the cutoff. If the safety
+    // check ran on the shortened copy, padding would be all it took to hide a
+    // second command behind a semicolon.
+    const safety = new ExecSafety(undefined, { maxAuditCommandChars: 20 });
+
+    const verdict = safety.checkCommand('ls ' + 'A'.repeat(5000) + '; rm -rf /');
+
+    expect(verdict.safe).toBe(false);
+    expect(verdict.injectionType).toBe('semicolon-chain');
+  });
+
+  it('still reads the real binary out of an oversized command', () => {
+    const safety = new ExecSafety(undefined, { maxAuditCommandChars: 5 });
+
+    safety.checkCommand('definitely-not-real ' + 'A'.repeat(5000));
+
+    expect(safety.getAuditLog()[0].binary).toBe('definitely-not-real');
+  });
+
+  it('has a length ceiling without being asked', () => {
+    const safety = new ExecSafety();
+    safety.checkCommand('ls ' + 'A'.repeat(DEFAULT_MAX_AUDIT_COMMAND_CHARS * 4));
+    expect(safety.getAuditLog()[0].truncated).toBe(true);
+  });
+});
+
+describe('finished approval tokens are let go', () => {
+  const heldTokens = (safety: ExecSafety): number =>
+    (safety as unknown as { approvalTokens: Map<string, unknown> }).approvalTokens.size;
+
+  it('does not hold on to tokens that have been spent', () => {
+    const safety = new ExecSafety(undefined, { maxApprovalTokens: 10 });
+
+    for (let i = 0; i < 500; i++) {
+      const token = safety.issueApprovalToken(`ls /path/${i}`);
+      safety.resolveApprovalToken(token.id, true);
+      expect(safety.consumeApprovalToken(token.id, `ls /path/${i}`).ok).toBe(true);
+    }
+
+    expect(heldTokens(safety)).toBeLessThanOrEqual(11);
+  });
+
+  it('never drops a token still waiting on a person', () => {
+    // Evicting a pending token would silently make an approval unanswerable.
+    const safety = new ExecSafety(undefined, { maxApprovalTokens: 5 });
+
+    const tokens = Array.from({ length: 100 }, (_, i) =>
+      safety.issueApprovalToken(`ls /path/${i}`)
+    );
+
+    expect(safety.getPendingApprovalTokens()).toHaveLength(100);
+    for (const token of tokens) {
+      expect(safety.resolveApprovalToken(token.id, true)).toBe(true);
+    }
+  });
+
+  it('never drops an approved token before it is spent', () => {
+    // This one is the sharp edge: the human has already said yes, and the
+    // command has not run yet. Losing it turns an approval into a refusal.
+    const safety = new ExecSafety(undefined, { maxApprovalTokens: 5 });
+
+    const approved = safety.issueApprovalToken('curl http://example.com');
+    safety.resolveApprovalToken(approved.id, true);
+
+    for (let i = 0; i < 200; i++) {
+      const noise = safety.issueApprovalToken(`ls /path/${i}`);
+      safety.resolveApprovalToken(noise.id, false);
+    }
+
+    expect(safety.consumeApprovalToken(approved.id, 'curl http://example.com').ok).toBe(true);
+  });
+
+  it('still catches a replay of a token that is recent', () => {
+    const safety = new ExecSafety(undefined, { maxApprovalTokens: 50 });
+
+    const token = safety.issueApprovalToken('ls /tmp');
+    safety.resolveApprovalToken(token.id, true);
+    expect(safety.consumeApprovalToken(token.id, 'ls /tmp').ok).toBe(true);
+
+    const replay = safety.consumeApprovalToken(token.id, 'ls /tmp');
+    expect(replay.ok).toBe(false);
+    expect(replay.reason).toContain('already used');
+  });
+
+  it('refuses a token it has forgotten, rather than honouring it', () => {
+    // Eviction must fail closed. A token pushed out of the table is unknown,
+    // and unknown has to mean no.
+    const safety = new ExecSafety(undefined, { maxApprovalTokens: 2 });
+
+    const token = safety.issueApprovalToken('ls /tmp');
+    safety.resolveApprovalToken(token.id, true);
+    safety.consumeApprovalToken(token.id, 'ls /tmp');
+
+    for (let i = 0; i < 50; i++) {
+      const noise = safety.issueApprovalToken(`ls /path/${i}`);
+      safety.resolveApprovalToken(noise.id, false);
+    }
+
+    const result = safety.consumeApprovalToken(token.id, 'ls /tmp');
+    expect(result.ok).toBe(false);
+  });
+
+  it('lets go of tokens whose time ran out', () => {
+    const safety = new ExecSafety(undefined, { maxApprovalTokens: 5 });
+
+    for (let i = 0; i < 100; i++) safety.issueApprovalToken(`ls /path/${i}`, -1);
+    safety.issueApprovalToken('ls /final');
+
+    expect(heldTokens(safety)).toBeLessThanOrEqual(6);
+  });
+
+  it('has a ceiling without being asked', () => {
+    const safety = new ExecSafety();
+
+    for (let i = 0; i < DEFAULT_MAX_APPROVAL_TOKENS + 200; i++) {
+      const token = safety.issueApprovalToken(`ls /path/${i}`);
+      safety.resolveApprovalToken(token.id, false);
+    }
+
+    expect(heldTokens(safety)).toBeLessThanOrEqual(DEFAULT_MAX_APPROVAL_TOKENS + 1);
+  });
+});
+
+describe('the shortened copy really does release the original', () => {
+  // No assertion on the string can tell these apart: a plain slice and a
+  // flattened copy are the same value. V8 just represents the first as a view
+  // onto the whole command, so the "truncated" entry pins all of it in memory.
+  // Measured, keeping 2,000 chars of 1,000 commands of 100,000 chars:
+  // slice 95.4 MB, slice-plus-suffix 95.5 MB, flattened copy 2.0 MB.
+  //
+  // So this one has to weigh the heap, which needs a child process with
+  // --expose-gc against the built output.
+  const distUrl = new URL('../../../dist/security/exec-safety.js', import.meta.url);
+
+  it.runIf(existsSync(fileURLToPath(distUrl)))(
+    'does not keep whole commands alive behind their truncations',
+    () => {
+      const script = `
+        const { ExecSafety } = await import(${JSON.stringify(distUrl.href)});
+        const heap = () => { global.gc(); return process.memoryUsage().heapUsed; };
+        const safety = new ExecSafety(undefined, { maxAuditEntries: 1000, maxAuditCommandChars: 2000 });
+        const before = heap();
+        for (let i = 0; i < 1000; i++) safety.checkCommand('nope ' + String(i) + 'A'.repeat(100000));
+        const grew = heap() - before;
+        if (safety.getAuditLog().length !== 1000) throw new Error('expected a full log');
+        console.log(String(Math.round(grew / 1024 / 1024)));
+      `;
+      const grewMb = Number(
+        execFileSync(process.execPath, ['--expose-gc', '--input-type=module', '-e', script], {
+          encoding: 'utf8',
+          timeout: 120_000,
+        }).trim()
+      );
+
+      // 1,000 entries x 2,000 chars is about 4 MB of UTF-16. Retaining the
+      // originals instead would be ~95 MB, so the two are not close.
+      expect(grewMb).toBeLessThan(25);
+    }
+  );
+});

--- a/typescript/src/security/exec-safety.ts
+++ b/typescript/src/security/exec-safety.ts
@@ -35,6 +35,11 @@ export interface AuditEntry {
   reason?: string;
   status: 'allowed' | 'blocked' | 'pending' | 'approved' | 'rejected' | 'used' | 'expired';
   timestamp: string;
+  /**
+   * Set when `cmd` above is not the whole command. The safety decision was
+   * still made on the full text; only what is kept for the log was shortened.
+   */
+  truncated?: boolean;
 }
 
 export interface PendingApproval {
@@ -160,7 +165,45 @@ export interface ExecSafetyOptions {
    * route to approval instead of running. Default false (backward-compatible).
    */
   strictDefaults?: boolean;
+
+  /**
+   * How many audit entries to keep. Older entries are dropped once the log is
+   * full, and `getAuditDroppedCount()` reports how many were lost.
+   *
+   * This engine is a process-wide singleton shared by ShellAgent and the
+   * gateway, so without a ceiling the log grows for the life of the server.
+   * Measured: 50,000 checks retained 13.8 MB, and refusing a command costs
+   * exactly as much as allowing one.
+   */
+  maxAuditEntries?: number;
+
+  /**
+   * How much of a command to keep in an audit entry. The safety decision is
+   * always made on the whole command; this only bounds what is stored.
+   *
+   * Without it the size of an entry is chosen by whoever sent the command:
+   * 2,000 refused 100 KB commands retained 191.5 MB.
+   */
+  maxAuditCommandChars?: number;
+
+  /**
+   * How many finished approval tokens to keep. Live ones (pending, or approved
+   * and not yet used) are never dropped. Measured: 20,000 fully-used tokens
+   * were all still held.
+   */
+  maxApprovalTokens?: number;
 }
+
+/**
+ * Defaults chosen to keep the whole engine comfortably inside a few megabytes
+ * while still holding enough history to investigate an incident.
+ */
+export const DEFAULT_MAX_AUDIT_ENTRIES = 1000;
+export const DEFAULT_MAX_AUDIT_COMMAND_CHARS = 2000;
+export const DEFAULT_MAX_APPROVAL_TOKENS = 500;
+
+/** Statuses a token can never leave; only these are eligible for eviction. */
+const TERMINAL_TOKEN_STATUSES = new Set(['used', 'rejected', 'expired']);
 
 export class ExecSafety {
   private safeBins: Set<string>;
@@ -169,9 +212,17 @@ export class ExecSafety {
   private pendingApprovals = new Map<string, PendingApproval>();
   private approvalListeners = new Set<(approval: PendingApproval) => void>();
   private approvalTokens = new Map<string, ApprovalToken>();
+  private maxAuditEntries: number;
+  private maxAuditCommandChars: number;
+  private maxApprovalTokens: number;
+  private droppedAuditEntries = 0;
 
   constructor(safeBins?: Iterable<string>, options?: ExecSafetyOptions) {
     this.strictDefaults = options?.strictDefaults ?? false;
+    this.maxAuditEntries = options?.maxAuditEntries ?? DEFAULT_MAX_AUDIT_ENTRIES;
+    this.maxAuditCommandChars =
+      options?.maxAuditCommandChars ?? DEFAULT_MAX_AUDIT_COMMAND_CHARS;
+    this.maxApprovalTokens = options?.maxApprovalTokens ?? DEFAULT_MAX_APPROVAL_TOKENS;
     if (safeBins) {
       this.safeBins = new Set(safeBins);
     } else if (this.strictDefaults) {
@@ -372,14 +423,16 @@ export class ExecSafety {
       }
 
       // Record in audit log with pending status
-      this.auditLog.push({
+      const stored = this.forAudit(cmd);
+      this.pushAudit({
         id,
-        cmd,
+        cmd: stored.text,
         binary,
         safe: false,
         reason: approval.reason,
         status: 'pending',
         timestamp: approval.createdAt,
+        ...(stored.truncated ? { truncated: true } : {}),
       });
     });
   }
@@ -444,10 +497,12 @@ export class ExecSafety {
       expiresAt: Date.now() + ttlMs,
     };
     this.approvalTokens.set(id, token);
+    this.evictFinishedTokens();
 
-    this.auditLog.push({
+    const stored = this.forAudit(normalized);
+    this.pushAudit({
       id,
-      cmd: normalized,
+      cmd: stored.text,
       binary: this.parseBinary(normalized),
       safe: false,
       reason: reason
@@ -456,9 +511,10 @@ export class ExecSafety {
         // the danger themselves. The caller was getting this explanation and
         // the reviewer was not, which is the wrong way round.
         ? reason
-        : `Approval token issued for: ${normalized}`,
+        : `Approval token issued for: ${stored.text}`,
       status: 'pending',
       timestamp: token.createdAt,
+      ...(stored.truncated ? { truncated: true } : {}),
     });
 
     return { ...token };
@@ -602,10 +658,23 @@ export class ExecSafety {
   }
 
   /**
+   * How many audit entries have been dropped to stay inside the ceiling.
+   *
+   * A capped log that looks complete is a trap: someone investigating an
+   * incident needs to know the history does not reach back far enough rather
+   * than concluding the thing they are looking for never happened.
+   */
+  getAuditDroppedCount(): number {
+    return this.droppedAuditEntries;
+  }
+
+  /**
    * Clear the audit log.
    */
   clearAuditLog(): void {
     this.auditLog = [];
+    // The caller asked for an empty log, so nothing has been lost from it yet.
+    this.droppedAuditEntries = 0;
   }
 
   // ── Private ────────────────────────────────────────────────────────────────
@@ -630,15 +699,107 @@ export class ExecSafety {
     result: SafetyCheckResult,
     status: AuditEntry['status']
   ): void {
-    this.auditLog.push({
+    // Only what gets stored is shortened. Every caller above has already run
+    // the injection patterns against the full command, which is the order that
+    // matters: truncating first would let anything past the cutoff go unread.
+    const { text, truncated } = this.forAudit(cmd);
+    this.pushAudit({
       id: `audit_${Date.now()}_${Math.random().toString(36).slice(2)}`,
-      cmd,
+      cmd: text,
       binary,
       safe: result.safe,
       reason: result.reason,
       status,
       timestamp: new Date().toISOString(),
+      ...(truncated ? { truncated: true } : {}),
     });
+  }
+
+  /**
+   * Shorten a command for storage, saying so in the text itself.
+   *
+   * The marker matters as much as the ceiling: someone reading the history
+   * needs to be able to tell "this is the command" from "this is the start of
+   * the command", or they will draw conclusions from a string that is missing
+   * the interesting part.
+   */
+  private forAudit(cmd: string): { text: string; truncated: boolean } {
+    if (cmd.length <= this.maxAuditCommandChars) {
+      return { text: cmd, truncated: false };
+    }
+    // The round-trip through a Buffer is load-bearing and must not be
+    // simplified back into a plain slice.
+    //
+    // V8 represents `s.slice(0, n)` as a view onto the original string, so the
+    // "truncated" copy keeps the whole command alive. Measured, keeping 2,000
+    // characters of 1,000 commands of 100,000 characters:
+    //
+    //   s.slice(0, n)              95.4 MB
+    //   `${s.slice(0, n)}…`        95.5 MB   (concatenation does not flatten)
+    //   Buffer round-trip           2.0 MB
+    //
+    // Encoding to bytes and back builds a genuinely new string with no
+    // reference to the original. It also replaces a surrogate pair that the
+    // cut landed in the middle of with U+FFFD, which is the right outcome for
+    // a log: half a character is not worth propagating to every reader.
+    const kept = Buffer.from(cmd.slice(0, this.maxAuditCommandChars), 'utf8').toString('utf8');
+    return {
+      text: `${kept}… [truncated, ${cmd.length} chars total]`,
+      truncated: true,
+    };
+  }
+
+  /**
+   * Append an entry and hold the log to its ceiling, oldest first.
+   *
+   * Dropping audit records is not free, so the count of what was dropped is
+   * kept and reported rather than the log quietly appearing complete.
+   */
+  private pushAudit(entry: AuditEntry): void {
+    this.auditLog.push(entry);
+    if (this.maxAuditEntries <= 0) {
+      this.droppedAuditEntries += this.auditLog.length;
+      this.auditLog = [];
+      return;
+    }
+    if (this.auditLog.length > this.maxAuditEntries) {
+      const excess = this.auditLog.length - this.maxAuditEntries;
+      this.auditLog.splice(0, excess);
+      this.droppedAuditEntries += excess;
+    }
+  }
+
+  /**
+   * Forget approval tokens that can no longer be used for anything.
+   *
+   * Only terminal ones go: a pending token is still waiting on a person, and
+   * an approved one is still waiting to be spent. Dropping either would break
+   * an approval that a human had already dealt with.
+   *
+   * The cost is that a replay of a token evicted long ago is reported as
+   * unknown rather than as a replay. Both refuse the command; only the wording
+   * differs, and a token has to be older than the last `maxApprovalTokens`
+   * finished ones — far outside any TTL — before that can happen.
+   */
+  private evictFinishedTokens(): void {
+    const now = Date.now();
+    for (const token of this.approvalTokens.values()) {
+      if (token.status === 'pending' && now > token.expiresAt) {
+        token.status = 'expired';
+      }
+    }
+
+    let overBy = this.approvalTokens.size - this.maxApprovalTokens;
+    if (overBy <= 0) return;
+
+    // Map iteration is insertion-ordered, so this drops the oldest first.
+    for (const [id, token] of this.approvalTokens) {
+      if (overBy <= 0) break;
+      if (TERMINAL_TOKEN_STATUSES.has(token.status)) {
+        this.approvalTokens.delete(id);
+        overBy--;
+      }
+    }
   }
 }
 


### PR DESCRIPTION
## What

`ExecSafety` records every command it inspects and never dropped any of it.
It is a process-wide singleton (`getSharedExecSafety`) shared by `ShellAgent`
and the gateway, so its history lives as long as the server does.

Two things make this worse than a slow leak.

**Refusing a command costs the same as allowing one.** `recordAudit` runs on
the blocked path too, so a caller who never once gets a command past the policy
can still drive the log up.

**The size of each record is chosen by the sender**, because the whole command
string is kept.

## Measured on the released build

| | retained |
| --- | --- |
| 20,000 refused commands | 20,000 entries, 8.3 MB |
| 20,000 fully-used approval tokens | all 20,000 still held |

Refusal cost, by command length (2,000 refusals each):

| command | before | after |
| --- | --- | --- |
| 100 chars | 1.0 MB | 0.5 MB |
| 10,000 chars | 19.8 MB | 2.4 MB |
| 100,000 chars | **191.5 MB** | **2.4 MB** |

`exec.history` maps the entire log into one response with no pagination, so the
same growth lands in the payload the macOS Bar fetches:

| refused 8 KB commands | before | after |
| --- | --- | --- |
| 1,000 | 8.0 MB | 2.1 MB |
| 5,000 | **40.1 MB** | 2.1 MB |

The cost no longer follows the sender's command length, which is the property
that matters.

## The fix

A ceiling on the number of entries, a ceiling on how much of a command is
stored, and eviction of approval tokens that can no longer be used.

Three decisions worth reviewing:

- **A capped log reports what it dropped.** `getAuditDroppedCount()` exists so
  a history that does not reach back far enough cannot be mistaken for one
  where the entry was never written. Silently losing audit records would be a
  worse bug than the leak.
- **Truncation applies to storage, never to the decision.** The injection
  patterns still run against the whole command. Checking the shortened copy
  would mean padding was all it took to hide `; rm -rf /` past the cutoff — the
  test for this is the one I would most want a second pair of eyes on.
- **Only finished tokens are evicted.** A pending token is still waiting on a
  person and an approved one is still waiting to be spent; dropping either
  turns a decision a human already made into a silent refusal.

## The part that looked right and did nothing

The first version of the truncation was `cmd.slice(0, max)`. It capped the
entry count correctly and barely helped: 100 KB commands still cost 49 KB each.

V8 represents `s.slice(a, b)` as a view onto the original string, so the
"truncated" copy pins the whole command in memory. Keeping 2,000 characters of
1,000 commands of 100,000 characters:

| | retained (ideal ~1.9 MB) |
| --- | --- |
| `s.slice(0, n)` | 95.4 MB |
| `` `${s.slice(0, n)}…` `` | 95.5 MB |
| Buffer round-trip | **2.0 MB** |

Encoding to bytes and back builds a string with no reference to the original.
That line is load-bearing and carries a comment saying so, because it looks
like something worth simplifying.

No assertion on the string value can catch this — a slice and a flattened copy
are the same value. It is pinned by a test that weighs the heap in a child
process with `--expose-gc` against `typescript/dist`, which CI builds before it
runs tests. Reverting that one line fails that one test.

## Tests

21 new tests. Eleven mutations, no survivors:

| mutation | caught by |
| --- | --- |
| never trim the log | `keeps no more than the ceiling` (+6) |
| trim silently | `says how much history it threw away` (+2) |
| drop newest instead of oldest | `drops the oldest and keeps what just happened` |
| check the shortened command | `truncates the record without ever truncating the decision` (+2) |
| truncate with a plain slice | `does not keep whole commands alive behind their truncations` |
| drop the truncation marker | `says so in the text, not just in a flag` |
| stop flagging truncated entries | `keeps only the head of an oversized command` (+1) |
| never evict tokens | `does not hold on to tokens that have been spent` (+2) |
| evict live tokens too | `never drops an approved token before it is spent` (+1) |
| honour a forgotten token | `refuses a token it has forgotten, rather than honouring it` |
| leave a stale dropped count | `reports nothing lost once the log is deliberately emptied` |

`dist` is rebuilt for every mutation. Without that the heap test would run
against the previous build and report a pass that means nothing — the same trap
as stale `.pyc` files on the Python side.

## Verification

- Full TypeScript suite: **5223 passed**, 21 skipped (baseline 5202)
- `parity_harness.py --runtime both`: **PASS**
- Existing security suite unchanged: 216 passed
- Defaults: 1000 entries, 2000 chars per command, 500 finished tokens, all
  overridable through `ExecSafetyOptions`

## Known and deliberate

- **A replay of a long-evicted token is reported as unknown rather than as a
  replay.** Both refuse the command; only the wording differs, and a token has
  to be older than the last 500 finished ones — far outside any TTL — before
  that can happen.
- **Pending tokens are not capped.** Bounding them would mean refusing to
  queue approvals under load, which fails closed on functionality rather than
  memory. They expire and are then evicted.
- `exec.history` still returns the whole log rather than paginating. It is
  bounded now, so this is no longer a growth problem, and pagination is an API
  change that does not belong in a bug fix.
- Approval and audit ids still come from `Math.random()`. Worth a look on its
  own terms, but it is a different defect and not one I measured here.

## Not this PR

While tracing reachability I found `security/dm-pairing.ts` writes its pairing
allowlist non-atomically and world-readable. It has **no production callers** —
only tests import it, and `dm-policy.ts` keeps its own pairings in memory — so
I left it alone rather than harden something nothing runs.
