### PR TITLE
fix(registry): a lock file missing a key crashed install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A registry lock file that was an object but not the expected shape crashed
+  `install`. Both registry clients read a lock and immediately evaluate
+  `lock["installed"]`; `read_json_object` guarded the top level, so a lock
+  holding `[]` or `"hello"` was moved aside, but a lock holding `{}` is a
+  perfectly good object and was handed straight back. Measured with nothing
+  actually installed: `{}` and `{"version": 1}` raised `KeyError`,
+  `{"installed": null}` and `{"installed": 7}` raised `TypeError`, and --
+  worse than either -- `{"installed": "alice/tool-and-more"}` and
+  `{"installed": ["alice/tool"]}` reported the agent as *already installed*,
+  because membership against a string is a substring test and against a list
+  an element test. For ClawHub the crash landed after the skill was already on
+  disk, so the install succeeded and only the bookkeeping exploded.
+  `read_json_object` now takes `object_fields` naming the keys a caller will
+  index into: a missing key is filled in from the default, since nothing was
+  ever written there, while a key present with the wrong type is quarantined,
+  since something did write that value and it is evidence. Callers that name
+  no fields are unaffected.
+
 - The command-safety engine's history grew without limit. `ExecSafety` records
   every command it inspects and dropped none of it, in a process-wide singleton
   shared by `ShellAgent` and the gateway, so the history lived as long as the

--- a/python/openrappter/atomic_io.py
+++ b/python/openrappter/atomic_io.py
@@ -31,7 +31,7 @@ import stat
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 DEFAULT_NEW_FILE_MODE = 0o600
 
