### PR TITLE
fix(pokemon): concurrent writes corrupted the published state file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Pokemon runtime corrupted its own state files when two threads wrote at
+  once. `atomic_write_json` named its temporary after the process id, which
+  threads share, so it was one name for the whole process rather than one per
+  writer; the viewer serves its control endpoint from a `ThreadingHTTPServer`
+  and answers `stop` by writing `desired.json`. Two overlapping requests opened
+  the same temporary, interleaved bytes into it, and raced to rename it. Over
+  60 rounds on two threads, 57 renames failed and a reader found the published
+  file unparseable 219 times; because `read_json` answers a damaged file with
+  its default, that surfaced as the runtime quietly forgetting its state rather
+  than as a crash. The open also used `O_TRUNC`, which followed a symlink
+  planted at that guessable path and truncated its target. Both lines now match
+  every other atomic writer here: a uuid-keyed name and `O_EXCL`.
 - A registry lock file that was an object but not the expected shape crashed
   `install`. Both registry clients read a lock and immediately evaluate
   `lock["installed"]`; `read_json_object` guarded the top level, so a lock

--- a/python/openrappter/agents/pokemon_agent.py
+++ b/python/openrappter/agents/pokemon_agent.py
@@ -343,23 +343,49 @@ def fsync_directory(path: Path) -> None:
 
 
 def atomic_write_json(path: Path, value: dict[str, Any]) -> None:
+    """Publish JSON so a reader sees whole content, never a fragment.
+
+    The temporary name carries a fresh uuid rather than the process id, and the
+    open asks for O_EXCL rather than O_TRUNC. Those are two fixes for two
+    different problems that happened to share one line each.
+
+    Threads share a process id, so a pid-keyed name is a single name for the
+    whole process rather than one per writer. The viewer serves its control
+    endpoint from a ThreadingHTTPServer and answers ``stop`` by writing
+    desired.json, so two overlapping requests opened the *same* temporary file,
+    interleaved their bytes into it, and then raced to rename it. Measured over
+    60 rounds on two threads: 57 renames failed with FileNotFoundError because
+    the other thread had already consumed the temporary, and a reader polling
+    the published file found it unparseable 219 times. read_json answers a
+    damaged file with the default, so this surfaced not as a crash but as the
+    runtime quietly forgetting its state. The same run against a uuid-keyed
+    name reported zero of both.
+
+    O_EXCL is what refuses to follow a symlink: it fails outright if anything
+    already exists at the path. Under O_TRUNC a link planted at the predictable
+    temporary name redirected the write onto its target and truncated it, which
+    the same measurement confirmed and which O_EXCL prevents.
+    """
     path.parent.mkdir(parents=True, exist_ok=True, mode=0o700)
     payload = json.dumps(value, indent=2, sort_keys=True).encode("utf-8")
-    temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
-    descriptor = os.open(
-        temporary,
-        os.O_WRONLY | os.O_CREAT | os.O_TRUNC,
-        0o600,
-    )
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
     try:
-        with os.fdopen(descriptor, "wb", closefd=False) as handle:
-            handle.write(payload)
-            handle.flush()
-            os.fsync(handle.fileno())
+        descriptor = os.open(
+            temporary,
+            os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+            0o600,
+        )
+        try:
+            with os.fdopen(descriptor, "wb", closefd=False) as handle:
+                handle.write(payload)
+                handle.flush()
+                os.fsync(handle.fileno())
+        finally:
+            os.close(descriptor)
+        os.replace(temporary, path)
+        os.chmod(path, 0o600)
     finally:
-        os.close(descriptor)
-    os.replace(temporary, path)
-    os.chmod(path, 0o600)
+        temporary.unlink(missing_ok=True)
     fsync_directory(path.parent)
 
 

