### PR TITLE
fix: stop the config view leaking secrets into desktop snapshots

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The config view no longer prints config values into a model-visible desktop
+  snapshot. `config` is a view `DesktopControlAgent` is told it can navigate to,
+  and the view already redacted values twice over -- raw mode keeps the file in
+  a `<textarea>` and scalars go in an `<input>`, both excluded from snapshots,
+  with inputs reported only as empty/set -- but nested values fell back to a
+  `<pre>` JSON dump that printed them verbatim. A channel with an array field
+  (`allowFrom` is in the schema) fails the "all sub-values are flat" check, so a
+  configured Telegram or Discord channel rendered its whole object, `botToken`
+  included, straight into the snapshot text. The dumps now carry
+  `data-desktop-private`, so the operator still sees their config and the model
+  does not.
+
 - Show-and-Tell's privacy boundary is now regression-tested against the real
   component instead of a hand-written fixture. A single `data-desktop-private`
   wrapper is the only thing keeping recordings, narration transcripts and their

--- a/typescript/ui/src/__tests__/config-desktop-privacy.test.ts
+++ b/typescript/ui/src/__tests__/config-desktop-privacy.test.ts
@@ -1,0 +1,87 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { snapshotDesktopUi } from '../services/desktop-control.js';
+import '../components/config.js';
+
+// `config` is one of the views DesktopControlAgent is told it can navigate to,
+// so whatever that surface renders is reachable by an agent snapshot. The view
+// already redacts config values twice over -- raw mode holds the file in a
+// <textarea>, and scalars go in an <input>, both excluded from snapshots, with
+// inputs reported only as empty/set -- but nested values fall back to a <pre>
+// JSON dump that prints them verbatim. These tests pin the invariant the other
+// two paths already keep: a config value never reaches a model-visible
+// snapshot, whichever shape it happens to render in.
+describe('the config view keeps config values out of model-visible snapshots', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  async function renderConfig(config: unknown, expand: string): Promise<HTMLElement> {
+    document.body.innerHTML = '';
+    const element = document.createElement('openrappter-config') as HTMLElement & {
+      configState: unknown;
+      expandedSections: Set<string>;
+      updateComplete: Promise<boolean>;
+    };
+    element.configState = {
+      client: null,
+      raw: JSON.stringify(config, null, 2),
+      hash: 'test-hash',
+      format: 'json',
+      dirty: false,
+      loading: false,
+      saving: false,
+      error: null,
+    };
+    element.expandedSections = new Set([expand]);
+    document.body.append(element);
+    await element.updateComplete;
+
+    // jsdom lays nothing out and the snapshot drops elements with no client
+    // rects, so without this the surface would look empty for the wrong reason.
+    for (const node of element.shadowRoot!.querySelectorAll<HTMLElement>('*')) {
+      node.getClientRects = () => [{ width: 10, height: 10 }] as unknown as DOMRectList;
+    }
+    return element;
+  }
+
+  it('redacts a channel token that renders as a nested JSON dump', async () => {
+    // A channel with any array field -- `allowFrom` is in the schema -- fails
+    // the "all sub-values are flat" check, so the whole object renders as JSON.
+    const element = await renderConfig(
+      {
+        channels: {
+          telegram: {
+            enabled: true,
+            botToken: 'secret-bot-token-do-not-leak',
+            allowFrom: ['user-1'],
+          },
+        },
+      },
+      'channels',
+    );
+    const shadow = element.shadowRoot!;
+
+    // Anti-vacuity: the operator must still be able to read their own config,
+    // and a surface that rendered nothing would pass the assertion below.
+    expect(shadow.querySelectorAll('pre').length).toBeGreaterThan(0);
+    expect(shadow.textContent ?? '').toContain('secret-bot-token-do-not-leak');
+
+    expect(JSON.stringify(snapshotDesktopUi())).not.toContain('secret-bot-token-do-not-leak');
+  });
+
+  it('redacts the gateway auth password that renders as an input', async () => {
+    const element = await renderConfig(
+      { gateway: { port: 18790, auth: { mode: 'password', password: 'secret-gateway-password' } } },
+      'gateway',
+    );
+    const shadow = element.shadowRoot!;
+
+    // Anti-vacuity: input values are not text content, so assert the field
+    // actually carries the secret before asserting the snapshot does not.
+    const values = Array.from(shadow.querySelectorAll('input')).map((input) => input.value);
+    expect(values).toContain('secret-gateway-password');
+
+    expect(JSON.stringify(snapshotDesktopUi())).not.toContain('secret-gateway-password');
+  });
+});

--- a/typescript/ui/src/components/config.ts
+++ b/typescript/ui/src/components/config.ts
@@ -477,6 +477,11 @@ export class OpenRappterConfig extends LitElement {
     `;
   }
 
+  // Config values never reach a model-visible desktop snapshot: raw mode keeps
+  // the whole file in a <textarea> and scalars go in an <input>, both of which
+  // the snapshot excludes and reports only as empty/set. The <pre> fallbacks
+  // below print values verbatim, so they carry the same marker -- a channel with
+  // an array field renders its whole object that way, bot token included.
   private renderValue(value: unknown, path: string[]): TemplateResult | typeof nothing {
     if (value === null || value === undefined) {
       return html`<label class="field"><span>${path[path.length - 1]}</span><input type="text" value="" placeholder="(empty)" @change=${(e: Event) => this.patchConfig(path, (e.target as HTMLInputElement).value || null)}></label>`;
@@ -538,14 +543,14 @@ export class OpenRappterConfig extends LitElement {
     }
 
     // Complex array items: show as formatted JSON
-    return html`<div class="field"><span>${path[path.length - 1]}</span><pre>${JSON.stringify(arr, null, 2)}</pre></div>`;
+    return html`<div class="field"><span>${path[path.length - 1]}</span><pre data-desktop-private>${JSON.stringify(arr, null, 2)}</pre></div>`;
   }
 
   private renderObject(obj: Record<string, unknown>, path: string[]) {
     const entries = Object.entries(obj);
     // Check nesting depth: if we're already deep, show as JSON
     if (path.length >= 3) {
-      return html`<div class="field"><span>${path[path.length - 1]}</span><pre>${JSON.stringify(obj, null, 2)}</pre></div>`;
+      return html`<div class="field"><span>${path[path.length - 1]}</span><pre data-desktop-private>${JSON.stringify(obj, null, 2)}</pre></div>`;
     }
 
     // Check if it's a simple flat object (all values are primitives)
@@ -578,7 +583,7 @@ export class OpenRappterConfig extends LitElement {
             </div>
           `;
         }
