### PR TITLE
fix: a brace in a description is not the end of the manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The gate read JavaScript manifests without knowing what a string was. It
+  counted braces to find the manifest block and then matched `key: value` per
+  line, so a `}` inside a description ended the manifest early and dropped
+  every field after it, a `{` inside a description or a comment meant the block
+  never closed and the manifest vanished entirely, a value stopped at the first
+  apostrophe, `'a ' + 'b'` kept only `'a '`, `\u2014` was never decoded, and a
+  nested object hoisted its keys — so a nested `capabilities` overwrote the
+  declared one. Measured against real JavaScript across the 35 shipped JS/TS
+  agents, **6 were already being misread**. The block scan and the value reader
+  now skip strings and comments, decode escapes, join concatenations, and parse
+  nested objects in place; all 35 now match the language exactly.
+
 - `conformance.py`'s capability table carried an entry nothing read. The
   `credential-access` capability listed `"attrs": {"environ"}`, but the syntax
   walker only ever consumed `modules`, `calls` and `builtins` — so the one entry

--- a/conformance.py
+++ b/conformance.py
@@ -225,19 +225,186 @@ def declared_manifest(path):
     return None
 
 
+_JS_ESCAPES = {"n": "\n", "t": "\t", "r": "\r", "b": "\b", "f": "\f",
+               "v": "\v", "0": "\0"}
+_JS_IDENT = re.compile(r"[A-Za-z_$][A-Za-z0-9_$]*")
+
+
+def _js_skip_atom(text, i):
+    """Index just past the string or comment starting at `i`, else None.
+
+    Brace counting that does not know about these is the defect this exists to
+    prevent. A `}` inside a description ended the manifest early and dropped
+    every field after it; a `{` in a comment meant the block never closed and
+    the manifest vanished entirely."""
+    ch = text[i]
+    if ch in "'\"`":
+        j = i + 1
+        while j < len(text):
+            if text[j] == "\\":
+                j += 2
+                continue
+            if text[j] == ch:
+                return j + 1
+            j += 1
+        return len(text)  # unterminated; treat the rest as opaque
+    if text.startswith("//", i):
+        nl = text.find("\n", i)
+        return len(text) if nl < 0 else nl
+    if text.startswith("/*", i):
+        end = text.find("*/", i + 2)
+        return len(text) if end < 0 else end + 2
+    return None
+
+
+def _js_skip_space(text, i, end):
+    """Index of the next thing that is neither whitespace nor a comment."""
+    while i < end:
+        if text[i] in " \t\r\n":
+            i += 1
+        elif text.startswith("//", i) or text.startswith("/*", i):
+            i = _js_skip_atom(text, i)
+        else:
+            break
+    return i
+
+
+def _js_string_at(text, i):
+    """(value, next index) for the quoted string at `i`, escapes decoded.
+
+    Decoding matters because the value is compared against the contract: a
+    name read as raw source would carry backslashes the runtime never sees."""
+    quote, out, j = text[i], [], i + 1
+    while j < len(text):
+        ch = text[j]
+        if ch == "\\":
+            esc = text[j + 1:j + 2]
+            if esc == "u" and re.fullmatch(r"[0-9a-fA-F]{4}", text[j + 2:j + 6]):
+                out.append(chr(int(text[j + 2:j + 6], 16)))
+                j += 6
+            elif esc == "x" and re.fullmatch(r"[0-9a-fA-F]{2}", text[j + 2:j + 4]):
+                out.append(chr(int(text[j + 2:j + 4], 16)))
+                j += 4
+            else:
+                out.append(_JS_ESCAPES.get(esc, esc))
+                j += 2
+            continue
+        if ch == quote:
+            return "".join(out), j + 1
+        out.append(ch)
+        j += 1
+    return "".join(out), len(text)
+
+
+def _js_value_at(text, i, end):
+    """(value, next index) for the JavaScript value starting at `i`."""
+    i = _js_skip_space(text, i, end)
+    if i >= end:
+        return None, i
+    ch = text[i]
+    if ch in "'\"`":
+        value, i = _js_string_at(text, i)
+        while True:  # `'half ' + 'half'` is one string, not the first half
+            plus = _js_skip_space(text, i, end)
+            if text[plus:plus + 1] != "+":
+                break
+            nxt = _js_skip_space(text, plus + 1, end)
+            if text[nxt:nxt + 1] not in ("'", '"', "`"):
+                break
+            more, i = _js_string_at(text, nxt)
+            value += more
+        return value, i
+    if ch == "[":
+        items, j, depth = [], i + 1, 1
+        while j < end and depth:
+            if text[j] in "'\"`" and depth == 1:
+                item, j = _js_string_at(text, j)
+                items.append(item)
+                continue
+            skip = _js_skip_atom(text, j)
+            if skip is not None:
+                j = skip
+                continue
+            if text[j] in "[{":
+                depth += 1
+            elif text[j] in "]}":
+                depth -= 1
+                if not depth:
+                    return items, j + 1
+            j += 1
+        return items, j
+    if ch == "{":
+        block = _js_balanced_block(text, i)
+        if block is None:
+            return {}, end
+        # Parsed, not hoisted: a nested `capabilities` used to land in the
+        # manifest itself, and last one written won.
+        return _js_object_entries(text, block[0], block[1]), block[1]
+    j = i
+    while j < end and text[j] not in ",\n":
+        j += 1
+    return text[i:j].strip(), j
+
+
+def _js_object_entries(text, lo, hi):
+    """Keys declared at the top level of the object literal `text[lo:hi]`."""
+    out, i = {}, lo + 1
+    while i < hi - 1:
+        skip = _js_skip_atom(text, i)
+        if skip is not None and text[i] not in "'\"":
+            i = min(skip, hi - 1)
+            continue
+        if text[i] in " \t\r\n,":
+            i += 1
+            continue
+        if text[i] in "'\"":
+            key, j = _js_string_at(text, i)
+        else:
+            m = _JS_IDENT.match(text, i, hi)
+            if m is None:
+                i += 1
+                continue
+            key, j = m.group(0), m.end()
+        j = _js_skip_space(text, j, hi)
+        if text[j:j + 1] != ":":
+            i = max(j, i + 1)
+            continue
+        value, i = _js_value_at(text, j + 1, hi - 1)
+        if value is not None:
+            out[key] = value
+    return out
+
+
 def _js_balanced_block(text, start):
