### PR TITLE
fix: stop handing bare builtins to commander as option parsers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `--evolve` was parsed by passing `parseInt` straight to commander, which calls
+  a parser as `fn(value, previous)` — so the previous value silently became
+  `parseInt`'s **radix**. `--evolve 9 --evolve 9` parsed to `NaN`, and because
+  the caller guards with `if (options.evolve)`, `NaN` and `0` ran no ticks,
+  exited 0 and fell through to an interactive session: asking for evolution and
+  getting silence looked exactly like success. `--evolve 10abc` ran ten ticks,
+  `--evolve 0x10` ran sixteen, and `--evolve -3` announced "Running -3
+  evolution ticks" before running none.
+- A seventh copy of the `--port` validator, in `src/cli/rappters.ts`, outlived
+  the consolidation of the other six and kept both defects they had: silent
+  `parseInt` truncation, and a plain `Error` that escaped as a stack trace.
 - `--port` and `OPENRAPPTER_PORT` read the same string two different ways.
   `--port 1e3` bound port 1 while `OPENRAPPTER_PORT=1e3` bound 1000; `--port
   8080.5` and `--port 18790abc` were silently truncated to 8080 and 18790. The

--- a/typescript/src/__tests__/unit/cli-args.test.ts
+++ b/typescript/src/__tests__/unit/cli-args.test.ts
@@ -1,0 +1,202 @@
+import { describe, expect, it } from 'vitest';
+import { Command, InvalidArgumentError } from 'commander';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { tickCountFromFlag, wholeNumberFromFlag, wholeNumberOrUndefined } from '../../infra/cli-args.js';
+import { portFromFlag } from '../../infra/cli-port.js';
+import { registerRappterCommand } from '../../cli/rappters.js';
+
+/**
+ * Commander calls an option parser as `fn(value, previous)`. Passing `parseInt`
+ * straight in therefore hands the previous value to the RADIX parameter — the
+ * `['1','2','3'].map(parseInt)` bug, in a shipped flag.
+ */
+describe('--evolve was parsed by a bare parseInt', () => {
+  const evolve = (parser: (v: string, p?: never) => unknown, args: string[]) => {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
+    program.option('-e, --evolve <n>', 'Run N evolution ticks', parser as never);
+    try {
+      program.parse(['node', 'openrappter', ...args]);
+    } catch {
+      return 'rejected';
+    }
+    return program.opts().evolve;
+  };
+
+  it('parsed a repeated flag as NaN, because the previous value became the radix', () => {
+    // parseInt('9', 9): base 9 has no digit 9.
+    expect(evolve(parseInt, ['-e', '9', '-e', '9'])).toBeNaN();
+    expect(evolve(tickCountFromFlag, ['-e', '9', '-e', '9'])).toBe(9);
+  });
+
+  it('turned a typo into silence rather than an error', () => {
+    // NaN is falsy, and the caller guards with `if (options.evolve)`, so the
+    // command ran no ticks and exited 0 — indistinguishable from success.
+    expect(evolve(parseInt, ['-e', 'abc'])).toBeNaN();
+    expect(evolve(tickCountFromFlag, ['-e', 'abc'])).toBe('rejected');
+  });
+
+  it.each([
+    ['10abc', 10],
+    ['5.7', 5],
+    ['0x10', 16],
+  ])('read %j as %i', (raw, wasParsedAs) => {
+    expect(evolve(parseInt, ['-e', raw])).toBe(wasParsedAs);
+    expect(evolve(tickCountFromFlag, ['-e', raw])).toBe('rejected');
+  });
+
+  it('accepted a negative count it could not possibly run', () => {
+    expect(evolve(parseInt, ['-e', '-3'])).toBe(-3);
+    expect(evolve(tickCountFromFlag, ['-e', '-3'])).toBe('rejected');
+  });
+
+  it('refuses zero, which fell past the guard into an interactive session', () => {
+    expect(evolve(parseInt, ['-e', '0'])).toBe(0);
+    expect(evolve(tickCountFromFlag, ['-e', '0'])).toBe('rejected');
+  });
+
+  it('still accepts an ordinary count', () => {
+    expect(evolve(tickCountFromFlag, ['-e', '5'])).toBe(5);
+  });
+
+  /**
+   * The consumer guards with `if (options.evolve)`. That guard is only safe
+   * because the parser can no longer produce NaN, 0 or a negative.
+   */
+  it('never yields a value the caller would silently skip', () => {
+    for (const raw of ['1', '2', '99', '1000']) {
+      expect(tickCountFromFlag(raw)).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('wholeNumberOrUndefined', () => {
+  it.each([
+    ['0x1F90', 0, 8080],
+    ['1e3', 1, 1000],
+    ['8080.5', 8080, 8080.5],
+    ['18790abc', 18790, Number.NaN],
+  ])('refuses %j, which parseInt read as %s and Number read as %s', (raw) => {
+    expect(wholeNumberOrUndefined(raw, 1, 65_535)).toBeUndefined();
+  });
+
+  it.each([['8080'], ['  9000  '], ['1'], ['65535']])('accepts %j', (raw) => {
+    expect(wholeNumberOrUndefined(raw, 1, 65_535)).toBe(Number(raw.trim()));
+  });
+
+  it('honours the bounds it is given', () => {
+    expect(wholeNumberOrUndefined('0', 1, 10)).toBeUndefined();
+    expect(wholeNumberOrUndefined('11', 1, 10)).toBeUndefined();
+    expect(wholeNumberOrUndefined('10', 1, 10)).toBe(10);
+  });
+});
+
+describe('wholeNumberFromFlag', () => {
+  it('throws the error commander knows how to print', () => {
+    expect(() => wholeNumberFromFlag('nope', 1, 10)).toThrow(InvalidArgumentError);
+  });
+
+  it('names the bounds it was given', () => {
+    expect(() => wholeNumberFromFlag('nope', 1, 10)).toThrow(/whole number from 1 to 10/);
+  });
+
+  /**
+   * `--evolve` has no real upper bound, and printing 9007199254740991 at
+   * someone who typed a typo tells them nothing about what to type instead.
+   */
+  it('does not print MAX_SAFE_INTEGER as though it were a limit', () => {
+    let message = '';
+    try {
+      tickCountFromFlag('abc');
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).not.toContain('9007199254740991');
+    expect(message).toBe('must be a whole number 1 or more');
+  });
+});
+
+/**
+ * The parsers above are only worth anything if the real commands use them.
+ * Mutation testing proved that gap was live: reverting `--evolve` to a bare
+ * `parseInt` broke none of the unit tests, because they all built their own
+ * throwaway `Command`. These two assert the wiring itself.
+ */
+describe('the real commands use the validated parsers', () => {
+  it('registerRappterCommand rejects a bad --port with a usage error', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({ writeErr: () => {}, writeOut: () => {} });
+    registerRappterCommand(program);
+
+    let message = '';
+    try {
+      program.parse(['node', 'openrappter', 'hatch', 'demo', '--port', '8080.5']);
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain("option '--port <port>' argument '8080.5' is invalid");
+  });
+
+  /**
+   * `index.ts` calls `program.parse()` at module scope, so it cannot be
+   * imported to be inspected. Read the decision out of the source instead —
+   * the same approach the repo already uses for rules that live in a module
+   * with side effects.
+   *
+   * Passing a builtin straight to `.option()` is never right: commander calls
+   * a parser as `fn(value, previous)`, so `parseInt` silently takes `previous`
+   * as its RADIX, and `--evolve 9 --evolve 9` parsed to NaN.
+   */
+  it('no command hands a bare builtin to commander as an option parser', () => {
+    const here = dirname(fileURLToPath(import.meta.url));
+    const sources = ['../../index.ts', '../../cli/rappters.ts', '../../twin/cli.ts'];
+
+    for (const relative of sources) {
+      const source = readFileSync(join(here, relative), 'utf8');
+      const offenders = [
+        ...source.matchAll(
+          /\.(?:option|requiredOption|argument)\([^)]*?,\s*(parseInt|parseFloat|Number|Boolean)\s*[,)]/g,
+        ),
+      ];
+      expect(
+        offenders.map((match) => `${relative}: ${match[1]}`),
+        `${relative} passes a builtin as a commander parser; commander calls it as `
+        + 'fn(value, previous), so previous becomes parseInt\'s radix',
+      ).toEqual([]);
+    }
+  });
+});
+
+/**
+ * The `--port` validator existed as SEVEN byte-identical copies, not six: the
+ * seventh lived in another file and outlived the consolidation. A rule written
+ * once cannot drift, so both flags now answer for the same reasons.
+ */
+describe('every --port flag answers the same way', () => {
+  it.each([['8080.5'], ['18790abc'], ['1e3'], ['0x1F90'], ['0'], ['-1'], ['65536'], ['']])(
+    'rejects %j',
+    (raw) => {
+      expect(() => portFromFlag(raw)).toThrow(InvalidArgumentError);
+    },
+  );
+
+  it('rejects with a usage error, not a stack trace, through commander', () => {
+    const program = new Command();
+    program.exitOverride();
+    program.configureOutput({ writeErr: () => {} });
+    program.option('--port <port>', 'override the port derived from the name', portFromFlag);
+
+    let message = '';
+    try {
+      program.parse(['node', 'rappters', '--port', '8080.5']);
+    } catch (error) {
+      message = (error as Error).message;
+    }
+    expect(message).toContain("option '--port <port>' argument '8080.5' is invalid");
+  });
+});

--- a/typescript/src/cli/rappters.ts
+++ b/typescript/src/cli/rappters.ts
@@ -26,7 +26,7 @@ import {
   type RappterStatus,
 } from '../infra/roster.js';
 import { canonicalInstanceKey } from '../infra/gateway-lock.js';
-import { portTypedOnCommandLine } from '../infra/cli-port.js';
+import { portFromFlag, portTypedOnCommandLine } from '../infra/cli-port.js';
 
 const EMOJI = '🦖';
 
@@ -104,13 +104,7 @@ export function registerRappterCommand(program: Command): void {
     .command('hatch')
     .description('Hatch a twin rappter on this device')
     .argument('<name>', 'what to call it')
-    .option('--port <port>', 'override the port derived from the name', (value: string) => {
-      const port = Number.parseInt(value, 10);
-      if (!Number.isSafeInteger(port) || port < 1 || port > 65535) {
-        throw new Error(`Invalid port: ${value}`);
-      }
-      return port;
-    })
+    .option('--port <port>', 'override the port derived from the name', portFromFlag)
     .action(async (name: string, options: { port?: number }, command: Command) => {
       const typed = name.trim();
       if (!typed) {

--- a/typescript/src/index.ts
+++ b/typescript/src/index.ts
@@ -34,6 +34,7 @@ import { registerAgentsCommand } from './cli/agents.js';
 import { registerModelsCommand } from './cli/models.js';
 import { registerUpdateCommand } from './cli/update.js';
 import { registerHubCommands } from './cli/hubs.js';
+import { tickCountFromFlag } from './infra/cli-args.js';
 import { portFromEnvironment, portFromFlag, portTypedOnCommandLine } from './infra/cli-port.js';
 import { watchOwnerProcess } from './infra/owner-watch.js';
 import {
@@ -1041,7 +1042,7 @@ program
 program
   .argument('[message]', 'Message to send')
   .option('-t, --task <task>', 'Run a single task')
-  .option('-e, --evolve <n>', 'Run N evolution ticks', parseInt)
+  .option('-e, --evolve <n>', 'Run N evolution ticks', tickCountFromFlag)
   .option('-d, --daemon', 'Run as background daemon')
   .option(
     '--instance <id>',

--- a/typescript/src/infra/cli-args.ts
+++ b/typescript/src/infra/cli-args.ts
@@ -1,0 +1,100 @@
+/**
+ * The rule for a whole number typed on the command line.
+ *
+ * This exists because the same rule was written seven times for `--port` alone
+ * and still managed to disagree with itself, and because `--evolve` skipped
+ * writing it at all and passed `parseInt` straight to commander. Both mistakes
+ * have the same shape: a number arrives as text, and every parser that reads it
+ * casually accepts something the user did not type.
+ *
+ * Callers name their own bounds and their own wording. The rule itself lives
+ * here once.
+ */
+
+import { InvalidArgumentError } from 'commander';
+
+/**
+ * A whole number written in decimal, within bounds, or undefined.
+ *
+ * Digits only, deliberately. Both of the obvious readings are worse:
+ *
+ *   input       parseInt(v, 10)   Number(v)
+ *   0x1F90      0                 8080
+ *   1e3         1                 1000
+ *   8080.5      8080              8080.5
+ *   18790abc    18790             NaN
+ *
+ * `parseInt` truncates at the first character it does not like, so garbage
+ * becomes a plausible-looking number instead of an error. `Number` accepts
+ * notations nobody uses for a port or a count. They disagree on every row
+ * above, which is exactly how `--port` and `OPENRAPPTER_PORT` ended up reading
+ * `1e3` a thousand apart. Requiring decimal digits settles all of it in one
+ * sentence, and no one writes a port or a tick count any other way.
+ *
+ * Returns undefined rather than throwing so each caller can say where the
+ * value came from; a user who typed `--port` wants to hear about `--port`.
+ */
+export function wholeNumberOrUndefined(
+  raw: string,
+  min: number,
+  max: number,
+): number | undefined {
+  const trimmed = raw.trim();
+  if (!/^\d+$/.test(trimmed)) return undefined;
+
+  const value = Number(trimmed);
+  if (!Number.isSafeInteger(value) || value < min || value > max) return undefined;
+  return value;
+}
+
+/**
+ * The same rule, as a commander option parser.
+ *
+ * `InvalidArgumentError` rather than a plain `Error`, because commander only
+ * recognises the former. A plain one escapes as an uncaught exception, which is
+ * how a typo used to earn a stack trace pointing into node_modules instead of
+ * the one-line usage error every other bad argument gets.
+ *
+ * Commander supplies the flag name and the offending value when it formats
+ * this, so `expected` is only the reason.
+ */
+export function wholeNumberFromFlag(raw: string, min: number, max: number): number {
+  const value = wholeNumberOrUndefined(raw, min, max);
+  if (value === undefined) {
+    // An upper bound of MAX_SAFE_INTEGER is not a real limit, it is the absence
+    // of one, and printing 9007199254740991 at someone who typed a typo tells
+    // them nothing about what to type instead.
+    const bounds = max === Number.MAX_SAFE_INTEGER
+      ? `${min} or more`
+      : `from ${min} to ${max}`;
+    throw new InvalidArgumentError(`must be a whole number ${bounds}`);
+  }
+  return value;
+}
+
+/**
+ * The count `--evolve` asks for.
+ *
+ * Commander calls a parser as `fn(value, previous)`, so passing `parseInt`
+ * directly — as this option did — silently hands the previous value in as the
+ * RADIX. It is the `['1','2','3'].map(parseInt)` bug, in a shipped flag.
+ * Measured before this change:
+ *
+ *   -e abc        NaN   ran nothing, exit 0, and fell through to interactive chat
+ *   -e 0          0     same: the caller guards with `if (options.evolve)`
+ *   -e 10abc      10    ran ten ticks
+ *   -e 5.7        5
+ *   -e 0x10       16    parseInt auto-detects hex when the radix is undefined
+ *   -e -3         -3    announced "Running -3 evolution ticks", then ran none
+ *   -e 9 -e 9     NaN   radix 9 has no digit 9, so a repeated flag parsed to NaN
+ *
+ * The NaN cases are the reason this matters: asking for evolution ticks and
+ * getting silence and a zero exit code looks exactly like success.
+ *
+ * Zero is refused rather than treated as a no-op, because it was not one — it
+ * fell past the guard into an interactive session, which is not what anyone
+ * typing `--evolve 0` in a script is expecting.
+ */
+export function tickCountFromFlag(raw: string): number {
+  return wholeNumberFromFlag(raw, 1, Number.MAX_SAFE_INTEGER);
+}

--- a/typescript/src/infra/cli-port.ts
+++ b/typescript/src/infra/cli-port.ts
@@ -30,6 +30,8 @@
 import { InvalidArgumentError } from 'commander';
 import type { Command } from 'commander';
 
+import { wholeNumberOrUndefined } from './cli-args.js';
+
 /**
  * Walk this command and its ancestors for a `--port` that came from the command
  * line, and return it.
@@ -101,10 +103,10 @@ export function portTypedOnCommandLine(command: Command): number | undefined {
 /**
  * The one rule for what counts as a port, wherever the value came from.
  *
- * A port is written in decimal. Insisting on that, rather than handing the
- * string to `Number` or `parseInt` and seeing what falls out, is what makes the
- * answer the same for every caller — see `portFromEnvironment` for what the
- * looser readings cost.
+ * A port is written in decimal, which is just the shared whole-number rule
+ * with the bounds a port has. Keeping it in one place is what makes the answer
+ * the same for every caller — see `portFromEnvironment` for what the looser
+ * readings cost.
  *
  * Returns undefined for anything unusable, including empty input, and leaves
  * the wording of the complaint to the caller that knows where the value came
@@ -112,16 +114,7 @@ export function portTypedOnCommandLine(command: Command): number | undefined {
  * environment variable they never set.
  */
 function portOrUndefined(raw: string): number | undefined {
-  const trimmed = raw.trim();
-  // Digits only. `Number` would take '0x1F90' as 8080 and '1e3' as 1000, and
-  // `parseInt` would take the same two as 0 and 1 — which is exactly how the
-  // flag and the variable came to disagree. No port is ever written that way,
-  // so neither reading is worth keeping.
-  if (!/^\d+$/.test(trimmed)) return undefined;
-
-  const port = Number(trimmed);
-  if (!Number.isSafeInteger(port) || port < 1 || port > 65_535) return undefined;
-  return port;
+  return wholeNumberOrUndefined(raw, 1, 65_535);
 }
 
 /**


### PR DESCRIPTION
`--evolve` passed `parseInt` straight to commander. Commander calls a parser as `fn(value, previous)`, so the previous value silently became `parseInt`'s **radix** — the `['1','2','3'].map(parseInt)` bug, in a shipped flag.

Measured on the built CLI, before this change:

| invocation | parsed as | ticks actually run |
|---|---|---|
| `-e abc` | `NaN` | **none, exit 0** |
| `-e 0` | `0` | **none, exit 0** |
| `-e 9 -e 9` | `NaN` | **none, exit 0** |
| `-e 10abc` | `10` | 10 |
| `-e 0x10` | `16` | 16 |
| `-e 5.7` | `5` | 5 |
| `-e -3` | `-3` | 0, after printing "Running -3 evolution ticks" |

`-e 9 -e 9` is the radix bug directly: the second call is `parseInt('9', 9)`, and base 9 has no digit 9. `-e 0x10` is the same cause from the other side — with an undefined radix `parseInt` auto-detects hex.

**The `NaN` cases are why this matters.** The caller guards with `if (options.evolve)`, so `NaN` and `0` both skip the work, exit 0, and fall through to an interactive session. Asking for evolution ticks and getting silence is indistinguishable from success.

```
before:  (no error; ran no ticks; exit 0)
after:   error: option '-e, --evolve <n>' argument 'abc' is invalid.
         must be a whole number 1 or more
```

## Correcting #388

That PR said `--port` had six copies of its validator. **It had seven.** The seventh is in `src/cli/rappters.ts`, and it outlived the consolidation with both original defects intact — `parseInt` truncation, and a plain `Error` that commander doesn't recognise and so escapes as a stack trace. It now uses the shared parser, so `hatch --port 8080.5` gives a usage error instead of a stack trace.

The rule itself now lives in one place for both flags, with each caller naming its own bounds.

## Mutation testing found a real gap

It did not just confirm the work. Reverting `--evolve` to bare `parseInt` broke **nothing** — every test had built its own throwaway `Command` and never touched the real wiring. Exactly the gap I flagged as a risk in #388 and then walked into anyway.

Two tests now close it:
- one drives `registerRappterCommand` directly
- one reads `index.ts`, which calls `program.parse()` at module scope and so cannot be imported — matching the source-reading idiom the repo already uses for modules with side effects. It guards **every** option against bare builtins, not just this one.

After adding them, the same mutations fail as they should:

| mutation | result |
|---|---|
| `--evolve` back to bare `parseInt` | **1 failed** |
| `rappters.ts --port` back to its old copy | **1 failed** |
| drop the decimal rule | **10 failed** |
| allow a zero tick count | **1 failed** |
| plain `Error` instead of `InvalidArgumentError` | **1 failed** |
| restored | 32/32 |

## Validation

- 32 new tests; full suite **5321 passed** / 21 skipped
- `tsc --noEmit`, `npm run lint`, `build:server` clean; `parity_harness.py --runtime both` PASS
- Verified against the built CLI, not just source — which is also how I noticed the first draft printed `must be a whole number from 1 to 9007199254740991` at anyone who typed a typo. An unbounded maximum now reads "1 or more".
