### PR TITLE
fix: TypeScript could not detect two of the five capabilities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- TypeScript agents could not be checked for `credential-access` or
+  `dynamic-code` at all. `conformance.py` knows five capabilities and hands
+  TypeScript coverage to `capability-reachability.test.ts`, saying so in R4's
+  own success message — but that file's evidence table held only three, so two
+  capabilities were undetectable in either direction. `PythonAgent.ts` was
+  wrong both ways at once: it reads `process.env.OPENRAPPTER_PYTHON` and
+  declared no `credential-access` (Python's table has always counted any
+  environment read — `pokemon_agent.py` declares it for a ROM path), and its
+  correct `dynamic-code` declaration could not be corroborated because the
+  runner it spawns loads an arbitrary `.py` file by path. The table now carries
+  all five, `PythonAgent.ts` declares what it reads, and a new test asserts the
+  two runtimes can detect the same capabilities so the mirror cannot drift
+  again. Over-declaration is deliberately *not* reported for `dynamic-code`:
+  evidence proves reach, absence of evidence does not prove its opposite, and a
+  false alarm there would push someone to delete a true declaration.
+
 - The gate read JavaScript manifests without knowing what a string was. It
   counted braces to find the manifest block and then matched `key: value` per
   line, so a `}` inside a description ended the manifest early and dropped

