### PR TITLE
fix: the capability table had an entry nothing read

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `conformance.py`'s capability table carried an entry nothing read. The
+  `credential-access` capability listed `"attrs": {"environ"}`, but the syntax
+  walker only ever consumed `modules`, `calls` and `builtins` — so the one entry
+  written to catch environment reads was inert. Ten of ten realistic forms went
+  unseen, including `os.environ["OPENAI_API_KEY"]`, `dict(os.environ)` and
+  `from os import environ`; only `os.getenv` and `os.environ.get` were caught, so
+  an agent passed or failed on which spelling its author happened to prefer. The
+  walker now reads `attrs` in any position and at the import site, and a new test
+  fails if *any* key in the table goes unread, so a dead key cannot recur
+  silently. No agent was under-declaring; this was a hole in the gate.
+
 - The capability gate's evidence patterns could not see most ways of writing to
   disk. They are what decides whether an agent is holding an undeclared
   capability, and nothing tested them directly — they were only ever run against

--- a/conformance.py
+++ b/conformance.py
@@ -62,7 +62,11 @@ CAPABILITY_EVIDENCE = {
     "credential-access": {
         "modules": {"keyring", "netrc", "getpass"},
         "calls": {"os.getenv", "os.environ.get", "getpass.getpass"},
-        "attrs": {"environ"},
+        # Read in any position, not just as a call. `os.environ["OPENAI_KEY"]`
+        # is a subscript, `dict(os.environ)` an argument, `os.environ.copy()`
+        # a method this table does not name. All three reach the same secrets
+        # as the `os.environ.get` above, so all three have to count.
+        "attrs": {"environ", "environb"},
     },
     "filesystem-write": {
         "modules": {"shutil"},
@@ -140,6 +144,12 @@ def observed_capabilities(path):
     `loads` would make every `json.loads` a dynamic-code finding, and a control
     that cries wolf on ordinary code gets switched off, and then it protects
     nothing.
+
+    `attrs` entries match an attribute in *any* position, because the reads
+    worth catching are not calls: `os.environ["TOKEN"]` is a subscript and
+    `dict(os.environ)` is an argument. Matching an attribute name this broadly
+    is only safe for names that mean one thing (`environ`); it is not a
+    mechanism to reach for casually.
     """
     try:
         with open(path, "rb") as fh:
@@ -154,11 +164,26 @@ def observed_capabilities(path):
             names = [a.name.split(".")[0] for a in node.names]
         elif isinstance(node, ast.ImportFrom) and node.module:
             names = [node.module.split(".")[0]]
+            # `from os import environ` binds the name directly, so every later
+            # use is a bare Name that no attribute rule can see. Catch it here,
+            # at the one point where the provenance is still visible.
+            for cap, spec in CAPABILITY_EVIDENCE.items():
+                for alias in node.names:
+                    if alias.name in spec.get("attrs", set()):
+                        found.add(cap)
+                        evidence.append(
+                            f"{cap}: from {node.module} import {alias.name}")
         for cap, spec in CAPABILITY_EVIDENCE.items():
             for name in names:
                 if name in spec.get("modules", set()):
                     found.add(cap)
                     evidence.append(f"{cap}: import {name}")
+
+        if isinstance(node, ast.Attribute):
+            for cap, spec in CAPABILITY_EVIDENCE.items():
+                if node.attr in spec.get("attrs", set()):
+                    found.add(cap)
+                    evidence.append(f"{cap}: {node.attr}")
 
         if isinstance(node, ast.Call):
             call = dotted(node.func)

--- a/python/tests/test_conformance_capability_evidence.py
+++ b/python/tests/test_conformance_capability_evidence.py
@@ -1,0 +1,130 @@
+"""The capability detector had a key in its table that nothing read.
+
+``CAPABILITY_EVIDENCE["credential-access"]`` carried ``"attrs": {"environ"}``.
+``observed_capabilities`` read ``modules``, ``calls`` and ``builtins`` — never
+``attrs``. So the one entry written specifically to catch environment reads was
+inert, and every non-call form of reaching the environment was invisible:
+
+    os.environ["OPENAI_API_KEY"]     a subscript, not a call
+    dict(os.environ)                 an argument, not a call
+    os.environ.copy()                a call the table does not name
+    from os import environ           binds a bare name with no receiver at all
+
+Ten of ten realistic forms escaped; only ``os.getenv`` and ``os.environ.get``
+were caught, so an agent passed or failed on which spelling its author
+happened to prefer. Nothing failed when the key went dead, because
+``observed_capabilities`` — the function that decides whether an agent secretly
+reaches a capability — had no tests at all.
+
+The first test below is the one that matters: it fails if any key in the table
+is not read by the walker, so this cannot recur silently for a future key.
+"""
+
+import ast
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+import conformance  # noqa: E402
+
+
+def _write(tmp_path, body):
+    p = tmp_path / "sample_agent.py"
+    p.write_text("import os\n" + body + "\n", encoding="utf-8")
+    return str(p)
+
+
+def _keys_the_walker_reads():
+    """Key names ``observed_capabilities`` actually looks up, from its source.
+
+    Read out of the syntax tree rather than hard-coded, so this stays true when
+    the walker is edited.
+    """
+    tree = ast.parse(Path(conformance.__file__).read_text(encoding="utf-8"))
+    fn = next(n for n in ast.walk(tree)
+              if isinstance(n, ast.FunctionDef)
+              and n.name == "observed_capabilities")
+    keys = set()
+    for node in ast.walk(fn):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "get"
+                and isinstance(node.func.value, ast.Name)
+                and node.func.value.id == "spec"
+                and node.args
+                and isinstance(node.args[0], ast.Constant)):
+            keys.add(node.args[0].value)
+    return keys
+
+
+def test_no_key_in_the_evidence_table_is_dead():
+    """A key nothing reads is a control that silently does nothing."""
+    declared = {k for spec in conformance.CAPABILITY_EVIDENCE.values()
+                for k in spec}
+    read = _keys_the_walker_reads()
+    assert declared <= read, (
+        f"evidence keys never read by observed_capabilities: "
+        f"{sorted(declared - read)}")
+
+
+def test_the_walker_reads_something():
+    """Guards the test above against passing because it found nothing."""
+    assert _keys_the_walker_reads() >= {"modules", "calls", "attrs"}
+
+
+ENV_FORMS = [
+    ("subscript", 'os.environ["OPENAI_API_KEY"]'),
+    ("subscript, single quotes", "os.environ['TOKEN']"),
+    ("bound to a local first", "env = os.environ\nvalue = env['SECRET']"),
+    ("copied wholesale", "leaked = os.environ.copy()"),
+    ("materialised as a dict", "leaked = dict(os.environ)"),
+    ("bytes environment", "os.environb[b'TOKEN']"),
+    ("from-import", "from os import environ\nvalue = environ['K']"),
+    ("setdefault", "os.environ.setdefault('A', 'b')"),
+    ("iterated", "[k for k in os.environ.items()]"),
+    ("names enumerated", "names = list(os.environ.keys())"),
+    ("passed to a callee", "send(os.environ)"),
+]
+
+
+@pytest.mark.parametrize("label,body", ENV_FORMS, ids=[f[0] for f in ENV_FORMS])
+def test_reaching_the_environment_is_credential_access(tmp_path, label, body):
+    found, _ = conformance.observed_capabilities(_write(tmp_path, body))
+    assert "credential-access" in found, f"{label} went unseen: {body!r}"
+
+
+@pytest.mark.parametrize("body", [
+    "os.getenv('TOKEN')",
+    "os.environ.get('TOKEN')",
+    "import getpass\ngetpass.getpass()",
+])
+def test_the_forms_that_already_worked_still_work(tmp_path, body):
+    found, _ = conformance.observed_capabilities(_write(tmp_path, body))
+    assert "credential-access" in found
+
+
+@pytest.mark.parametrize("body", [
+    # An attribute rule matching too broadly would fire on all of these.
+    "config = load()\nprint(config.environment)",
+    "import json\njson.loads('{}')",
+    "row = table['environ']",
+    "environment = 'staging'",
+    "# read os.environ later, maybe",
+    "'''docstring mentioning os.environ'''",
+])
+def test_it_stays_quiet_on_code_that_reads_no_secrets(tmp_path, body):
+    found, _ = conformance.observed_capabilities(_write(tmp_path, body))
+    assert "credential-access" not in found, f"false positive on {body!r}"
+
+
+@pytest.mark.parametrize("cap", sorted(conformance.CAPABILITY_EVIDENCE))
+def test_every_capability_in_the_table_can_be_detected(cap):
+    """Anti-vacuity: a capability whose evidence is all unreachable keys would
+    otherwise sit in the table looking like protection."""
+    spec = conformance.CAPABILITY_EVIDENCE[cap]
+    assert any(spec.get(k) for k in _keys_the_walker_reads()), \
+        f"{cap} has no evidence the walker can act on"


### PR DESCRIPTION
`CAPABILITY_EVIDENCE["credential-access"]` carried this:

```python
"attrs": {"environ"},
```

`observed_capabilities` read `modules`, `calls` and `builtins`. It never read `attrs`. The single entry written to catch environment reads was **inert**, and `attrs` appears exactly once in the whole repository — at its own definition.

## What escaped

Ten of ten realistic forms, measured:

| form | why it escaped |
|---|---|
| `os.environ["OPENAI_API_KEY"]` | a subscript, not a call |
| `dict(os.environ)` | an argument, not a call |
| `os.environ.copy()` | a call the table does not name |
| `from os import environ` | binds a bare name with no receiver at all |
| `os.environb[b"TOKEN"]` | not listed |
| `env = os.environ` then `env["SECRET"]` | receiver is a local |
| `setdefault` · `.items()` · `.keys()` · passed to a callee | not calls the table names |

Only `os.getenv` and `os.environ.get` were caught — so **an agent passed or failed on which spelling its author happened to prefer.**

## Why it stayed hidden

`observed_capabilities` decides whether an agent secretly reaches a capability. It had **no tests**. There are tests for R6, R8, R9 and JS manifests, but none for the detector itself, so when the key went dead nothing went red.

That is the same root cause as #392 on the other runtime. In that PR I wrote that the Python table "does not have this defect." That was wrong — it has a different one, and I'd rather say so than leave it standing.

## No live violation

Two agents touch `os.environ` (`pokemon_agent`, `twin_agent`); both use `.get` and both correctly declare `credential-access`. **Zero under-declarations today.** The subscript form appears 17 times elsewhere in `python/`, so the form is real here — no agent had reached for it yet. A hole in the gate, not an exploit.

## The load-bearing test

Not the ten form tests — this one:

```
test_no_key_in_the_evidence_table_is_dead
```

It reads which keys the walker actually looks up out of the walker's own syntax tree and asserts the table declares no others. Against the **shipped** code it fails with:

```
AssertionError: evidence keys never read by observed_capabilities: ['attrs']
```

It names the root cause, not a symptom. And it closes the class: adding a *brand-new* unread key `"subscripts"` fails immediately with `['subscripts']`.

## Mutations

| mutation | result |
|---|---|
| shipped `conformance.py` + these tests | **13 failed**, incl. the dead-key test naming `['attrs']` |
| add a new unread key `subscripts` | **1 failed**, names `['subscripts']` |
| broaden `attrs` with `environment` | **1 failed** — `false positive on config.environment` |
| restored | 27 passed |

## Scope of the matching rule

Matching an attribute name in any position is broad, so it is only safe for names that mean one thing. `environ` and `environb` qualify; this is not a mechanism to reach for casually, and the docstring says so. Six false-positive guards hold the line — `config.environment`, `json.loads`, `table['environ']`, a local named `environment`, and `os.environ` inside a comment and a docstring. AST matching ignores the last two for free.

## Validation

pytest **2067 passed**, 6 skipped (+27) · `conformance.py` 8 passed / 0 failed / 1 skipped · `parity_harness.py --runtime both` PASS
