### PR TITLE
fix: one rule for a port, whether it arrives by flag or by variable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `--port` and `OPENRAPPTER_PORT` read the same string two different ways.
+  `--port 1e3` bound port 1 while `OPENRAPPTER_PORT=1e3` bound 1000; `--port
+  8080.5` and `--port 18790abc` were silently truncated to 8080 and 18790. The
+  flag's validator existed as six byte-identical copies of a `parseInt`, which
+  is how it drifted from the variable in the first place. There is now one rule
+  for both — a whole number from 1 to 65535, written in decimal — so hex,
+  exponents, fractions and trailing garbage are refused rather than quietly
+  becoming some other port.
+- A bad `--port` answered with an uncaught exception and a stack trace pointing
+  into node_modules, because all six copies threw a plain `Error` and Commander
+  only recognises `InvalidArgumentError`. It now prints the same one-line usage
+  error as every other bad argument.
 - OPENRAPPTER_PORT was read by two different parsers that disagreed, so one
   setting could put the gateway on one port and its lock file on another. The
   paths deciding what to bind used parseInt; the paths naming the lock used

--- a/typescript/src/__tests__/unit/openrappter-port-env.test.ts
+++ b/typescript/src/__tests__/unit/openrappter-port-env.test.ts
@@ -11,20 +11,27 @@
  */
 
 import { describe, expect, it } from 'vitest';
+import { Command, InvalidArgumentError } from 'commander';
 
