### PR TITLE
test: bind port 0 everywhere instead of reserving a port and racing for it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Tests no longer reserve a port and then race something else to bind it.
+  Reserving means binding a port, closing it, and handing the number over to be
+  bound again, which leaves a window in which anything may take it — the window
+  that failed CI on 2026-08-19. Now that the gateway reports the port it bound,
+  the 26 files that start one pass port 0 and ask afterwards, and the three that
+  start a plain `http` server read it back from `address()`. Two callers remain
+  and are inherent rather than an oversight: neither starts a server, and both
+  need a port number that stays unbound — candidate ports to hand the burrow
+  beacon, and an address nothing answers on to prove pairing with an unreachable
+  peer fails.
 - The gateway could not report the port it actually bound. `listen(0)` asks the
   kernel to choose a free port, and nothing read that choice back, so
   `config.port` stayed `0`: the startup log said `127.0.0.1:0`, and

--- a/typescript/src/__tests__/docs/autonomous-rpc.test.ts
+++ b/typescript/src/__tests__/docs/autonomous-rpc.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * `docs/AUTONOMOUS.md` hands an autonomous agent a list of RPC methods to
@@ -34,8 +33,7 @@ afterEach(async () => {
 });
 
 async function registeredMethods(): Promise<Set<string>> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   await server.start();
   const registry = (server as unknown as {
     methods: Map<string, unknown>;

--- a/typescript/src/__tests__/integration/agents-import-response-safety.test.ts
+++ b/typescript/src/__tests__/integration/agents-import-response-safety.test.ts
@@ -22,7 +22,6 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import type { ServerResponse } from 'http';
 import { GatewayServer, writeJsonResponse } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 let server: GatewayServer | undefined;
 
@@ -39,15 +38,15 @@ function cyclic(): Record<string, unknown> {
 }
 
 async function startWithImporter(result: () => unknown): Promise<number> {
-  const port = await reserveTestPort();
   server = new GatewayServer({
-    port,
+    port: 0,
     bind: 'loopback',
     auth: { mode: 'none' },
     dataDir: mkdtempSync(join(tmpdir(), 'import-safety-')),
   });
   server.setAgentImporter(async () => result() as never);
   await server.start();
+  const port = server.port;
   return port;
 }
 

--- a/typescript/src/__tests__/integration/agents-list-shape.test.ts
+++ b/typescript/src/__tests__/integration/agents-list-shape.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect } from 'vitest';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * `agents.list` answers with a shape, and that shape must not drift.
@@ -29,8 +28,7 @@ const EXPECTED_KEYS = ['description', 'id', 'type'];
 async function listFrom(
   entries: { id: string; type: string; description?: string }[],
 ): Promise<Record<string, unknown>[]> {
-  const port = await reserveTestPort();
-  const server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  const server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   server.setAgentList(() => entries);
   try {
     await server.start();

--- a/typescript/src/__tests__/integration/approval-event-contract.test.ts
+++ b/typescript/src/__tests__/integration/approval-event-contract.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from 'vitest';
 import WebSocket from 'ws';
 import { GatewayServer } from '../../gateway/server.js';
 import { GatewayEvents } from '../../gateway/types.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * The Bar's approval screen listens for an `approval` event that nothing sent.
@@ -35,9 +34,9 @@ afterEach(async () => {
 });
 
 async function startServer(): Promise<number> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   await server.start();
+  const port = server.port;
   return port;
 }
 

--- a/typescript/src/__tests__/integration/brainstem-abort.test.ts
+++ b/typescript/src/__tests__/integration/brainstem-abort.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach, vi } from 'vitest';
 import WebSocket from 'ws';
 
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * Stop has to stop the brainstem, not just stop the gateway listening.
@@ -84,9 +83,9 @@ describe('aborting a brainstem turn', () => {
       return new Response('{}');
     }) as unknown as typeof fetch);
 
-    const port = await reserveTestPort();
-    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
     await server.start();
