### PR TITLE
fix: stop desktop automation reading and driving the debug RPC console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The debug view's RPC console can no longer be read or driven by desktop
+  automation. `debug` is in the enforced navigable view list, and the console
+  invokes whatever gateway method is typed into it, so an agent could set the
+  method to `config.get` -- which returns the entire config file and, unlike
+  `config.set`/`config.apply`, requires no auth -- click Call, and read the
+  result out of the next snapshot. That bypassed the config view's own
+  redaction entirely. The console card is now marked `data-desktop-private`,
+  which both hides its output and drops its controls from the snapshot so no
+  ref can reach them, and each control additionally carries
+  `data-desktop-sensitive` as defence in depth. The status, models and
+  heartbeat cards render fixed, known-shape payloads and stay readable.
+
 - The config view no longer prints config values into a model-visible desktop
   snapshot. `config` is a view `DesktopControlAgent` is told it can navigate to,
   and the view already redacted values twice over -- raw mode keeps the file in

--- a/typescript/ui/src/__tests__/debug-rpc-console-privacy.test.ts
+++ b/typescript/ui/src/__tests__/debug-rpc-console-privacy.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+import { afterEach, describe, expect, it } from 'vitest';
+import { handleDesktopUiCommand, snapshotDesktopUi } from '../services/desktop-control.js';
+import '../components/debug.js';
+
+interface Snapshot {
+  text: string;
+  elements: { ref: string; tag: string; text: string; type: string }[];
+}
+
+// `debug` is in the enforced navigable view list in desktop-control.ts, so an
+// agent can reach this surface. That matters because the RPC console invokes
+// whatever gateway method is typed into it, which turns the bounded desktop
+// vocabulary (navigate/snapshot/click/input/select/scroll/wait) into "call any
+// gateway method and read the answer". config.get alone returns the entire
+// config file and, unlike config.set/config.apply, carries no auth
+// requirement. These tests pin both halves: a model cannot read the console's
+// output, and cannot drive the console either.
+describe('the debug RPC console is not usable by desktop automation', () => {
+  afterEach(() => {
+    document.body.innerHTML = '';
+  });
+
+  async function renderDebug(state: Record<string, unknown>): Promise<HTMLElement> {
+    document.body.innerHTML = '';
+    const element = document.createElement('openrappter-debug') as HTMLElement & {
+      updateComplete: Promise<boolean>;
+    };
+    document.body.append(element);
+    await element.updateComplete;
+    // The view fetches status and models on connect. Those calls fail here and
+    // overwrite the very fields under test, so apply the fixture only once they
+    // have settled.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    Object.assign(element, state);
+    await element.updateComplete;
+
+    // jsdom lays nothing out and the snapshot drops elements with no client
+    // rects, so without this every assertion below would pass for the wrong
+    // reason: an empty snapshot trivially contains no secret.
+    for (const node of element.shadowRoot!.querySelectorAll<HTMLElement>('*')) {
+      node.getClientRects = () => [{ width: 10, height: 10 }] as unknown as DOMRectList;
+    }
+    return element;
+  }
+
+  const findRef = (shot: Snapshot, match: (e: Snapshot['elements'][number]) => boolean): string => {
+    const hits = shot.elements.filter(match);
+    // Guard the guard: if this ever matches zero or many, the assertions below
+    // would be testing something other than the control they name.
+    expect(hits).toHaveLength(1);
+    return hits[0].ref;
+  };
+
+  it('keeps an RPC result out of the snapshot while still showing it to the operator', async () => {
+    // The shape config.get actually returns: the raw config file as a string.
+    const element = await renderDebug({
+      rpcResult: JSON.stringify(
+        { raw: '{"gateway":{"auth":{"password":"rpc-console-secret"}}}' },
+        null,
+        2,
+      ),
+    });
+
+    // Anti-vacuity: the operator's own view must genuinely contain the secret,
+    // otherwise this passes against a console that rendered nothing at all.
+    expect(element.shadowRoot!.textContent).toContain('rpc-console-secret');
+
+    expect(JSON.stringify(snapshotDesktopUi())).not.toContain('rpc-console-secret');
+  });
+
+  it('does not offer the console controls as refs an agent could drive', async () => {
+    await renderDebug({ rpcMethod: 'config.get', rpcParams: '{}' });
+    const shot = snapshotDesktopUi() as unknown as Snapshot;
+
+    // Anti-vacuity: the view must be reachable at all, or "no console controls"
+    // would be equally true of a snapshot that found nothing.
+    expect(shot.elements.length).toBeGreaterThan(0);
+
+    expect(shot.elements.some((e) => e.text.startsWith('Call'))).toBe(false);
+    expect(shot.elements.some((e) => e.tag === 'input' && e.type === 'text')).toBe(false);
+    expect(shot.elements.some((e) => e.tag === 'textarea')).toBe(false);
+  });
+
+  it('still refuses the console controls if the card stops being private', async () => {
+    // Defence in depth. The private boundary on the card is what hides these
+    // controls today; this proves the per-control markers stand on their own,
+    // so restructuring the card cannot quietly hand an agent arbitrary RPC.
+    const element = await renderDebug({ rpcMethod: 'config.get' });
+    // Select the console's own card rather than the first private element on
+    // the page, so this keeps testing the console if anything else is marked.
+    const card = element
+      .shadowRoot!.querySelector('.rpc-form')!
+      .closest('[data-desktop-private]') as HTMLElement;
+    expect(card).toBeTruthy();
+    card.removeAttribute('data-desktop-private');
+
+    const shot = snapshotDesktopUi() as unknown as Snapshot;
+    // With the boundary gone the controls really are back in reach, which is
+    // precisely why each one carries its own marker.
+    const method = findRef(shot, (e) => e.tag === 'input' && e.type === 'text');
+    const params = findRef(shot, (e) => e.tag === 'textarea');
+    const call = findRef(shot, (e) => e.text.startsWith('Call'));
+
+    await expect(
+      handleDesktopUiCommand({ action: 'input', args: { ref: method, value: 'config.get' } }),
+    ).rejects.toThrow(/sensitive/i);
+    await expect(
+      handleDesktopUiCommand({ action: 'input', args: { ref: params, value: '{}' } }),
+    ).rejects.toThrow(/sensitive/i);
+    await expect(
+      handleDesktopUiCommand({ action: 'click', args: { ref: call } }),
+    ).rejects.toThrow(/sensitive/i);
+  });
+
+  it('leaves the fixed-shape diagnostic cards readable', async () => {
+    // Scope guard. Only the console renders whatever the operator asked for;
+    // status, models and heartbeat render known-shape payloads and are the
+    // reason to read this view. Marking the whole view private would satisfy
+    // every test above while destroying the diagnostics, so pin it here.
+    await renderDebug({ statusJson: '{"uptimeSeconds":42}' });
+    expect(JSON.stringify(snapshotDesktopUi())).toContain('uptimeSeconds');
+  });
+});