-import { portFromEnvironment } from '../../infra/cli-port.js';
+import { portFromEnvironment, portFromFlag } from '../../infra/cli-port.js';
 import { gatewayPortFor } from '../../infra/gateway-lock.js';
 
 describe('portFromEnvironment', () => {
   describe('the inputs where the two old parsers disagreed', () => {
     // parseInt('0x1F90', 10) stops at the 'x' and yields 0 — a request for an
     // arbitrary ephemeral port. Number('0x1F90') yields 8080. The server took
-    // the first answer and the lock took the second.
+    // the first answer and the lock took the second. Neither reading survives:
+    // a port is written in decimal.
     it('refuses hex-looking input rather than binding one port and locking another', () => {
       expect(Number.parseInt('0x1F90', 10)).toBe(0);
       expect(Number('0x1F90')).toBe(8080);
-      // One answer now, whatever the caller is going to do with it.
-      expect(portFromEnvironment('0x1F90')).toBe(8080);
+      expect(() => portFromEnvironment('0x1F90')).toThrow(/Invalid OPENRAPPTER_PORT/);
+    });
+
+    it('refuses exponent notation, which the two parsers read 1000 apart', () => {
+      expect(Number.parseInt('1e3', 10)).toBe(1);
+      expect(Number('1e3')).toBe(1000);
+      expect(() => portFromEnvironment('1e3')).toThrow(/Invalid OPENRAPPTER_PORT/);
     });
 
     it('refuses a number with trailing garbage instead of silently truncating', () => {
@@ -114,5 +121,99 @@ describe('portFromEnvironment', () => {
         else process.env.OPENRAPPTER_PORT = previous;
       }
     });
+  });
+});
+
+describe('portFromFlag', () => {
+  /**
+   * `--port` was six byte-identical copies of a `parseInt` validator. Because
+   * they were copies of the WRONG parser, fixing only the environment variable
+   * moved the disagreement rather than ending it: the flag and the variable
+   * then read the same string two different ways.
+   */
+  it.each([
+    ['18790abc', 18790],
+    ['8080.5', 8080],
+    ['1e3', 1],
+  ])('rejects %j, which the old copies silently truncated to %i', (raw) => {
+    expect(() => portFromFlag(raw)).toThrow(/whole number from 1 to 65535/);
+  });
+
+  it.each([['0'], ['-1'], ['65536'], ['abc'], [''], ['  '], ['+8080'], ['0x1F90']])(
+    'rejects %j',
+    (raw) => {
+      expect(() => portFromFlag(raw)).toThrow(/whole number from 1 to 65535/);
+    },
+  );
+
+  it.each([['1'], ['80'], ['8080'], ['18790'], ['65535']])('accepts %s', (raw) => {
+    expect(portFromFlag(raw)).toBe(Number(raw));
+  });
+
+  /**
+   * Commander only formats what it recognises. A plain Error escapes as an
+   * uncaught exception, which is how a typo used to earn a stack trace instead
+   * of the one-line usage error every other bad argument gets.
+   */
+  it('throws the error commander knows how to print', () => {
+    expect(() => portFromFlag('nonsense')).toThrow(InvalidArgumentError);
+  });
+
+  it('is formatted by commander as an ordinary usage error', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
+    program.option('--port <port>', 'Gateway port', portFromFlag);
+
+    let message = '';
+    try {
+      program.parse(['node', 'openrappter', '--port', '8080.5']);
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain("option '--port <port>' argument '8080.5' is invalid");
+    expect(message).toContain('whole number from 1 to 65535');
+  });
+
+  it('still accepts a good value through commander', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.option('--port <port>', 'Gateway port', portFromFlag);
+    program.parse(['node', 'openrappter', '--port', '8080']);
+    expect(program.opts().port).toBe(8080);
+  });
+});
+
+describe('the flag and the variable are the same rule', () => {
+  /**
+   * The point of the round. Measured before the fix:
+   *
+   *   value       --port      OPENRAPPTER_PORT
+   *   1e3         1           1000
+   *   8080.5      8080        rejected
+   *   0x1F90      rejected    8080
+   *
+   * `--port 1e3` and `OPENRAPPTER_PORT=1e3` landed a thousand ports apart.
+   */
+  const values = [
+    '8080', '1', '65535', '18790', '  9000  ',
+    '0', '-1', '65536', '99999', 'abc', '',
+    '0x1F90', '1e3', '8080.5', '18790abc', '+8080', 'Infinity',
+  ];
+
+  it.each(values.map((v) => [v]))('agrees on %j', (raw) => {
+    let viaFlag: number | 'rejected';
+    let viaEnv: number | 'rejected' | undefined;
+    try { viaFlag = portFromFlag(raw); } catch { viaFlag = 'rejected'; }
+    try { viaEnv = portFromEnvironment(raw); } catch { viaEnv = 'rejected'; }
+
+    // Empty is the one honest difference: a flag is only present because
+    // someone typed it, while an empty variable is how a shell says nothing.
+    if (raw.trim() === '') {
+      expect(viaFlag).toBe('rejected');
+      expect(viaEnv).toBeUndefined();
+      return;
+    }
+    expect(viaEnv).toBe(viaFlag);
   });
 });

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -34,7 +34,7 @@ import { registerAgentsCommand } from './cli/agents.js';
 import { registerModelsCommand } from './cli/models.js';
 import { registerUpdateCommand } from './cli/update.js';
 import { registerHubCommands } from './cli/hubs.js';
-import { portFromEnvironment, portTypedOnCommandLine } from './infra/cli-port.js';
+import { portFromEnvironment, portFromFlag, portTypedOnCommandLine } from './infra/cli-port.js';
 import { watchOwnerProcess } from './infra/owner-watch.js';
 import {
   ensureFlightRecorderFromEnv,
@@ -1048,13 +1048,7 @@ program
     'Name this rappter, so an alpha and its hatched twins can run on one device. '
     + 'Omit it for the alpha. Also settable as OPENRAPPTER_INSTANCE.',
   )
-  .option('--port <port>', 'Gateway port', (value: string) => {
-    const port = Number.parseInt(value, 10);
-    if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
-      throw new Error(`Invalid port: ${value}`);
-    }
-    return port;
-  })
+  .option('--port <port>', 'Gateway port', portFromFlag)
   .option('-s, --status', 'Show status')
   .option('-l, --list-agents', 'List available agents')
   .option('--exec <agent>', 'Execute a specific agent')
