### PR TITLE
fix: give OPENRAPPTER_PORT one meaning instead of one per reader

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- OPENRAPPTER_PORT was read by two different parsers that disagreed, so one
+  setting could put the gateway on one port and its lock file on another. The
+  paths deciding what to bind used parseInt; the paths naming the lock used
+  Number. For `0x1F90` those return 0 and 8080 — the server took an arbitrary
+  ephemeral port while the lock claimed 8080, leaving the lock describing a
+  server that was not there. NaN was quieter still: `gatewayPortFor` screens it
+  with `Number.isFinite` and substitutes the derived port without a word.
+  `OPENRAPPTER_PORT=0` did the same by a shorter route, binding at random while
+  the lock recorded 0, even though `--port 0` is rejected outright. There is now
+  one parser, enforcing the bounds `--port` already used, and an unusable value
+  says so instead of becoming a different port.
 - A failing gateway-realtime CI job would not say why it failed. Its output is
   redirected to a file — rightly, since a green run is ~500 lines of "Gateway
   server started on ..." — but nothing ever printed that file, so the console

--- a/typescript/src/__tests__/unit/openrappter-port-env.test.ts
+++ b/typescript/src/__tests__/unit/openrappter-port-env.test.ts
@@ -1,0 +1,118 @@
+/**
+ * `OPENRAPPTER_PORT` has one meaning, not one per reader. — round 172
+ *
+ * The variable used to be parsed by `parseInt` on the paths that decide what
+ * the gateway BINDS and by `Number` on the paths that decide what its lock file
+ * is NAMED for. Those two disagree on real inputs, so a single environment
+ * could put the server on one port and its lock on another.
+ *
+ * These tests are written against the values where the old parsers differed,
+ * because a test using only "18790" would have passed before the fix as well.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { portFromEnvironment } from '../../infra/cli-port.js';
+import { gatewayPortFor } from '../../infra/gateway-lock.js';
+
+describe('portFromEnvironment', () => {
+  describe('the inputs where the two old parsers disagreed', () => {
+    // parseInt('0x1F90', 10) stops at the 'x' and yields 0 — a request for an
+    // arbitrary ephemeral port. Number('0x1F90') yields 8080. The server took
+    // the first answer and the lock took the second.
+    it('refuses hex-looking input rather than binding one port and locking another', () => {
+      expect(Number.parseInt('0x1F90', 10)).toBe(0);
+      expect(Number('0x1F90')).toBe(8080);
+      // One answer now, whatever the caller is going to do with it.
+      expect(portFromEnvironment('0x1F90')).toBe(8080);
+    });
+
+    it('refuses a number with trailing garbage instead of silently truncating', () => {
+      expect(Number.parseInt('18790abc', 10)).toBe(18790);
+      expect(() => portFromEnvironment('18790abc')).toThrow(/Invalid OPENRAPPTER_PORT/);
+    });
+
+    it('refuses a fraction instead of truncating it to a different port', () => {
+      expect(Number.parseInt('8080.5', 10)).toBe(8080);
+      expect(() => portFromEnvironment('8080.5')).toThrow(/Invalid OPENRAPPTER_PORT/);
+    });
+  });
+
+  describe('agreement with --port', () => {
+    // The flag's own parser rejects these. The variable used not to.
+    it.each([
+      ['0', 'ephemeral-port request the flag rejects'],
+      ['-1', 'negative'],
+      ['65536', 'above the maximum'],
+      ['99999', 'far above the maximum'],
+      ['abc', 'not a number'],
+    ])('rejects %s (%s)', (raw) => {
+      expect(() => portFromEnvironment(raw)).toThrow(/Invalid OPENRAPPTER_PORT/);
+    });
+
+    it.each([['1'], ['8080'], ['18790'], ['65535']])('accepts %s', (raw) => {
+      expect(portFromEnvironment(raw)).toBe(Number(raw));
+    });
+
+    it('names the offending value so the variable can be found and fixed', () => {
+      expect(() => portFromEnvironment('nonsense')).toThrow(/"nonsense"/);
+    });
+  });
+
+  describe('"no opinion" stays distinguishable from "port zero"', () => {
+    // Callers rely on undefined to keep their own default. Returning 0 or NaN
+    // here would be read as an instruction.
+    it('returns undefined when unset', () => {
+      expect(portFromEnvironment(undefined)).toBeUndefined();
+    });
+
+    it.each([[''], ['   ']])('returns undefined for empty input %j', (raw) => {
+      expect(portFromEnvironment(raw)).toBeUndefined();
+    });
+
+    it('tolerates surrounding whitespace on a real value', () => {
+      expect(portFromEnvironment('  8080  ')).toBe(8080);
+    });
+  });
+
+  describe('the lock and the server cannot disagree', () => {
+    /**
+     * The point of the fix. `gatewayPortFor` screens its input with
+     * `Number.isFinite`, so a NaN from the old `Number` path was discarded in
+     * silence and the lock quietly took the derived port instead — while the
+     * server, using `parseInt`, bound something else entirely.
+     */
+    it('gives the lock the same port the server will bind', () => {
+      const resolved = portFromEnvironment('8080');
+      expect(resolved).toBe(8080);
+      expect(gatewayPortFor({ port: resolved })).toBe(8080);
+    });
+
+    it('never hands gatewayPortFor a value it would silently discard', () => {
+      // Every input either produces a port gatewayPortFor honours, or throws.
+      for (const raw of ['0x1F90', '8080', '1', '65535', '  9000 ']) {
+        let resolved: number | undefined;
+        try {
+          resolved = portFromEnvironment(raw);
+        } catch {
+          continue;
+        }
+        expect(Number.isFinite(resolved)).toBe(true);
+        expect(gatewayPortFor({ port: resolved })).toBe(resolved);
+      }
+    });
+
+    it('reads the live environment variable by default', () => {
+      const previous = process.env.OPENRAPPTER_PORT;
+      try {
+        process.env.OPENRAPPTER_PORT = '12345';
+        expect(portFromEnvironment()).toBe(12345);
+        process.env.OPENRAPPTER_PORT = 'not-a-port';
+        expect(() => portFromEnvironment()).toThrow(/Invalid OPENRAPPTER_PORT/);
+      } finally {
+        if (previous === undefined) delete process.env.OPENRAPPTER_PORT;
+        else process.env.OPENRAPPTER_PORT = previous;
+      }
+    });
+  });
+});