-        return html`<div class="field"><span>${k}</span><pre>${JSON.stringify(v, null, 2)}</pre></div>`;
+        return html`<div class="field"><span>${k}</span><pre data-desktop-private>${JSON.stringify(v, null, 2)}</pre></div>`;
       }
       return this.renderValue(v, [...path, k]);
     })}`;


### PR DESCRIPTION
## The leak

`config` is one of the views `DesktopControlAgent` is told it can navigate to:

```
'OpenRappter view id for navigate, such as chat, show-and-tell, agents, skills, cron, config, logs, or surgeon.'
```

So whatever that surface renders is reachable by an agent snapshot.

The config view redacts values on both of its other rendering paths, and it is worth being precise that this is deliberate, not incidental:

- **Raw mode** keeps the entire config file in a `<textarea>` — excluded from snapshots.
- **Scalars** render into an `<input>` — excluded from snapshot text, and descriptors report only `valueState: 'empty' | 'set'`, never the value.

Nested values fall back to a third path:

```ts
return html`<div class="field"><span>${k}</span><pre>${JSON.stringify(v, null, 2)}</pre></div>`;
```

Nothing excluded `<pre>`. The snapshot's text walker skips `script, style, input, textarea, select, [contenteditable="true"], [data-desktop-private]` — a `<pre>` is none of those, so its contents were collected verbatim.

## Why it is reachable, not theoretical

The shape that trips the fallback is ordinary. `renderObject` only renders a sub-object as fields when **every** sub-value is flat; otherwise it dumps the whole object as JSON. `channelConfigSchema` declares:

```ts
allowFrom: z.array(z.string()).optional(),
```

An array is not flat. So a configured Telegram or Discord channel — and the Channels UI writes `botToken` / `token` straight into config — renders its **entire object, token included**, as text.

Measured before the fix, rendering the real `openrappter-config` with a channels config:

```
PRE_TEXT           "{ "enabled": true, "botToken": "LEAKED-BOT-TOKEN-123456", "allowFrom": [ "user-1" ] }"
SNAPSHOT_HAS_TOKEN true
```

After:

```
RENDERED_HAS_TOKEN true      <- the operator still sees their own config
SNAPSHOT_HAS_TOKEN false     <- the model does not
```

The agent can reach it unaided: navigate to `config`, click the Channels header to expand it (an ordinary button in the snapshot), snapshot again, read the token.

## The fix

`data-desktop-private` on the three `<pre>` dumps. That is the mechanism the codebase already uses for exactly this, and it restores the invariant the other two paths kept: **a config value never reaches a model-visible snapshot, whichever shape it renders in.** Nothing changes for the human reading the page.

## Mutation proof

Each mutation applied to the product, run, reverted.

| mutation | result |
|---|---|
| `data-desktop-private` removed from the `<pre>` dumps | ✗ nested-dump test fails |
| `<pre>` renders no value (anti-vacuity) | ✗ nested-dump test fails |
| descriptors emit the raw input value instead of `valueState` | ✗ input test fails |

The second and third matter most. Both tests are `not.toContain` assertions, which a surface that rendered nothing would satisfy perfectly, so each asserts the secret **is** present in the page first — in the text for the `<pre>`, in `input.value` for the field, since input values are not text content.

## Scope, honestly

- This is about what an **agent snapshot** can see. It is not a remote exploit, and it requires a channel to be configured with a token in the config file.
- The second test covers the `<input>` path, which was **already correct**. It is here because that path is the invariant's other half and had no test against the real component; it should fail loudly if descriptor redaction ever regresses.
- I did **not** exclude `<pre>` globally in the snapshot service. Other views use `<pre>` for output an agent legitimately needs to read; the marker belongs on the surface that renders secrets.

## Validation

- `ui` suite 134 passed (13 files), `ui` tsc clean
- root `vitest` 5353 passed / 21 skipped / 329 files
- root `tsc --noEmit` clean, `eslint --max-warnings 0` clean
- `conformance.py` 8 passed / 0 failed / 1 skipped
- `parity_harness.py --runtime both` PASS

## Adjacent things I checked and cleared

Worth recording so nobody re-audits them:

- **`auth.password` is safe.** It renders through `renderValue`'s scalar branch into a `<label class="field">` that *wraps* the input, so `controlIsSensitive`'s `element.closest('label')` picks up the key name, `/\bpassword\b/` matches, and `set_value` is refused. It is protected by the label being a wrapper rather than a sibling — a detail worth not "tidying" away.
- **`channels.ts` field masking is fragile but not broken.** `type="${f.key.toLowerCase().includes('token') ? 'password' : 'text'}"` only masks keys containing "token". Every credential field that exists today (`botToken`, `token`) happens to match. A future `apiKey` or `appPassword` field would render in the clear.
- **`debug.ts` dumps RPC results into `<pre>` too**, but `debug` is not in the agent's navigable view list, so it is not reachable the same way.