--- a/python/tests/test_capability_vocabulary_parity.py
+++ b/python/tests/test_capability_vocabulary_parity.py
@@ -1,0 +1,166 @@
+"""Knowing a capability's name is not the same as being able to detect it.
+
+Two different tables carry the word "capability", and only one of them was
+guarded.
+
+`agent-capability-vocabulary.test.ts` already reads `CAPABILITY_EVIDENCE` out
+of `conformance.py` and rejects any TypeScript agent that *declares* a word not
+in it. That check is sound, it has anti-vacuity guards, and it caught
+`PhoneAgent` declaring `network-access`. Nothing here duplicates it.
+
+What it cannot see is the other table. `capability-reachability.test.ts` holds
+the regexes that decide whether an agent *reaches* a capability, and that is
+what detects a declaration which is missing. Its own comment introduces it as
+"mirroring CAPABILITY_EVIDENCE" — and nothing checked that mirror. Python
+listed five capabilities; the evidence table listed three.
+
+So an agent could pass the vocabulary check with flying colours while reaching
+a capability no pattern could see. `credential-access` and `dynamic-code` could not be reported for a
+TypeScript agent in either direction — not as under-declared, not as
+over-declared — while R4's passing message asserted that
+"TypeScript is covered by capability-reachability.test.ts".
+
+That is not hypothetical. `PythonAgent.ts` was wrong both ways at once:
+
+* it reads `process.env.OPENRAPPTER_PYTHON` and declared no
+  `credential-access`, while `pokemon_agent.py` declares exactly that
+  capability for `os.environ.get("OPENRAPPTER_POKEMON_ROM")` — a ROM path. The
+  same code got two verdicts depending on the language it was written in.
+* it declares `dynamic-code`, correctly, because the runner it spawns loads an
+  arbitrary `.py` file by path. Nothing in its own source shows that, so
+  extending the table naively reported a *true* declaration as over-declared —
+  which would have pushed someone to delete it. Hence `NO_ABSENCE_PROOF`:
+  evidence proves reach, absence of evidence does not prove its opposite.
+
+Both tables have now been found defective on their own, in separate rounds,
+for the same underlying reason — they are maintained separately. These tests
+make the vocabularies unable to diverge again without something going red.
+
+They deliberately compare *vocabulary*, not patterns. The two runtimes look for
+genuinely different things (`import subprocess` versus
+`from 'child_process'`), so demanding identical regexes would be a false
+equivalence. What must match is which capabilities each side is able to speak
+about at all.
+"""
+
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(ROOT))
+
+import conformance  # noqa: E402
+
+TS_TEST = ROOT / "typescript" / "src" / "agents" / "__tests__" / \
+    "capability-reachability.test.ts"
+
+
+def _ts_source():
+    if not TS_TEST.exists():  # pragma: no cover - the file is committed
+        pytest.fail(f"{TS_TEST} is missing; R4 names it as TypeScript's cover")
+    return TS_TEST.read_text(encoding="utf-8")
+
+
+def _ts_object_keys(source, header):
+    """Quoted keys declared at the top level of the object opened by `header`.
+
+    A line-oriented read on purpose. The block holds regex literals containing
+    quotes and braces, which no brace counter parses correctly, so this looks
+    only at what a key declaration looks like: two spaces, a quoted name, a
+    colon. If that formatting ever changes this fails loudly, which is the
+    right outcome for a test whose whole subject is that file.
+    """
+    start = source.index(header) + len(header)
+    end = source.index("\n};", start)
+    return {m.group(1) for m in
+            re.finditer(r"(?m)^  '([a-z][a-z-]*)':", source[start:end])}
+
+
+def _ts_set_members(source, name):
+    m = re.search(r"const %s = new Set\(\[(.*?)\]\)" % re.escape(name),
+                  source, re.S)
+    if m is None:
+        pytest.fail(f"{name} is not declared in {TS_TEST.name}")
+    return set(re.findall(r"'([a-z][a-z-]*)'", m.group(1)))
+
+
+EVIDENCE_HEADER = "const EVIDENCE: Record<string, RegExp> = {"
+
+
+def test_the_typescript_table_is_still_where_r4_says_it_is():
+    # Anti-vacuity: every assertion below reads this file.
+    assert EVIDENCE_HEADER in _ts_source()
+
+
+def test_python_knows_more_than_zero_capabilities():
+    assert len(conformance.CAPABILITY_EVIDENCE) >= 5
+
+
+def test_both_runtimes_speak_the_same_capability_vocabulary():
+    """The drift this file exists to prevent.
+
+    Before this test, Python had five entries and TypeScript three.
+    """
+    python_caps = set(conformance.CAPABILITY_EVIDENCE)
+    ts_caps = _ts_object_keys(_ts_source(), EVIDENCE_HEADER)
+    missing_in_ts = sorted(python_caps - ts_caps)
+    missing_in_python = sorted(ts_caps - python_caps)
+    assert not missing_in_ts, (
+        "TypeScript agents cannot be checked for %s, but R4 reports that "
+        "TypeScript is covered" % missing_in_ts)
+    assert not missing_in_python, (
+        "TypeScript checks %s and Python has no evidence for it"
+        % missing_in_python)
+
+
+def test_every_capability_is_detectable_in_at_least_one_direction():
+    """Evidence is what turns a vocabulary word into an enforced rule.
+
+    A capability with no pattern is a word an agent may declare and no runtime
+    can check, which is the state `credential-access` and `dynamic-code` were
+    in for TypeScript.
+    """
+    ts_caps = _ts_object_keys(_ts_source(), EVIDENCE_HEADER)
+    exempt = _ts_set_members(_ts_source(), "NO_ABSENCE_PROOF")
+    undetectable = sorted(set(conformance.CAPABILITY_EVIDENCE) - ts_caps)
+    assert not undetectable, (
+        "no TypeScript evidence, so an agent may reach these undeclared: %s"
+        % undetectable)
+    assert exempt < ts_caps, "an exemption must not remove a capability entirely"
+
+
+def test_the_over_declaration_exemption_names_real_capabilities():
+    exempt = _ts_set_members(_ts_source(), "NO_ABSENCE_PROOF")
+    assert exempt, "the exemption set is empty; the comment explains why it is not"
+    assert exempt <= set(conformance.CAPABILITY_EVIDENCE), (
+        "exempted from over-declaration but not a capability: %s"
+        % sorted(exempt - set(conformance.CAPABILITY_EVIDENCE)))
+
+
+def test_the_exemption_stays_narrow():
+    """An exemption for everything would silently retire the whole check."""
+    exempt = _ts_set_members(_ts_source(), "NO_ABSENCE_PROOF")
+    assert len(exempt) < len(conformance.CAPABILITY_EVIDENCE)
+
+
+def test_an_environment_read_counts_as_credential_access_in_python():
+    """The rule TypeScript now matches, stated where it is enforced.
+
+    A config-shaped name is still an environment read: nothing here can tell
+    `OPENRAPPTER_POKEMON_ROM` from `OPENAI_API_KEY`.
+    """
+    spec = conformance.CAPABILITY_EVIDENCE["credential-access"]
+    assert "environ" in spec.get("attrs", set())
+    assert "os.environ.get" in spec["calls"]
+
+
+def test_r4_still_delegates_typescript_to_the_file_this_test_guards():
+    """If R4 stops naming that file, this test is guarding nothing."""
+    ok, detail = conformance.r4_capabilities_honest.__wrapped__() \
+        if hasattr(conformance.r4_capabilities_honest, "__wrapped__") \
+        else conformance.r4_capabilities_honest()
+    assert ok, detail
+    assert "capability-reachability.test.ts" in detail