--- a/typescript/ui/src/components/debug.ts
+++ b/typescript/ui/src/components/debug.ts
@@ -380,7 +380,26 @@ export class OpenRappterDebug extends LitElement {
         </div>
       </div>
 
-      <div class="card">
+      <!--
+        The RPC console invokes any gateway method the operator types, so it is
+        a general-purpose escape from the bounded vocabulary DesktopControl
+        gives a model (navigate/snapshot/click/input/select/scroll/wait). Left
+        open, an agent could drive it to call config.get -- which returns the
+        whole config file and, unlike config.set/apply, requires no auth -- and
+        read the result straight out of the snapshot.
+
+        data-desktop-private on the card is what actually closes this: it
+        hides the result text and, because the same boundary check filters the
+        interactive list, drops these controls from the snapshot so no ref can
+        reach them. The per-control markers below are defence in depth, kept in
+        the same spirit as the Show-and-Tell surface, so restructuring the card
+        cannot quietly hand an agent arbitrary RPC.
+
+        This is deliberately narrower than the whole view: the status, models
+        and heartbeat cards render fixed, known-shape payloads, while only this
+        one renders whatever the operator asked for.
+      -->
+      <div class="card" data-desktop-private>
         <div class="card-header">🧪 RPC Test Console</div>
         <div class="card-body">
           <div class="rpc-form">
@@ -388,6 +407,7 @@ export class OpenRappterDebug extends LitElement {
               <label>Method</label>
               <input
                 type="text"
+                data-desktop-sensitive
                 placeholder="e.g. agents.list, channels.list"
                 .value=${this.rpcMethod}
                 @input=${(e: InputEvent) => {
@@ -401,6 +421,7 @@ export class OpenRappterDebug extends LitElement {
             <div>
               <label>Params (JSON)</label>
               <textarea
+                data-desktop-sensitive
                 placeholder="{}"
                 .value=${this.rpcParams}
                 @input=${(e: InputEvent) => {
@@ -409,7 +430,11 @@ export class OpenRappterDebug extends LitElement {
               ></textarea>
             </div>
             <div class="rpc-actions">
-              <button @click=${this.handleRpcCall} ?disabled=${this.rpcLoading}>
+              <button
+                data-desktop-sensitive
+                @click=${this.handleRpcCall}
+                ?disabled=${this.rpcLoading}
+              >
                 ${this.rpcLoading ? 'Calling…' : 'Call'}
               </button>
             </div>


### PR DESCRIPTION
## First, a correction

Last change (#399) I wrote that the debug view's `<pre>` dumps were unreachable "because `debug` is absent from the navigable view list at `DesktopControlAgent.ts:50`". That was wrong, and it is worth being precise about why, because the mistake is an easy one to repeat.

That list is a **description string** on a free-form parameter:

```ts
view: {
  type: 'string',
  description: 'OpenRappter view id for navigate, such as chat, show-and-tell, agents, skills, cron, config, logs, or surgeon.',
},
```

"such as" — it is illustrative prose for the model, not an `enum`, and not enforcement. The actual allowlist is in `desktop-control.ts`, it has 17 entries, and `debug` is one of them (along with `channels`, `sessions`, `devices`, `presence`, `accounts`).

So the surface I dismissed is reachable, and it is worse than the one I fixed.

## The defect

The RPC console runs whatever method is typed into it:

```ts
const result = await gateway.call(this.rpcMethod.trim(), params as Record<string, unknown>);
this.rpcResult = JSON.stringify(result, null, 2);
```

No allowlist, and the result renders into a `<pre>` that nothing excluded from snapshots. `Method` is a plain text input, `Params` a textarea, `Call` an ordinary button — none marked sensitive.

That converts the bounded vocabulary `DesktopControlAgent` hands a model — navigate, snapshot, click, input, select, scroll, wait — into **"call any gateway method and read the answer."** The bound that matters here isn't the UI's, it's the agent contract's, and the console dissolves it.

And there is a method that makes it concrete. `config.get`:

```ts
this.registerMethod('config.get', async () => {
  const raw = this.loadConfig();
  return { raw, hash: this.configHash(raw), format: 'yaml', content: raw };
});
```

Returns the **entire raw config file** — and note the contrast two lines down, where `config.set` and `config.apply` are both registered `{ requiresAuth: true }`. The read path has no such requirement.

Full chain: navigate to `debug` → set Method to `config.get` → click Call → snapshot → read the gateway password and every channel token. This **bypasses #399 completely**; that change stopped the config *view* printing secrets, and this fetches the same bytes over RPC into an unmarked `<pre>`.

## Measured, not assumed

Probing the real component before the fix:

```
RESULT_IN_SNAPSHOT        true      <- the secret, verbatim
METHOD_SENSITIVE_ATTR     false     <- set_value allowed
CALL_SENSITIVE_ATTR       false     <- click allowed
NAVIGATE_DEBUG_ERROR      "OpenRappter app surface is not mounted."
```

That last line is the one that settles reachability: navigating to `debug` fails on the *missing test harness*, not on `Unknown OpenRappter view` — so it passed the allowlist check.

After:

```
RESULT_IN_SNAPSHOT        false
CONSOLE_CONTROL_REACHABLE false     <- 7 reachable elements -> 4
RENDERED_FOR_HUMAN        true      <- operator's view unchanged
```

## The fix

`data-desktop-private` on the console card is what actually closes it. `crossesDesktopPrivateBoundary` is consulted by **both** the text walker and `interactiveElements()`, so the marker hides the output *and* drops the controls from the snapshot — and since `requireRef` only resolves refs minted by a snapshot, the agent cannot address them at all.

Each control also carries `data-desktop-sensitive`. That is redundant today, and deliberately so: it means restructuring the card cannot quietly hand an agent arbitrary RPC. Same posture as the Show-and-Tell surface.

**Scope is deliberate.** Only this card renders whatever was asked for; `status`, `models.list` and the heartbeat event are fixed, known-shape payloads and are the reason to open this view. They stay readable, and a test pins that — so an over-broad "mark the whole view private" fails instead of passing quietly.

## Mutation proof

Each applied to the product, run, reverted.

| mutation | result |
|---|---|
| private marker off the card | ✗ read + reachability tests fail |
| sensitive marker off the Method input | ✗ defence-in-depth test fails |
| sensitive marker off the Call button | ✗ defence-in-depth test fails |
| console renders a fixed string, not the result | ✗ anti-vacuity assertion fails |
| status card *also* marked private | ✗ scope guard fails |

The last two carry the most weight. Three of the four tests are `not.toContain`, which a surface rendering nothing would satisfy perfectly — so each asserts the secret **is** present first. And the scope guard means this PR cannot be "fixed harder" into uselessness without a test objecting.

Mutation testing also caught a flaw in my own test: the defence-in-depth case selected `[data-desktop-private]` by first match, so marking another card retargeted it. Now it selects the console's card via `.rpc-form`, and mutation 5 is caught by the scope guard alone.

## Validation

- ui 138 passed / 14 files (was 134/13); ui `tsc` and `vite build` clean
- root vitest 5353 passed / 21 skipped / 329 files (baseline, unchanged)
- root `tsc --noEmit` clean; `eslint --max-warnings 0` clean
- `conformance.py` 8 passed / 0 failed / 1 skipped
- `parity_harness.py --runtime both` PASS

## Honest scope

- This is about what an **agent** can do through the UI, not a remote exploit. It needs a model driving desktop control.
- I did **not** touch `config.get`'s missing auth. It is reachable by any local gateway client, and whether reads should require auth is a broader decision than this change — worth its own issue.
- I did **not** narrow the RPC console for humans. It is a legitimate developer tool; the change is only that automation cannot use it.
