### PR TITLE
fix: a shipped agent that cannot load now fails CI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A shipped agent could not be loaded at all. `agents/morning_brief_agent.js`
+  ended its manifest with `} as const;` — TypeScript, in a `.js` file — so Node
+  threw `Unexpected identifier 'as'` before reading any of it. It had been that
+  way for 26 days, since the commit that put a `__manifest__` on all 43 agents.
+  The RAPP conformance gate reported `8 passed, 0 failed` either way, because it
+  reads the manifest out of the file and never asks Node whether the file can be
+  loaded; the only symptom was one WARN per gateway start. Shipped agents are now
+  loaded the way the registry loads them — import, `createAgent(BasicAgent)`,
+  `new AgentClass()` — so an unloadable one fails CI instead of going quiet.
 - `--evolve` was parsed by passing `parseInt` straight to commander, which calls
   a parser as `fn(value, previous)` — so the previous value silently became
   `parseInt`'s **radix**. `--evolve 9 --evolve 9` parsed to `NaN`, and because

--- a/agents/morning_brief_agent.js
+++ b/agents/morning_brief_agent.js
@@ -32,7 +32,7 @@ export const __manifest__ = {
   category: 'general',
   quality_tier: 'official',
   requires_env: []
-} as const;
+};
 export function createAgent(BasicAgent) {
 
   // Lazy-load sibling agents from the built-in agents directory

--- a/typescript/src/__tests__/unit/shipped-agents-load.test.ts
+++ b/typescript/src/__tests__/unit/shipped-agents-load.test.ts
@@ -1,0 +1,90 @@
+/**
+ * A shipped agent has to load. — the gap behind #144
+ *
+ * `agents/morning_brief_agent.js` could not be imported at all for 26 days.
+ * Its manifest declaration ended `} as const;` — TypeScript, in a `.js` file —
+ * so Node threw `Unexpected identifier 'as'` before reading a line of it. It
+ * arrived that way in "all 43 agents on the RAPP contract, and a gate that can
+ * prove it", which put a `__manifest__` on every agent.
+ *
+ * The gate could not prove it. Run `conformance.py` against the broken file
+ * and against the fixed one and it reports `8 passed, 0 failed` both times,
+ * because it reads the manifest out of the file and never asks Node whether
+ * the file is loadable. Everything downstream agreed: the agent was contract-
+ * compliant, correctly named, tagged `quality_tier: 'official'` — and absent.
+ *
+ * The only symptom was one WARN per gateway start:
+ *
+ *   WARN [agents] Agent file failed to load
+ *     {"file":"~/.openrappter/agents/morning_brief_agent.js",
+ *      "reason":"Unexpected identifier 'as'"}
+ *
+ * `LearnNewAgent` already carries a comment naming this exact file as the
+ * casualty that proved a generated agent could report success while being
+ * unloadable. That fixed the generator. Nobody fixed the file it generated,
+ * and nothing in CI would have said so.
+ *
+ * `node --check` is not the missing check: it passes on `as const` because it
+ * parses as a script, while the ESM import that the registry actually performs
+ * fails. So this runs the registry's real sequence instead — import, then
+ * `createAgent(BasicAgent)`, then `new AgentClass()`, then read `.name` — which
+ * is the only thing that answers the question being asked.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readdirSync } from 'node:fs';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+import { dirname, join } from 'node:path';
+
+import { BasicAgent } from '../../agents/BasicAgent.js';
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..', '..', '..', '..');
+const shippedAgentsDir = join(repoRoot, 'agents');
+
+const shippedAgents = readdirSync(shippedAgentsDir).filter((file) => file.endsWith('_agent.js'));
+
+describe('every shipped agent loads the way the registry loads it', () => {
+  /**
+   * Without this, the suite would pass by finding nothing — which is the same
+   * kind of hole as a gate that proves a manifest and not a load.
+   */
+  it('finds the shipped agents at all', () => {
+    expect(shippedAgents.length).toBeGreaterThan(0);
+  });
+
+  it.each(shippedAgents)('%s imports as an ES module', async (file) => {
+    const url = pathToFileURL(join(shippedAgentsDir, file)).href;
+    await expect(import(url)).resolves.toBeDefined();
+  });
+
+  it.each(shippedAgents)('%s exports createAgent and instantiates', async (file) => {
+    const url = pathToFileURL(join(shippedAgentsDir, file)).href;
+    const mod = await import(url);
+
+    expect(typeof mod.createAgent, `${file} must export createAgent(BasicAgent)`).toBe('function');
+
+    const AgentClass = mod.createAgent(BasicAgent);
+    expect(AgentClass, `${file} createAgent returned nothing`).toBeTruthy();
+
+    const instance = new AgentClass();
+    // The registry keys the agent map on this, so a blank name is a silent no-op.
+    expect(typeof instance.name).toBe('string');
+    expect(instance.name.length).toBeGreaterThan(0);
+  });
+
+  it.each(shippedAgents)('%s declares a manifest that survives the import', async (file) => {
+    const url = pathToFileURL(join(shippedAgentsDir, file)).href;
+    const mod = await import(url);
+
+    // Read from the imported module rather than the file text: the whole point
+    // is that a manifest can be perfectly well-formed in a file Node refuses.
+    expect(mod.__manifest__?.schema).toBe('rapp-agent/1.0');
+    expect(mod.__manifest__?.name).toBeTruthy();
+  });
+
+  it('would have caught the TypeScript-in-JavaScript that broke this', async () => {
+    const url = pathToFileURL(join(shippedAgentsDir, 'morning_brief_agent.js')).href;
+    const mod = await import(url);
+    expect(mod.__manifest__.name).toBe('@openrappter/morning-brief');
+  });
+});