--- a/typescript/src/agents/PythonAgent.ts
+++ b/typescript/src/agents/PythonAgent.ts
@@ -71,7 +71,14 @@ export const __manifest__ = {
   //                   into it, so the code executed is not this file's code
   // A strain that forbids either MUST withhold this agent. Undeclared, it would
   // have been the quietest way in the repo to run arbitrary code.
+  //   credential-access — `process.env.OPENRAPPTER_PYTHON` picks the
+  //                   interpreter. A config name rather than a secret, but the
+  //                   contract counts any environment read, because nothing
+  //                   reading this file can tell the two apart. The Python
+  //                   table has always counted it; the TypeScript one could not
+  //                   see it, which is why this sat here undeclared.
   capabilities: [
+    'credential-access',
     'process-exec',
     'dynamic-code',
   ],

--- a/typescript/src/agents/__tests__/capability-reachability.test.ts
+++ b/typescript/src/agents/__tests__/capability-reachability.test.ts
@@ -69,7 +69,42 @@ const EVIDENCE: Record<string, RegExp> = {
   'filesystem-write': new RegExp(
     `\\b(?:${FS_WRITE_VERBS.join('|')})(?:Sync)?\\b|\\b(?:rm|cp)(?:Sync)?\\s*\\(`,
   ),
+  // Any environment read, deliberately — matching the Python table, which
+  // counts `os.environ` in every position. Neither side can tell
+  // `OPENRAPPTER_PYTHON` from `OPENAI_API_KEY`; both are one subscript away
+  // from each other, and a table that tried to guess which names are secret
+  // would be wrong the first time someone invented a new one. Python already
+  // paid this false-positive cost -- `pokemon_agent.py` declares
+  // credential-access for `os.environ.get("OPENRAPPTER_POKEMON_ROM")`, a ROM
+  // path. Until now the TypeScript twin of that read declared nothing, so the
+  // same code got two verdicts depending on which language it was written in.
+  'credential-access':
+    /\bprocess\.env\b|from\s+['"]keytar['"]|\bfind-generic-password\b/,
+  // `import(` only when the specifier is computed: a literal `import('./x.js')`
+  // is an ordinary dependency, while a computed one runs code chosen at
+  // runtime.
+  'dynamic-code':
+    /\beval\s*\(|\bnew\s+Function\s*\(|\bvm\.runIn|from\s+['"](?:node:)?vm['"]|\bimport\s*\((?!\s*['"])/,
 };
+
+/**
+ * Capabilities that may not be reported as over-declared.
+ *
+ * Under-declaration and over-declaration are not mirror images, and treating
+ * them as one cost a correct declaration. Evidence in the file proves an agent
+ * *reaches* a capability; the absence of evidence does not prove it does not,
+ * because reaching it can be delegated. `PythonAgent.ts` is the live proof: it
+ * declares `dynamic-code` because `spawn('python3', [runner.py, ...])` loads
+ * an arbitrary `.py` file by path and calls into it. Nothing in the agent's own
+ * source can show that, so a regex would have called a true declaration false
+ * and pushed someone to delete it -- the permissive direction, and the one
+ * failure this file must never cause.
+ *
+ * The other capabilities stay in both directions because their evidence cannot
+ * be delegated out of the file: an import or a call is either written here or
+ * it is not.
+ */
+const NO_ABSENCE_PROOF = new Set(['dynamic-code']);
 
 function agentFiles(): string[] {
   return readdirSync(agentsDir)
@@ -193,6 +228,51 @@ describe('agents do not declare capabilities they cannot reach', () => {
       }
     });
 
+    it('sees any environment read, secret-looking or not', () => {
+      const cred = EVIDENCE['credential-access'];
+      expect(cred.test("const k = process.env.OPENAI_API_KEY;")).toBe(true);
+      expect(cred.test("const p = process.env.OPENRAPPTER_PYTHON ?? 'python3';"))
+        .toBe(true);
+      expect(cred.test('const { HOME } = process.env;')).toBe(true);
+      expect(cred.test("import keytar from 'keytar';")).toBe(true);
+      // Not an environment read. `env` as an ordinary word must not fire, or
+      // agents get pushed into declaring a capability they do not hold.
+      expect(cred.test('const env = buildEnvironment(opts);')).toBe(false);
+      expect(cred.test('// pass the environment through to the child')).toBe(false);
+    });
+
+    it('sees code chosen at runtime, but not an ordinary import', () => {
+      const dyn = EVIDENCE['dynamic-code'];
+      expect(dyn.test('const out = eval(expr);')).toBe(true);
+      expect(dyn.test('const f = new Function("return 1");')).toBe(true);
+      expect(dyn.test("import vm from 'node:vm';")).toBe(true);
+      expect(dyn.test('vm.runInNewContext(src);')).toBe(true);
+      expect(dyn.test('const mod = await import(specifier);')).toBe(true);
+      // A literal specifier is a dependency, not dynamic code. Every
+      // self-contained agent uses this form to reach BasicAgent.
+      expect(dyn.test("const mod = await import('./BasicAgent.js');")).toBe(false);
+      expect(dyn.test("import { spawn } from 'child_process';")).toBe(false);
+    });
+
+    it('every capability the contract knows has evidence here', () => {
+      // The Python table is the contract's other half. It had five entries
+      // while this one had three, so `credential-access` and `dynamic-code`
+      // could not be reported in TypeScript at all -- and R4 said in its own
+      // success message that TypeScript was covered by this file.
+      for (const cap of [
+        'process-exec', 'network', 'filesystem-write',
+        'credential-access', 'dynamic-code',
+      ]) {
+        expect(Object.keys(EVIDENCE)).toContain(cap);
+      }
+    });
+
+    it('nothing is exempted from over-declaration that is not a capability', () => {
+      for (const cap of NO_ABSENCE_PROOF) {
+        expect(Object.keys(EVIDENCE)).toContain(cap);
+      }
+    });
+
     it('sees network transports beyond http', () => {
       const net = EVIDENCE['network'];
       expect(net.test("import dgram from 'node:dgram';")).toBe(true);
@@ -212,7 +292,7 @@ describe('agents do not declare capabilities they cannot reach', () => {
         { capabilities?: readonly string[] } | undefined
       >;
       for (const cap of mod.__manifest__?.capabilities ?? []) {
-        const evidence = EVIDENCE[cap];
+        const evidence = NO_ABSENCE_PROOF.has(cap) ? undefined : EVIDENCE[cap];
         if (evidence && !evidence.test(source)) {
           over.push(`${file} declares ${cap} with nothing in the file that reaches it`);
         }


### PR DESCRIPTION
`conformance.py` knows **five** capabilities. It enforces R4/R5 over Python agents only and delegates TypeScript to `capability-reachability.test.ts` — it says so in R4's own success message:

> all 20 Python agents declare every capability their syntax tree can reach; **TypeScript is covered by capability-reachability.test.ts**

That file's table introduces itself as *"mirroring CAPABILITY_EVIDENCE"*. Nothing checked the mirror. It held **three**.

So `credential-access` and `dynamic-code` could not be reported for a TypeScript agent **in either direction** — not under-declared, not over-declared.

## Why the existing test didn't catch it

`agent-capability-vocabulary.test.ts` already reads the vocabulary out of `conformance.py` and rejects any agent declaring a word that isn't in it. It's sound, it has anti-vacuity guards, it caught `PhoneAgent` declaring `network-access`. **Nothing here duplicates it** — I removed a test I'd written that did.

It validates that a declared word is a *real word*. It cannot tell whether anything is able to *detect* the capability behind it. Those are different tables in different files, and only one was guarded.

## The live proof

Adding the two patterns and running the real test failed immediately — `PythonAgent.ts` was wrong **both ways at once**:

```
× PythonAgent.ts reaches credential-access without declaring it
× PythonAgent.ts declares dynamic-code with nothing in the file that reaches it
```

**Under-declared.** It reads `process.env.OPENRAPPTER_PYTHON`. Python's table has always counted any environment read in any position — `pokemon_agent.py` declares `credential-access` for `os.environ.get("OPENRAPPTER_POKEMON_ROM")`, a *ROM path*. The same code drew two different verdicts depending on which language it was written in. Now declared.

**Over-declared — and this one was my error, not the agent's.** Its `dynamic-code` is correct and the manifest already explains why: `spawn('python3', [runner.py, ...])` loads an arbitrary `.py` file by path. Nothing in the agent's own source can show that.

That result shaped the fix. Evidence proves an agent *reaches* a capability; **absence of evidence does not prove the opposite**, because reaching it can be delegated to a subprocess. `dynamic-code` is therefore exempt from over-declaration reporting via `NO_ABSENCE_PROOF`, with `PythonAgent` recorded as the reason. A false alarm there pushes someone to *delete a true declaration* — the permissive direction, and the one failure this check must never cause. The other four stay in both directions: an import or a call is either written in the file or it isn't.

## Mutations

| mutation | result |
|---|---|
| evidence table loses `credential-access` | 2 failed — *"TypeScript agents cannot be checked for ['credential-access'], but R4 reports that TypeScript is covered"* |
| `PythonAgent.ts` drops the declaration | TS: 1 failed — *reaches credential-access without declaring it* |
| over-declaration ignores the exemption | TS: 1 failed — the false alarm returns |
| exemption names a non-capability | 2 failed — *exempted from over-declaration but not a capability* |
| restored | py 8 passed · ts 27 passed |

## Validation

pytest **2108 passed**, 6 skipped (+8, exactly the new tests) · vitest **5350 passed**, 0 failed (full suite — a shipped manifest changed, so all of it ran) · `tsc --noEmit` clean · `eslint --max-warnings 0` clean · `conformance.py` 8 passed / 0 failed / 1 skipped · `parity_harness.py --runtime both` PASS.

## Deliberately not done

The new test compares **vocabulary, not patterns**. The runtimes look for genuinely different things (`import subprocess` vs `from 'child_process'`); demanding identical regexes would be a false equivalence.

`ui-control` remains declared by `DesktopControlAgent.ts` with no evidence pattern in either table — a real gap, but a TypeScript-only capability with no Python counterpart, so it needs its own decision rather than being swept into this one.