+    const port = server.port;
 
     const ws = await connect(port);
     await rpc(ws, 'c-1', 'connect', {

--- a/typescript/src/__tests__/integration/channel-status-event.test.ts
+++ b/typescript/src/__tests__/integration/channel-status-event.test.ts
@@ -4,7 +4,6 @@ import path from 'node:path';
 import WebSocket from 'ws';
 import { GatewayServer as RuntimeGatewayServer } from '../../gateway/server.js';
 import type { GatewayConfig } from '../../gateway/types.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * The channels screen updates when a channel connects or disconnects.
@@ -116,10 +115,10 @@ describe('channel.status reaches subscribers', () => {
 
   async function startWithRegistry(): Promise<{ port: number; connected: () => boolean }> {
     const { registry, connected } = fakeRegistry();
-    const port = await reserveTestPort();
-    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
     (server as unknown as { channelRegistry: unknown }).channelRegistry = registry;
     await server.start();
+    const port = server.port;
     return { port, connected };
   }
 

--- a/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
+++ b/typescript/src/__tests__/integration/client-rpc-coverage.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'fs';
 import { resolve, join } from 'path';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * Every RPC method a client calls must exist on the gateway.
@@ -121,8 +120,7 @@ afterEach(async () => {
 
 /** Method names registered by a server with every optional service present. */
 async function registeredMethods(): Promise<Set<string>> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   // surgeon.* and rappter.* register only when their service is set, and only
   // inside start(). A bare server reports them missing and would send someone
   // chasing methods that are fine.

--- a/typescript/src/__tests__/integration/config-contract.test.ts
+++ b/typescript/src/__tests__/integration/config-contract.test.ts
@@ -3,7 +3,6 @@ import { mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * Binds the config clients to the handler that actually runs.
@@ -34,10 +33,10 @@ afterEach(async () => {
 });
 
 async function startServer(): Promise<{ port: number; configPath: string }> {
-  const port = await reserveTestPort();
   dataDir = mkdtempSync(join(tmpdir(), 'cfg-contract-'));
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir });
   await server.start();
+  const port = server.port;
   return { port, configPath: join(dataDir, 'config.yaml') };
 }
 

--- a/typescript/src/__tests__/integration/cron-create-contract.test.ts
+++ b/typescript/src/__tests__/integration/cron-create-contract.test.ts
@@ -5,7 +5,6 @@ import { join } from 'path';
 import { GatewayServer } from '../../gateway/server.js';
 import { CronService } from '../../cron/service.js';
 import { createCronGatewayAdapter } from '../../cron/gateway-adapter.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * Binds the macOS Bar's cron payload to the handler that actually runs.
@@ -40,7 +39,6 @@ afterEach(async () => {
 
 /** Wires CronService into GatewayServer with the daemon's own adapter. */
 async function startServer(): Promise<{ port: number; service: CronService; fired: string[] }> {
-  const port = await reserveTestPort();
   dataDir = mkdtempSync(join(tmpdir(), 'cron-contract-'));
 
   const fired: string[] = [];
@@ -53,8 +51,9 @@ async function startServer(): Promise<{ port: number; service: CronService; fire
   });
   cron = service;
 
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir });
   await server.start();
+  const port = server.port;
   server.setCronService(createCronGatewayAdapter({ service, persist: () => {} }));
 
   return { port, service, fired };
@@ -160,10 +159,10 @@ describe('cron.create contract, against the wired gateway', () => {
 
   it('refuses before touching the file store, so no half-written job survives', async () => {
     // No cron service: the file-backed fallback path.
-    const port = await reserveTestPort();
     dataDir = mkdtempSync(join(tmpdir(), 'cron-contract-'));
-    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+    server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir });
     await server.start();
+    const port = server.port;
 
     const { error } = await rpc(port, 'cron.add', { name: 'x', schedule: '* * * * *' });
     expect(error?.message).toMatch(/non-empty `message`/);
@@ -173,10 +172,10 @@ describe('cron.create contract, against the wired gateway', () => {
   });
 
   it('the file-only fallback normalises the legacy spelling too', async () => {
-    const port = await reserveTestPort();
     dataDir = mkdtempSync(join(tmpdir(), 'cron-contract-'));
-    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+    server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir });
     await server.start();
+    const port = server.port;
 
     await rpc(port, 'cron.create', legacyBarPayload('from an old bar'));
 

--- a/typescript/src/__tests__/integration/cron-get-update-contract.test.ts
+++ b/typescript/src/__tests__/integration/cron-get-update-contract.test.ts
@@ -5,7 +5,6 @@ import { join } from 'path';
 import { GatewayServer } from '../../gateway/server.js';
 import { CronService } from '../../cron/service.js';
 import { createCronGatewayAdapter } from '../../cron/gateway-adapter.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * `cron.get` read only the gateway's file fallback, never the live scheduler.
@@ -41,15 +40,15 @@ afterEach(async () => {
 });
 
 async function startServer(): Promise<number> {
-  const port = await reserveTestPort();
   dataDir = mkdtempSync(join(tmpdir(), 'cron-get-'));
 
   const service = new CronService();
   await service.start({ execute: async () => 'ok' });
   cron = service;
 
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir });
   await server.start();
+  const port = server.port;
   server.setCronService(createCronGatewayAdapter({ service, persist: () => {} }));
   return port;
 }

--- a/typescript/src/__tests__/integration/dormant-methods-stay-dormant.test.ts
+++ b/typescript/src/__tests__/integration/dormant-methods-stay-dormant.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { readdirSync, readFileSync } from 'fs';
 import { resolve, join } from 'path';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * The dormant method modules stay dormant.
@@ -88,8 +87,7 @@ afterEach(async () => {
 });
 
 async function registered(): Promise<Set<string>> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   server.setSurgeonService({} as never);
   server.setRappterManager({} as never);
   await server.start();

--- a/typescript/src/__tests__/integration/exec-approval-contract.test.ts
+++ b/typescript/src/__tests__/integration/exec-approval-contract.test.ts
@@ -5,7 +5,6 @@ import { WebSocket } from 'ws';
 import { GatewayServer } from '../../gateway/server.js';
 import { ShellAgent } from '../../agents/ShellAgent.js';
 import { getSharedExecSafety, resetSharedExecSafety } from '../../security/exec-safety.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * Binds the macOS Bar's approval screen to handlers that actually run.
@@ -50,9 +49,9 @@ afterEach(async () => {
 });
 
 async function startServer(): Promise<number> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir: sandbox });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir: sandbox });
   await server.start();
+  const port = server.port;
   return port;
 }
 