--- a/python/tests/test_pokemon_atomic_write.py
+++ b/python/tests/test_pokemon_atomic_write.py
@@ -1,0 +1,295 @@
+"""The Pokemon runtime publishes JSON from several threads at once.
+
+``atomic_write_json`` named its temporary file after the process id and opened
+it with ``O_TRUNC``. Threads share a process id, so that was one temporary name
+for the whole process rather than one per writer, and the viewer answers its
+control endpoint from a ThreadingHTTPServer. Two overlapping requests therefore
+opened the same temporary file, interleaved bytes into it, and raced to rename
+it -- and ``O_TRUNC`` additionally followed any symlink planted at that very
+guessable path.
+
+Every other atomic writer in this codebase (brainstem, imessage.config,
+imessage.state, show_and_tell, atomic_io) already uses a unique name and either
+``mkstemp`` or ``O_EXCL``. These tests pin this one to the same contract.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from pathlib import Path
+
+import pytest
+
+import openrappter.agents.pokemon_agent as pokemon_module
+from openrappter.agents.pokemon_agent import atomic_write_json
+
+SMALL = {"who": "small", "pad": "x"}
+LARGE = {"who": "large", "pad": "y" * 4000}
+
+
+@pytest.fixture()
+def runtime(tmp_path: Path) -> Path:
+    root = tmp_path / "pokemon-red"
+    root.mkdir(mode=0o700)
+    return root
+
+
+class TestConcurrentWritersNeverPublishAFragment:
+    """The whole point of an atomic write is that readers see one value."""
+
+    @staticmethod
+    def _hammer(path: Path, rounds: int = 50):
+        write_errors: list[str] = []
+        decode_failures: list[str] = []
+        unknown_values: list[object] = []
+        stop = threading.Event()
+
+        def write_loop(value: dict) -> None:
+            for _ in range(rounds):
+                try:
+                    atomic_write_json(path, value)
+                except Exception as exc:  # noqa: BLE001
+                    write_errors.append(f"{type(exc).__name__}: {exc}")
+
+        def read_loop() -> None:
+            while not stop.is_set():
+                try:
+                    raw = path.read_bytes()
+                except FileNotFoundError:
+                    write_errors.append("published file vanished")
+                    continue
+                if not raw:
+                    continue
+                try:
+                    parsed = json.loads(raw)
+                except (json.JSONDecodeError, UnicodeDecodeError) as exc:
+                    decode_failures.append(str(exc))
+                    continue
+                if parsed not in (SMALL, LARGE):
+                    unknown_values.append(parsed)
+
+        reader = threading.Thread(target=read_loop, daemon=True)
+        reader.start()
+        writers = [
+            threading.Thread(target=write_loop, args=(SMALL,)),
+            threading.Thread(target=write_loop, args=(LARGE,)),
+        ]
+        for thread in writers:
+            thread.start()
+        for thread in writers:
+            thread.join()
+        stop.set()
+        reader.join(timeout=10)
+        return write_errors, decode_failures, unknown_values
+
+    def test_a_reader_never_sees_unparseable_json(self, runtime: Path) -> None:
+        path = runtime / "status.json"
+        atomic_write_json(path, SMALL)
+        _, decode_failures, _ = self._hammer(path)
+        assert decode_failures == []
+
+    def test_a_reader_never_sees_a_value_nobody_wrote(self, runtime: Path) -> None:
+        path = runtime / "status.json"
+        atomic_write_json(path, SMALL)
+        _, _, unknown = self._hammer(path)
+        assert unknown == []
+
+    def test_no_writer_fails_because_another_consumed_its_temporary(
+        self, runtime: Path
+    ) -> None:
+        path = runtime / "desired.json"
+        atomic_write_json(path, SMALL)
+        write_errors, _, _ = self._hammer(path)
+        assert write_errors == []
+
+    def test_the_file_is_left_holding_a_complete_value(self, runtime: Path) -> None:
+        path = runtime / "status.json"
+        atomic_write_json(path, SMALL)
+        self._hammer(path)
+        assert json.loads(path.read_text(encoding="utf-8")) in (SMALL, LARGE)
+
+
+class TestEachWriteUsesItsOwnTemporary:
+    """Two writers must not be able to collide on one name."""
+
+    def test_two_writes_use_different_temporary_names(
+        self, runtime: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[str] = []
+        real_replace = os.replace
+
+        def recording_replace(source, destination):
+            seen.append(Path(source).name)
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(os, "replace", recording_replace)
+        atomic_write_json(runtime / "status.json", SMALL)
+        atomic_write_json(runtime / "status.json", LARGE)
+        assert len(seen) == 2
+        assert seen[0] != seen[1]
+
+    def test_the_temporary_name_does_not_carry_the_process_id(
+        self, runtime: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        seen: list[str] = []
+        real_replace = os.replace
+
+        def recording_replace(source, destination):
+            seen.append(Path(source).name)
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(os, "replace", recording_replace)
+        atomic_write_json(runtime / "status.json", SMALL)
+        assert str(os.getpid()) not in seen[0]
+
+
+class TestASymlinkCannotRedirectTheWrite:
+    """O_EXCL refuses to follow a link; O_TRUNC happily truncated its target."""
+
+    def test_a_symlink_at_the_temporary_path_is_refused(
+        self, runtime: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        victim = runtime / "VICTIM.txt"
+        victim.write_text("precious\n", encoding="utf-8")
+        path = runtime / "desired.json"
+
+        fixed = uuid.UUID("00000000-0000-4000-8000-000000000000")
+        monkeypatch.setattr(pokemon_module.uuid, "uuid4", lambda: fixed)
+        os.symlink(victim, runtime / f".{path.name}.{fixed.hex}.tmp")
+
+        with pytest.raises(FileExistsError):
+            atomic_write_json(path, {"running": True})
+
+        assert victim.read_text(encoding="utf-8") == "precious\n"
+
+    def test_the_refused_write_does_not_publish_anything(
+        self, runtime: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        victim = runtime / "VICTIM.txt"
+        victim.write_text("precious\n", encoding="utf-8")
+        path = runtime / "desired.json"
+
+        fixed = uuid.UUID("00000000-0000-4000-8000-000000000000")
+        monkeypatch.setattr(pokemon_module.uuid, "uuid4", lambda: fixed)
+        os.symlink(victim, runtime / f".{path.name}.{fixed.hex}.tmp")
+
+        with pytest.raises(FileExistsError):
+            atomic_write_json(path, {"running": True})
+
+        assert not path.exists()
+
+    def test_a_link_at_the_old_predictable_name_is_simply_irrelevant(
+        self, runtime: Path
+    ) -> None:
+        victim = runtime / "VICTIM.txt"
+        victim.write_text("precious\n", encoding="utf-8")
+        path = runtime / "desired.json"
+        os.symlink(victim, runtime / f".{path.name}.{os.getpid()}.tmp")
+
+        atomic_write_json(path, {"running": True})
+
+        assert victim.read_text(encoding="utf-8") == "precious\n"
+        assert json.loads(path.read_text(encoding="utf-8")) == {"running": True}
+
+
+class TestTheOrdinaryWriteStillBehaves:
+    """A guard that broke the happy path would be worse than the bug."""
+
+    def test_it_writes_a_value_that_reads_back(self, runtime: Path) -> None:
+        path = runtime / "status.json"
+        atomic_write_json(path, {"running": True, "frame": 12})
+        assert json.loads(path.read_text(encoding="utf-8")) == {
+            "running": True,
+            "frame": 12,
+        }
+
+    def test_it_replaces_the_previous_value(self, runtime: Path) -> None:
+        path = runtime / "status.json"
+        atomic_write_json(path, SMALL)
+        atomic_write_json(path, LARGE)
+        assert json.loads(path.read_text(encoding="utf-8")) == LARGE
+
+    def test_the_published_file_stays_owner_only(self, runtime: Path) -> None:
+        path = runtime / "status.json"
+        atomic_write_json(path, SMALL)
+        assert oct(path.stat().st_mode & 0o777) == oct(0o600)
+
+    def test_it_creates_a_missing_parent_directory(self, tmp_path: Path) -> None:
+        path = tmp_path / "made" / "up" / "status.json"
+        atomic_write_json(path, SMALL)
+        assert json.loads(path.read_text(encoding="utf-8")) == SMALL
+
+    def test_a_successful_write_leaves_no_temporary_behind(
+        self, runtime: Path
+    ) -> None:
+        path = runtime / "status.json"
+        atomic_write_json(path, SMALL)
+        assert [entry.name for entry in runtime.iterdir()] == ["status.json"]
+
+    def test_the_directory_is_synced_so_the_rename_survives_a_crash(
+        self, runtime: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        synced: list[Path] = []
+        monkeypatch.setattr(
+            pokemon_module, "fsync_directory", lambda directory: synced.append(directory)
+        )
+        atomic_write_json(runtime / "status.json", SMALL)
+        assert synced == [runtime]
+
+    def test_the_payload_reaches_disk_before_the_rename_publishes_it(
+        self, runtime: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        order: list[str] = []
+        real_fsync = os.fsync
+        real_replace = os.replace
+
+        def recording_fsync(descriptor):
+            order.append("fsync")
+            return real_fsync(descriptor)
+
+        def recording_replace(source, destination):
+            order.append("replace")
+            return real_replace(source, destination)
+
+        monkeypatch.setattr(os, "fsync", recording_fsync)
+        monkeypatch.setattr(os, "replace", recording_replace)
+        atomic_write_json(runtime / "status.json", SMALL)
+        assert "replace" in order
+        assert order.index("fsync") < order.index("replace")
+
+
+class TestAFailedWriteCleansUpAfterItself:
+    """A uuid name never gets reused, so a leaked temporary leaks forever."""
+
+    def test_a_failed_rename_leaves_no_temporary_behind(
+        self, runtime: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = runtime / "status.json"
+        atomic_write_json(path, SMALL)
+
+        def exploding_replace(source, destination):
+            raise OSError("no room")
+
+        monkeypatch.setattr(os, "replace", exploding_replace)
+        with pytest.raises(OSError):
+            atomic_write_json(path, LARGE)
+
+        assert [entry.name for entry in runtime.iterdir()] == ["status.json"]
+
+    def test_a_failed_rename_leaves_the_previous_value_intact(
+        self, runtime: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        path = runtime / "status.json"
+        atomic_write_json(path, SMALL)
+
+        def exploding_replace(source, destination):
+            raise OSError("no room")
+
+        monkeypatch.setattr(os, "replace", exploding_replace)
+        with pytest.raises(OSError):
+            atomic_write_json(path, LARGE)
+
+        assert json.loads(path.read_text(encoding="utf-8")) == SMALL

--- a/python/tests/test_pokemon_atomic_write.py
+++ b/python/tests/test_pokemon_atomic_write.py
@@ -217,6 +217,25 @@ class TestTheOrdinaryWriteStillBehaves:
         atomic_write_json(path, SMALL)
         assert oct(path.stat().st_mode & 0o777) == oct(0o600)
 
+    def test_it_stays_owner_only_even_under_a_hostile_umask(
+        self, runtime: Path
+    ) -> None:
+        """The open mode is only a request; umask subtracts from it.
+
+        Under an ordinary umask the create mode already lands on 0600, which
+        makes the explicit chmod look redundant -- a mutation removing it
+        survived a test that asserted the mode without controlling the umask.
+        A umask of 0377 strips the write bit at create time, so only the chmod
+        can put it back.
+        """
+        path = runtime / "status.json"
+        previous = os.umask(0o377)
+        try:
+            atomic_write_json(path, SMALL)
+        finally:
+            os.umask(previous)
+        assert oct(path.stat().st_mode & 0o777) == oct(0o600)
+
     def test_it_creates_a_missing_parent_directory(self, tmp_path: Path) -> None:
         path = tmp_path / "made" / "up" / "status.json"
         atomic_write_json(path, SMALL)


### PR DESCRIPTION
## What's wrong

`atomic_write_json` in `python/openrappter/agents/pokemon_agent.py` named its temporary file after the **process id** and opened it with **`O_TRUNC`**:

```python
temporary = path.with_name(f".{path.name}.{os.getpid()}.tmp")
descriptor = os.open(temporary, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
```

Threads share a process id. That is one temporary name for the *whole process*, not one per writer.

And the runtime is threaded. `ViewerServer` runs a `http.server.ThreadingHTTPServer` — a thread per request — and its handler answers `stop` by calling `set_desired_running(runtime_dir, False)`, which writes `desired.json` through this function. Two overlapping POSTs therefore open the **same** temporary file, interleave their bytes into it, and race to rename it.

## Measured, not argued

Two threads writing the same path, 60 rounds each, with a third thread polling the published file. Same probe run against a control writer built the way the other seven atomic writers in this repo are built:

| | shipped | control (uuid + `O_EXCL`) |
|---|---|---|
| writer exceptions | **57** (`FileNotFoundError` on rename) | 0 |
| reader saw unparseable JSON | **219** | 0 |
| symlink at temp path clobbered its target | **yes**, silently | no |

The rename failures are the honest half. The 219 unparseable reads are the dangerous half: `read_json` catches `JSONDecodeError` and returns the default, so a torn `status.json` doesn't crash anything — the runtime just **quietly forgets its state**. That is the same failure `atomic_io`'s own docstring warns about: it "reads the same as nothing is installed, and the next save then overwrites the only evidence."

Separately, `O_TRUNC` does not refuse symlinks. A link planted at the entirely guessable `.desired.json.<pid>.tmp` redirected the write onto its target and truncated it, raising nothing. This needs an attacker who can write to the runtime directory — `--runtime-dir` is user-supplied — so I rate it hardening, not the headline. The same one-line change closes it.

## The fix

This function was the **only** outlier. Every other atomic writer here already uses a unique name plus either `mkstemp` or `O_EXCL`:

| writer | temp name | flags |
|---|---|---|
| `atomic_io.py:69` | `mkstemp` | — |
| `brainstem.py:203`, `:546` | `mkstemp` | — |
| `brainstem.py:400` | `uuid4().hex` | `O_EXCL` |
| `imessage/config.py:77` | `uuid4().hex` | `O_EXCL` |
| `imessage/state.py:644` | `uuid4().hex` | `O_EXCL` |
| `show_and_tell.py:87` | `uuid4()` | `O_EXCL` |
| **`pokemon_agent.py:348`** | **`os.getpid()`** | **`O_TRUNC`** |

So the fix is not an invention, it is bringing the last holdout in line: a uuid-keyed name, `O_EXCL` (which refuses to follow a link), and cleanup of the temporary on failure — because unlike a pid name, a uuid name is never reused, so a leaked temporary would leak forever. Re-running the probe against the fix gives zero of all three columns.

## Tests

19 new tests in `python/tests/test_pokemon_atomic_write.py`, covering the concurrency contract, the symlink refusal, the ordinary write path, and failure cleanup.

The symlink test deliberately pins `O_EXCL` *itself* rather than the name change: it monkeypatches `uuid4` to a fixed value so the test can plant a link at the exact path the writer will use, then requires `FileExistsError`. Otherwise the test would pass merely because the name got harder to guess, which is not the property worth relying on.

## Mutation matrix

6 mutants, `__pycache__` cleared before and after each:

| # | mutation | result | caught by |
|---|---|---|---|
| M1 | temporary named after pid again | CAUGHT | `test_no_writer_fails_because_another_consumed_its_temporary`, `test_two_writes_use_different_temporary_names`, `test_the_temporary_name_does_not_carry_the_process_id` |
| M2 | `O_EXCL` downgraded to `O_TRUNC` | CAUGHT | `test_a_symlink_at_the_temporary_path_is_refused`, `test_the_refused_write_does_not_publish_anything` |
| M3 | failed-write cleanup removed | CAUGHT | `test_a_failed_rename_leaves_no_temporary_behind` |
| M4 | `chmod 0600` removed | CAUGHT | `test_it_stays_owner_only_even_under_a_hostile_umask` |
| M5 | directory fsync removed | CAUGHT | `test_the_directory_is_synced_so_the_rename_survives_a_crash` |
| M6 | file fsync before rename removed | CAUGHT | `test_the_payload_reaches_disk_before_the_rename_publishes_it` |

**6/6 caught, 0 survivors.**

M4 is worth calling out because **it survived the first run.** I had written a test asserting the published file is `0600`, and it passed with the `chmod` deleted — because `os.open(..., 0o600)` already lands on `0600` under an ordinary umask, so the line under test was never exercised. The replacement sets a umask of `0377` first, which strips the write bit at create time so only the `chmod` can restore it. A test that asserts a true thing for the wrong reason is worse than no test, and only the mutation run exposed it.

## Validation

- Full Python suite: **2040 passed**, 6 skipped, 51 subtests (baseline was 2021)
- `parity_harness.py --runtime both`: **PASS**
- `test_pokemon_agent.py`: 87 existing tests still green

## Not claimed here

While comparing the writers I re-confirmed the finding noted on #382: `atomic_io`'s module docstring asserts that `brainstem`, `show_and_tell`, `imessage.config`, `imessage.state` and `pokemon_agent` all handle atomic writes "correctly by hand", but only `pokemon_agent` calls `fsync_directory`. The other four fsync the file and then `os.replace` with no directory fsync. That is a code-reading fact, not a measurement — the failure needs power loss, and on macOS `fsync` doesn't reach the platter without `F_FULLFSYNC`. Left out of this diff as scope creep; a docstring correction is the defensible version of it.
