### PR TITLE
fix: stop the smoke flag waiving consent it never needed waived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Two consent dialogs could be switched off by an environment variable that
+  nothing needed switched off. `OPENRAPPTER_DESKTOP_SMOKE=1` skipped the
+  approval prompts for the Whisper model download and the local VibeVoice
+  install, but the desktop smoke script only ever asks those two services for
+  their status -- it never downloads or enables. The release workflow sets that
+  variable on the packaged, signed binary, so the waiver shipped. Both prompts
+  are now unconditional. The agent-install prompt still honours the flag
+  because the smoke run genuinely installs agents, and it is now the only one
+  that does.
+
 - Nothing defended the line between an agent driving the desktop UI and an
   agent asking to install another agent. `BasicAgent.run` pipes every agent's
   result through `dispatchAgentUiCommands`, so the `ui_commands` channel is

--- a/typescript/desktop/src/main.ts
+++ b/typescript/desktop/src/main.ts
@@ -549,22 +549,20 @@ async function handleNarration(
   const action = input.action;
   if (action === 'status') return narration().status();
   if (action === 'download') {
-    if (process.env.OPENRAPPTER_DESKTOP_SMOKE !== '1') {
-      const approval = await dialog.showMessageBox(mainWindow!, {
-        type: 'question',
-        title: 'Download local Whisper?',
-        message: 'Download the on-device narration model?',
-        detail:
-          `Whisper Small q8 is ${NARRATION_MODEL_DOWNLOAD_LABEL}. ` +
-          'It is downloaded once, cached locally, and used offline. Audio never leaves this device.',
-        buttons: ['Cancel', 'Download model'],
-        cancelId: 0,
-        defaultId: 0,
-        noLink: true,
-      });
-      if (approval.response !== 1) {
-        throw new Error('Whisper download was cancelled.');
-      }
+    const approval = await dialog.showMessageBox(mainWindow!, {
+      type: 'question',
+      title: 'Download local Whisper?',
+      message: 'Download the on-device narration model?',
+      detail:
+        `Whisper Small q8 is ${NARRATION_MODEL_DOWNLOAD_LABEL}. ` +
+        'It is downloaded once, cached locally, and used offline. Audio never leaves this device.',
+      buttons: ['Cancel', 'Download model'],
+      cancelId: 0,
+      defaultId: 0,
+      noLink: true,
+    });
+    if (approval.response !== 1) {
+      throw new Error('Whisper download was cancelled.');
     }
     return narration().download();
   }
@@ -629,23 +627,21 @@ async function handleVoice(
     return vibeVoice().status();
   }
   if (action === 'enable') {
-    if (process.env.OPENRAPPTER_DESKTOP_SMOKE !== '1') {
-      const approval = await dialog.showMessageBox(mainWindow!, {
-        type: 'warning',
-        title: 'Enable local VibeVoice?',
-        message: 'Install Microsoft VibeVoice Realtime locally?',
-        detail:
-          `The preview downloads about ${VIBEVOICE_MODEL_LABEL} of model weights, ` +
-          'creates an isolated Python 3.11 environment, and runs only on 127.0.0.1. ' +
-          'Do not use it for impersonation, deception, or undisclosed synthetic speech.',
-        buttons: ['Cancel', 'Enable local voice'],
-        cancelId: 0,
-        defaultId: 0,
-        noLink: true,
-      });
-      if (approval.response !== 1) {
-        throw new Error('VibeVoice setup was cancelled.');
-      }
+    const approval = await dialog.showMessageBox(mainWindow!, {
+      type: 'warning',
+      title: 'Enable local VibeVoice?',
+      message: 'Install Microsoft VibeVoice Realtime locally?',
+      detail:
+        `The preview downloads about ${VIBEVOICE_MODEL_LABEL} of model weights, ` +
+        'creates an isolated Python 3.11 environment, and runs only on 127.0.0.1. ' +
+        'Do not use it for impersonation, deception, or undisclosed synthetic speech.',
+      buttons: ['Cancel', 'Enable local voice'],
+      cancelId: 0,
+      defaultId: 0,
+      noLink: true,
+    });
+    if (approval.response !== 1) {
+      throw new Error('VibeVoice setup was cancelled.');
     }
     return vibeVoice().enable();
   }

--- a/typescript/desktop/test/desktop-contract.test.mjs
+++ b/typescript/desktop/test/desktop-contract.test.mjs
@@ -167,6 +167,11 @@ test('desktop reuses the packaged OpenRappter gateway and core', () => {
 // the flag without widening that allowlist would fail only in the release
 // smoke run, which is the worst place to find out.
 
+// A Windows checkout can carry CRLF, and these assertions slice on line
+// shapes, so normalise first. Without this the slice lookup fails outright on
+// Windows rather than quietly returning the wrong text.
+const mainSource = main.replace(/\r\n/g, '\n');
+
 function functionBody(source, name) {
   const start = source.indexOf(`\nasync function ${name}(`);
   assert.notEqual(start, -1, `main.ts no longer declares ${name}`);
@@ -185,7 +190,7 @@ const CONSENT_DIALOG_FUNCTIONS = [
 test('only the agent install consent dialog answers to the smoke flag', () => {
   const gated = [];
   for (const name of CONSENT_DIALOG_FUNCTIONS) {
-    const body = functionBody(main, name);
+    const body = functionBody(mainSource, name);
     // Anti-vacuity: if a rename or refactor empties one of these slices the
     // loop would silently pass, so require the dialog to still be in there.
     assert.match(
@@ -199,8 +204,8 @@ test('only the agent install consent dialog answers to the smoke flag', () => {
 });
 
 test('the smoke run never asks narration or voice to do the gated work', () => {
-  const smokeScript = main.slice(
-    main.indexOf("customElements.whenDefined('openrappter-show-and-tell')"),
+  const smokeScript = mainSource.slice(
+    mainSource.indexOf("customElements.whenDefined('openrappter-show-and-tell')"),
   );
   assert.ok(smokeScript.length > 1000, 'could not locate the smoke script');
   assert.match(smokeScript, /\.narration\(\{/);
@@ -210,7 +215,7 @@ test('the smoke run never asks narration or voice to do the gated work', () => {
 });
 
 test('the Show-and-Tell consent bypass needs a second per-request factor', () => {
-  const body = functionBody(main, 'handleShowAndTell');
+  const body = functionBody(mainSource, 'handleShowAndTell');
   assert.match(
     body,
     /OPENRAPPTER_DESKTOP_SMOKE === '1'[\s\S]{0,60}input\.__smoke === true/,

--- a/typescript/desktop/test/desktop-contract.test.mjs
+++ b/typescript/desktop/test/desktop-contract.test.mjs
@@ -146,3 +146,74 @@ test('desktop reuses the packaged OpenRappter gateway and core', () => {
   assert.match(main, /OPENRAPPTER_DESKTOP_SMOKE/);
   assert.match(main, /customElements\.whenDefined\('openrappter-show-and-tell'\)/);
 });
+
+// OPENRAPPTER_DESKTOP_SMOKE is a process-wide launch flag, and the release
+// workflow sets it on the packaged, signed binary -- so whatever it switches
+// off is switched off in the shipped app, not just in a dev build.
+//
+// main.ts raises consent dialogs from four functions. Three of them used to be
+// skipped outright when that variable was set. Two of those three were never
+// needed: the embedded smoke script only ever asks narration and voice for
+// their status, never for a download or an enable, so the bypasses bought
+// nothing and waived consent for a multi-gigabyte model download and a local
+// Python environment install.
+//
+// The remaining one is real -- the smoke run does install two agents. It is
+// left as a single-factor bypass on purpose. The obvious tightening, copying
+// the per-request `__smoke` flag that handleShowAndTell uses, does not work
+// here: DesktopControlAgent.perform copies args through a fixed eight-key
+// allowlist (view, ref, value, direction, amount, milliseconds, filename,
+// source), so an extra key is dropped before it ever reaches the queue. Adding
+// the flag without widening that allowlist would fail only in the release
+// smoke run, which is the worst place to find out.
+
+function functionBody(source, name) {
+  const start = source.indexOf(`\nasync function ${name}(`);
+  assert.notEqual(start, -1, `main.ts no longer declares ${name}`);
+  const end = source.indexOf('\n}\n', start);
+  assert.notEqual(end, -1, `could not find the end of ${name}`);
+  return source.slice(start, end + 2);
+}
+
+const CONSENT_DIALOG_FUNCTIONS = [
+  'handleNarration',
+  'handleVoice',
+  'nativeConsent',
+  'installAgentFromCommand',
+];
+
+test('only the agent install consent dialog answers to the smoke flag', () => {
+  const gated = [];
+  for (const name of CONSENT_DIALOG_FUNCTIONS) {
+    const body = functionBody(main, name);
+    // Anti-vacuity: if a rename or refactor empties one of these slices the
+    // loop would silently pass, so require the dialog to still be in there.
+    assert.match(
+      body,
+      /dialog\.showMessageBox/,
+      `${name} no longer raises a consent dialog`,
+    );
+    if (body.includes('OPENRAPPTER_DESKTOP_SMOKE')) gated.push(name);
+  }
+  assert.deepEqual(gated, ['installAgentFromCommand']);
+});
+
+test('the smoke run never asks narration or voice to do the gated work', () => {
+  const smokeScript = main.slice(
+    main.indexOf("customElements.whenDefined('openrappter-show-and-tell')"),
+  );
+  assert.ok(smokeScript.length > 1000, 'could not locate the smoke script');
+  assert.match(smokeScript, /\.narration\(\{/);
+  assert.match(smokeScript, /\.voice\(\{/);
+  assert.doesNotMatch(smokeScript, /action: 'download'/);
+  assert.doesNotMatch(smokeScript, /action: 'enable'/);
+});
+
+test('the Show-and-Tell consent bypass needs a second per-request factor', () => {
+  const body = functionBody(main, 'handleShowAndTell');
+  assert.match(
+    body,
+    /OPENRAPPTER_DESKTOP_SMOKE === '1'[\s\S]{0,60}input\.__smoke === true/,
+  );
+  assert.match(body, /!smokeBypass && !\(await nativeConsent\(purpose\)\)/);
+});


### PR DESCRIPTION
`OPENRAPPTER_DESKTOP_SMOKE` is a process-wide launch flag, and `release.yml` sets it on the **packaged, signed binary**:

```yaml
OPENRAPPTER_DESKTOP_SMOKE=1 "$app_binary"
```

So whatever it switches off is switched off in the shipped app, not just in a dev build. It switched off three consent dialogs:

| gated dialog | what it authorises | does the smoke run need it? |
|---|---|---|
| Whisper model download | a multi-GB model download | **no** |
| VibeVoice enable | downloads weights, creates an isolated Python 3.11 env | **no** |
| hot-loaded agent install | runs code with full user authority | yes |

The first two are the finding. The smoke script only ever asks those services for their status:

```js
const narrationStatus = await window.openrappterDesktop.narration({ action: 'status' });
const voiceStatus     = await window.openrappterDesktop.voice({ action: 'status' });
```

It never calls `download` or `enable`. I checked every other caller of those two actions — `show-and-tell.ts:383`, `chat.ts:1056`, and a tray menu item — and all three are user click handlers. **No automated path invokes them at all**, so the bypasses bought nothing and waived consent for two expensive, invasive operations. They are now unconditional.

The third is real: the smoke run installs two agents. It keeps the flag and is now the only dialog that answers to it.

## Why I did not two-factor the third one

`handleShowAndTell` already shows the better pattern — the env var **and** a per-request opt-in:

```ts
const smokeBypass =
  process.env.OPENRAPPTER_DESKTOP_SMOKE === '1' &&
  input.__smoke === true;
```

Copying that to the install path does not work, and I nearly shipped it before checking. `DesktopControlAgent.perform` copies args through a fixed eight-key allowlist — `view, ref, value, direction, amount, milliseconds, filename, source`. A `__smoke` key is **dropped before it reaches the queue**. Adding the flag without widening that allowlist would have failed only in the release smoke run against a packaged binary, which is the worst possible place to find out. Left alone, and the reasoning is recorded in a comment so the next person doesn't repeat it.

## Scope, stated honestly

This is not a live remote exploit. Setting the variable requires control of how the app is launched, and anyone with that already has options. What it removes is a latent waiver that was **shipping in the signed build and buying nothing** — and it makes consent for those two operations unconditional, which is where it belonged.

## The tests

1. **Inventory** — of the four functions that raise a consent dialog, exactly `installAgentFromCommand` may reference the flag. A newly gated dialog fails the test and forces the decision. It also fails if a dialog is *deleted* or its function renamed, so the slices can't quietly go empty.
2. **Why removal is safe** — the smoke script never calls `download` or `enable`. If it ever starts, this fails and the removal gets revisited.
3. **The good pattern stays** — Show-and-Tell keeps its second per-request factor.

## Mutations

| mutation | result |
|---|---|
| revert the product change | **1 failed** — inventory |
| Show-and-Tell bypass reduced to one factor | **1 failed** — two-factor test |
| smoke script calls `narration({action:'download'})` | **1 failed** — safety-of-removal test |
| consent dialog deleted from `handleVoice` | **1 failed** — anti-vacuity |
| `handleNarration` renamed | **1 failed** — slice lookup |
| restored | **31 passed** |

A sixth attempt renamed `showMessageBox` to `showMessageBoxSync` and did **not** fail — that was a bad mutation, not a test gap: the substring still matches. Replaced with the two anti-vacuity mutations above, which do fail.

## Validation

desktop contract **31 passed / 0 failed** (28 baseline + 3) · desktop `tsc` build clean · core `tsc --noEmit` clean · `eslint --max-warnings 0` clean · vitest **5353 passed** · `conformance.py` 8/0/1 · `parity_harness.py --runtime both` PASS.

`desktop.yml` runs on every PR with a **real Electron smoke on Linux, macOS and Windows**, so this change gets end-to-end verification on the actual app before merge — which is exactly the check that matters here.
