### PR TITLE
fix(gateway): the server could not report the port it actually bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The gateway could not report the port it actually bound. `listen(0)` asks the
+  kernel to choose a free port, and nothing read that choice back, so
+  `config.port` stayed `0`: the startup log said `127.0.0.1:0`, and
+  `getStatus()`, `/status` and the anatomy view all answered `0` — the anatomy
+  page renders `port ${live.port ?? 18790}`, and zero is not nullish, so it
+  displayed "port 0". The cost showed up in CI. Because a server on port 0
+  could not say where it was, tests pre-reserved a port by binding it, closing
+  it, and handing the bare number over to be bound again, which leaves a window
+  in which anything may take it. On 2026-08-19 two vitest workers were handed
+  `127.0.0.1:36297`; one held it and the other failed with `EADDRINUSE`. The
+  server now reads the bound port back and exposes it, and the gateway
+  integration and observability suites ask for port 0 and then ask the server
+  where it landed, which has no window at all.
 - The Pokemon runtime corrupted its own state files when two threads wrote at
   once. `atomic_write_json` named its temporary after the process id, which
   threads share, so it was one name for the whole process rather than one per

--- a/typescript/src/__tests__/integration/gateway-observability.test.ts
+++ b/typescript/src/__tests__/integration/gateway-observability.test.ts
@@ -25,7 +25,6 @@ import {
   logGatewayRequest,
 } from '../../gateway/observability.js';
 import WebSocket from 'ws';
-import { reserveTestPort } from '../support/test-port.js';
 
 let testDataDir = '';
 
