### PR TITLE
fix: the capability gate could not see most disk writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The capability gate's evidence patterns could not see most ways of writing to
+  disk. They are what decides whether an agent is holding an undeclared
+  capability, and nothing tested them directly — they were only ever run against
+  whichever agents happened to exist, so a gap sat there without a single test
+  going red. An agent could call `fs.rm(dir, { recursive: true })` and the gate
+  reported nothing, though it already listed that call's synchronous twin.
+  `renameSync` and `copyFileSync` were missed too, on a word boundary: the `S`
+  that follows `rename` is a word character. Those forms appear 71 times
+  elsewhere in the TypeScript sources, so it was luck rather than design that no
+  agent had reached for one. The patterns are now generated from verb plus
+  optional `Sync`, cover UDP and HTTP/2 alongside HTTP, and have unit tests of
+  their own — including that they stay quiet on ordinary prose, since a false
+  positive here pushes people to declare capabilities they do not hold.
 - The capability-reachability gate asserted about agents whose source it could
   not fully see. It excluded an agent that statically imports deep internals —
   "the source is the whole story" only holds for self-contained files — but read

--- a/typescript/src/agents/__tests__/capability-reachability.test.ts
+++ b/typescript/src/agents/__tests__/capability-reachability.test.ts
@@ -32,13 +32,43 @@ import { fileURLToPath } from 'node:url';
 const here = path.dirname(fileURLToPath(import.meta.url));
 const agentsDir = path.resolve(here, '..');
 