-    """(start, end) of the `{...}` beginning at or after `start`, nesting-aware."""
-    open_at = text.find("{", start)
+    """(start, end) of the `{...}` beginning at or after `start`.
+
+    Nesting-aware, and aware that a brace inside a string or a comment is
+    punctuation rather than structure."""
+    open_at, i = -1, start
+    while i < len(text):
+        skip = _js_skip_atom(text, i)
+        if skip is not None:
+            i = skip
+            continue
+        if text[i] == "{":
+            open_at = i
+            break
+        i += 1
     if open_at == -1:
         return None
-    depth = 0
-    for i in range(open_at, len(text)):
+    depth, i = 0, open_at
+    while i < len(text):
+        skip = _js_skip_atom(text, i)
+        if skip is not None:
+            i = skip
+            continue
         if text[i] == "{":
             depth += 1
         elif text[i] == "}":
             depth -= 1
             if depth == 0:
                 return open_at, i + 1
+        i += 1
     return None
 
 
@@ -254,7 +421,11 @@ def js_declared_manifest(path):
     substring a text check looks for while exporting no manifest at all. A
     manifest block spans lines, and the only JavaScript string that can span
     lines is a template literal, so an odd number of backticks before the
-    declaration means it is inside one and is not a declaration."""
+    declaration means it is inside one and is not a declaration.
+
+    Reading the block is a small scan rather than a line-oriented regex,
+    because a line-oriented one cannot tell a brace in a description from the
+    end of the manifest, and stopped a quoted value at the first apostrophe."""
     try:
         with open(path, encoding="utf-8", errors="replace") as fh:
             body = fh.read()