--- a/typescript/src/__tests__/integration/gateway-buffer-limit.test.ts
+++ b/typescript/src/__tests__/integration/gateway-buffer-limit.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from 'vitest';
 import WebSocket from 'ws';
 
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * A client that stops reading must not be buffered without limit.
@@ -73,9 +72,9 @@ async function advertisedLimit(port: number): Promise<number> {
 
 describe('gateway outbound buffer limit', () => {
   it('enforces the buffer limit it advertises', async () => {
-    const port = await reserveTestPort();
-    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
     await server.start();
+    const port = server.port;
 
     const limit = await advertisedLimit(port);
     expect(typeof limit).toBe('number');

--- a/typescript/src/__tests__/integration/gateway-payload-limit.test.ts
+++ b/typescript/src/__tests__/integration/gateway-payload-limit.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from 'vitest';
 import WebSocket from 'ws';
 
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * The advertised payload limit has to be the enforced one.
@@ -48,9 +47,9 @@ async function handshake(port: number): Promise<Record<string, unknown>> {
 
 describe('gateway payload limit', () => {
   it('enforces the limit it advertises', async () => {
-    const port = await reserveTestPort();
-    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
     await server.start();
+    const port = server.port;
 
     const res = await handshake(port);
     const payload = res.payload as { policy?: { maxPayload?: number } } | undefined;
@@ -74,9 +73,9 @@ describe('gateway payload limit', () => {
   }, 30_000);
 
   it('accepts a frame comfortably inside the limit', async () => {
-    const port = await reserveTestPort();
-    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+    server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
     await server.start();
+    const port = server.port;
 
     const res = await handshake(port);
     // The handshake itself is the proof: a connection that completes a request

--- a/typescript/src/__tests__/integration/gateway-rpc-parity.test.ts
+++ b/typescript/src/__tests__/integration/gateway-rpc-parity.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, afterEach } from 'vitest';
 import { readFileSync } from 'fs';
 import { resolve } from 'path';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 /**
  * The TypeScript gateway registers the shared RPC surface, and nothing that the
@@ -36,8 +35,7 @@ afterEach(async () => {
 });
 
 async function registered(): Promise<Set<string>> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   await server.start();
   return new Set((server as unknown as { methods: Map<string, unknown> }).methods.keys());
 }

--- a/typescript/src/__tests__/integration/rapp-chat-contract.test.ts
+++ b/typescript/src/__tests__/integration/rapp-chat-contract.test.ts
@@ -22,7 +22,6 @@ import { readFileSync } from 'fs';
 import { resolve, dirname } from 'path';
 import { fileURLToPath } from 'url';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const CONTRACT = resolve(__dirname, '../../../../contracts/rapp-chat-v1.json');
@@ -52,8 +51,7 @@ afterEach(async () => {
 
 /** Start a gateway whose agent echoes the prompt it was handed. */
 async function startGateway(): Promise<number> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   server.setAgentHandler(async (request) => ({
     // `sessionId` is required by AgentResponse; the gateway echoes whatever the
     // handler returns, so a stub that omits it is not a conforming handler.
@@ -62,6 +60,7 @@ async function startGateway(): Promise<number> {
     agentLogs: [],
   }));
   await server.start();
+  const port = server.port;
   return port;
 }
 

--- a/typescript/src/__tests__/integration/readyz-response-safety.test.ts
+++ b/typescript/src/__tests__/integration/readyz-response-safety.test.ts
@@ -20,7 +20,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import { GatewayServer } from '../../gateway/server.js';
 import type { GatewayReadiness } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 let server: GatewayServer | undefined;
 
@@ -39,10 +38,10 @@ function unserialisableReport(): GatewayReadiness {
 async function startGateway(
   provider?: () => Promise<GatewayReadiness>,
 ): Promise<number> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   if (provider) server.setReadinessProvider(provider);
   await server.start();
+  const port = server.port;
   return port;
 }
 

--- a/typescript/src/__tests__/integration/rpc-response-safety.test.ts
+++ b/typescript/src/__tests__/integration/rpc-response-safety.test.ts
@@ -15,7 +15,6 @@
  */
 import { describe, it, expect, afterEach } from 'vitest';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 import { RPC_ERROR } from '../../gateway/types.js';
 
 let server: GatewayServer | undefined;
@@ -33,10 +32,10 @@ function cyclic(): Record<string, unknown> {
 }
 
 async function startWithMethod(result: () => unknown): Promise<number> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   server.registerMethod('plugin.result', async () => result());
   await server.start();
+  const port = server.port;
   return port;
 }
 

--- a/typescript/src/__tests__/integration/skills-connections-contract.test.ts
+++ b/typescript/src/__tests__/integration/skills-connections-contract.test.ts
@@ -58,15 +58,15 @@ interface StartOptions {
 }
 
 async function startServer(options: StartOptions = {}): Promise<number> {
-  const port = await reserveTestPort();
   const dataDir = scratch('skills-contract-');
   server = new GatewayServer({
-    port,
+    port: 0,
     bind: 'loopback',
     auth: options.auth ?? { mode: 'none' },
     dataDir,
   });
   await server.start();
+  const port = server.port;
   if (options.bundledSkillsDir !== undefined) server.setBundledSkillsDir(options.bundledSkillsDir);
   if (options.skillsRegistry) server.setSkillsRegistry(options.skillsRegistry);
   return port;

--- a/typescript/src/__tests__/integration/surgeon-gateway.test.ts
+++ b/typescript/src/__tests__/integration/surgeon-gateway.test.ts
@@ -2,7 +2,6 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { WebSocket } from 'ws';
 import { GatewayServer } from '../../gateway/server.js';
 import type { SurgeonService } from '../../surgeon/service.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 function connect(port: number): Promise<WebSocket> {
   return new Promise((resolve, reject) => {
@@ -41,7 +40,6 @@ describe('surgeon gateway integration', () => {
   });
 
   it('advertises and serves the surgeon while protecting mutating turns', async () => {
-    const port = await reserveTestPort();
     const service = {
       getPatient: vi.fn(async () => ({ patient: 'OpenRappter', state: 'stable' })),
       listCases: vi.fn(() => []),
@@ -52,12 +50,13 @@ describe('surgeon gateway integration', () => {
       operate: vi.fn(),
     } as unknown as SurgeonService;
     server = new GatewayServer({
-      port,
+      port: 0,
       bind: 'loopback',
       auth: { mode: 'token', tokens: ['surgeon-token'] },
     });
     server.setSurgeonService(service);
     await server.start();
+    const port = server.port;
 
     const socket = await connect(port);
     const hello = await request(socket, 'connect', 'connect', {

--- a/typescript/src/__tests__/integration/ws-frame-serialisation.test.ts
+++ b/typescript/src/__tests__/integration/ws-frame-serialisation.test.ts
@@ -18,7 +18,6 @@
 import { describe, it, expect, afterEach } from 'vitest';
 import WebSocket from 'ws';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 import { RPC_ERROR } from '../../gateway/types.js';
 
 let server: GatewayServer | undefined;
@@ -70,12 +69,12 @@ function call(
 }
 
 async function connect(): Promise<WebSocket> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   server.registerMethod('plugin.bad', async () => cyclic());
   server.registerMethod('plugin.big', async () => ({ big: BigInt(1) }));
   server.registerMethod('plugin.good', async () => ({ hello: 'world' }));
   await server.start();
+  const port = server.port;
 
   const ws = new WebSocket(`ws://127.0.0.1:${port}`);
   await new Promise((resolve) => ws.once('open', resolve));

--- a/typescript/src/__tests__/integration/zen-contract.test.ts
+++ b/typescript/src/__tests__/integration/zen-contract.test.ts
@@ -26,7 +26,6 @@ import WebSocket from 'ws';
 import { GatewayServer } from '../../gateway/server.js';
 import { TuiGatewayClient } from '../../tui/gateway-client.js';
 import { createZenPublisher } from '../../tui/zen-publisher.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 let server: GatewayServer | undefined;
 const clients: TestClient[] = [];
@@ -38,9 +37,9 @@ afterEach(async () => {
 });
 
 async function startServer(): Promise<number> {
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' } });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
   await server.start();
+  const port = server.port;
   return port;
 }
 

--- a/typescript/src/__tests__/support/test-port.ts
+++ b/typescript/src/__tests__/support/test-port.ts
@@ -24,10 +24,27 @@
  * So treat this helper as a last resort. If the thing you are starting can
  * report the port it bound, pass it port 0 and ask it afterwards -- there is
  * no window at all in that arrangement, because the socket is never closed.
- * `GatewayServer` does this via its `port` getter, which is why the gateway
- * integration and observability suites no longer appear below.
+ * `GatewayServer` does this via its `port` getter, and every test that binds a
+ * real socket now works that way.
  *
- * The remaining callers here start servers that have no such accessor.
+ * An earlier version of this note predicted the remaining callers would be
+ * servers lacking such an accessor. That turned out to be wrong. Converting
+ * them found something else: the two callers left do not start a server at
+ * all. They need a port *number* for something that will deliberately never be
+ * bound --
+ *
+ *   - `conformance.test.ts` hands `startBurrowBeacon` a list of candidate
+ *     ports and checks which one it picks, so the candidates must be real
+ *     numbers, and one of them must be free.
+ *   - `skills-connections-contract.test.ts` needs an address nothing answers
+ *     on, to prove that pairing with an unreachable peer reports failure.
+ *
+ * Port 0 cannot express either of those. Both still carry the window described
+ * above, and that is not fixable here: you cannot hold a port to guarantee it
+ * stays free, because holding it is exactly what makes it not free. The
+ * exposure is much smaller than it was -- two ports instead of the seventy-six
+ * that collided in CI -- but it is not zero, so if one of these ever flakes,
+ * this comment is the explanation.
  */
 import net from 'net';
 
@@ -36,8 +53,9 @@ const issued = new Set<number>();
 /**
  * Ask the OS for a free TCP port on the loopback interface.
  *
- * Prefer binding port 0 on the real server and reading the port back. Use this
- * only when the server cannot tell you which port it bound.
+ * Do not use this to pick a port for a server you are about to start: pass it
+ * port 0 and read the port back instead. This is for the narrow case where you
+ * need a port number that stays unbound -- see the note at the top of the file.
  */
 export async function reserveTestPort(): Promise<number> {
   for (let attempt = 0; attempt < 50; attempt++) {

--- a/typescript/src/__tests__/unit/gateway-web.test.ts
+++ b/typescript/src/__tests__/unit/gateway-web.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeAll, afterAll, beforeEach, afterEach } from
 import fs from 'fs';
 import path from 'path';
 import { GatewayServer } from '../../gateway/server.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 describe('Gateway static file serving', () => {
   let tmpDir: string;
@@ -24,14 +23,14 @@ describe('Gateway static file serving', () => {
   });
 
   beforeEach(async () => {
-    port = await reserveTestPort();
     server = new GatewayServer({
-      port,
+      port: 0,
       bind: 'loopback',
       webRoot: tmpDir,
       dataDir: path.join(tmpDir, 'data'),
     });
     await server.start();
+    port = server.port;
   });
 
   afterEach(async () => {

--- a/typescript/src/__tests__/unit/neighbor-speaks-as-itself.test.ts
+++ b/typescript/src/__tests__/unit/neighbor-speaks-as-itself.test.ts
@@ -24,6 +24,7 @@
 
 import { describe, it, expect, afterEach } from 'vitest';
 import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
@@ -35,7 +36,6 @@ import {
 } from '../../infra/current-instance.js';
 import { gatewayEndpointFileFor } from '../../infra/gateway-lock.js';
 import { deviceRappid } from '../../twin/send.js';
-import { reserveTestPort } from '../support/test-port.js';
 
 const servers: Server[] = [];
 const homes: string[] = [];
@@ -50,7 +50,6 @@ afterEach(async () => {
 /** A neighbour that records the envelope it was handed. */
 async function neighbourNamed(name: string): Promise<{ received: Record<string, unknown>[] }> {
   const received: Record<string, unknown>[] = [];
-  const port = await reserveTestPort();
   const server = createServer((req, res) => {
     let body = '';
     req.on('data', (c) => { body += c; });
@@ -70,8 +69,9 @@ async function neighbourNamed(name: string): Promise<{ received: Record<string, 
     });
   });
   servers.push(server);
-  await new Promise<void>((resolve) => { server.listen(port, '127.0.0.1', resolve); });
+  await new Promise<void>((resolve) => { server.listen(0, '127.0.0.1', resolve); });
 
+  const port = (server.address() as AddressInfo).port;
   // The roster resolves neighbours by name from a record, so give it one that
   // points at this listener and names the pid actually holding it.
   const file = gatewayEndpointFileFor({ instance: name });
@@ -143,7 +143,6 @@ describe('a rappter names itself to a neighbour', () => {
     // /twin forces it.
     isolatedHome();
     const received: Record<string, unknown>[] = [];
-    const port = await reserveTestPort();
     const server = createServer((req, res) => {
       let body = '';
       req.on('data', (c) => { body += c; });
@@ -164,7 +163,8 @@ describe('a rappter names itself to a neighbour', () => {
       });
     });
     servers.push(server);
-    await new Promise<void>((resolve) => { server.listen(port, '127.0.0.1', resolve); });
+    await new Promise<void>((resolve) => { server.listen(0, '127.0.0.1', resolve); });
+    const port = (server.address() as AddressInfo).port;
     const file = gatewayEndpointFileFor({ instance: 'chatonly' });
     mkdirSync(dirname(file), { recursive: true });
     writeFileSync(file, JSON.stringify({

--- a/typescript/src/__tests__/unit/rappter-roster.test.ts
+++ b/typescript/src/__tests__/unit/rappter-roster.test.ts
@@ -24,9 +24,9 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join, dirname } from 'node:path';
 import { createServer, type Server } from 'node:http';
+import type { AddressInfo } from 'node:net';
 import { execFile } from 'node:child_process';
 import { promisify } from 'node:util';
-import { reserveTestPort } from '../support/test-port.js';
 import {
   listRappters,
   plannedPortFor,
@@ -267,7 +267,6 @@ afterEach(async () => {
  * test say whether the roster can tell one owner from another.
  */
 async function gatewayServing(options: { instance?: string } = {}): Promise<number> {
-  const port = await reserveTestPort();
   const server = createServer((req, res) => {
     if (req.url === '/health') {
       res.writeHead(200, { 'content-type': 'application/json' });
@@ -286,7 +285,8 @@ async function gatewayServing(options: { instance?: string } = {}): Promise<numb
     res.end();
   });
   servers.push(server);
-  await new Promise<void>((resolve) => { server.listen(port, '127.0.0.1', resolve); });
+  await new Promise<void>((resolve) => { server.listen(0, '127.0.0.1', resolve); });
+  const port = (server.address() as AddressInfo).port;
   return port;
 }
 

--- a/typescript/src/__tests__/unit/service-status-ownership.test.ts
+++ b/typescript/src/__tests__/unit/service-status-ownership.test.ts
@@ -21,7 +21,7 @@ import os from 'os';
 import path from 'path';
 import fs from 'fs/promises';
 import http from 'http';
-import { reserveTestPort } from '../support/test-port.js';
+import type { AddressInfo } from 'node:net';
 import {
   getIMessageServiceStatus,
   parseLaunchdPid,
@@ -82,9 +82,9 @@ describe('getIMessageServiceStatus ownership', () => {
     lockPid: number | null,
     userPrint: { stdout: string; exitCode: number },
   ) {
-    const port = await reserveTestPort();
     const server = http.createServer((_req, res) => { res.writeHead(200); res.end('{}'); });
-    await new Promise<void>((r) => server.listen(port, '127.0.0.1', r));
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+    const port = (server.address() as AddressInfo).port;
     try {
       const home = await homeWithPlist();
       return await getIMessageServiceStatus({
@@ -131,9 +131,9 @@ describe('getIMessageServiceStatus ownership', () => {
   it('names a foreign owner when the port answers from a pid the supervisor does not own', async () => {
     // A real listener, because `live` is only true when something actually
     // answers — which is precisely how the false "healthy" reading arose.
-    const port = await reserveTestPort();
     const server = http.createServer((_req, res) => { res.writeHead(200); res.end('{}'); });
-    await new Promise<void>((r) => server.listen(port, '127.0.0.1', r));
+    await new Promise<void>((r) => server.listen(0, '127.0.0.1', r));
+    const port = (server.address() as AddressInfo).port;
     try {
       const home = await homeWithPlist();
       const status = await getIMessageServiceStatus({

--- a/typescript/src/gateway/__tests__/agent-files-rpc.test.ts
+++ b/typescript/src/gateway/__tests__/agent-files-rpc.test.ts
@@ -28,7 +28,6 @@ import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, readFileSync, rmSyn
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { GatewayServer } from '../server.js';
-import { reserveTestPort } from '../../__tests__/support/test-port.js';
 import { userAgentsDir } from '../../agents/agent-import.js';
 
 let server: GatewayServer | undefined;
@@ -77,9 +76,9 @@ async function boot(): Promise<Fixture> {
   writeFileSync(secretPath, 'TOP SECRET\n');
   symlinkSync(outside, join(agentsRoot, 'escape'), 'dir');
 
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir });
   await server.start();
+  const port = server.port;
   return { port, agentsRoot, outside, secretPath };
 }
 
@@ -376,14 +375,14 @@ describe('mutating and content-bearing calls require the credential', () => {
     mkdirSync(agentsRoot, { recursive: true });
     writeFileSync(join(agentsRoot, 'hello_agent.py'), 'print("hello")\n');
 
-    const port = await reserveTestPort();
     server = new GatewayServer({
-      port,
+      port: 0,
       bind: 'loopback',
       auth: { mode: 'token', tokens: ['s3cret'] },
       dataDir,
     });
     await server.start();
+    const port = server.port;
     return { port, agentsRoot };
   }
 

--- a/typescript/src/gateway/__tests__/bar-logs-and-session-reset.test.ts
+++ b/typescript/src/gateway/__tests__/bar-logs-and-session-reset.test.ts
@@ -37,7 +37,6 @@ import { WebSocket } from 'ws';
 import path from 'node:path';
 import { GatewayServer } from '../server.js';
 import { MAX_MESSAGE_LENGTH } from '../log-store.js';
-import { reserveTestPort } from '../../__tests__/support/test-port.js';
 import type { AgentRequest, AgentResponse, ChatSession } from '../types.js';
 
 /**
@@ -57,10 +56,8 @@ let agentReply: (request: AgentRequest) => Promise<AgentResponse>;
 beforeAll(async () => {
   fs.mkdirSync(TMP_ROOT, { recursive: true });
   dataDir = fs.mkdtempSync(path.join(TMP_ROOT, 'bar-logs-'));
-  const port = await reserveTestPort();
-  base = `http://127.0.0.1:${port}`;
   server = new GatewayServer({
-    port,
+    port: 0,
     bind: 'loopback',
     auth: { mode: 'none' },
     heartbeatInterval: 60_000,
@@ -68,6 +65,7 @@ beforeAll(async () => {
   });
   server.setAgentHandler((request) => agentReply(request));
   await server.start();
+  base = `http://127.0.0.1:${server.port}`;
 });
 
 afterAll(async () => {
@@ -452,15 +450,15 @@ describe('the Bar transport — WebSocket frames, exactly as RpcClient sends the
 
 describe('both methods are fail-closed when the gateway has credentials', () => {
   it('rejects an unauthenticated HTTP caller', async () => {
-    const port = await reserveTestPort();
     const secured = new GatewayServer({
-      port,
+      port: 0,
       bind: 'loopback',
       auth: { mode: 'token', tokens: [freshSecret('gateway')] },
       heartbeatInterval: 60_000,
       dataDir,
     });
     await secured.start();
+    const port = secured.port;
     try {
       for (const method of ['logs.get', 'sessions.reset']) {
         const response = await fetch(`http://127.0.0.1:${port}/rpc`, {

--- a/typescript/src/gateway/__tests__/cron-runs-alias.test.ts
+++ b/typescript/src/gateway/__tests__/cron-runs-alias.test.ts
@@ -20,7 +20,6 @@ import { mkdtempSync, rmSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 import { GatewayServer } from '../server.js';
-import { reserveTestPort } from '../../__tests__/support/test-port.js';
 
 let server: GatewayServer | undefined;
 const temps: string[] = [];
@@ -50,9 +49,9 @@ function schedulerWithHistory() {
 async function boot(): Promise<number> {
   const dataDir = mkdtempSync(join(tmpdir(), 'cron-runs-alias-'));
   temps.push(dataDir);
-  const port = await reserveTestPort();
-  server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+  server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir });
   await server.start();
+  const port = server.port;
   server.setCronService(schedulerWithHistory() as never);
   return port;
 }
@@ -105,9 +104,9 @@ describe('cron.runs', () => {
   it('answers { runs: [] } when no scheduler is wired, rather than throwing', async () => {
     const dataDir = mkdtempSync(join(tmpdir(), 'cron-runs-bare-'));
     temps.push(dataDir);
-    const port = await reserveTestPort();
-    server = new GatewayServer({ port, bind: 'loopback', auth: { mode: 'none' }, dataDir });
+    server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' }, dataDir });
     await server.start();
+    const port = server.port;
 
     const { result, error } = await rpc(port, 'cron.runs', { jobId: 'job1' });
     expect(error).toBeUndefined();


### PR DESCRIPTION
Follow-through on #384. That change let the gateway report the port it bound; this one uses it to delete the racy reservation from every test that binds a socket.

## Why

`reserveTestPort()` binds a port, closes it, and hands the bare number to a caller that binds it again. Between the close and that second bind the port belongs to nobody. On 2026-08-19 that window failed CI — two vitest workers were handed `127.0.0.1:36297`, and the second could not bind it.

That job drew **76 ports** across two files. It is now down to zero.

## What changed

| shape | files | how |
|---|---|---|
| starts a `GatewayServer` | 26 | `port: 0`, then `const port = server.port` after `start()` |
| starts a plain `http.createServer` | 3 | `listen(0, …)`, then `(server.address() as AddressInfo).port` |

31 + 5 sites. Nothing is closed before being rebound, so there is no window at all.

The transform keeps the local `port` variable and only moves its declaration below `start()`, so the ~200 downstream `${port}` usages are byte-identical. That is why a 30-file change is +95/−108 rather than a rewrite.

## The two callers I did not convert

I predicted in #384 that the stragglers would be servers lacking a port accessor. **That was wrong**, and converting them is what showed it. The two left do not start a server at all — they need a port number for something that will deliberately *never* be bound:

- `conformance.test.ts` hands `startBurrowBeacon` a list of candidate ports and asserts which one it picks. The candidates have to be real numbers, and one has to be free.
- `skills-connections-contract.test.ts` needs an address nothing answers on, to prove pairing with an unreachable peer reports failure rather than success.

Port 0 cannot express either. And this is not fixable by being cleverer: you cannot prove a port will stay free without holding it, and holding it is precisely what makes it not free. So those two keep the window. The exposure is two ports instead of seventy-six, and the helper's comment now says exactly this, so a future flake there has a written explanation instead of a mystery.

## Evidence the converted tests still test something

The risk with a change like this is tests that pass without connecting to anything. So I broke the accessor they now depend on — `get port()` returning `boundPort + 1` — and re-ran everything:

```
Test Files  26 failed | 300 passed | 3 skipped (329)
     Tests  260 failed | 4972 passed | 21 skipped
```

26 files, which is the set converted here. They are genuinely reaching a real server through the accessor, not passing vacuously.

## Validation

- Full suite: **5232 passed**, 21 skipped — identical to the count before the change, so no test was silently dropped
- Run **5×** consecutively: `EADDRINUSE` count **0** every time
- `tsc --noEmit`, `npm run lint` (`--max-warnings 0`), `npm run build:server`: all clean
- `parity_harness.py --runtime both`: PASS

## Note on the tooling

I scripted the transform rather than hand-editing 30 files, and had the script **report** anything not matching the expected shape instead of guessing. It flagged two sites, and both flags were correct — one was `deadPort`, which is one of the two legitimate cases above.

`tsc` then caught a third problem the script got wrong silently: in `bar-logs-and-session-reset.test.ts` a `` base = `…${port}` `` line sat between the reservation and the constructor, and my property regex matched that `${port}` first, producing `${port: 0}`. Fixed by hand. Worth stating plainly because it is the argument for running the typechecker over a scripted edit rather than trusting the script's own success count.