@@ -2112,13 +2106,7 @@ registerServiceStatusCommand(serviceCommand);
 serviceCommand
   .command('install')
   .description('Install or adopt the gateway service')
-  .option('--port <port>', 'Gateway port', (value: string) => {
-    const port = Number.parseInt(value, 10);
-    if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
-      throw new Error(`Invalid port: ${value}`);
-    }
-    return port;
-  }, 18790)
+  .option('--port <port>', 'Gateway port', portFromFlag, 18790)
   .action(async (options: { port: number }, command: Command) => {
     // The root's --port swallows this command's own, so ask where the user
     // actually typed it before installing a service on the wrong port. #108
@@ -2148,13 +2136,7 @@ const imessageCommand = program
 imessageCommand
   .command('install-service')
   .description('Install and start the launchd-supervised gateway')
-  .option('--port <port>', 'Gateway port', (value: string) => {
-    const port = Number.parseInt(value, 10);
-    if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
-      throw new Error(`Invalid port: ${value}`);
-    }
-    return port;
-  }, 18790)
+  .option('--port <port>', 'Gateway port', portFromFlag, 18790)
   .action(async (options: { port: number }, command: Command) => {
     const port = portTypedOnCommandLine(command) ?? options.port;
     const { readIMessageConfig } = await import('./channels/imessage-gateway.js');
@@ -2187,13 +2169,7 @@ imessageCommand
   .command('service-status')
   .description('Show sanitized launchd, liveness, and readiness status')
   .option('--json', 'Print machine-readable JSON')
-  .option('--port <port>', 'Gateway port', (value: string) => {
-    const port = Number.parseInt(value, 10);
-    if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
-      throw new Error(`Invalid port: ${value}`);
-    }
-    return port;
-  }, 18790)
+  .option('--port <port>', 'Gateway port', portFromFlag, 18790)
   .action(async (options: { json?: boolean; port: number }, command: Command) => {
     const port = portTypedOnCommandLine(command) ?? options.port;
     const { getIMessageServiceStatus } = await import(
@@ -2235,13 +2211,7 @@ imessageCommand
   .command('diagnose')
   .description('Run privacy-safe iMessage readiness diagnostics')
   .option('--json', 'Print machine-readable JSON')
-  .option('--port <port>', 'Gateway port', (value: string) => {
-    const port = Number.parseInt(value, 10);
-    if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
-      throw new Error(`Invalid port: ${value}`);
-    }
-    return port;
-  }, 18790)
+  .option('--port <port>', 'Gateway port', portFromFlag, 18790)
   .action(async (options: { json?: boolean; port: number }, command: Command) => {
     const port = portTypedOnCommandLine(command) ?? options.port;
     const managedEnv = await loadEnv();
@@ -2638,13 +2608,7 @@ registerHubCommands(program);
 program
   .command('gateway')
   .description('Start the gateway server (same runtime as `openrappter --daemon`)')
-  .option('--port <port>', 'Gateway port', (value: string) => {
-    const port = Number.parseInt(value, 10);
-    if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
-      throw new Error(`Invalid port: ${value}`);
-    }
-    return port;
-  })
+  .option('--port <port>', 'Gateway port', portFromFlag)
   .option(
     '--instance <id>',
     'Name this rappter, so an alpha and its hatched twins can run on one device.',

--- a/typescript/src/infra/cli-port.ts
+++ b/typescript/src/infra/cli-port.ts
@@ -27,6 +27,7 @@
  * SOURCE rather than comparing against the default.
  */
 
+import { InvalidArgumentError } from 'commander';
 import type { Command } from 'commander';
 
 /**
@@ -48,9 +49,11 @@ export function portTypedOnCommandLine(command: Command): number | undefined {
     if (node.getOptionValueSource?.('port') !== 'cli') continue;
 
     const raw = (node.opts() as { port?: unknown }).port;
-    const value = typeof raw === 'string' ? Number.parseInt(raw, 10) : raw;
     // A root that declared `--port` without a parser hands back a string, and
-    // an unparseable one must never become a bind or install target.
+    // an unparseable one must never become a bind or install target. Same rule
+    // as everywhere else, so a value the flag would have rejected cannot get
+    // in through this door instead.
+    const value = typeof raw === 'string' ? portOrUndefined(raw) : raw;
     if (
       typeof value === 'number'
       && Number.isSafeInteger(value)
@@ -95,17 +98,101 @@ export function portTypedOnCommandLine(command: Command): number | undefined {
  * and empty both mean "no opinion" and return undefined, so each caller keeps
  * the default it already had.
  */
+/**
+ * The one rule for what counts as a port, wherever the value came from.
+ *
+ * A port is written in decimal. Insisting on that, rather than handing the
+ * string to `Number` or `parseInt` and seeing what falls out, is what makes the
+ * answer the same for every caller — see `portFromEnvironment` for what the
+ * looser readings cost.
+ *
+ * Returns undefined for anything unusable, including empty input, and leaves
+ * the wording of the complaint to the caller that knows where the value came
+ * from. A user who typed `--port` wants to hear about `--port`, not about an
+ * environment variable they never set.
+ */
+function portOrUndefined(raw: string): number | undefined {
+  const trimmed = raw.trim();
+  // Digits only. `Number` would take '0x1F90' as 8080 and '1e3' as 1000, and
+  // `parseInt` would take the same two as 0 and 1 — which is exactly how the
+  // flag and the variable came to disagree. No port is ever written that way,
+  // so neither reading is worth keeping.
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const port = Number(trimmed);
+  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) return undefined;
+  return port;
+}
+
+/**
+ * The port `--port` asks for.
+ *
+ * `InvalidArgumentError` rather than a plain `Error`, because Commander only
+ * recognises the former. All six copies of this parser threw a plain one, so
+ * `openrappter service status --port 8080.5` answered a typo with an uncaught
+ * exception and a stack trace pointing into node_modules. Commander turns this
+ * into the usage error it already prints for every other bad argument:
+ *
+ *   error: option '--port <port>' argument '8080.5' is invalid.
+ *   must be a whole number from 1 to 65535
+ *
+ * Commander supplies the flag and the offending value, so the message here is
+ * only the reason.
+ *
+ * The copies were also copies of the wrong parser: a `parseInt` that read
+ * `--port 8080.5` as 8080 and `--port 18790abc` as 18790.
+ */
+export function portFromFlag(value: string): number {
+  const port = portOrUndefined(value);
+  if (port === undefined) {
+    throw new InvalidArgumentError('must be a whole number from 1 to 65535');
+  }
+  return port;
+}
+
+/**
+ * The port `OPENRAPPTER_PORT` asks for, parsed once and the same way everywhere.
+ *
+ * The variable was read in five places with two different parsers, and they do
+ * not agree. Measured:
+ *
+ *   OPENRAPPTER_PORT   parseInt(v, 10)          Number(v)
+ *   0x1F90             0     -> ephemeral port  8080
+ *   18790abc           18790 -> binds           NaN
+ *   8080.5             8080                     8080.5
+ *   1e3                1                        1000
+ *   ""                 NaN                      0
+ *
+ * The disagreement was not cosmetic, because the two parsers fed different
+ * things. `parseInt` produced the port the gateway BINDS; `Number` produced the
+ * port its lock file is NAMED for. So `OPENRAPPTER_PORT=0x1F90` bound an
+ * arbitrary ephemeral port and then took the lock for 8080: the lock stopped
+ * describing the server it is supposed to be guarding, which is the only job a
+ * lock has. `NaN` was worse rather than better — `gatewayPortFor` screens it
+ * with `Number.isFinite` and quietly substitutes the derived port, so the
+ * mismatch left no trace at all.
+ *
+ * `0` reached the same place by a shorter route. `parseInt('0', 10)` is a
+ * request for an ephemeral port, so the server landed somewhere unpredictable
+ * while the lock recorded the literal 0. `--port 0` is rejected outright, and
+ * a variable has no business being more permissive than the flag it mirrors.
+ *
+ * Hence: one parser, and the bounds `--port` already enforces. An unusable
+ * value raises rather than quietly becoming some other port, because every
+ * silent fallback here ends with a lock pointing at the wrong server. Unset
+ * and empty both mean "no opinion" and return undefined, so each caller keeps
+ * the default it already had.
+ */
 export function portFromEnvironment(
   raw: string | undefined = process.env.OPENRAPPTER_PORT,
 ): number | undefined {
   if (raw === undefined) return undefined;
-  const trimmed = raw.trim();
-  if (trimmed === '') return undefined;
+  // Unlike `--port`, which is only present because someone typed it, an empty
+  // variable is how a shell says nothing at all. It must not become an error.
+  if (raw.trim() === '') return undefined;
 
-  // `Number` rather than `parseInt`: it refuses trailing garbage and fractions
-  // instead of truncating them into a plausible-looking port.
-  const port = Number(trimmed);
-  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) {
+  const port = portOrUndefined(raw);
+  if (port === undefined) {
     throw new Error(
       `Invalid OPENRAPPTER_PORT: ${JSON.stringify(raw)} `
       + '(expected a whole number from 1 to 65535)',


### PR DESCRIPTION
#387 unified the five readers of `OPENRAPPTER_PORT` with each other, but left them disagreeing with `--port` — which is **six byte-identical copies** of a `parseInt` validator. So the divergence moved rather than ended. Measured on the built CLI:

| value | `--port` | `OPENRAPPTER_PORT` |
|---|---|---|
| `1e3` | **1** | **1000** |
| `8080.5` | **8080** | rejected |
| `18790abc` | **18790** | rejected |
| `0x1F90` | rejected | **8080** |

`--port 1e3` and `OPENRAPPTER_PORT=1e3` landed a thousand ports apart, and `--port 8080.5` was silently truncated.

## One rule instead of seven copies

Six copies of a validator are *how* the flag and the variable drifted apart, so this replaces them rather than correcting each one. The rule: **a port is written in decimal — digits only, 1 to 65535.**

That single sentence disposes of hex, exponents, fractions, signs and trailing garbage at once, where `Number` and `parseInt` each accepted some subset and disagreed about the rest. It also *tightens* the variable, which briefly read `0x1F90` as 8080 — free to change, since #387 is still unreleased.

The seventh copy of the bounds, inside `portTypedOnCommandLine`, shares the rule too, so a value the flag rejects cannot get in by that door instead.

## A stack trace for a typo

All six copies threw a plain `Error`. Commander only recognises `InvalidArgumentError`, so a plain one escaped as an uncaught exception. Measured on the built CLI:

```
$ openrappter service status --port 8080.5

before:  file:///…/dist/infra/cli-port.js:127
                 throw new Error(`Invalid port: ${value}`);
                 ^
         Error: Invalid port: 8080.5
             at …

after:   error: option '--port <port>' argument '8080.5' is invalid.
         must be a whole number from 1 to 65535
```

Exit code 1 either way; the difference is whether the user is shown a bug or a usage error. This was pre-existing on `main` — and fixing it is exactly the payoff of having one copy instead of six.

## Validation

- **37 new tests** (57 in the file), including a table asserting the flag and the variable now agree on all 17 values above — the one honest difference being empty input, since a flag is only present because someone typed it while an empty variable is how a shell says nothing
- Two tests drive **real Commander instances**, because a unit test of the parser would not have caught the plain-`Error` defect
- **Mutation-tested.** Restoring the `parseInt` validator fails **8** tests; dropping the decimal rule fails **5**; restored → 57/57
- One mutant (loosening the regex to allow `.`) **survived and is genuinely equivalent** — verified the edit applied, then confirmed `Number.isSafeInteger` independently rejects fractions. Two guards cover that case, so it is defence in depth rather than a test gap
- Full suite **5289 passed** / 21 skipped; `tsc --noEmit`, `npm run lint`, `build:server` clean; `parity_harness.py --runtime both` PASS
- `index.ts` loses 42 lines of duplication