@@ -267,19 +438,7 @@ def js_declared_manifest(path):
         block = _js_balanced_block(body, m.end())
         if block is None:
             continue
-        raw = body[block[0]:block[1]]
-        man = {}
-        for key, value in re.findall(
-                r"(?m)^\s*([A-Za-z_][A-Za-z0-9_]*)\s*:\s*"
-                r"(\[[^\]]*\]|'[^']*'|\"[^\"]*\"|[^,\n]+)", raw):
-            value = value.strip().rstrip(",")
-            if value.startswith("["):
-                man[key] = [a or b for a, b in
-                            re.findall(r"'([^']*)'|\"([^\"]*)\"", value)]
-            elif value[:1] in "'\"":
-                man[key] = value[1:-1]
-            else:
-                man[key] = value
+        man = _js_object_entries(body, block[0], block[1])
         if man:
             return man
     return None

--- a/python/tests/test_conformance_js_manifest_strings.py
+++ b/python/tests/test_conformance_js_manifest_strings.py
@@ -1,0 +1,284 @@
+"""A brace in a description is punctuation, not the end of the manifest.
+
+``js_declared_manifest`` read a manifest block by counting braces and then
+matching ``key: value`` per line. Neither step knew what a string was, so the
+gate disagreed with JavaScript about what an agent had declared.
+
+Measured against real JavaScript semantics over the 35 shipped JS/TS agents,
+**6 were already being misread**: two had a description truncated at an
+apostrophe (``Place real phone calls on the owner\\``), two truncated at a
+line-continuing ``'a ' + 'b'`` concatenation, and two carried a literal
+``\\u2014`` the runtime renders as an em dash.
+
+Constructed-but-valid manifests fared worse, because the failure was not
+limited to values:
+
+* ``description: 'Emit } to close.'`` ended the block at the brace inside the
+  string. Every field after it vanished and R3 reported the agent "lacks
+  ['version', 'capabilities']".
+* ``description: 'Emits JSON that starts with {'`` meant the block never
+  closed, ``js_declared_manifest`` returned ``None``, and R2 reported the
+  agent "carries no rapp-agent/1.0 manifest" — of a file whose manifest the
+  runtime loads perfectly.
+* A ``// returns { ok: true`` comment *inside* the manifest did the same.
+* A nested object hoisted its keys into the manifest, so a nested
+  ``capabilities`` overwrote the real one and the gate read a capability list
+  the agent had never declared.
+
+The first two directions fail loudly, which is the safe way to be wrong. The
+last does not: it makes the gate confidently wrong about what an agent may do.
+
+These tests state the values real JavaScript produces. Where node is present
+they also diff the parser against it across every shipped agent, which is the
+form that closes the class rather than the six instances.
+"""
+
+import json
+import shutil
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+import conformance  # noqa: E402
+
+
+HEAD = """\
+export const __manifest__ = {
+  schema: 'rapp-agent/1.0',
+  name: '@openrappter/demo',
+  version: '1.0.0',
+"""
+TAIL = """\
+  capabilities: ['process-exec', 'filesystem-write'],
+} as const;
+"""
+
+
+def _parse(tmp_path, middle, tail=TAIL, name="Demo.ts"):
+    path = tmp_path / name
+    path.write_text(HEAD + middle + tail, encoding="utf-8")
+    return conformance.js_declared_manifest(str(path))
+
+
+# ── values the old line regex truncated or left encoded ──────────────────────
+
+VALUE_CASES = [
+    pytest.param(
+        r"  description: 'Acts on the owner\'s behalf.'," + "\n",
+        "Acts on the owner's behalf.",
+        id="escaped-single-quote",
+    ),
+    pytest.param(
+        '  description: "She said \\"go\\" once.",\n',
+        'She said "go" once.',
+        id="escaped-double-quote",
+    ),
+    pytest.param(
+        r"  description: 'em\u2014dash'," + "\n",
+        "em\u2014dash",
+        id="unicode-escape-decoded",
+    ),
+    pytest.param(
+        r"  description: 'tab\there'," + "\n",
+        "tab\there",
+        id="short-escape-decoded",
+    ),
+    pytest.param(
+        "  description: 'first half ' +\n    'second half',\n",
+        "first half second half",
+        id="concatenation-across-lines",
+    ),
+    pytest.param(
+        "  description: 'Returns {ok: true} on success.',\n",
+        "Returns {ok: true} on success.",
+        id="balanced-braces-in-string",
+    ),
+    pytest.param(
+        "  description: 'Emit } to close.',\n",
+        "Emit } to close.",
+        id="close-brace-in-string",
+    ),
+    pytest.param(
+        "  description: 'Emits JSON that starts with {',\n",
+        "Emits JSON that starts with {",
+        id="open-brace-in-string",
+    ),
+    pytest.param(
+        "  description: 'see [docs] here',\n",
+        "see [docs] here",
+        id="brackets-in-string",
+    ),
+    pytest.param(
+        "  description: `a template value`,\n",
+        "a template value",
+        id="template-literal-value",
+    ),
+]
+
+
+@pytest.mark.parametrize("middle,expected", VALUE_CASES)
+def test_a_value_reads_as_javascript_reads_it(tmp_path, middle, expected):
+    man = _parse(tmp_path, middle)
+    assert man is not None, "the manifest disappeared entirely"
+    assert man["description"] == expected
+
+
+@pytest.mark.parametrize("middle,_expected", VALUE_CASES)
+def test_a_value_never_costs_the_fields_around_it(tmp_path, middle, _expected):
+    # The truncating failures dropped whatever followed. R3's required fields
+    # are the thing that has to survive.
+    man = _parse(tmp_path, middle) or {}
+    for key in ("schema", "name", "version", "description", "capabilities"):
+        assert key in man, f"{key} was lost while reading the value before it"
+    assert man["capabilities"] == ["process-exec", "filesystem-write"]
+
+
+# ── braces that are not structure ────────────────────────────────────────────
+
+@pytest.mark.parametrize("comment", [
+    pytest.param("  // returns { ok: true\n", id="line-comment-open-brace"),
+    pytest.param("  // closes with }\n", id="line-comment-close-brace"),
+    pytest.param("  /* a { in a block comment */\n", id="block-comment-brace"),
+    pytest.param("  // an apostrophe's fine too\n", id="comment-apostrophe"),
+])
+def test_a_comment_inside_the_manifest_is_not_structure(tmp_path, comment):
+    man = _parse(tmp_path, comment)
+    assert man is not None, "a comment made the manifest invisible"
+    assert man["capabilities"] == ["process-exec", "filesystem-write"]
+
+
+def test_a_string_element_containing_a_bracket_does_not_end_the_array(tmp_path):
+    man = _parse(tmp_path, "  description: 'x',\n",
+                 tail="  capabilities: ['process-exec', 'a]b'],\n};\n")
+    assert man["capabilities"] == ["process-exec", "a]b"]
+
+
+# ── nesting, the direction that fails quietly ────────────────────────────────
+
+def test_a_nested_object_does_not_hoist_its_keys(tmp_path):
+    man = _parse(tmp_path, "  description: 'x',\n",
+                 tail=TAIL.replace("} as const;", "  ui: {\n"
+                                   "    label: 'Demo',\n"
+                                   "  },\n} as const;"))
+    assert man["ui"] == {"label": "Demo"}
+    assert "label" not in man, "a nested key was hoisted into the manifest"
+
+
+def test_a_nested_capabilities_does_not_overwrite_the_declared_one(tmp_path):
+    # The quiet failure: last key written won, so a nested list the agent
+    # never declared became the list the gate enforced.
+    man = _parse(tmp_path, "  description: 'x',\n",
+                 tail=TAIL.replace("} as const;", "  examples: {\n"
+                                   "    capabilities: [],\n"
+                                   "  },\n} as const;"))
+    assert man["capabilities"] == ["process-exec", "filesystem-write"]
+    assert man["examples"] == {"capabilities": []}
+
+
+def test_a_quoted_key_is_still_a_key(tmp_path):
+    man = _parse(tmp_path, "  description: 'x',\n  'display_name': 'Demo',\n")
+    assert man["display_name"] == "Demo"
+
+
+# ── the shipped agents ───────────────────────────────────────────────────────
+
+def _js_agents():
+    return [p for p in conformance.all_agent_files() if not p.endswith(".py")]
+
+
+def test_there_are_js_agents_to_check():
+    # Anti-vacuity: every assertion below is over this list.
+    assert len(_js_agents()) >= 10
+
+
+def test_every_shipped_manifest_parses():
+    unread = [str(Path(p).relative_to(conformance.ROOT))
+              for p in _js_agents() if conformance.js_declared_manifest(p) is None]
+    assert not unread, f"manifest unreadable: {unread}"
+
+
+def test_no_shipped_value_carries_an_escape_javascript_would_have_decoded():
+    # `\u2014` and `\'` reaching a caller mean the value was copied out of the
+    # source rather than read as a string.
+    bad = []
+    for path in _js_agents():
+        man = conformance.js_declared_manifest(path) or {}
+        for key, value in man.items():
+            for text in ([value] if isinstance(value, str) else
+                         value if isinstance(value, list) else []):
+                if not isinstance(text, str):
+                    continue
+                if any(e in text for e in ("\\u", "\\x", "\\'", '\\"', "\\\\")):
+                    bad.append(f"{Path(path).name}:{key}={text[-40:]!r}")
+    assert not bad, "undecoded escapes: " + "; ".join(bad[:4])
+
+
+def test_no_shipped_value_ends_mid_escape():
+    # `'Place real phone calls on the owner\` is what truncation looked like.
+    bad = [f"{Path(p).name}:{k}"
+           for p in _js_agents()
+           for k, v in (conformance.js_declared_manifest(p) or {}).items()
+           if isinstance(v, str) and v.endswith("\\")]
+    assert not bad, "values truncated at an escape: " + "; ".join(bad[:4])
+
+
+NODE_DIFF = r"""
+const fs = require("fs");
+const spec = JSON.parse(fs.readFileSync(process.argv[2], "utf8"));
+const out = {};
+for (const [rel, raw] of Object.entries(spec)) {
+  try {
+    out[rel] = new Function("return (" + raw.replace(/\bas\s+const\s*$/, "") + ")")();
+  } catch (e) { out[rel] = null; }
+}
+process.stdout.write(JSON.stringify(out));
+"""
+
+
+@pytest.mark.skipif(shutil.which("node") is None, reason="node not installed")
+def test_every_shipped_manifest_matches_real_javascript(tmp_path):
+    """The class-closing form: the parser must agree with the language.
+
+    Six of the thirty-five disagreed before this change.
+    """
+    blocks, mine = {}, {}
+    for path in _js_agents():
+        rel = str(Path(path).relative_to(conformance.ROOT))
+        body = Path(path).read_text(encoding="utf-8", errors="replace")
+        import re
+        for m in re.finditer(r"(?m)^\s*(?:export\s+)?(?:const|let|var)?\s*"
+                             r"__manifest__\s*[:=]", body):
+            if len(re.findall(r"(?<!\\)`", body[:m.start()])) % 2:
+                continue
+            block = conformance._js_balanced_block(body, m.end())
+            if block:
+                blocks[rel] = body[block[0]:block[1]]
+                mine[rel] = conformance.js_declared_manifest(path)
+                break
+    assert blocks, "no manifest blocks extracted"
+
+    script = tmp_path / "diff.cjs"
+    script.write_text(textwrap.dedent(NODE_DIFF), encoding="utf-8")
+    spec = tmp_path / "blocks.json"
+    spec.write_text(json.dumps(blocks), encoding="utf-8")
+    proc = subprocess.run(["node", str(script), str(spec)],
+                          capture_output=True, text=True, timeout=120)
+    assert proc.returncode == 0, proc.stderr
+    truth = json.loads(proc.stdout)
+
+    divergent = []
+    for rel, expected in truth.items():
+        if expected is None:
+            continue  # node could not evaluate it; nothing to compare against
+        got = mine.get(rel) or {}
+        for key in set(expected) | set(got):
+            if expected.get(key) != got.get(key):
+                divergent.append(f"{rel}:{key} js={expected.get(key)!r} "
+                                 f"parsed={got.get(key)!r}")
+    assert not divergent, "\n".join(divergent[:6])