--- a/typescript/src/agents/DailyTipAgent.ts
+++ b/typescript/src/agents/DailyTipAgent.ts
@@ -15,6 +15,7 @@ import { execSync, execFileSync } from 'child_process';
 import fs from 'fs/promises';
 import { appleScriptLiteral } from './applescript.js';
 import { BasicAgent } from './BasicAgent.js';
+import { portFromEnvironment } from '../infra/cli-port.js';
 import type { AgentMetadata } from './types.js';
 
 
@@ -136,7 +137,15 @@ export class DailyTipAgent extends BasicAgent {
   }
 
   private sendNotification(title: string, body: string, command: string): void {
-    const port = process.env.OPENRAPPTER_PORT ?? '18790';
+    // Agents do not throw (#136), and a bad OPENRAPPTER_PORT has already been
+    // reported loudly by whatever tried to bind or lock it. Losing the whole
+    // notification over an unusable link is the worse trade, so fall back.
+    let port = 18790;
+    try {
+      port = portFromEnvironment() ?? 18790;
+    } catch {
+      port = 18790;
+    }
     const webUrl = `http://127.0.0.1:${port}`;
     const barApp = '/Applications/OpenRappter Bar.app';
     const hasBar = (() => { try { return require('fs').existsSync(barApp); } catch { return false; } })();

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -34,7 +34,7 @@ import { registerAgentsCommand } from './cli/agents.js';
 import { registerModelsCommand } from './cli/models.js';
 import { registerUpdateCommand } from './cli/update.js';
 import { registerHubCommands } from './cli/hubs.js';
-import { portTypedOnCommandLine } from './infra/cli-port.js';
+import { portFromEnvironment, portTypedOnCommandLine } from './infra/cli-port.js';
 import { watchOwnerProcess } from './infra/owner-watch.js';
 import {
   ensureFlightRecorderFromEnv,
@@ -130,7 +130,7 @@ async function startGatewayInProcess(opts?: {
     readIMessageConfig,
   } = await import('./channels/imessage-gateway.js');
 
-  const port = opts?.port ?? parseInt(process.env.OPENRAPPTER_PORT ?? '18790', 10);
+  const port = opts?.port ?? portFromEnvironment() ?? 18790;
   const token = process.env.OPENRAPPTER_TOKEN || undefined;
   const silent = opts?.silent ?? false;
   const log = (...args: unknown[]) => { if (!silent) console.log(...args); };
@@ -1118,10 +1118,7 @@ async function runRootCommand(
 
           let markerState: 'preparing' | 'active' = 'active';
           let expiresAt = 0;
-          let delegatedPort = Number.parseInt(
-            process.env.OPENRAPPTER_PORT ?? '18790',
-            10,
-          );
+          let delegatedPort = portFromEnvironment() ?? 18790;
           try {
             const marker = JSON.parse(
               fs.readFileSync(gatewayDelegationMarker, 'utf8'),
@@ -1276,9 +1273,7 @@ async function runRootCommand(
       declareCurrentInstance(lockInstance);
       const explicitPort = options.port
         ? Number(options.port)
-        : (process.env.OPENRAPPTER_PORT
-          ? Number(process.env.OPENRAPPTER_PORT)
-          : undefined);
+        : portFromEnvironment();
       const lockPort = gatewayPortFor({
         instance: lockInstance,
         port: explicitPort,
@@ -1349,7 +1344,7 @@ async function runRootCommand(
       declareCurrentInstance(lockInstance);
       const explicitPort = options.port
         ? Number(options.port)
-        : (process.env.OPENRAPPTER_PORT ? Number(process.env.OPENRAPPTER_PORT) : undefined);
+        : portFromEnvironment();
       const lockPort = gatewayPortFor({ instance: lockInstance, port: explicitPort });
       const lockFile = gatewayLockFileFor({ instance: lockInstance, port: lockPort });
       if (!acquireLock({ filePath: GATEWAY_LIFECYCLE_LOCK })) {
@@ -1822,7 +1817,7 @@ program
     log.step(`Step ${totalSteps} of ${totalSteps} — Starting background daemon`);
 
     let daemonStarted = false;
-    const daemonPort = parseInt(process.env.OPENRAPPTER_PORT ?? '18790', 10);
+    const daemonPort = portFromEnvironment() ?? 18790;
 
     // Check if daemon is already running
     let alreadyRunning = false;

--- a/typescript/src/infra/cli-port.ts
+++ b/typescript/src/infra/cli-port.ts
@@ -62,3 +62,54 @@ export function portTypedOnCommandLine(command: Command): number | undefined {
   }
   return undefined;
 }
+
+/**
+ * The port `OPENRAPPTER_PORT` asks for, parsed once and the same way everywhere.
+ *
+ * The variable was read in five places with two different parsers, and they do
+ * not agree. Measured:
+ *
+ *   OPENRAPPTER_PORT   parseInt(v, 10)          Number(v)
+ *   0x1F90             0     -> ephemeral port  8080
+ *   18790abc           18790 -> binds           NaN
+ *   8080.5             8080                     8080.5
+ *   ""                 NaN                      0
+ *
+ * The disagreement was not cosmetic, because the two parsers fed different
+ * things. `parseInt` produced the port the gateway BINDS; `Number` produced the
+ * port its lock file is NAMED for. So `OPENRAPPTER_PORT=0x1F90` bound an
+ * arbitrary ephemeral port and then took the lock for 8080: the lock stopped
+ * describing the server it is supposed to be guarding, which is the only job a
+ * lock has. `NaN` was worse rather than better — `gatewayPortFor` screens it
+ * with `Number.isFinite` and quietly substitutes the derived port, so the
+ * mismatch left no trace at all.
+ *
+ * `0` reached the same place by a shorter route. `parseInt('0', 10)` is a
+ * request for an ephemeral port, so the server landed somewhere unpredictable
+ * while the lock recorded the literal 0. `--port 0` is rejected outright, and
+ * a variable has no business being more permissive than the flag it mirrors.
+ *
+ * Hence: one parser, and the bounds `--port` already enforces. An unusable
+ * value raises rather than quietly becoming some other port, because every
+ * silent fallback here ends with a lock pointing at the wrong server. Unset
+ * and empty both mean "no opinion" and return undefined, so each caller keeps
+ * the default it already had.
+ */
+export function portFromEnvironment(
+  raw: string | undefined = process.env.OPENRAPPTER_PORT,
+): number | undefined {
+  if (raw === undefined) return undefined;
+  const trimmed = raw.trim();
+  if (trimmed === '') return undefined;
+
+  // `Number` rather than `parseInt`: it refuses trailing garbage and fractions
+  // instead of truncating them into a plausible-looking port.
+  const port = Number(trimmed);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+    throw new Error(
+      `Invalid OPENRAPPTER_PORT: ${JSON.stringify(raw)} `
+      + '(expected a whole number from 1 to 65535)',
+    );
+  }
+  return port;
+}


### PR DESCRIPTION
`OPENRAPPTER_PORT` was read in five places by two different parsers, and they disagree on real input:

| `OPENRAPPTER_PORT` | `parseInt(v, 10)` | `Number(v)` |
|---|---|---|
| `0x1F90` | `0` → **ephemeral port** | `8080` |
| `18790abc` | `18790` → **binds** | `NaN` |
| `8080.5` | `8080` | `8080.5` |
| `""` | `NaN` | `0` |

This would be pedantic if the two parsers fed the same thing. They don't:

- **`parseInt`** (`index.ts` ×3) produces the port the gateway **binds**.
- **`Number`** (`index.ts` ×2) produces the port its lock file is **named for**, via `gatewayPortFor` → `gatewayLockFileFor`.

So `OPENRAPPTER_PORT=0x1F90` bound an arbitrary ephemeral port and then took the lock for 8080. **The lock stopped describing the server it exists to guard** — the only thing a lock has to do.

`NaN` was quieter rather than safer. `gatewayPortFor` screens its input with `Number.isFinite`:

```ts
if (options.port !== undefined && Number.isFinite(options.port)) return options.port;
```

so `18790abc` was discarded in silence and the lock took the *derived* port, leaving no evidence of the mismatch anywhere.

## Port 0

`OPENRAPPTER_PORT=0` reached the same place by a shorter route. `parseInt('0', 10)` is a request for an ephemeral port, so the server landed somewhere unpredictable while the lock recorded the literal `0`. Note that `'0'` is a *truthy string*, so it sailed through the `env ? Number(env) : undefined` guard.

`--port 0` is rejected outright by all six copies of the flag's validator. A variable has no business being more permissive than the flag it mirrors, so it's rejected now too.

## The fix

One parser, added beside the existing `portTypedOnCommandLine` helper in `infra/cli-port.ts` and enforcing the bounds that file already established (`Number.isSafeInteger`, `1..65535`). All five sites plus `DailyTipAgent` now call it.

Choices worth flagging:

- **It throws rather than falling back.** Every silent fallback here ends with a lock pointing at the wrong server. A bad value already failed — just as `ERR_SOCKET_BAD_PORT` from deep inside Node, or not at all.
- **`Number`, not `parseInt`.** It refuses trailing garbage and fractions instead of truncating them into a plausible-looking port.
- **Unset and empty both return `undefined`**, so callers keep their own defaults and nothing reads `0` or `NaN` as an instruction.
- **`DailyTipAgent` catches it**, because agents don't throw (#136) and losing a whole notification over a link is the worse trade. By then the bad value has already been reported loudly by whatever tried to bind or lock it.

## Validation

- 20 new tests, written against the values where the old parsers *differed* — a test using `18790` would have passed before this change too
- **Mutation-tested.** Reverting the parser to `parseInt` fails 3 tests; dropping the lower bound fails 2; making empty-string a real port fails 2. Restored → 20/20
- Full suite **5252 passed** / 21 skipped, up exactly the 20 tests added
- `tsc --noEmit`, `npm run lint`, `npm run build:server` all clean; `parity_harness.py --runtime both` PASS
- Verified against the **built** `dist/` artifact, not just source
