### PR TITLE
fix: the capability gate now sees dynamic imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The capability-reachability gate asserted about agents whose source it could
+  not fully see. It excluded an agent that statically imports deep internals —
+  "the source is the whole story" only holds for self-contained files — but read
+  static `import ... from` lines only, so `await import('../infra/gateway-lock.js')`
+  was invisible to it. Three of the thirteen agents it asserted against reached
+  deep modules that way. Dynamic imports now count, and a computed specifier
+  excludes the file outright, since nothing static can say what it loads. No
+  mis-declaration was hiding behind this; the assertions were simply resting on
+  a premise that was not true. The anti-vacuity floor now sits at the true count
+  so the set cannot erode one agent at a time.
 - A shipped agent could not be loaded at all. `agents/morning_brief_agent.js`
   ended its manifest with `} as const;` — TypeScript, in a `.js` file — so Node
   threw `Unexpected identifier 'as'` before reading any of it. It had been that

--- a/typescript/src/agents/__tests__/capability-reachability.test.ts
+++ b/typescript/src/agents/__tests__/capability-reachability.test.ts
@@ -50,23 +50,79 @@ function agentFiles(): string[] {
  * An agent whose every import is a Node builtin, `./BasicAgent.js` or a type.
  * `BasicAgent` itself performs no disk or process I/O, so for these files the
  * source is the whole story.
+ *
+ * Dynamic imports count. This used to read static `import ... from` lines only,
+ * which meant `await import('../infra/gateway-lock.js')` was invisible to it —
+ * the very same specifier that disqualifies a file when written statically.
+ * Three of the thirteen agents this asserted against reached deep internals
+ * that way (`CronAgent` into `../cron/service.js`, `TTSAgent` into
+ * `../voice/tts.js`, and `NeighborAgent` into nine modules under `../infra`
+ * and `../twin`), so the file claimed "the source is the whole story" about
+ * files whose story continued somewhere it never looked. No live
+ * mis-declaration was hiding there — each one calls a pure helper — but the
+ * assertions were resting on a premise that was not true, which is the kind of
+ * thing that holds until it suddenly doesn't.
+ *
+ * A dynamic import with a computed specifier is excluded outright: if the
+ * target is only known at runtime, nothing here can say what it reaches. No
+ * agent in this directory does that today, but `morning_brief_agent.js` loads
+ * siblings by `import(path.join(...))`, so the shape is not hypothetical.
  */
 function isSelfContained(source: string): boolean {
-  const imports = [...source.matchAll(/^import\s[^;]*?from\s+['"]([^'"]+)['"]/gm)]
+  const isDeep = (spec: string) =>
+    spec.startsWith('../') || /^\.\/(?!BasicAgent|types)/.test(spec);
+
+  const staticImports = [...source.matchAll(/^import\s[^;]*?from\s+['"]([^'"]+)['"]/gm)]
     .map((m) => m[1]);
-  return imports.every(
-    (spec) => !spec.startsWith('../') && !/^\.\/(?!BasicAgent|types)/.test(spec),
-  );
+  if (!staticImports.every((spec) => !isDeep(spec))) return false;
+
+  const literalDynamic = [...source.matchAll(/\bimport\s*\(\s*['"]([^'"]+)['"]\s*\)/g)]
+    .map((m) => m[1]);
+  if (!literalDynamic.every((spec) => !isDeep(spec))) return false;
+
+  const everyDynamic = source.match(/\bimport\s*\(/g)?.length ?? 0;
+  return everyDynamic === literalDynamic.length;
 }
 
 describe('agents do not declare capabilities they cannot reach', () => {
   it('checks a meaningful number of agents', () => {
     // Anti-vacuity: if the self-contained set shrank to nothing, every
-    // assertion below would pass without examining anything.
+    // assertion below would pass without examining anything. The floor sits at
+    // the true current count rather than comfortably below it, because the
+    // failure this guards against is the set eroding one agent at a time —
+    // teaching an agent to reach a deep module through a dynamic import now
+    // drops it out of these assertions, and that should require saying so here
+    // rather than happening quietly.
     const selfContained = agentFiles().filter((f) =>
       isSelfContained(readFileSync(path.join(agentsDir, f), 'utf8')),
     );
-    expect(selfContained.length).toBeGreaterThanOrEqual(8);
+    expect(selfContained.length).toBeGreaterThanOrEqual(10);
+  });
+
+  describe('the self-contained rule sees past static imports', () => {
+    const builtinOnly = "import fs from 'node:fs';\nimport { BasicAgent } from './BasicAgent.js';\n";
+
+    it('accepts builtins and BasicAgent', () => {
+      expect(isSelfContained(builtinOnly)).toBe(true);
+    });
+
+    it('rejects a deep static import', () => {
+      expect(isSelfContained(`${builtinOnly}import { x } from '../infra/roster.js';\n`)).toBe(false);
+    });
+
+    it('rejects a deep dynamic import — the case that was invisible', () => {
+      expect(isSelfContained(`${builtinOnly}const m = await import('../infra/gateway-lock.js');`))
+        .toBe(false);
+    });
+
+    it('rejects a computed dynamic import, whose target it cannot know', () => {
+      expect(isSelfContained(`${builtinOnly}const m = await import(path.join(dir, name));`))
+        .toBe(false);
+    });
+
+    it('still accepts a dynamic import of a builtin', () => {
+      expect(isSelfContained(`${builtinOnly}const m = await import('node:os');`)).toBe(true);
+    });
   });
 
   it('no self-contained agent declares an unreachable capability', async () => {


### PR DESCRIPTION
`capability-reachability.test.ts` excludes an agent that imports deep internals, on the stated grounds that for the remaining files *"the source is the whole story"*. It read static `import ... from` lines only. A dynamic import of the **very same specifier** was invisible to it.

Three of the thirteen agents it asserted against reached deep modules that way:

| agent | reaches, unseen |
|---|---|
| `CronAgent` | `../cron/service.js` |
| `TTSAgent` | `../voice/tts.js` |
| `NeighborAgent` | nine modules under `../infra` and `../twin` |

So the gate was excluding agents that statically import `../infra/...` while asserting about `NeighborAgent`, which dynamically loads `roster.js`, `current-instance.js`, `gateway-lock.js` and `twin/send.js` — and declares only `network`.

## Nothing was hiding behind it

`gateway-lock.ts` contains 11 filesystem-write sites, which looks damning until you check what is actually called. I did, before claiming otherwise:

```
export { canonicalInstanceKey } from './instance-key.js';
```

A pure string helper. Each of the three agents calls a pure export from the module it loads, so **no capability is reached undeclared today**. The defect is not a hidden violation — it is that the assertions rested on a premise that was not true, which holds right up until it doesn't.

## What changed

Dynamic imports now count. A **computed** specifier excludes the file outright: if the target is only known at runtime, nothing static is entitled to say what it reaches. No agent in this directory does that today, but `morning_brief_agent.js` loads siblings by `import(path.join(...))`, so the shape is not hypothetical.

That is also why this PR **does not touch** `morning_brief_agent.js`, which declares `filesystem-write` while containing only `fs.readFile`. It looks like an over-declaration and it is not one to fix blind: the agent loads arbitrary sibling agents at runtime, so the capability is defensible and no static rule should overrule it. I started to "fix" that manifest and stopped when the evidence didn't support it.

The anti-vacuity floor moves from `8` to the true count of `10`. The failure it guards against is the set eroding one agent at a time, and a floor with slack in it cannot see that.

## Mutations

| mutation | result |
|---|---|
| revert to the static-imports-only rule | **2 failed** |
| give a real set member a deep dynamic import | **1 failed** (the floor fires) |
| make a set member write without declaring it | **1 failed** (original check intact) |
| restored | 8 passed |

One mutation initially *survived* — I had picked `DailyTipAgent`, which already had deep static imports and so was never in the assertion set. That is a failed edit, not a weak test; redone against a real member it fails correctly.

## Validation

Full TS suite **5331 passed** / 21 skipped · `tsc --noEmit` and `npm run lint` clean · `conformance.py` 8 passed, 0 failed · `parity_harness.py --runtime both` PASS
