### PR TITLE
test: pin Show-and-Tell's privacy boundary to the real component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Show-and-Tell's privacy boundary is now regression-tested against the real
+  component instead of a hand-written fixture. A single `data-desktop-private`
+  wrapper is the only thing keeping recordings, narration transcripts and their
+  controls out of a model-visible desktop snapshot, and the panel promises the
+  user "frames never go to Copilot", but every test asserting that built its own
+  markup, so narrowing or moving that div would have broken the promise
+  silently.
+- The `data-desktop-sensitive` markers in Show-and-Tell were on the wrong
+  controls: `model-download` sat on "Start recording" and `microphone` on the
+  note button, while "Download Whisper (~252 MB)" and "Start narration" -- which
+  performs the download *and* opens the microphone -- carried none. Not
+  reachable today, because the whole surface is `data-desktop-private`, so this
+  is defence in depth for if that wrapper ever narrows.
+
 ### Added
 
 - Parity vector `history-carried-to-model`, the only one that reaches the model

--- a/typescript/ui/src/__tests__/desktop-control.test.ts
+++ b/typescript/ui/src/__tests__/desktop-control.test.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
+import '../components/show-and-tell.js';
 import {
   handleDesktopUiCommand,
   snapshotDesktopUi,
@@ -83,5 +84,91 @@ describe('desktop UI command handler', () => {
     const snapshot = snapshotDesktopUi();
     expect(JSON.stringify(snapshot)).not.toContain('private narration transcript');
     expect(JSON.stringify(snapshot)).not.toContain('Approve private analysis');
+  });
+});
+
+// The privacy test above builds its own `data-desktop-private` section, so it
+// proves the snapshot honours the attribute but never proves the shipped
+// Show-and-Tell markup still carries it. That matters more than it looks:
+// a single wrapper div is the only thing keeping recordings, narration
+// transcripts and their controls out of a model-visible snapshot, and the
+// panel promises the user "frames never go to Copilot". Narrow or move that
+// div and the promise breaks silently. These tests pin it against the real
+// component.
+describe('the real Show-and-Tell surface stays private from desktop automation', () => {
+  afterEach(() => {
+    delete window.openrappterDesktop;
+    vi.restoreAllMocks();
+  });
+
+  async function renderRecordingSession(): Promise<HTMLElement> {
+    // The fixture from the suite above is still attached, and it contains a
+    // decoy "Start narration" button, so start from a clean document.
+    document.body.innerHTML = '';
+    window.openrappterDesktop = {
+      platform: 'darwin',
+      gatewayUrl: 'ws://127.0.0.1:18791',
+      gatewayToken: 'test',
+      showAndTell: vi.fn(),
+      desktopControl: vi.fn(),
+      narration: vi.fn().mockResolvedValue({ model: 'missing', phase: 'idle' }),
+      onNarrationStatus: vi.fn().mockReturnValue(() => {}),
+      voice: vi.fn(),
+      onVoiceStatus: vi.fn().mockReturnValue(() => {}),
+      getInfo: vi.fn(),
+    } as unknown as typeof window.openrappterDesktop;
+
+    const element = document.createElement('openrappter-show-and-tell') as HTMLElement & {
+      session: { id: string; state: string } | null;
+      narrationState: string;
+      narrationPhase: string;
+      narrationText: string;
+      updateComplete: Promise<boolean>;
+    };
+    element.session = { id: 'session-1', state: 'recording' };
+    element.narrationState = 'missing';
+    element.narrationPhase = 'idle';
+    element.narrationText = 'transcribed-desk-audio-do-not-leak';
+    document.body.append(element);
+    await element.updateComplete;
+
+    // jsdom lays nothing out, and the snapshot drops elements with no client
+    // rects, so without this the surface would look empty for the wrong reason.
+    for (const node of element.shadowRoot!.querySelectorAll<HTMLElement>('*')) {
+      node.getClientRects = () => [{ width: 10, height: 10 }] as unknown as DOMRectList;
+    }
+    return element;
+  }
+
+  it('keeps the recording controls and narration transcript out of the snapshot', async () => {
+    const element = await renderRecordingSession();
+    const rendered = element.shadowRoot!.textContent ?? '';
+
+    // Anti-vacuity: a surface that failed to render would pass every
+    // "not.toContain" assertion below without proving anything.
+    expect(rendered).toContain('transcribed-desk-audio-do-not-leak');
+    expect(rendered).toContain('Download Whisper');
+    expect(element.shadowRoot!.querySelectorAll('button').length).toBeGreaterThan(0);
+
+    const snapshot = JSON.stringify(snapshotDesktopUi());
+    expect(snapshot).not.toContain('transcribed-desk-audio-do-not-leak');
+    expect(snapshot).not.toContain('Download Whisper');
+    expect(snapshot).not.toContain('Start narration');
+    expect(snapshot).not.toContain('Capture window');
+  });
+
+  it('marks the controls that reach consent-gated work, in case the surface stops being private', async () => {
+    const element = await renderRecordingSession();
+    const marked = Array.from(
+      element.shadowRoot!.querySelectorAll<HTMLElement>('[data-desktop-sensitive]'),
+    ).map((node) => ({
+      marker: node.dataset.desktopSensitive,
+      label: (node.textContent ?? '').replace(/\s+/g, ' ').trim(),
+    }));
+
+    const download = marked.find((entry) => entry.label.startsWith('Download Whisper'));
+    const narration = marked.find((entry) => entry.label === 'Start narration');
+    expect(download?.marker).toBe('model-download');
+    expect(narration?.marker).toBe('microphone');
   });
 });