### PR DESCRIPTION
`js_declared_manifest` found the manifest block by counting braces, then read it with a per-line `key: value` regex. Neither step knew what a string was, so **the gate disagreed with JavaScript about what an agent had declared.**

## Already wrong, today

Parsed every shipped JS/TS manifest twice — once with the gate, once by evaluating the same block as real JavaScript. **6 of 35 diverged:**

```
ComputerUseAgent.ts  js='…like a person — takes…'      gate='…like a person \u2014 takes…'
OuroborosAgent.ts    js='Adds wordStats() — word…'     gate='Adds wordStats() \u2014 word…'
MemoryAgent.ts       js="…memory. Use 'remember' to…"  gate='…memory. Use \'
PhoneAgent.ts        js="…on the owner's behalf…"      gate='Place real phone calls on the owner\'
GoogleVoiceAgent.ts  js='…reply policy — rate limits…' gate='…reply policy — '
PythonAgent.ts       js='…cartridge is callable from…' gate='…cartridge is '
```

Two truncated at an apostrophe, two at a `'a ' + 'b'` concatenation, two kept a literal `\u2014`.

## Worse on valid input

| manifest contains | what the gate did |
|---|---|
| `description: 'Emit } to close.'` | block ended at the brace; **every later field dropped** → R3: *lacks `['version','capabilities']`* |
| `description: 'JSON starts with {'` | block never closed → parser returned `None` → R2: *carries no rapp-agent/1.0 manifest* |
| `// returns { ok: true` inside the manifest | same — **a comment made the manifest invisible** |
| a nested object | its keys were **hoisted into the manifest** |

