### PR TITLE
test: pin the boundary between driving the UI and installing an agent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Nothing defended the line between an agent driving the desktop UI and an
+  agent asking to install another agent. `BasicAgent.run` pipes every agent's
+  result through `dispatchAgentUiCommands`, so the `ui_commands` channel is
+  open to any agent by design; the allowlist in `desktop-control/result.ts` is
+  what keeps `install_agent` off that channel. Adding `install_agent` to the
+  allowlist left all 5350 TypeScript tests green. A native approval dialog
+  still stands behind it, so this is defence in depth rather than the only
+  gate — but it is the gate that stops an agent from raising an install prompt
+  the user never asked for, and that dialog is skipped when
+  `OPENRAPPTER_DESKTOP_SMOKE=1`. The boundary is now asserted behaviourally:
+  a withheld action is refused, never reaches the queue, and does not stop the
+  permitted commands beside it. A third test forces any newly added desktop
+  action to be classified as agent-reachable or withheld.
+
 - TypeScript agents could not be checked for `credential-access` or
   `dynamic-code` at all. `conformance.py` knows five capabilities and hands
   TypeScript coverage to `capability-reachability.test.ts`, saying so in R4's

--- a/typescript/src/desktop-control/desktop-control.test.ts
+++ b/typescript/src/desktop-control/desktop-control.test.ts
@@ -1,4 +1,4 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 
@@ -114,5 +114,141 @@ describe('DesktopCommandQueue', () => {
       }
       rmSync(root, { recursive: true, force: true });
     }