### PR DESCRIPTION
`agents/morning_brief_agent.js` has not been loadable since **2026-07-25**. Its manifest ended `} as const;` — TypeScript, in a `.js` file — so Node threw `Unexpected identifier 'as'` before reading a line of it. **26 days.**

```
$ node -e "import('./agents/morning_brief_agent.js').catch(e => console.log(e.message))"
Unexpected identifier 'as'
```

It arrived that way in *"all 43 agents on the RAPP contract, and a gate that can prove it"*, the commit that put a `__manifest__` on every agent.

## The gate could not prove it

Running `conformance.py` against the broken file and the fixed one gives the same answer both times:

| file | conformance.py |
|---|---|
| broken (as on `main`) | `8 passed, 0 failed, 1 skipped` |
| fixed | `8 passed, 0 failed, 1 skipped` |

It reads the manifest **out of** the file and never asks Node whether the file can be **loaded**. So everything downstream agreed the agent was contract-compliant, correctly named, tagged `quality_tier: 'official'` — and absent. The only symptom was one WARN per gateway start:

```
WARN [agents] Agent file failed to load
  {"file":"~/.openrappter/agents/morning_brief_agent.js","reason":"Unexpected identifier 'as'"}
```

## This was already known, and half-fixed

`LearnNewAgent.ts` carries a comment naming *this exact file* as the casualty that proved a generated agent could report `status: 'success'` while being unloadable (#144):

> *"A real `morning_brief_agent.js`, whose header says it was auto-generated here, had been failing to load on every start for at least ten days."*

That fixed the generator. **Nobody fixed the file the generator had already written**, and nothing in CI would say so.

## `node --check` is not the missing check

It **passes** on `as const`, because it parses the file as a script — while the ESM import the registry actually performs fails:

```
node --check probe.js   → exit 0
import('./probe.js')    → Unexpected identifier 'as'
```

So the new test runs the registry's *real* sequence instead — `import` → `createAgent(BasicAgent)` → `new AgentClass()` → read `.name` — against every shipped `*_agent.js`. It also asserts it found some, so it cannot pass by finding nothing, which is the same hole as a gate that proves a manifest and not a load.

## Mutation results

| mutation | result |
|---|---|
| restore the exact `as const` that shipped | **4 failed** |
| rename the `createAgent` export | **1 failed** |
| blank the manifest name | **2 failed** |
| restored | 5 passed |

The first row is the one that matters: `conformance.py` still reports `8 passed, 0 failed` on that same file.

## Validation

- The agent now actually loads: `LOADED name=MorningBrief`
- Full TS suite **5326 passed** / 21 skipped; Python **2040 passed**
- `tsc --noEmit`, `npm run lint` clean; `conformance.py` 8/0; `parity_harness.py --runtime both` PASS

Note: the copy at `~/.openrappter/agents/` on a machine that already installed it is separate user state and still carries the old line; it is not touched by this PR.