The first three fail loudly, which is the safe way to be wrong: a correct agent is rejected with a false accusation.

Nesting is the one that doesn't. Keys hoisted, last write won — so a nested `capabilities: []` **overwrote the declared list**, and the gate enforced a capability list the agent never wrote. That is the gate being confidently wrong in the permissive direction.

## The fix

The block scan and the value reader skip strings and comments, decode escapes (`\u`, `\x`, `\'`, `\n`), join `+` concatenations, and parse nested objects **in place** instead of hoisting. Still no import — deciding whether to trust a file by running it remains the wrong order.

**All 35 shipped manifests now match real JavaScript exactly.**

## Mutations

| mutation | result |
|---|---|
| shipped parser + these tests | **20 failed** / 13 passed — the differential names all 6 files above |
| stop skipping line comments | 9 failed |
| stop decoding escapes | 5 failed |
| drop `+` concatenation | 2 failed |
| let nested objects hoist again | 2 failed |
| restored | **38 passed** |

The load-bearing test is `test_every_shipped_manifest_matches_real_javascript` — it diffs the parser against node across every shipped agent, closing the class rather than the six instances. It skips if node is absent, so two node-free invariants back it up (no value may carry an escape JS would have decoded; none may end mid-escape) — those alone catch 4 of the 6.

## Validation

pytest **2100 passed**, 6 skipped (+33, exactly the new tests) · `conformance.py` 8 passed / 0 failed / 1 skipped · `parity_harness.py --runtime both` PASS · no TS or workflow files touched.

Not changed: regex literals and `${}` interpolation are still treated as opaque text. Neither occurs in a manifest block, and inventing a JavaScript parser to cover them would trade a measured bug for an unmeasured one.
