### PR TITLE
ci: make a failing gateway job say what failed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,8 +96,13 @@ jobs:
 
   # Dedicated gate for the real-socket gateway integration/observability
   # surfaces. Bounded so a hung real socket/connection can't stall CI
-  # indefinitely, and uploads only a small, targeted log on failure (no
-  # verbose default vitest/CI output dump).
+  # indefinitely.
+  #
+  # Output goes to a file rather than the console because these suites log a
+  # line per server start: a green run is ~500 lines of "Gateway server started
+  # on ...", which is noise nobody reads. But a *red* run has to explain itself,
+  # so the log is printed below when the tests don't pass. Piping through `tee`
+  # instead would trade one problem for the other.
   gateway-realtime:
     name: Gateway Integration & Observability (real sockets)
     runs-on: ubuntu-latest
@@ -114,14 +119,22 @@ jobs:
           cache-dependency-path: typescript/package-lock.json
       - run: npm ci
       - name: Run real-socket gateway tests (bounded per-test timeout)
+        # Bounded here as well as on the job. A job-level timeout *cancels*,
+        # and a cancelled job skips `if: failure()` steps, so a hang would
+        # throw away the log that explains the hang. Failing the step instead
+        # keeps the diagnostics below reachable, with job budget to spare.
+        timeout-minutes: 4
         run: |
           npx vitest run \
             src/__tests__/integration/gateway.test.ts \
             src/__tests__/integration/gateway-observability.test.ts \
             --testTimeout=15000 --hookTimeout=15000 \
             --reporter=default > gateway-realtime.log 2>&1
+      - name: Explain the failure in the log above
+        if: failure() || cancelled()
+        run: cat gateway-realtime.log || echo "the tests produced no output before dying"
       - name: Upload concise log on failure
-        if: failure()
+        if: failure() || cancelled()
         uses: actions/upload-artifact@v4
         with:
           name: gateway-realtime-failure-log

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A failing gateway-realtime CI job would not say why it failed. Its output is
+  redirected to a file — rightly, since a green run is ~500 lines of "Gateway
+  server started on ..." — but nothing ever printed that file, so the console
+  showed the command, then `Process completed with exit code 1`, and nothing
+  else. Diagnosing the port collision behind the 2026-08-19 failure meant
+  downloading and unzipping an artifact. The log is now printed when the tests
+  don't pass, and a green run stays as quiet as before.
+- The same job discarded its log entirely if the tests hung, which is the one
+  case its timeout exists for. A job-level `timeout-minutes` *cancels* the job,
+  and a cancelled job skips `if: failure()` steps, so both the artifact upload
+  and any diagnosis were skipped exactly when they were needed. Measured on a
+  throwaway workflow rather than assumed: a job-level timeout yields
+  `cancelled` and skips `failure()`, while a step-level one yields `failure`.
+  The test step is now bounded itself, so a hang fails rather than cancels, and
+  the diagnostic steps additionally accept `cancelled()` as a backstop.
 - Tests no longer reserve a port and then race something else to bind it.
   Reserving means binding a port, closing it, and handing the number over to be
   bound again, which leaves a window in which anything may take it — the window


### PR DESCRIPTION
A failing `gateway-realtime` job doesn't say what failed. Its entire console output on the 2026-08-19 red run was:

```
##[group]Run npx vitest run \
  src/__tests__/integration/gateway.test.ts \
  ...
##[endgroup]
##[error]Process completed with exit code 1.
```

Learning that the cause was two vitest workers colliding on `127.0.0.1:36297` required downloading and unzipping artifact `9376593292`.

## Why not just pipe through `tee`

That was my first instinct and it's wrong. The redirect has a real justification — I measured it. These suites log a line per server start, so a **passing** run is:

```
497 lines, 31,945 bytes
```

`tee` would fix the red case by putting ~500 lines of `Gateway server started on ...` into every green one. Printing the log **only when the tests don't pass** keeps both properties: a green run is exactly as quiet as before, a red run explains itself inline.

## The second bug: a hang discards the evidence

The job carries `timeout-minutes: 5` specifically so "a hung real socket/connection can't stall CI indefinitely." But a **job-level** timeout *cancels* the job, and a cancelled job **skips `if: failure()` steps** — so the upload was skipped in exactly the scenario the bound exists for. The hang case produced no artifact and no console output at all.

Rather than infer this from the docs, I measured it on a throwaway workflow with three jobs — an ordinary failure, a job-level timeout, and a step-level timeout — each with steps guarded by `failure()`, `cancelled()`, and `failure() || cancelled()`:

| bound | job conclusion | `if: failure()` | `if: cancelled()` | `if: failure() \|\| cancelled()` |
|---|---|---|---|---|
| ordinary `exit 1` | `failure` | ✅ ran | skipped | ✅ ran |
| **job**-level timeout | `cancelled` | ❌ **skipped** | ✅ ran | ✅ ran |
| **step**-level timeout | `failure` | ✅ ran | skipped | ✅ ran |

In every case a marker written only to the redirected file appeared in the console, confirming the log is both flushed and readable — including in the cancelled job, where content written before the hang survived.

That branch has been deleted; it was a measurement, not a deliverable.

## The fix

- Bound the test **step** at 4 minutes as well as the job at 5. A hang now *fails* rather than *cancels*, which keeps the diagnostics reachable and leaves a minute of job budget to run them.
- Print the log when the tests don't pass.
- Guard both diagnostic steps with `failure() || cancelled()`, so the artifact survives even if something cancels the job by another route.

Chose `failure() || cancelled()` over `always()` (GitHub's docs warn against `always()` on upload steps) and over `${{ !success() }}` (the bare `!` form is a YAML parse error, which is an easy way to silently disable the guard later).

## Validation

- Every branch of the table above measured on real CI, not inferred
- `ci.yml` parses; the `gateway-realtime` job's steps and conditions verified programmatically after the edit
- No product code touched — workflow and CHANGELOG only

## Note

I also checked the other seven output redirects in `.github/workflows/` and am **not** touching them, because they're correct. `pinned-install.yml` suppresses output from commands it *expects* to fail and echoes its own diagnostic on the unexpected outcome; `signing-health.yml` redirects only stdout, so errors still surface. `ci.yml` was the only one sending both streams to a file with nothing to replace them.