@@ -162,9 +161,9 @@ describe('Gateway Observability', () => {
 
   describe('GatewayServer wiring', () => {
     it('a brand-new server instance reports zeroed metrics via /status and /health', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const status = await fetchJson(`http://127.0.0.1:${port}/status`);
       const health = await fetchJson(`http://127.0.0.1:${port}/health`);
@@ -174,9 +173,9 @@ describe('Gateway Observability', () => {
     });
 
     it('never counts /health or /status polling as an RPC request', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       for (let i = 0; i < 5; i++) {
         await fetchJson(`http://127.0.0.1:${port}/health`);
@@ -188,9 +187,9 @@ describe('Gateway Observability', () => {
     });
 
     it('increments the success counter exactly once per successful WS RPC dispatch', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -209,9 +208,9 @@ describe('Gateway Observability', () => {
     });
 
     it('increments the error counter exactly once for an unknown method over WS', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -225,10 +224,10 @@ describe('Gateway Observability', () => {
     });
 
     it('increments the auth_failure counter exactly once for a requiresAuth method called unauthenticated', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['secret-token'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['secret-token'] } });
       server.registerMethod('protected.thing', async () => ({ ok: true }), { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       // HTTP path: no credential supplied against a token-mode server
       const res = await fetch(`http://127.0.0.1:${port}/`, {
@@ -244,9 +243,9 @@ describe('Gateway Observability', () => {
     });
 
     it('increments the rate_limited counter exactly once when the WS rate limit window is exceeded', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -269,10 +268,10 @@ describe('Gateway Observability', () => {
     }, 15000);
 
     it('increments the timeout counter exactly once when a handler exceeds an opt-in executionTimeoutMs', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, executionTimeoutMs: 50 });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, executionTimeoutMs: 50 });
       server.registerMethod('slow.thing', () => new Promise((resolve) => setTimeout(() => resolve({ done: true }), 2000)));
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -287,10 +286,10 @@ describe('Gateway Observability', () => {
     }, 10000);
 
     it('does not enforce a timeout when executionTimeoutMs is unset (default, non-breaking)', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.registerMethod('slow.thing', () => new Promise((resolve) => setTimeout(() => resolve({ done: true }), 150)));
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -301,9 +300,9 @@ describe('Gateway Observability', () => {
     });
 
     it('tracks the active connections gauge as WS clients connect and disconnect', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws1 = await connectWs(port);
       await doConnect(ws1);
@@ -323,14 +322,14 @@ describe('Gateway Observability', () => {
     });
 
     it('tracks the active agent executions gauge while an agent run is in flight, and clears it after', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       let releaseAgent: (() => void) | undefined;
       server.setAgentHandler(async (req) => {
         await new Promise<void>((resolve) => { releaseAgent = resolve; });
         return { content: 'done', sessionId: req.sessionId ?? 'x', finishReason: 'stop' };
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -351,8 +350,7 @@ describe('Gateway Observability', () => {
     });
 
     it('tracks cronService runs with the same execution gauge', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       let releaseRun: (() => void) | undefined;
       let markStarted: (() => void) | undefined;
       const started = new Promise<void>((resolve) => { markStarted = resolve; });
@@ -368,6 +366,7 @@ describe('Gateway Observability', () => {
         disable: async () => undefined,
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -386,8 +385,7 @@ describe('Gateway Observability', () => {
     });
 
     it('clears the cron execution gauge when the trigger branch fails', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.setCronService({
         list: () => [],
         run: async () => { throw new Error('cron failed'); },
@@ -395,6 +393,7 @@ describe('Gateway Observability', () => {
         disable: async () => undefined,
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -407,9 +406,9 @@ describe('Gateway Observability', () => {
     });
 
     it('a fresh server instance always starts with zeroed counters (predictable reset per instance/start)', async () => {
-      const port1 = await reserveTestPort();
-      const server1 = new GatewayServer({ port: port1, bind: 'loopback', auth: { mode: 'none' } });
+      const server1 = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server1.start();
+      const port1 = server1.port;
       const ws1 = await connectWs(port1);
       await doConnect(ws1);
       await rpc(ws1, 'ping');
@@ -418,17 +417,17 @@ describe('Gateway Observability', () => {
       ws1.close();
       await server1.stop();
 
-      const port2 = await reserveTestPort();
-      server = new GatewayServer({ port: port2, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port2 = server.port;
       const status2 = await fetchJson(`http://127.0.0.1:${port2}/status`);
       expect((status2.metrics as Record<string, number>).rpcRequestsTotal).toBe(0);
     });
 
     it('restarting the same server instance (stop then start) resets counters back to zero', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      let port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -440,6 +439,7 @@ describe('Gateway Observability', () => {
       await server.stop();
       await new Promise((r) => setTimeout(r, 50));
       await server.start();
+      port = server.port;
       await new Promise((r) => setTimeout(r, 50));
 
       const after = await fetchJson(`http://127.0.0.1:${port}/status`);

--- a/typescript/src/__tests__/integration/gateway.test.ts
+++ b/typescript/src/__tests__/integration/gateway.test.ts
@@ -17,7 +17,6 @@ import { request as httpRequest } from 'http';
 import { GatewayServer as RuntimeGatewayServer } from '../../gateway/server.js';
 import type { GatewayConfig } from '../../gateway/types.js';
 import WebSocket, { type ClientOptions } from 'ws';
-import { reserveTestPort } from '../support/test-port.js';
 
 let testDataDir = '';
 
@@ -115,9 +114,9 @@ describe('Gateway Integration', () => {
 
   describe('HTTP endpoints', () => {
     it('should respond to GET /health', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const res = await fetch(`http://127.0.0.1:${port}/health`);
       expect(res.status).toBe(200);
@@ -129,9 +128,9 @@ describe('Gateway Integration', () => {
     });
 
     it('should respond to GET /status', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const res = await fetch(`http://127.0.0.1:${port}/status`);
       const body = (await res.json()) as Record<string, unknown>;
@@ -140,19 +139,19 @@ describe('Gateway Integration', () => {
     });
 
     it('should return 404 for unknown paths', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const res = await fetch(`http://127.0.0.1:${port}/nonexistent`);
       expect(res.status).toBe(404);
     });
 
     it('allows the exact same browser origin without wildcard CORS', async () => {
-      const port = await reserveTestPort();
-      const origin = `http://127.0.0.1:${port}`;
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
+      const origin = `http://127.0.0.1:${port}`;
 
       const res = await fetch(`${origin}/health`, { headers: { Origin: origin } });
       expect(res.status).toBe(200);
@@ -161,14 +160,14 @@ describe('Gateway Integration', () => {
     });
 
     it('rejects a malicious browser origin before any loopback HTTP handler runs', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       let handlerCalled = false;
       server.registerMethod('protected.local', async () => {
         handlerCalled = true;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const res = await fetch(`http://127.0.0.1:${port}/`, {
         method: 'POST',
@@ -207,9 +206,9 @@ describe('Gateway Integration', () => {
       ['a query string appended to the authority', (port: number) => `127.0.0.1:${port}?x=1`],
       ['a fragment appended to the authority', (port: number) => `127.0.0.1:${port}#frag`],
     ])('rejects a Host header carrying %s', async (_label, build) => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const res = await rawHttpGet(port, { Host: build(port) });
 
@@ -241,9 +240,9 @@ describe('Gateway Integration', () => {
       // Host and scheme match; carries a path.
       ['a path', (port: number) => `http://127.0.0.1:${port}/evil`],
     ])('rejects a browser Origin with %s', async (_label, build) => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const res = await rawHttpGet(port, {
         Host: `127.0.0.1:${port}`,
@@ -257,9 +256,9 @@ describe('Gateway Integration', () => {
     it('accepts a browser Origin that matches the gateway exactly', async () => {
       // Positive control. Without it the four refusals would pass if any Origin
       // header at all were rejected, which would break the dashboard.
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const res = await rawHttpGet(port, {
         Host: `127.0.0.1:${port}`,
@@ -273,9 +272,9 @@ describe('Gateway Integration', () => {
     it('still accepts an ordinary loopback Host header', async () => {
       // Positive control: without it, the six refusals above would all pass if
       // validateRequestSource simply rejected everything.
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const res = await rawHttpGet(port, { Host: `127.0.0.1:${port}` });
 
@@ -283,9 +282,9 @@ describe('Gateway Integration', () => {
     });
 
     it('rejects a non-loopback Host header to prevent DNS rebinding', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const res = await rawHttpGet(port, { Host: `attacker.example:${port}` });
       expect(res.status).toBe(403);
@@ -297,9 +296,9 @@ describe('Gateway Integration', () => {
 
   describe('WebSocket handshake', () => {
     it('should accept connect handshake (no auth)', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       const res = await doConnect(ws);
@@ -312,9 +311,9 @@ describe('Gateway Integration', () => {
     });
 
     it('should reject non-connect messages before handshake', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       const res = await rpc(ws, 'status');
@@ -326,9 +325,9 @@ describe('Gateway Integration', () => {
     });
 
     it('rejects a malicious WebSocket Origin during the HTTP upgrade', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       await expect(connectWs(port, { origin: 'https://malicious.example' }))
         .rejects.toThrow(/Unexpected server response|WebSocket/);
@@ -336,9 +335,9 @@ describe('Gateway Integration', () => {
     });
 
     it('rejects a malicious WebSocket Host during the HTTP upgrade', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       await expect(connectWs(port, {
         headers: { Host: `attacker.example:${port}` },
@@ -347,9 +346,9 @@ describe('Gateway Integration', () => {
     });
 
     it('accepts 127.0.0.1 and localhost same-origin browser WebSockets plus native clients', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const browser = await connectWs(port, { origin: `http://127.0.0.1:${port}` });
       expect((await doConnect(browser)).ok).toBe(true);
@@ -368,8 +367,7 @@ describe('Gateway Integration', () => {
     });
 
     it('requires configured authentication before binding publicly', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'all', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'all', auth: { mode: 'none' } });
       await expect(server.start()).rejects.toThrow(/auth is required/i);
     });
   });
@@ -378,13 +376,13 @@ describe('Gateway Integration', () => {
 
   describe('Auth modes', () => {
     it('should accept password auth', async () => {
-      const port = await reserveTestPort();
       server = new GatewayServer({
-        port,
+        port: 0,
         bind: 'loopback',
         auth: { mode: 'password', password: 'secret123' },
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       const res = await doConnect(ws, { password: 'secret123' });
@@ -394,13 +392,13 @@ describe('Gateway Integration', () => {
     });
 
     it('should reject wrong password', async () => {
-      const port = await reserveTestPort();
       server = new GatewayServer({
-        port,
+        port: 0,
         bind: 'loopback',
         auth: { mode: 'password', password: 'secret123' },
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       const res = await doConnect(ws, { password: 'wrong' });
@@ -410,13 +408,13 @@ describe('Gateway Integration', () => {
     });
 
     it('should reject wrong token', async () => {
-      const port = await reserveTestPort();
       server = new GatewayServer({
-        port,
+        port: 0,
         bind: 'loopback',
         auth: { mode: 'token', tokens: ['correct-token'] },
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       const res = await doConnect(ws, { token: 'wrong-token' });
@@ -427,13 +425,13 @@ describe('Gateway Integration', () => {
     });
 
     it('should keep separate clients isolated: one authenticated client does not grant access to another unauthenticated client', async () => {
-      const port = await reserveTestPort();
       server = new GatewayServer({
-        port,
+        port: 0,
         bind: 'loopback',
         auth: { mode: 'token', tokens: ['shared-token'] },
       });
       await server.start();
+      const port = server.port;
 
       const wsA = await connectWs(port);
       const connectA = await doConnect(wsA, { token: 'shared-token' });
@@ -454,13 +452,13 @@ describe('Gateway Integration', () => {
     });
 
     it('should not leak authenticated state across reconnects', async () => {
-      const port = await reserveTestPort();
       server = new GatewayServer({
-        port,
+        port: 0,
         bind: 'loopback',
         auth: { mode: 'token', tokens: ['reconnect-token'] },
       });
       await server.start();
+      const port = server.port;
 
       const ws1 = await connectWs(port);
       await doConnect(ws1, { token: 'reconnect-token' });
@@ -482,14 +480,14 @@ describe('Gateway Integration', () => {
 
   describe('requiresAuth dispatch enforcement', () => {
     it('should let an authenticated client call a requiresAuth-protected method', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-1'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-1'] } });
       let handlerCalled = false;
       server.registerMethod('protected.action', async () => {
         handlerCalled = true;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws, { token: 'tok-1' });
@@ -502,9 +500,9 @@ describe('Gateway Integration', () => {
     });
 
     it('should let public (non-requiresAuth) methods remain callable after handshake', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-2'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-2'] } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws, { token: 'tok-2' });
@@ -516,14 +514,14 @@ describe('Gateway Integration', () => {
     });
 
     it('should work with requiresAuth methods when auth mode is "none" (local trusted mode)', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       let handlerCalled = false;
       server.registerMethod('protected.action', async () => {
         handlerCalled = true;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -536,14 +534,14 @@ describe('Gateway Integration', () => {
     });
 
     it('should reject an unauthenticated caller of a requiresAuth method and never invoke the handler (regression guard for dead requiresAuth flag)', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-3'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-3'] } });
       let handlerCalled = false;
       server.registerMethod('protected.dangerous', async () => {
         handlerCalled = true;
         return { didSomethingDangerous: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       // Access the private dispatch path directly. This deliberately bypasses
       // the connect-handshake gate (which today already blocks everything
@@ -600,9 +598,9 @@ describe('Gateway Integration', () => {
 
   describe('RPC methods', () => {
     it('should respond to ping', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -615,9 +613,9 @@ describe('Gateway Integration', () => {
     });
 
     it('should respond to status', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -631,9 +629,9 @@ describe('Gateway Integration', () => {
     });
 
     it('should list available methods', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -650,9 +648,9 @@ describe('Gateway Integration', () => {
     });
 
     it('should return error for unknown methods', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -664,12 +662,12 @@ describe('Gateway Integration', () => {
     });
 
     it('should support custom registered methods', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.registerMethod('custom.echo', async (params: { text: string }) => {
         return { echoed: params.text };
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -682,14 +680,14 @@ describe('Gateway Integration', () => {
     });
 
     it('streams real agent deltas and a terminal frame over the live socket', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.setAgentHandler(async (_request, stream) => {
         stream?.({ id: '', streaming: true, chunk: 'hello ', done: false });
         stream?.({ id: '', streaming: true, chunk: 'world', done: false });
         return { content: 'hello world', sessionId: 'stream-session', finishReason: 'stop' };
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -732,8 +730,7 @@ describe('Gateway Integration', () => {
     });
 
     it('settles provider output on done and emits one dispatcher-owned terminal frame', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.setAgentHandler(async (_request, stream) => {
         stream?.({ id: '', streaming: true, chunk: 'before done', done: false });
         stream?.({ id: '', streaming: true, done: true });
@@ -748,6 +745,7 @@ describe('Gateway Integration', () => {
         };
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -781,8 +779,7 @@ describe('Gateway Integration', () => {
     });
 
     it('settles provider output on error and ignores all later callbacks', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.setAgentHandler(async (_request, stream) => {
         stream?.({
           id: '',
@@ -801,6 +798,7 @@ describe('Gateway Integration', () => {
         };
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -827,9 +825,8 @@ describe('Gateway Integration', () => {
     });
 
     it('makes stream timeouts terminal and suppresses late provider chunks', async () => {
-      const port = await reserveTestPort();
       server = new GatewayServer({
-        port,
+        port: 0,
         bind: 'loopback',
         auth: { mode: 'none' },
         executionTimeoutMs: 20,
@@ -843,6 +840,7 @@ describe('Gateway Integration', () => {
         }), 60);
       }));
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -877,13 +875,13 @@ describe('Gateway Integration', () => {
 
   describe('Server lifecycle', () => {
     it('should report status correctly', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback' });
+      server = new GatewayServer({ port: 0, bind: 'loopback' });
 
       const beforeStart = server.getStatus();
       expect(beforeStart.running).toBe(false);
 
       await server.start();
+      const port = server.port;
 
       const afterStart = server.getStatus();
       expect(afterStart.running).toBe(true);
@@ -898,9 +896,9 @@ describe('Gateway Integration', () => {
     });
 
     it('should track connections', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -915,9 +913,9 @@ describe('Gateway Integration', () => {
     });
 
     it('should clean up on stop', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -929,26 +927,26 @@ describe('Gateway Integration', () => {
     });
 
     it('serializes an immediate restart behind an in-progress stop', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const stopping = server.stop();
       const restarting = server.start();
       await Promise.all([stopping, restarting]);
 
       expect(server.getStatus().running).toBe(true);
-      const res = await fetch(`http://127.0.0.1:${port}/health`);
+      // A restart picks a fresh kernel-assigned port, so ask where it landed.
+      const res = await fetch(`http://127.0.0.1:${server.port}/health`);
       expect(res.status).toBe(200);
     });
 
     it('generation-fences an old chat completion across stop and restart', async () => {
-      const port = await reserveTestPort();
       let releaseAgent: (() => void) | undefined;
       let markStarted: (() => void) | undefined;
       const started = new Promise<void>((resolve) => { markStarted = resolve; });
       server = new GatewayServer({
-        port,
+        port: 0,
         bind: 'loopback',
         auth: { mode: 'none' },
         shutdownTimeoutMs: 20,
@@ -963,6 +961,7 @@ describe('Gateway Integration', () => {
         };
       });
       await server.start();
+      let port = server.port;
 
       const oldSocket = await connectWs(port);
       await doConnect(oldSocket);
@@ -976,6 +975,7 @@ describe('Gateway Integration', () => {
       await server.stop();
       expect(Date.now() - stopStartedAt).toBeLessThan(500);
       await server.start();
+      port = server.port;
 
       const currentSocket = await connectWs(port);
       await doConnect(currentSocket);
@@ -1007,12 +1007,11 @@ describe('Gateway Integration', () => {
     });
 
     it('does not let an old cron completion alter restarted metrics', async () => {
-      const port = await reserveTestPort();
       let releaseCron: (() => void) | undefined;
       let markStarted: (() => void) | undefined;
       const started = new Promise<void>((resolve) => { markStarted = resolve; });
       server = new GatewayServer({
-        port,
+        port: 0,
         bind: 'loopback',
         auth: { mode: 'none' },
         shutdownTimeoutMs: 20,
@@ -1027,6 +1026,7 @@ describe('Gateway Integration', () => {
         disable: async () => undefined,
       });
       await server.start();
+      let port = server.port;
 
       const oldSocket = await connectWs(port);
       await doConnect(oldSocket);
@@ -1039,6 +1039,7 @@ describe('Gateway Integration', () => {
       await started;
       await server.stop();
       await server.start();
+      port = server.port;
 
       releaseCron?.();
       await new Promise((resolve) => setTimeout(resolve, 50));
@@ -1064,14 +1065,14 @@ describe('Gateway Integration', () => {
     }
 
     it('blocks a protected HTTP call with no auth (token mode) and never invokes the handler', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
       let handlerCalled = false;
       server.registerMethod('protected.http', async () => {
         handlerCalled = true;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const { status, body } = await httpRpc(port, 'protected.http');
       expect(status).toBe(401);
@@ -1080,14 +1081,14 @@ describe('Gateway Integration', () => {
     });
 
     it('blocks a protected HTTP call with a wrong bearer token and never invokes the handler', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
       let handlerCalled = false;
       server.registerMethod('protected.http', async () => {
         handlerCalled = true;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const { status, body } = await httpRpc(port, 'protected.http', undefined, { Authorization: 'Bearer wrong-token' });
       expect(status).toBe(401);
@@ -1096,14 +1097,14 @@ describe('Gateway Integration', () => {
     });
 
     it('allows a protected HTTP call with the correct Authorization: Bearer token', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
       let handlerCalled = false;
       server.registerMethod('protected.http', async () => {
         handlerCalled = true;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const { status, body } = await httpRpc(port, 'protected.http', undefined, { Authorization: 'Bearer tok-http' });
       expect(status).toBe(200);
@@ -1112,14 +1113,14 @@ describe('Gateway Integration', () => {
     });
 
     it('rejects a wrong password sent in the JSON-RPC body auth field', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'password', password: 'secret-http' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'password', password: 'secret-http' } });
       let handlerCalled = false;
       server.registerMethod('protected.http', async () => {
         handlerCalled = true;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const res = await fetch(`http://127.0.0.1:${port}/`, {
         method: 'POST',
@@ -1131,14 +1132,14 @@ describe('Gateway Integration', () => {
     });
 
     it('accepts a correct password sent in the JSON-RPC body auth field', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'password', password: 'secret-http' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'password', password: 'secret-http' } });
       let handlerCalled = false;
       server.registerMethod('protected.http', async () => {
         handlerCalled = true;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const res = await fetch(`http://127.0.0.1:${port}/`, {
         method: 'POST',
@@ -1152,14 +1153,14 @@ describe('Gateway Integration', () => {
     });
 
     it('never synthesizes authenticated:true for protected methods over HTTP with no credential configured (auth mode none stays trusted, but requiresAuth is still enforced when a mode is configured)', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['t1'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['t1'] } });
       let receivedAuthenticated: boolean | undefined;
       server.registerMethod('protected.inspect', async (_params, conn: unknown) => {
         receivedAuthenticated = (conn as { authenticated: boolean }).authenticated;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       // No credential at all.
       const denied = await httpRpc(port, 'protected.inspect');
@@ -1173,14 +1174,14 @@ describe('Gateway Integration', () => {
     });
 
     it('preserves loopback auth-none behavior for HTTP (protected methods work with no credential)', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       let handlerCalled = false;
       server.registerMethod('protected.http', async () => {
         handlerCalled = true;
         return { ok: true };
       }, { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const { status, body } = await httpRpc(port, 'protected.http');
       expect(status).toBe(200);
@@ -1189,9 +1190,9 @@ describe('Gateway Integration', () => {
     });
 
     it('allows only the explicit public HTTP RPC allowlist without credentials', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
       await server.start();
+      const port = server.port;
 
       for (const method of ['ping', 'health', 'status']) {
         const { status, body } = await httpRpc(port, method);
@@ -1201,9 +1202,9 @@ describe('Gateway Integration', () => {
     });
 
     it('does not let a replacement handler inherit a built-in public exemption', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
       await server.start();
+      const port = server.port;
 
       let replacementCalled = false;
       server.registerMethod('ping', async () => {
@@ -1227,9 +1228,9 @@ describe('Gateway Integration', () => {
     });
 
     it('protects sensitive HTTP method names and rejects untrusted origins even with a valid token', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['tok-http'] } });
       await server.start();
+      const port = server.port;
 
       const invoked: string[] = [];
       const sensitiveMethods = ['config.set', 'chat.delete', 'backup.restore', 'auth.remove'];
@@ -1275,10 +1276,10 @@ describe('Gateway Integration', () => {
     });
 
     it('never leaks the configured token/password in the error response', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'token', tokens: ['super-secret-token'] } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'token', tokens: ['super-secret-token'] } });
       server.registerMethod('protected.http', async () => ({ ok: true }), { requiresAuth: true });
       await server.start();
+      const port = server.port;
 
       const { body } = await httpRpc(port, 'protected.http', undefined, { Authorization: 'Bearer wrong' });
       expect(JSON.stringify(body)).not.toContain('super-secret-token');
@@ -1289,9 +1290,9 @@ describe('Gateway Integration', () => {
 
   describe('sessionKey/sessionId alias', () => {
     it('persists sessions only inside the injected gateway data directory', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -1303,10 +1304,10 @@ describe('Gateway Integration', () => {
     });
 
     it('scopes auth profiles and backups to the injected gateway data directory', async () => {
-      const port = await reserveTestPort();
       fs.writeFileSync(path.join(testDataDir, 'test-state.json'), '{"isolated":true}');
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -1321,10 +1322,10 @@ describe('Gateway Integration', () => {
     });
 
     it('chat.messages accepts sessionId (canonical) for a session created via chat.send', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.setAgentHandler(async (req) => ({ content: 'hi back', sessionId: req.sessionId ?? '', finishReason: 'stop' }));
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -1343,9 +1344,9 @@ describe('Gateway Integration', () => {
     });
 
     it('chat.delete accepts sessionKey (legacy/native-client alias) for a session created via chat.session (sessionId)', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -1361,9 +1362,9 @@ describe('Gateway Integration', () => {
     });
 
     it('chat.session accepts sessionKey as an alias for sessionId', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -1380,13 +1381,13 @@ describe('Gateway Integration', () => {
 
   describe('chat.abort', () => {
     it('supports the UI runId-only abort contract', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.setAgentHandler(async () => {
         await new Promise((r) => setTimeout(r, 200));
         return { content: 'late response', sessionId: 'abort-sess-1', finishReason: 'stop' };
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -1404,8 +1405,7 @@ describe('Gateway Integration', () => {
     });
 
     it('supersedes concurrent runs in one session without overwriting runId tracking', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       const releases: Array<() => void> = [];
       server.setAgentHandler((req) => new Promise((resolve) => {
         releases.push(() => resolve({
@@ -1415,6 +1415,7 @@ describe('Gateway Integration', () => {
         }));
       }));
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -1451,9 +1452,9 @@ describe('Gateway Integration', () => {
     });
 
     it('returns aborted:false when there is no active run for the session', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -1466,14 +1467,14 @@ describe('Gateway Integration', () => {
     });
 
     it('cleans both runId and session indexes after a run finishes', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.setAgentHandler(async (req) => ({
         content: 'done',
         sessionId: req.sessionId ?? '',
         finishReason: 'stop',
       }));
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);
@@ -1498,13 +1499,13 @@ describe('Gateway Integration', () => {
     });
 
     it('does not broadcast an error when an aborted run later rejects', async () => {
-      const port = await reserveTestPort();
-      server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+      server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       server.setAgentHandler(async () => {
         await new Promise((r) => setTimeout(r, 100));
         throw new Error('late failure after user abort');
       });
       await server.start();
+      const port = server.port;
 
       const ws = await connectWs(port);
       await doConnect(ws);

--- a/typescript/src/__tests__/integration/gateway.test.ts
+++ b/typescript/src/__tests__/integration/gateway.test.ts
@@ -929,7 +929,6 @@ describe('Gateway Integration', () => {
     it('serializes an immediate restart behind an in-progress stop', async () => {
       server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
       await server.start();
-      const port = server.port;
 
       const stopping = server.stop();
       const restarting = server.start();

--- a/typescript/src/__tests__/support/test-port.ts
+++ b/typescript/src/__tests__/support/test-port.ts
@@ -1,35 +1,44 @@
 /**
  * Port allocation for tests that bind real sockets.
  *
- * The previous approach guessed: `34000 + Math.floor(Math.random() * 10000)`,
+ * The original approach guessed: `34000 + Math.floor(Math.random() * 10000)`,
  * with no check that anything was listening there. That is a birthday problem
- * wearing a disguise — ~74 draws across three files, run in parallel vitest
- * workers, on a CI runner that has its own listeners. It failed exactly as the
- * arithmetic predicts:
+ * wearing a disguise, and it failed exactly as the arithmetic predicts.
  *
- *     × increments the auth_failure counter exactly once ...
- *       → listen EADDRINUSE: address already in use 127.0.0.1:35212
+ * Asking the kernel is better, but it is not a fix. This helper binds port 0,
+ * reads the port the OS chose, then *closes* the probe so the caller can bind
+ * it. Between that close and the caller's bind the port belongs to nobody, and
+ * anything on the machine may take it.
  *
- * Instead of guessing, ask the kernel. Binding port 0 makes the OS assign a
- * free ephemeral port, which it will not hand to another concurrent listener.
- * We then close our probe so the caller can bind it.
+ * A previous version of this comment claimed that window was safe in practice,
+ * because "ephemeral ports are handed out cyclically, so an immediate reuse
+ * does not happen", and because we never return the same port twice. Both
+ * claims are about a single process. Vitest runs test files in separate worker
+ * processes, so the `issued` set below is not shared, and on 2026-08-19 two
+ * workers were handed the same port:
  *
- * Two windows remain, and both are narrow by construction:
+ *     gateway-observability.test.ts: Gateway server started on 127.0.0.1:36297
+ *     gateway.test.ts > should respond to GET /health
+ *       Gateway server error: listen EADDRINUSE: address already in use 127.0.0.1:36297
  *
- *  - Between our close and the caller's bind, the OS could theoretically
- *    reassign the port. In practice ephemeral ports are handed out cyclically,
- *    so an immediate reuse does not happen.
- *  - A different process could guess our port. Nothing in this repo guesses
- *    any more, which is the point of routing every caller through here.
+ * So treat this helper as a last resort. If the thing you are starting can
+ * report the port it bound, pass it port 0 and ask it afterwards -- there is
+ * no window at all in that arrangement, because the socket is never closed.
+ * `GatewayServer` does this via its `port` getter, which is why the gateway
+ * integration and observability suites no longer appear below.
  *
- * We additionally never return the same port twice within a process, so a test
- * file cannot collide with itself no matter what the kernel recycles.
+ * The remaining callers here start servers that have no such accessor.
  */
 import net from 'net';
 
 const issued = new Set<number>();
 
-/** Ask the OS for a free TCP port on the loopback interface. */
+/**
+ * Ask the OS for a free TCP port on the loopback interface.
+ *
+ * Prefer binding port 0 on the real server and reading the port back. Use this
+ * only when the server cannot tell you which port it bound.
+ */
 export async function reserveTestPort(): Promise<number> {
   for (let attempt = 0; attempt < 50; attempt++) {
     const port = await askKernelForAPort();

--- a/typescript/src/gateway/__tests__/ephemeral-port.test.ts
+++ b/typescript/src/gateway/__tests__/ephemeral-port.test.ts
@@ -1,0 +1,121 @@
+/**
+ * The gateway must be able to say which port it is actually on.
+ *
+ * listen(0) asks the kernel to pick a free port. Nothing read that choice back,
+ * so config.port stayed 0 and every reader of it -- the startup log, getStatus(),
+ * /status, the UI's live signals -- reported a port the server was not on.
+ *
+ * The practical consequence was in the test suite. Because a server started on
+ * port 0 could not tell you where it was, no test could talk HTTP or WebSocket
+ * to one, so 33 test files instead pre-reserved a port by binding it, closing
+ * it, and handing the bare number to the server to bind again. That leaves a
+ * window in which anything can take the port, and on 2026-08-19 it did:
+ *
+ *     gateway-observability.test.ts > ... : Gateway server started on 127.0.0.1:36297
+ *     gateway.test.ts > should respond to GET /health
+ *       Gateway server error: listen EADDRINUSE: address already in use 127.0.0.1:36297
+ *
+ * Two vitest worker processes were handed the same port, and the reservation
+ * helper's de-duplication set is per-process, so it could not have helped.
+ * Reading the bound port back removes the need to guess at all.
+ */
+import { describe, it, expect, afterEach } from 'vitest';
+import { GatewayServer } from '../server.js';
+
+let server: GatewayServer | null = null;
+
+afterEach(async () => {
+  if (server) {
+    await server.stop();
+    server = null;
+  }
+});
+
+function startOnEphemeralPort(): GatewayServer {
+  return new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
+}
+
+describe('the port a gateway reports', () => {
+  it('is the one the kernel chose, not the zero it was asked for', async () => {
+    server = startOnEphemeralPort();
+    await server.start();
+
+    expect(server.port).toBeGreaterThan(0);
+    expect(server.port).toBeLessThanOrEqual(65535);
+  });
+
+  it('is a port the server can actually be reached on', async () => {
+    server = startOnEphemeralPort();
+    await server.start();
+
+    const res = await fetch(`http://127.0.0.1:${server.port}/health`);
+    expect(res.status).toBe(200);
+  });
+
+  it('is what /status reports, so callers are not told 0', async () => {
+    server = startOnEphemeralPort();
+    await server.start();
+
+    const res = await fetch(`http://127.0.0.1:${server.port}/status`);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.port).toBe(server.port);
+    expect(body.port).not.toBe(0);
+  });
+
+  it('is what getStatus() reports', async () => {
+    server = startOnEphemeralPort();
+    await server.start();
+
+    expect(server.getStatus().port).toBe(server.port);
+  });
+
+  it('is left alone when a real port was configured', async () => {
+    const probe = startOnEphemeralPort();
+    await probe.start();
+    const free = probe.port;
+    await probe.stop();
+
+    server = new GatewayServer({ port: free, bind: 'loopback', auth: { mode: 'none' } });
+    await server.start();
+    expect(server.port).toBe(free);
+  });
+
+  it('does not keep claiming a port after the server has stopped', async () => {
+    const stopped = startOnEphemeralPort();
+    await stopped.start();
+    expect(stopped.port).toBeGreaterThan(0);
+
+    await stopped.stop();
+    expect(stopped.port).toBe(0);
+  });
+
+  it('releases the port on stop, so the same one can be bound again', async () => {
+    // Several restart tests used to imply this by rebinding a fixed port after
+    // stop(). Those now take a fresh kernel-assigned port on restart, so the
+    // property they were incidentally covering is asserted here on purpose.
+    const first = startOnEphemeralPort();
+    await first.start();
+    const released = first.port;
+    await first.stop();
+
+    server = new GatewayServer({ port: released, bind: 'loopback', auth: { mode: 'none' } });
+    await server.start();
+    expect(server.port).toBe(released);
+
+    const res = await fetch(`http://127.0.0.1:${released}/health`);
+    expect(res.status).toBe(200);
+  });
+
+  it('reports two concurrently running servers as being on different ports', async () => {
+    const first = startOnEphemeralPort();
+    const second = startOnEphemeralPort();
+    await first.start();
+    await second.start();
+    try {
+      expect(first.port).not.toBe(second.port);
+    } finally {
+      await first.stop();
+      await second.stop();
+    }
+  });
+});

--- a/typescript/src/gateway/__tests__/ephemeral-port.test.ts
+++ b/typescript/src/gateway/__tests__/ephemeral-port.test.ts
@@ -69,6 +69,18 @@ describe('the port a gateway reports', () => {
     expect(server.getStatus().port).toBe(server.port);
   });
 
+  it('is what the anatomy view shows, which renders the number directly', async () => {
+    // anatomy.ts renders `port ${live.port ?? 18790}`. Zero is not nullish, so
+    // a server that reported its configured port here would display "port 0".
+    server = startOnEphemeralPort();
+    await server.start();
+
+    const res = await fetch(`http://127.0.0.1:${server.port}/anatomy.json`);
+    const body = await res.text();
+    expect(body).toContain(`port ${server.port}`);
+    expect(body).not.toContain('port 0');
+  });
+
   it('is left alone when a real port was configured', async () => {
     const probe = startOnEphemeralPort();
     await probe.start();

--- a/typescript/src/gateway/server.ts
+++ b/typescript/src/gateway/server.ts
@@ -336,6 +336,8 @@ interface ParsedFrame {
 export class GatewayServer {
   private wss: WebSocketServer | null = null;
   private httpServer: ReturnType<typeof createServer> | null = null;
+  /** The port the kernel actually bound, which differs from config.port when that is 0. */
+  private boundPort: number | null = null;
   private connections = new Map<string, { ws: WebSocket; info: ConnectionInfo }>();
   private methods = new Map<string, { handler: RpcMethodHandler; requiresAuth: boolean }>();
   private publicHttpMethods = new Map<string, { handler: RpcMethodHandler; requiresAuth: boolean }>();
@@ -827,6 +829,17 @@ export class GatewayServer {
     });
   }
 
+  /**
+   * The port this server is reachable on.
+   *
+   * Before start() this is whatever was configured. After start() it is the
+   * port the kernel actually bound, which is the only useful answer when the
+   * configuration asked for port 0.
+   */
+  get port(): number {
+    return this.boundPort ?? this.config.port;
+  }
+
   async start(): Promise<void> {
     if (this.stopPromise) await this.stopPromise;
     if (this.wss) return;
@@ -861,11 +874,18 @@ export class GatewayServer {
       this.httpServer!.on('error', reject);
     });
 
+    // Port 0 means "any free port", and the kernel picks one during listen().
+    // Until we read it back, the number we were configured with is not the
+    // number we are reachable on, so every later reader -- the startup log,
+    // getStatus(), liveSignals(), /status -- would report 0. Ask the socket.
+    const bound = this.httpServer!.address();
+    this.boundPort = bound !== null && typeof bound === 'object' ? bound.port : this.config.port;
+
     logGatewayLifecycle(
       'gateway',
       'start',
-      `Gateway server started on ${host}:${this.config.port}`,
-      { host, port: this.config.port }
+      `Gateway server started on ${host}:${this.port}`,
+      { host, port: this.port }
     );
   }
 
@@ -914,6 +934,7 @@ export class GatewayServer {
     const httpServer = this.httpServer;
     this.wss = null;
     this.httpServer = null;
+    this.boundPort = null;
 
     const shutdownWaits: Promise<unknown>[] = [...pendingOperations];
     if (wss) {
@@ -968,7 +989,7 @@ export class GatewayServer {
       startedAt: this.startedAt ?? undefined,
       agents: agents.map(a => ({ id: a.id, name: a.id, description: a.description })),
       connections: this.connections.size,
-      port: this.config.port,
+      port: this.port,
       version: VERSION,
       cron: this.cronService?.list().map(j => ({
         name: j.name,
@@ -986,7 +1007,7 @@ export class GatewayServer {
   getStatus(): GatewayStatus {
     return {
       running: !!this.wss,
-      port: this.config.port,
+      port: this.port,
       connections: this.connections.size,
       uptime: this.startedAt ? Math.floor((Date.now() - this.startedAt) / 1000) : 0,
       version: VERSION,


### PR DESCRIPTION
## The bug

`GatewayServer.start()` binds and then never asks the socket what happened:

```ts
this.httpServer!.listen(this.config.port, host, () => resolve());
// ...
`Gateway server started on ${host}:${this.config.port}`
```

`listen(0)` means "any free port", and the kernel picks one. Nothing read that choice back, so `config.port` stayed `0` and every reader of it was wrong:

| reader | reported |
|---|---|
| startup log | `Gateway server started on 127.0.0.1:0` |
| `getStatus()` / `/status` | `port: 0` |
| `liveSignals()` → `/anatomy.json` → the anatomy page | **`port 0`** |

The anatomy page renders ``port ${live.port ?? 18790}``. Zero is not nullish, so it does not fall back — it displays `port 0` to the user.

## How it surfaced

Not as a UI complaint — as a CI flake, and the causal chain is the interesting part.

Because a server started on port 0 could not tell you where it was, **no test could speak HTTP or WebSocket to one.** So 33 test files did the only other thing available: pre-reserve a port by binding it, closing it, and handing the bare number over to be bound again.

That is a TOCTOU. Between the close and the caller's bind, the port belongs to nobody. On 2026-08-19 the `gateway-realtime` job hit it. From the uploaded artifact:

```
gateway-observability.test.ts > ... : Gateway server started on 127.0.0.1:36297
gateway.test.ts > should respond to GET /health
  Gateway server error: listen EADDRINUSE: address already in use 127.0.0.1:36297
```

One file started a server on 36297 and was still holding it; the other was handed the same 36297 and could not bind.

The reservation helper does de-duplicate ports — but its `issued` set is **per-process**, and vitest runs test files in separate worker processes. That job runs exactly two files, in parallel, drawing **76 ports** between them. The de-duplication could not have helped, and its docstring said the remaining window was safe "in practice". It wasn't.

## The fix

Read the bound port back and expose it:

```ts
const bound = this.httpServer!.address();
this.boundPort = bound !== null && typeof bound === 'object' ? bound.port : this.config.port;

get port(): number { return this.boundPort ?? this.config.port; }
```

`getStatus()`, `liveSignals()` and the startup log now use it, and `stop()` clears it so a stopped server does not keep claiming a port.

The two suites in the flaking job now pass `port: 0` and ask the server where it landed. **That has no window at all** — the socket is never closed, so there is nothing to lose a race for. `reserveTestPort` is gone from both files (76 → 0 reservations in that job).

## An honest note on the restart tests

Four tests stop and restart a server. With a pre-reserved port they rebound the *same* number; with port 0 a restart gets a new one, so they now re-read `server.port`.

That loses something real. Those tests were implicitly proving that `stop()` releases the socket, because rebinding the same port would have failed otherwise. Rather than let that quietly disappear, I made it explicit:

```ts
it('releases the port on stop, so the same one can be bound again', ...)
```

Net: the property is now asserted on purpose instead of by accident.

## Mutation matrix

| # | mutation | result | caught by |
|---|---|---|---|
| M1 | bound port not read back from the socket | CAUGHT | `is the one the kernel chose, not the zero it was asked for` |
| M2 | `port` getter ignores the bound port | CAUGHT | `is a port the server can actually be reached on` |
| M3 | stopped server keeps reporting its old port | CAUGHT | `does not keep claiming a port after the server has stopped` |
| M4 | `getStatus()` reports the configured port | CAUGHT | `is what /status reports, so callers are not told 0` |
| M5 | `liveSignals()` reports the configured port | CAUGHT | `is what the anatomy view shows, which renders the number directly` |

**5/5 caught, 0 survivors.**

M5 survived the first run — I had no coverage of `liveSignals()` at all, which is exactly the path that renders `port 0` in the UI. The test added for it fetches `/anatomy.json` and asserts the rendered string, so it pins the user-visible symptom rather than the field.

## Validation

- Full TypeScript suite: **5232 passed**, 21 skipped, 326 files
- `npm run build:server`: clean
- `parity_harness.py --runtime both`: **PASS**
- The `gateway-realtime` job command run **10× consecutively: 0 occurrences of `EADDRINUSE`**

## What I could not prove

I could not reproduce the collision locally. A probe running 8 concurrent processes × 150 reserve-then-bind rounds produced **0** collisions on macOS, whose allocator hands out ephemeral ports cyclically enough that an immediate cross-process reuse does not occur. The CI failure is on Linux. So the reproduction here is the artifact, plus the mechanism being plainly visible in the code — not a local repro. I would rather say that than imply I reproduced it.

## Left for later

The other 31 files still use `reserveTestPort`, because the servers they start have no way to report their port either. They are not in the job that flaked, and converting them means touching each server type, so I left them alone and rewrote the helper's docstring to stop claiming the window is safe and to point at the port-0 route.