--- a/typescript/ui/src/components/show-and-tell.ts
+++ b/typescript/ui/src/components/show-and-tell.ts
@@ -826,6 +826,7 @@ export class OpenRappterShowAndTell extends LitElement {
                         ${this.narrationState !== 'ready'
                           ? html`
                               <button
+                                data-desktop-sensitive="model-download"
                                 ?disabled=${this.busy || this.narrationPhase !== 'idle'}
                                 @click=${() => void this.ensureNarrationModel()
                                   .catch((error) => {
@@ -835,6 +836,7 @@ export class OpenRappterShowAndTell extends LitElement {
                             `
                           : nothing}
                         <button
+                          data-desktop-sensitive="microphone"
                           class=${this.narrationRecording ? 'danger' : ''}
                           ?disabled=${this.busy || this.narrationPhase === 'loading'}
                           @click=${() => void (


### PR DESCRIPTION
## What this is

A regression test for a product promise that had no test, plus a small defence-in-depth correction found while proving it.

**This is not a security fix and I want to be precise about that.** I started this round believing I had found a live hole, and the evidence said otherwise. The retraction is in the "What I got wrong" section below.

## The promise with no test

The Show-and-Tell panel tells the user, in the UI copy:

> frames never go to Copilot · native confirmation guards every sensitive action

The mechanism behind the first half is one wrapper in `show-and-tell.ts`:

```html
<div data-desktop-private>
```

`snapshotDesktopUi()` skips any element under `[data-desktop-private]`, both for interactive elements and for text extraction. That single div is the only thing keeping recordings, narration transcripts and their controls out of a model-visible snapshot.

It was tested — but only against markup the test wrote itself:

```ts
const privateSurface = document.createElement('section');
privateSurface.dataset.desktopPrivate = '';
```

That proves the snapshot honours the attribute. It cannot notice if the shipped component stops carrying it. Narrow that div, move it, or wrap the grid one level higher, and every existing test stays green while narration transcripts start flowing into model-visible snapshots.

The new tests render the real `openrappter-show-and-tell` with an active recording session and a transcript, then assert the snapshot contains none of it.

## What I got wrong

I opened this round chasing a different claim: that `data-desktop-sensitive` was missing from the two controls that matter. It is missing, and the markers really are on the wrong buttons:

| control | what it does | marker |
|---|---|---|
| ● Start recording | starts a session | `model-download` |
| Add note | submits text | `microphone` |
| Download Whisper (~252 MB) | `narration({action:'download'})` | **none** |
| Start narration | download **+ `getUserMedia`** | **none** |

The attribute values name the concerns of exactly the two buttons that lacked them, and the existing test fixture spells out the intent: `<button data-desktop-sensitive="microphone">Start narration</button>`.

So I wrote a test asserting an agent is refused when it clicks those controls. It failed, and the reason is the point: **the snapshot returns zero elements for that entire surface.** With client rects stubbed so nothing was hidden for the wrong reason:

```
BUTTONS_IN_SHADOW  5  ["Add note","Capture window","Download Whisper (~252 MB)","Start narration","■ Stop recording"]
SNAPSHOT_ELEMENTS  0
```

Every one of those buttons is inside the `data-desktop-private` wrapper. An agent can never obtain a ref for them, so it can never click them, marked or not. **There was no reachable hole, and I retract that framing.**

The marker fix is still here, as the commit says, "as defence in depth rather than as a live hole" — the wrapper is the load-bearing guard, and if it ever narrows, these markers become the only thing left. It is the secondary change in this PR, not the headline.

## Mutation proof

Each mutation was applied to the product, run, and reverted.

| mutation | result |
|---|---|
| `data-desktop-private` → `<div>` | ✗ privacy test fails |
| `data-desktop-sensitive="model-download"` removed | ✗ marker test fails |
| `data-desktop-sensitive="microphone"` removed | ✗ marker test fails |
| transcript not rendered (anti-vacuity) | ✗ privacy test fails |

The last one matters most. A privacy test is all `not.toContain`, so a surface that silently stopped rendering would pass it perfectly. The test asserts the transcript and controls **are** in the shadow root before asserting they are **not** in the snapshot, and that mutation proves those guards bite.

## Validation

- `ui` suite 132 passed (12 files), `ui` tsc clean
- root `vitest` 5353 passed / 21 skipped / 329 files
- root `tsc --noEmit` clean, `eslint --max-warnings 0` clean
- `conformance.py` 8 passed / 0 failed / 1 skipped
- `parity_harness.py --runtime both` PASS

## Two notes for whoever is next

**The `/jsdom/i` visibility fallback is dead under vitest 4.** `isVisible()` falls back to `/jsdom/i.test(navigator.userAgent)` when an element has no client rects. Vitest 4's jsdom no longer puts "jsdom" in the user agent, so that fallback never fires and every element looks invisible. Tests here must stub `getClientRects`, which is why the new helper does. Product behaviour is unaffected — it only matters in tests — but it silently turns a snapshot into an empty one, which is an easy way to write a privacy test that proves nothing.

**Show-and-Tell is entirely invisible to `DesktopControlAgent`.** The agent advertises `show-and-tell` as a navigable view, and navigation works, but the surface snapshots as zero elements. That appears deliberate. Worth knowing before someone files it as a bug.