-/** Evidence that a capability is reachable, mirroring CAPABILITY_EVIDENCE. */
+/**
+ * Evidence that a capability is reachable, mirroring CAPABILITY_EVIDENCE.
+ *
+ * These patterns are the security-critical core of this file, and until now
+ * nothing tested them directly — they were only ever exercised against
+ * whichever agents happened to exist, so a gap could sit here indefinitely
+ * without a single test going red. Fourteen of fifteen realistic
+ * `filesystem-write` forms were invisible, including `fs.rm(dir, {recursive:
+ * true})`, the async twin of the `rmSync` the table already listed. The
+ * `\b...\b` word boundary also meant `rename` did not match `renameSync` and
+ * `copyFile` did not match `copyFileSync`, because the `S` that follows is a
+ * word character. Those forms are used 71 times elsewhere in `typescript/src`;
+ * it was luck, not design, that no self-contained agent had reached for one.
+ *
+ * The list is now built from verb + optional `Sync` so a twin cannot go
+ * missing again, and the classifier has unit tests of its own below.
+ *
+ * `rm` and `cp` are matched only in call position, since two letters are too
+ * little to spend a false positive on. Bare `link` is deliberately absent for
+ * the same reason — it is far more likely to be a markup helper than
+ * `fs.link`, and `symlink` covers the case that matters. A false positive here
+ * would push someone to declare a capability they do not have, which is the
+ * exact disease this file exists to treat.
+ */
+const FS_WRITE_VERBS = [
+  'writeFile', 'appendFile', 'copyFile', 'rename', 'mkdir', 'rmdir', 'unlink',
+  'truncate', 'ftruncate', 'symlink', 'chmod', 'chown', 'mkdtemp', 'writev',
+  'createWriteStream',
+];
+
 const EVIDENCE: Record<string, RegExp> = {
   'process-exec': /from\s+['"](?:node:)?child_process['"]/,
   'network':
-    /from\s+['"](?:node:)?(?:http|https|net|dns|dns\/promises|tls)['"]|from\s+['"](?:axios|node-fetch|undici|ws)['"]|\bfetch\s*\(/,
-  'filesystem-write':
-    /\b(writeFile|writeFileSync|mkdir|mkdirSync|rmSync|unlink|unlinkSync|appendFile|appendFileSync|copyFile|rename|createWriteStream)\b/,
+    /from\s+['"](?:node:)?(?:http|https|http2|net|dgram|dns|dns\/promises|tls)['"]|from\s+['"](?:axios|node-fetch|undici|ws)['"]|\bfetch\s*\(|\bnew\s+WebSocket\s*\(/,
+  'filesystem-write': new RegExp(
+    `\\b(?:${FS_WRITE_VERBS.join('|')})(?:Sync)?\\b|\\b(?:rm|cp)(?:Sync)?\\s*\\(`,
+  ),
 };
 
 function agentFiles(): string[] {
@@ -122,6 +152,53 @@ describe('agents do not declare capabilities they cannot reach', () => {
 
     it('still accepts a dynamic import of a builtin', () => {
       expect(isSelfContained(`${builtinOnly}const m = await import('node:os');`)).toBe(true);
+    });
+  });
+
+  describe('the evidence patterns see the forms this codebase actually uses', () => {
+    // These patterns decide whether an agent is holding an undeclared
+    // capability, and nothing tested them until now — they were only ever run
+    // against whichever agents existed, so a missing form failed silently.
+    // Every case below was measured as invisible to the previous table.
+    const fsWrite = EVIDENCE['filesystem-write'];
+
+    it.each([
+      ['await fs.rm(dir, { recursive: true, force: true });', 'recursive delete'],
+      ['fs.rmSync(dir, { recursive: true });', 'rmSync'],
+      ['await fs.rmdir(dir);', 'rmdir'],
+      ['fs.rmdirSync(dir);', 'rmdirSync'],
+      ['fs.renameSync(a, b);', 'renameSync — the word boundary hid this'],
+      ['fs.copyFileSync(a, b);', 'copyFileSync — likewise'],
+      ['await fs.cp(src, dst, { recursive: true });', 'cp'],
+      ['fs.cpSync(src, dst);', 'cpSync'],
+      ['await fs.truncate(p, 0);', 'truncate erases a file'],
+      ['await fs.symlink(target, linkPath);', 'symlink'],
+      ['await fs.chmod(p, 0o777);', 'chmod'],
+      ['await fs.mkdtemp(prefix);', 'mkdtemp creates a directory'],
+      ['await fsp.writeFile(p, data);', 'writeFile, which always worked'],
+    ])('sees %s (%s)', (source) => {
+      expect(fsWrite.test(source)).toBe(true);
+    });
+
+    it('does not fire on ordinary prose or unrelated calls', () => {
+      // A false positive here would push someone to declare a capability they
+      // do not hold, which is the failure this file exists to prevent.
+      for (const benign of [
+        'const url = link(label, href);',
+        '// remove the item from the array',
+        'const form = new FormData();',
+        'return items.map((i) => i.id);',
+      ]) {
+        expect(fsWrite.test(benign)).toBe(false);
+      }
+    });
+
+    it('sees network transports beyond http', () => {
+      const net = EVIDENCE['network'];
+      expect(net.test("import dgram from 'node:dgram';")).toBe(true);
+      expect(net.test("import http2 from 'node:http2';")).toBe(true);
+      expect(net.test('const s = new WebSocket(url);')).toBe(true);
+      expect(net.test("import path from 'node:path';")).toBe(false);
     });
   });
 


### PR DESCRIPTION
The `EVIDENCE` patterns decide whether an agent is holding a capability it never declared. **Nothing tested them.** They were only ever run against whichever agents happened to exist, so a missing form failed silently — no test went red, and the gate reported success.

Fourteen of fifteen realistic `filesystem-write` forms were invisible:

| form | note |
|---|---|
| `fs.rm(dir, {recursive:true})` | the async twin of the `rmSync` it **did** list |
| `rmdir` / `rmdirSync` | not listed at all |
| `cp` / `cpSync` | recursive copy, not listed |
| `truncate` / `truncateSync` | erases a file, not listed |
| `symlink`, `chmod`, `mkdtemp` | not listed |
| `renameSync`, `copyFileSync` | lost to a word boundary |

That last pair is the sharp one. The table listed `rename` and `copyFile` inside `\b...\b`, and the `S` of `renameSync` is a word character, so the boundary never matched. **Listing a verb was not the same as catching it.**

## Not hypothetical

These forms appear **71 times** elsewhere in `typescript/src` — `fs.rm` alone 22 times. It was luck, not design, that none of the ten self-contained agents had reached for one.

I checked before claiming a breach: **there is no live under-declaration in the tree today.** This is a hole in the gate, not an exploit in the agents.

## The side-by-side

Give a real member of the assertion set an undeclared recursive delete:

```ts
export const wipe = async (d: string) => { await fs.rm(d, { recursive: true, force: true }); };
```

```
old table   1 passed    ← blind
new table   1 failed    PongAgent.ts reaches filesystem-write without declaring it
```

## What changed

Patterns are now generated from **verb + optional `Sync`**, so a twin cannot go missing again. `network` covers `dgram` and `http2` alongside `http`, plus a global `WebSocket`.

`rm` and `cp` match only in **call position**, and bare `link` is deliberately absent. Two letters are too little to spend a false positive on, and a false positive here pushes someone to declare a capability they do **not** hold — the exact disease this file exists to treat. There is a test that the patterns stay quiet on ordinary prose (`link(label, href)`, `new FormData()`, a `// remove the item` comment).

## Mutations

| mutation | result |
|---|---|
| revert the table | **11 failed** |
| undeclared `fs.rm` in a real set member | **1 failed** (old table: *passed*) |
| undeclared `renameSync` | **1 failed** |
| restored | 23 passed |

## Validation

TS suite **5346 passed** (+15) · pytest **2040 passed** · `conformance.py` 8 passed / 0 failed · `parity_harness.py --runtime both` PASS · `tsc --noEmit` and `npm run lint` clean

## Not touched

`conformance.py`'s Python `CAPABILITY_EVIDENCE` is AST-based, not regex, and already covers `os.rmdir`, `os.truncate`, `os.symlink`, `os.chmod`, `shutil.rmtree`. It does not have this defect. Its one arguable gap — `open(p, 'w')` — needs argument inspection rather than name matching, and I have no evidence it bites today, so I left it alone rather than change code speculatively.