@@ -87,7 +87,12 @@ def write_json_atomic(
     _sync_directory(path.parent)
 
 
-def read_json_object(path: Path, default: dict) -> dict:
+def read_json_object(
+    path: Path,
+    default: dict,
+    *,
+    object_fields: Sequence[str] = (),
+) -> dict:
     """Read a JSON object, moving the file aside if it is not one.
 
     Returns ``default`` when the file is missing, unreadable as JSON, or holds
@@ -99,6 +104,23 @@ def read_json_object(path: Path, default: dict) -> dict:
     evidence of what was there. Renaming keeps the bytes next to the file they
     came from, so the state is recoverable by hand and visible to anyone
     wondering why the tool suddenly forgot something.
+
+    ``object_fields`` names keys the caller is going to index into, and so
+    cannot cope with holding anything but an object. Checking only that the
+    *file* is an object stopped one level short of what every caller needed:
+    both registry clients read a lock and immediately evaluate
+    ``lock["installed"]``, which measured as ``KeyError`` for ``{}``,
+    ``TypeError`` for ``{"installed": null}``, and -- worst of the three --
+    a quiet wrong answer for ``{"installed": "alice/tool-and-then-some"}``,
+    where ``in`` is a substring test that reports an agent as installed that
+    was never installed.
+
+    A missing key and a wrong-typed one are not the same failure and are not
+    treated the same. Missing means nothing was ever written there, so it is
+    filled in from ``default``: no evidence exists to destroy, and quarantining
+    would punish a file that is merely older than the key. Present-but-wrong
+    means something did write a value, so the file is moved aside under the
+    same rule as any other damage rather than being silently reinterpreted.
     """
     path = Path(path)
     if not path.exists():
@@ -113,6 +135,13 @@ def read_json_object(path: Path, default: dict) -> dict:
     if not isinstance(parsed, dict):
         quarantine(path)
         return default
+
+    for field in object_fields:
+        if field not in parsed:
+            parsed[field] = default.get(field, {})
+        elif not isinstance(parsed[field], dict):
+            quarantine(path)
+            return default
 
     return parsed
 

--- a/python/openrappter/clawhub.py
+++ b/python/openrappter/clawhub.py
@@ -257,7 +257,9 @@ class ClawHubClient:
 
     def _load_lock(self) -> dict:
         """Load the lock file tracking installed skills."""
-        return read_json_object(self._lock_file, {"installed": {}})
+        return read_json_object(
+            self._lock_file, {"installed": {}}, object_fields=("installed",)
+        )
 
     def _save_lock(self, lock: dict):
         """Save the lock file."""

--- a/python/openrappter/rappterhub.py
+++ b/python/openrappter/rappterhub.py
@@ -157,7 +157,9 @@ class RappterHubClient:
 
     def _load_lock(self) -> dict:
         """Load the lock file tracking installed agents."""
-        return read_json_object(LOCK_FILE, {"installed": {}, "version": 1})
+        return read_json_object(
+            LOCK_FILE, {"installed": {}, "version": 1}, object_fields=("installed",)
+        )
 
     def _save_lock(self, lock: dict):
         """Save the lock file."""

--- a/python/tests/test_atomic_io.py
+++ b/python/tests/test_atomic_io.py
@@ -315,3 +315,136 @@ class TestQuarantine:
 
         monkeypatch.setattr(os, "replace", refusing_replace)
         assert read_json_object(target, {"installed": {}}) == {"installed": {}}
+
+
+class TestFieldsTheCallerWillIndexInto:
+    """Checking that the file is an object stopped one level short.
+
+    Measured against the released code, with nothing actually installed:
+
+        {}                                     KeyError: 'installed'
+        {"version": 1}                         KeyError: 'installed'
+        {"installed": null}                    TypeError: not iterable
+        {"installed": 7}                       TypeError: not iterable
+        {"installed": "alice/tool-and-more"}   "already installed"  <- wrong
+        {"installed": ["alice/tool"]}          "already installed"  <- wrong
+
+    The last two are the reason this is not merely a crash bug. ``in`` against
+    a string is a substring test and against a list a membership test, so both
+    answer True and install refuses to do anything, reporting an agent as
+    present that was never installed.
+    """
+
+    def test_a_missing_field_is_filled_in_rather_than_exploding(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text("{}")
+
+        result = read_json_object(target, {"installed": {}}, object_fields=("installed",))
+
+        assert result["installed"] == {}
+
+    def test_filling_a_missing_field_keeps_the_rest_of_the_file(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text(json.dumps({"version": 3, "note": "hand written"}))
+
+        result = read_json_object(
+            target, {"installed": {}, "version": 1}, object_fields=("installed",)
+        )
+
+        assert result == {"version": 3, "note": "hand written", "installed": {}}
+
+    def test_a_missing_field_does_not_move_the_file_aside(self, tmp_path):
+        """There is nothing there to preserve, and a file that predates the
+        key is not damaged -- quarantining it would punish it for being old."""
+        target = tmp_path / "lock.json"
+        target.write_text(json.dumps({"version": 1}))
+
+        read_json_object(target, {"installed": {}}, object_fields=("installed",))
+
+        assert target.exists()
+        assert not [p for p in tmp_path.iterdir() if "corrupt" in p.name]
+
+    def test_a_field_absent_from_the_default_too_becomes_an_empty_object(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text("{}")
+
+        result = read_json_object(target, {}, object_fields=("installed",))
+
+        assert result == {"installed": {}}
+
+    def test_the_filled_in_field_is_still_the_caller_s_to_mutate(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text("{}")
+        default = {"installed": {}}
+
+        result = read_json_object(target, default, object_fields=("installed",))
+        result["installed"]["a/b"] = {"name": "b"}
+
+        assert default["installed"] == {"a/b": {"name": "b"}}
+
+    @pytest.mark.parametrize(
+        "payload",
+        ['"alice/tool-and-then-some"', "[]", '["alice/tool"]', "null", "7", "true"],
+    )
+    def test_a_field_holding_the_wrong_type_is_moved_aside(self, tmp_path, payload):
+        target = tmp_path / "lock.json"
+        target.write_text('{"installed": %s}' % payload)
+
+        result = read_json_object(
+            target, {"installed": {}}, object_fields=("installed",)
+        )
+
+        assert result == {"installed": {}}
+        assert not target.exists()
+
+    def test_the_wrongly_typed_value_is_preserved_not_discarded(self, tmp_path):
+        """Something wrote that value. Whatever it meant, it is evidence."""
+        target = tmp_path / "lock.json"
+        target.write_text('{"installed": "alice/tool"}')
+
+        read_json_object(target, {"installed": {}}, object_fields=("installed",))
+
+        kept = [p for p in tmp_path.iterdir() if "corrupt" in p.name]
+        assert len(kept) == 1
+        assert kept[0].read_text() == '{"installed": "alice/tool"}'
+
+    def test_a_healthy_file_is_untouched(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text(json.dumps({"installed": {"a/b": {"name": "b"}}}))
+
+        result = read_json_object(
+            target, {"installed": {}}, object_fields=("installed",)
+        )
+
+        assert result == {"installed": {"a/b": {"name": "b"}}}
+        assert target.exists()
+
+    def test_every_named_field_is_checked_not_just_the_first(self, tmp_path):
+        target = tmp_path / "lock.json"
+        target.write_text(json.dumps({"installed": {}, "pinned": "nope"}))
+
+        result = read_json_object(
+            target, {"installed": {}, "pinned": {}}, object_fields=("installed", "pinned")
+        )
+
+        assert result == {"installed": {}, "pinned": {}}
+        assert not target.exists()
+
+    def test_naming_no_fields_leaves_the_old_behaviour_alone(self, tmp_path):
+        """The two registry clients are the only callers today. Anyone else
+        passing a dict-shaped default has not asked for this and must not get
+        their file moved aside because of it."""
+        target = tmp_path / "lock.json"
+        target.write_text("{}")
+
+        assert read_json_object(target, {"installed": {}}) == {}
+        assert target.exists()
+
+    def test_a_missing_file_still_gives_the_default_untouched(self, tmp_path):
+        default = {"installed": {}, "version": 1}
+
+        result = read_json_object(
+            tmp_path / "nope.json", default, object_fields=("installed",)
+        )
+
+        assert result is default

--- a/python/tests/test_registry_lock_shape.py
+++ b/python/tests/test_registry_lock_shape.py
@@ -1,0 +1,167 @@
+"""A lock file that is an object but not the expected shape must not crash.
+
+Both registry clients read a lock and immediately evaluate
+``lock["installed"]``. ``atomic_io.read_json_object`` guarded the top level --
+a lock holding ``[]`` or ``"hello"`` is moved aside -- but a lock holding
+``{}`` is a perfectly good object and was handed straight back.
+
+Measured against the released code, calling ``install`` with nothing actually
+installed:
+
+    {}                                     KeyError: 'installed'
+    {"version": 1}                         KeyError: 'installed'
+    {"installed": null}                    TypeError: not iterable
+    {"installed": 7}                       TypeError: not iterable
+    {"installed": "alice/tool-and-more"}   "already installed"
+    {"installed": ["alice/tool"]}          "already installed"
+
+The two that do not raise are the worse pair: ``in`` against a string is a
+substring test, so ``install`` refuses to run and reports an agent as present
+that was never installed.
+
+For ClawHub the crash lands after ``npx clawhub install`` has already put the
+skill on disk, so the work succeeds and only the bookkeeping explodes -- the
+caller sees a traceback and the lock never learns what was installed.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from openrappter import clawhub as ch
+from openrappter import rappterhub as rh
+
+
+MALFORMED = [
+    pytest.param({}, id="empty-object"),
+    pytest.param({"version": 1}, id="version-only"),
+    pytest.param({"installed": None}, id="installed-null"),
+    pytest.param({"installed": 7}, id="installed-number"),
+    pytest.param({"installed": True}, id="installed-bool"),
+    pytest.param({"installed": "alice/tool-and-then-some"}, id="installed-string"),
+    pytest.param({"installed": ["alice/tool"]}, id="installed-list"),
+]
+
+
+@pytest.fixture
+def hub(tmp_path, monkeypatch):
+    """A RappterHub client rooted in tmp_path, pointed at a dead registry."""
+    agents = tmp_path / "home" / ".openrappter" / "agents"
+    agents.mkdir(parents=True)
+    hub_dir = tmp_path / "home" / ".rappterhub"
+    hub_dir.mkdir(parents=True)
+
+    monkeypatch.setattr(rh, "AGENTS_DIR", agents)
+    monkeypatch.setattr(rh, "RAPPTERHUB_DIR", hub_dir)
+    monkeypatch.setattr(rh, "LOCK_FILE", hub_dir / "lock.json")
+    monkeypatch.setattr(rh, "REGISTRY_GITHUB", "http://127.0.0.1:1/registry")
+    monkeypatch.setattr(rh, "REGISTRY_URL", "http://127.0.0.1:1")
+
+    return rh.RappterHubClient()
+
+
+def write_lock(hub_client, value) -> None:
+    rh.LOCK_FILE.write_text(json.dumps(value), encoding="utf-8")
+
+
+class TestRappterHubSurvivesAMalformedLock:
+    @pytest.mark.parametrize("lock", MALFORMED)
+    def test_install_does_not_raise(self, hub, lock):
+        write_lock(hub, lock)
+
+        result = hub.install("alice/tool")
+
+        assert isinstance(result, dict)
+        assert result.get("status") in {"error", "success"}
+
+    @pytest.mark.parametrize("lock", MALFORMED)
+    def test_install_never_claims_an_agent_is_already_installed(self, hub, lock):
+        """Nothing is installed, so "already installed" is a false answer that
+        leaves the user unable to install without passing force=True."""
+        write_lock(hub, lock)
+
+        result = hub.install("alice/tool")
+
+        assert "already installed" not in result.get("message", "")
+
+    @pytest.mark.parametrize("lock", MALFORMED)
+    def test_the_loaded_lock_is_usable_as_the_code_expects(self, hub, lock):
+        write_lock(hub, lock)
+
+        loaded = hub._load_lock()
+
+        assert isinstance(loaded["installed"], dict)
+
+    def test_a_lock_that_lost_only_the_key_keeps_its_other_contents(self, hub):
+        write_lock(hub, {"version": 4})
+
+        loaded = hub._load_lock()
+
+        assert loaded["version"] == 4
+        assert loaded["installed"] == {}
+        assert rh.LOCK_FILE.exists()
+
+    def test_a_wrongly_typed_lock_is_preserved_on_disk(self, hub):
+        original = {"installed": "alice/tool"}
+        write_lock(hub, original)
+
+        hub._load_lock()
+
+        kept = [p for p in rh.LOCK_FILE.parent.iterdir() if "corrupt" in p.name]
+        assert len(kept) == 1
+        assert json.loads(kept[0].read_text()) == original
+
+    def test_a_real_lock_still_reports_an_installed_agent(self, hub):
+        """The guard must not swallow the answer it exists to protect."""
+        write_lock(hub, {"installed": {"alice/tool": {"version": "1"}}, "version": 1})
+
+        result = hub.install("alice/tool")
+
+        assert "already installed" in result["message"]
+
+    def test_a_real_lock_survives_a_load_unchanged(self, hub):
+        write_lock(hub, {"installed": {"alice/tool": {"version": "1"}}, "version": 1})
+
+        loaded = hub._load_lock()
+
+        assert loaded == {"installed": {"alice/tool": {"version": "1"}}, "version": 1}
+        assert rh.LOCK_FILE.exists()
+
+    def test_uninstall_does_not_raise_on_a_malformed_lock(self, hub):
+        write_lock(hub, {"installed": "alice/tool"})
+
+        result = hub.uninstall("tool")
+
+        assert isinstance(result, dict)
+
+
+class TestClawHubSurvivesAMalformedLock:
+    @pytest.mark.parametrize("lock", MALFORMED)
+    def test_recording_an_install_does_not_raise(self, tmp_path, lock):
+        client = ch.ClawHubClient(skills_dir=tmp_path / "skills")
+        client._lock_file.parent.mkdir(parents=True, exist_ok=True)
+        client._lock_file.write_text(json.dumps(lock), encoding="utf-8")
+
+        loaded = client._load_lock()
+        loaded["installed"]["some-skill"] = {"version": "latest"}
+        client._save_lock(loaded)
+
+        assert client._load_lock()["installed"]["some-skill"] == {"version": "latest"}
+
+    def test_a_real_lock_is_not_disturbed(self, tmp_path):
+        client = ch.ClawHubClient(skills_dir=tmp_path / "skills")
+        client._lock_file.parent.mkdir(parents=True, exist_ok=True)
+        client._lock_file.write_text(
+            json.dumps({"installed": {"kept": {"version": "1"}}}), encoding="utf-8"
+        )
+
+        loaded = client._load_lock()
+
+        assert loaded == {"installed": {"kept": {"version": "1"}}}
+        assert client._lock_file.exists()
+
+    def test_a_missing_lock_still_starts_empty(self, tmp_path):
+        client = ch.ClawHubClient(skills_dir=tmp_path / "skills")
+
+        assert client._load_lock() == {"installed": {}}


### PR DESCRIPTION
## What was wrong

Both registry clients read a lock file and then immediately evaluate `lock["installed"]`:

```python
# rappterhub.install
lock = self._load_lock()
if agent_ref in lock["installed"] and not force:
    return {"status": "info", "message": f"Agent '{agent_ref}' is already installed. …"}
```

`atomic_io.read_json_object` was written to make that safe, and it *nearly* does. It moves a file aside when it is missing, unparseable, or valid JSON that is not an object — there are already tests for `[]`, `"hello"`, `null`, `123`, `true`. But it stops at the top level. A lock holding `{}` is a perfectly good object, so it is handed straight back to a caller that cannot cope with it.

## Measured, before the fix

`install("alice/tool")` with nothing actually installed:

| lock file on disk | result |
|---|---|
| `{"installed": {}, "version": 1}` | reaches the real install path (control) |
| `{}` | **`KeyError: 'installed'`** |
| `{"version": 1}` | **`KeyError: 'installed'`** |
| `{"installed": null}` | **`TypeError: argument of type 'NoneType' is not iterable`** |
| `{"installed": 7}` | **`TypeError: argument of type 'int' is not iterable`** |
| `{"installed": "alice/tool-and-then-some"}` | **"already installed"** |
| `{"installed": ["alice/tool"]}` | **"already installed"** |

The last two are the reason this is not merely a crash bug. `in` against a string is a substring test and against a list an element test, so both answer `True`, and `install` refuses to do anything while reporting an agent as present that was never installed. A crash is at least honest.

For ClawHub the failure lands somewhere worse. The lock is updated *after* `npx clawhub install` returns successfully:

```python
if result.returncode == 0:
    lock = self._load_lock()
    lock["installed"][skill_slug] = {…}   # KeyError / TypeError here
```

so the skill really is on disk, the work succeeded, and only the bookkeeping explodes — the caller sees a traceback instead of a success, and the lock never learns what was installed.

Nothing in this repository *writes* a lock in these shapes. The realistic sources are outside it: a lock hand-edited or reset with `echo '{}' >`, a partial restore from backup, a file older than the key, or another tool writing the same path. The point is that `read_json_object` exists precisely to be honest about a file it did not write, and it was one type-check short of that.

## The fix

`read_json_object` gains an `object_fields` argument naming the keys a caller is going to index into. Both registry clients declare `object_fields=("installed",)`; nothing else changes at the call sites.

A missing key and a wrong-typed key are **not** the same failure and are deliberately not treated the same:

- **Missing** → filled in from the default, file untouched. Nothing was ever written there, so there is no evidence to preserve, and quarantining would punish a file merely for being older than the key. That also keeps a rename-a-key migration from destroying a newer file's visibility.
- **Present but not an object** → the file is quarantined and the default returned. Something *did* write that value. Whatever it meant, it is evidence, and this module's existing documented policy is that ignoring a damaged file "reads the same as nothing is installed, and the next save then overwrites the only evidence of what was there."

Callers that name no fields get exactly the old behaviour, which is pinned by a test.

## Measured, after the fix

All seven lock shapes above now reach the same real install path as the healthy control. `_load_lock()["installed"]` is a dict in every case.

## Tests

24 new tests: `TestFieldsTheCallerWillIndexInto` in `test_atomic_io.py`, and a new `test_registry_lock_shape.py` driving both clients end to end.

They pin the things that are easy to get wrong later: that a healthy lock still reports an already-installed agent (the guard must not swallow the answer it exists to protect); that a file losing only the key keeps its other contents and stays on disk; that the quarantined bytes are byte-identical to what was there; that the filled-in value is still the caller's own object to mutate; that *every* named field is checked, not just the first; and that naming no fields changes nothing.

## Mutation matrix

12 mutations, **12 caught, 0 survivors**, `__pycache__` cleared between each so no mutation was tested against stale bytecode.

| # | mutation | caught by |
|---|---|---|
| 1 | remove the shape check entirely | both files |
| 2 | missing field not filled in | `-k missing` |
| 3 | wrong type fixed in memory, file not preserved | both files |
| 4 | wrong type accepted | both files |
| 5 | fill uses a fresh `{}` instead of the default's | `caller_s_to_mutate` |
| 6 | only the first named field checked | `every_named_field` |
| 7 | `object_fields` silently defaults to `("installed",)` | `naming_no_fields` |
| 8 | quarantines but returns the bad object anyway | both files |
| 9 | a missing field also moves the file aside | `does_not_move_the_file_aside` |
| 10 | lists count as objects | both files |
| 11 | rappterhub stops declaring its shape | `test_registry_lock_shape` |
| 12 | clawhub stops declaring its shape | `test_registry_lock_shape` |

## Validation

- Full Python suite: **2021 passed, 6 skipped, 51 subtests** (baseline 1997 + 24 new)
- `parity_harness.py --runtime both`: **PASS**, 15/15

## Two findings from this round that are *not* in this PR

**`Math.random()` for approval ids is not exploitable — negative result.** I set out to check whether the ids at `exec-safety.ts:391/490/707` and `approvals.ts:206` are predictable enough to forge an approval. They are not worth hardening, because the ids are not secrets in the first place: `exec.pending` publishes every pending approval id to any caller, by design, so the Bar can render the queue. Predicting an id gains an attacker nothing they cannot simply ask for; the control is authorization on `exec.respond`, not id entropy. I am recording this so nobody spends the effort again.

**Four of five hand-rolled atomic writers omit the directory fsync — noted, not claimed.** `atomic_io`'s own docstring says `brainstem`, `show_and_tell`, `imessage.config`, `imessage.state` and `pokemon_agent` "already do this correctly by hand". Reading them, only `pokemon_agent.atomic_write_json` calls `fsync_directory`; the other four fsync the file and then `os.replace` without flushing the parent directory — the exact step `atomic_io._sync_directory` exists for and documents as necessary. I am *not* claiming an impact here, because the difference only shows up on power loss or a kernel crash, and I cannot measure that on this machine. Flagging it as a code-reading fact for someone who can.