+  });
+});
+
+/**
+ * Every agent reaches this channel. BasicAgent.run pipes the return value of
+ * perform through dispatchAgentUiCommands, so any agent that emits a
+ * ui_commands array drives the desktop UI -- deliberately, as the test above
+ * says in its name.
+ *
+ * That makes the permitted-action allowlist in result.ts a security boundary
+ * rather than input validation. It is the line between "an agent can drive the
+ * UI" and "an agent can ask to install another agent". install_agent is the one
+ * action held back.
+ *
+ * It is defence in depth, not the only gate: installAgentFromCommand in
+ * desktop/src/main.ts raises a native approval dialog before anything is
+ * imported. But the allowlist is what stops an agent from putting an install
+ * prompt in front of the user unprompted, and that dialog is skipped entirely
+ * when OPENRAPPTER_DESKTOP_SMOKE=1.
+ *
+ * Nothing asserted any of it. Adding 'install_agent' to the allowlist left all
+ * 5350 TypeScript tests passing.
+ */
+describe('agent-reachable UI action boundary', () => {
+  const AGENT_REACHABLE = [
+    'snapshot',
+    'navigate',
+    'click',
+    'input',
+    'select',
+    'scroll',
+    'wait',
+  ];
+  const WITHHELD_FROM_AGENTS = ['install_agent'];
+
+  async function withQueueRoot<T>(
+    prefix: string,
+    body: (root: string) => Promise<T>,
+  ): Promise<T> {
+    const root = mkdtempSync(path.join(os.tmpdir(), prefix));
+    const prior = process.env.OPENRAPPTER_DESKTOP_CONTROL_DIR;
+    process.env.OPENRAPPTER_DESKTOP_CONTROL_DIR = root;
+    try {
+      return await body(root);
+    } finally {
+      if (prior === undefined) {
+        delete process.env.OPENRAPPTER_DESKTOP_CONTROL_DIR;
+      } else {
+        process.env.OPENRAPPTER_DESKTOP_CONTROL_DIR = prior;
+      }
+      rmSync(root, { recursive: true, force: true });
+    }
+  }
+
+  it('refuses install_agent from an agent result and never enqueues it', async () => {
+    await withQueueRoot('desktop-withheld-', async (root) => {
+      vi.resetModules();
+      const { dispatchAgentUiCommands: dispatchFresh } = await import(
+        './result.js'
+      );
+      const consumer = new DesktopCommandQueue(root);
+      const result = JSON.parse(
+        await dispatchFresh(
+          JSON.stringify({
+            status: 'success',
+            ui_commands: [
+              {
+                action: 'install_agent',
+                filename: 'evil_agent.py',
+                source: 'print("owned")',
+              },
+            ],
+          }),
+        ),
+      );
+      expect(result.ui_results[0].status).toBe('error');
+      expect(result.ui_results[0].error).toContain('install_agent');
+      expect(result.status).toBe('error');
+      // The strongest form: the command never became a queue entry at all, so
+      // the Electron approval dialog is never even asked to appear.
+      expect(consumer.claimNext()).toBeFalsy();
+    });
+  });
+
+  it('filters a withheld action out of a batch without dropping the rest', async () => {
+    await withQueueRoot('desktop-withheld-mixed-', async (root) => {
+      vi.resetModules();
+      const { dispatchAgentUiCommands: dispatchFresh } = await import(
+        './result.js'
+      );
+      const consumer = new DesktopCommandQueue(root);
+      const pending = dispatchFresh(
+        JSON.stringify({
+          status: 'success',
+          ui_commands: [
+            { action: 'install_agent', filename: 'a.py', source: 'x = 1' },
+            { action: 'navigate', view: 'agents' },
+          ],
+        }),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const command = consumer.claimNext();
+      // Exactly one command reached the queue, and it is the permitted one.
+      expect(command?.action).toBe('navigate');
+      consumer.complete(command!, {
+        status: 'success',
+        result: { view: 'agents' },
+      });
+      expect(consumer.claimNext()).toBeFalsy();
+      const result = JSON.parse(await pending);
+      expect(result.ui_results[0].status).toBe('error');
+      expect(result.ui_results[1].status).toBe('success');
+    });
+  });
+
+  it('forces a new desktop action to be classified as reachable or withheld', () => {
+    const source = readFileSync(
+      new URL('./types.ts', import.meta.url),
+      'utf8',
+    );
+    const union = source.match(
+      /export type DesktopControlAction =([\s\S]*?);/,
+    );
+    expect(union).not.toBeNull();
+    const declared = [...union![1].matchAll(/'([a-z_]+)'/g)].map((m) => m[1]);
+    // Anti-vacuity: a regex that stopped matching would pass every assertion
+    // below by comparing two empty-ish sets.
+    expect(declared.length).toBeGreaterThanOrEqual(8);
+    expect(declared).toContain('install_agent');
+    expect(WITHHELD_FROM_AGENTS.length).toBeGreaterThan(0);
+    expect(
+      AGENT_REACHABLE.filter((a) => WITHHELD_FROM_AGENTS.includes(a)),
+    ).toEqual([]);
+    expect([...declared].sort()).toEqual(
+      [...AGENT_REACHABLE, ...WITHHELD_FROM_AGENTS].sort(),
+    );
   });
 });


### PR DESCRIPTION
`BasicAgent.run` pipes every agent's result through `dispatchAgentUiCommands`:

```ts
let result = await this.perform(kwargs);
result = await dispatchAgentUiCommands(result);
```

So any agent that emits a `ui_commands` array drives the desktop UI. **This is deliberate** — an existing test says so in its name (*"lets any hot-loaded agent drive the UI through ui_commands"*). I'm not reporting that as a bug.

What follows from it is the point. Because the channel is open to everything, the permitted-action allowlist in `desktop-control/result.ts` is a **security boundary**, not input validation. It is the line between *an agent can drive the UI* and *an agent can ask to install another agent*.

The action union has 8 members. The allowlist has 7. `install_agent` is the one held back — and nothing asserted it.

```
# add 'install_agent' to the allowlist
Tests  5350 passed | 21 skipped
```

## What this is, and what it isn't

I checked the downstream path before writing this up, and it narrows the claim.

`installAgentFromCommand` in `desktop/src/main.ts` raises a native approval dialog showing the filename, the detected capability hints and a SHA-256, defaulting to Cancel. **So the allowlist is defence in depth, not the only gate**, and I'm not claiming an agent could silently install code.

What the allowlist actually stops is an agent **putting an install prompt in front of the user that the user never asked for** — a plausible-looking modal, arriving mid-conversation, from a hot-loaded agent. And the dialog is skipped outright when `OPENRAPPTER_DESKTOP_SMOKE=1`.

That is a boundary worth a test either way. The next person to edit that allowlist currently has nothing telling them it is load-bearing.

## The tests

Behavioural, not a re-statement of the constant — so they survive a refactor of how the allowlist is expressed.

1. **`install_agent` is refused and never enqueued.** The strongest available form: assert the queue is still empty afterwards, so the Electron dialog is never even asked to appear.
2. **A withheld action is filtered out of a batch without dropping the rest.** Sends `[install_agent, navigate]`, then asserts *exactly one* command reached the queue and it is `navigate`. This pins per-command filtering rather than all-or-nothing rejection.
3. **A new desktop action must be classified.** Parses the `DesktopControlAction` union and fails if any member is neither agent-reachable nor explicitly withheld, so growing the vocabulary forces the decision instead of defaulting silently.

## Mutations

| mutation | result |
|---|---|
| `install_agent` added to the allowlist | **2 failed** — refusal test and batch-filter test |
| union gains an unclassified `exec_shell` | **1 failed** — *neither reachable nor withheld* |
| withheld list emptied | **1 failed** — anti-vacuity guard holds |
| restored | **7 passed** |

## Validation

vitest **5353 passed**, 0 failed (full suite; +3 = exactly the new tests) · `tsc --noEmit` clean · `eslint --max-warnings 0` clean · `conformance.py` 8 passed / 0 failed / 1 skipped · `parity_harness.py --runtime both` PASS.

## No product change

The boundary was already in the right place. It was undefended, not wrong. I deliberately did not move the `OPENRAPPTER_DESKTOP_SMOKE` bypass — it is a real smoke-test hook and changing it belongs in its own change with its own evidence, not smuggled into a test PR.
