### PR TITLE
fix: stop DesktopControl advertising a query parameter it silently drops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `DesktopControl` no longer advertises a `query` parameter that it silently
+  threw away. The schema offered `query: 'Natural-language fallback.'` --
+  copied from `ShowAndTell`, where every `query` really does land in a free-text
+  field -- but `perform` forwards a fixed key allowlist that never contained it.
+  A model that took the documented fallback at its word had the instruction
+  stripped, `action` defaulted to `snapshot`, and the reply came back
+  `status: "success"`: a request reported as performed that never ran. Wiring it
+  up was not the fix either, because the only fields it could plausibly feed are
+  `value`, which reaches `setControlValue`, and `view`, which reaches the
+  navigation allowlist. The dead parameter is gone, a prose-only call is now
+  refused with an error naming the typed actions instead of being answered with
+  a substituted snapshot, and a typed action that happens to carry stray prose
+  still runs unchanged. A new contract test asserts every advertised parameter
+  other than `action` actually reaches the command queue, so schema and
+  implementation cannot drift apart again in either direction.
+
 - The debug view's RPC console can no longer be read or driven by desktop
   automation. `debug` is in the enforced navigable view list, and the console
   invokes whatever gateway method is typed into it, so an agent could set the

--- a/typescript/src/agents/DesktopControlAgent.ts
+++ b/typescript/src/agents/DesktopControlAgent.ts
@@ -78,10 +78,21 @@ export class DesktopControlAgent extends BasicAgent {
             type: 'string',
             description: 'Complete single-file agent source for install_agent.',
           },
-          query: {
-            type: 'string',
-            description: 'Natural-language fallback.',
-          },
+          // There is deliberately no `query` parameter here.
+          //
+          // This schema used to advertise `query: 'Natural-language fallback.'`,
+          // copied from ShowAndTellAgent, where every `query` genuinely lands in
+          // a free-text field (`kwargs.note ?? kwargs.query`). Desktop control
+          // has no free-text field: every parameter is a control signal, and
+          // `perform` forwards a fixed key allowlist that never included
+          // `query`. So a model that took the fallback at its word had the
+          // instruction stripped, `action` silently defaulted to `snapshot`,
+          // and got `status: "success"` back for a request nobody performed.
+          //
+          // It is not safe to simply wire it up either: the only fields it
+          // could plausibly feed are `value`, which reaches `setControlValue`,
+          // and `view`, which reaches the navigation allowlist. Typed actions
+          // are the contract; prose is refused below rather than guessed at.
         },
         required: [],
       },
@@ -90,6 +101,21 @@ export class DesktopControlAgent extends BasicAgent {
   }
 
   async perform(kwargs: Record<string, unknown>): Promise<string> {
+    // A caller working from a stale schema can still send prose. Substituting a
+    // snapshot for it and reporting success is the one outcome worse than
+    // failing, because the caller is told its instruction ran. Refuse instead —
+    // the same "reject, never coerce" rule the numeric guards use. An explicit
+    // typed action wins, so `{ action: 'click', query: 'the save button' }`
+    // keeps working and only the ambiguous prose-only call is rejected.
+    if (typeof kwargs.action !== 'string' && typeof kwargs.query === 'string' && kwargs.query.trim() !== '') {
+      return JSON.stringify({
+        status: 'error',
+        action: 'snapshot',
+        message:
+          'DesktopControl takes a typed action, not a natural-language query. ' +
+          'Use action with one of: snapshot, navigate, click, input, select, scroll, wait, install_agent.',
+      });
+    }
     const action = (
       typeof kwargs.action === 'string' ? kwargs.action : 'snapshot'
     ) as DesktopControlAction;

--- a/typescript/src/desktop-control/desktop-control.test.ts
+++ b/typescript/src/desktop-control/desktop-control.test.ts
@@ -252,3 +252,103 @@ describe('agent-reachable UI action boundary', () => {
     );
   });
 });
+
+/**
+ * The action union already has an anti-rot test above ("forces a new desktop
+ * action to be classified"). Parameters had no such test, and one rotted: the
+ * schema advertised `query: 'Natural-language fallback.'` while `perform`
+ * forwarded a fixed key allowlist that never contained it. A model that used
+ * the documented fallback had its instruction dropped, `action` defaulted to
+ * `snapshot`, and the reply came back `status: "success"` — a request reported
+ * as performed that never was.
+ */
+describe('DesktopControl parameter contract', () => {
+  function advertisedParameters(): string[] {
+    const agent = new DesktopControlAgent(
+      undefined as unknown as DesktopCommandQueue,
+    );
+    const parameters = agent.metadata.parameters as {
+      properties: Record<string, unknown>;
+    };
+    return Object.keys(parameters.properties);
+  }
+
+  function forwardedParameters(): string[] {
+    const source = readFileSync(
+      new URL('../agents/DesktopControlAgent.ts', import.meta.url),
+      'utf8',
+    );
+    const block = source.match(
+      /const args: Record<string, unknown> = \{\};\s*for \(const key of \[([\s\S]*?)\]\)/,
+    );
+    expect(block).not.toBeNull();
+    return [...block![1].matchAll(/'([a-zA-Z_]+)'/g)].map((m) => m[1]);
+  }
+
+  it('never advertises a parameter that perform() silently drops', () => {
+    const advertised = advertisedParameters();
+    const forwarded = forwardedParameters();
+
+    // Anti-vacuity: a regex or schema that stopped matching would pass the
+    // comparison below by measuring two empty sets against each other.
+    expect(advertised).toContain('action');
+    expect(advertised.length).toBeGreaterThanOrEqual(9);
+    expect(forwarded.length).toBeGreaterThanOrEqual(8);
+
+    // `action` selects the command; every other advertised parameter is an
+    // argument and must actually reach the queue.
+    const declaredArgs = advertised.filter((name) => name !== 'action');
+    expect([...declaredArgs].sort()).toEqual([...forwarded].sort());
+  });
+
+  it('does not advertise the unimplemented natural-language query parameter', () => {
+    expect(advertisedParameters()).not.toContain('query');
+  });
+
+  it('refuses a prose-only call instead of substituting a snapshot and reporting success', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'desktop-prose-'));
+    try {
+      const queue = new DesktopCommandQueue(root);
+      const agent = new DesktopControlAgent(queue);
+
+      const result = JSON.parse(
+        await agent.perform({ query: 'go to the agents view' }),
+      );
+
+      expect(result.status).toBe('error');
+      expect(result.message).toMatch(/typed action/i);
+      // The prose must not be laundered into a snapshot: nothing was queued.
+      expect(queue.claimNext()).toBeNull();
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+
+  it('still runs a typed action that carries stray prose alongside it', async () => {
+    const root = mkdtempSync(path.join(os.tmpdir(), 'desktop-typed-'));
+    try {
+      const queue = new DesktopCommandQueue(root);
+      const agent = new DesktopControlAgent(queue);
+
+      const pending = agent.perform({
+        action: 'navigate',
+        view: 'agents',
+        query: 'go to the agents view',
+      });
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const command = queue.claimNext();
+
+      // Scope guard: rejecting prose must not reject a well-formed command.
+      expect(command?.action).toBe('navigate');
+      expect(command?.args).toEqual({ view: 'agents' });
+
+      queue.complete(command!, {
+        status: 'success',
+        result: { view: 'agents' },
+      });
+      expect(JSON.parse(await pending).status).toBe('success');
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});


### PR DESCRIPTION
## The defect

`DesktopControlAgent`'s tool schema advertised a natural-language fallback that did not exist:

```ts
query: {
  type: 'string',
  description: 'Natural-language fallback.',
},
```

`perform` forwards a fixed key allowlist — `view, ref, value, direction, amount, milliseconds, filename, source` — and `query` was never in it. So the key was stripped, `action` fell through to its `snapshot` default, and the caller was told the request succeeded.

Measured directly against the real queue before changing anything:

| | before |
|---|---|
| `ADVERTISED_PARAMS` | `action, view, ref, value, direction, amount, milliseconds, filename, source, `**`query`** |
| `perform({ query: 'go to the agents view' })` → enqueued action | `"snapshot"` |
| → enqueued args | `{}` |
| → **reported status** | **`"success"`** |

A request reported as performed that never ran. That is the one outcome worse than failing, because the caller has no signal to retry.

## Why it was there, and why wiring it up is not the fix

The parameter was copied from `ShowAndTellAgent`, where `query` is genuinely live — consumed in four places in **both** runtimes:

- `ShowAndTellAgent.ts:296,427,440,703` — `sanitizeShowAndTellText(kwargs.note ?? kwargs.query, 2000)`
- `show_and_tell_agent.py:300,438,453,719` — `kwargs.get("note") or kwargs.get("query", "")`

Those all land in free-text note/detail fields, where prose is the correct payload. Desktop control has no such field: every parameter is a control signal. The only two it could plausibly feed are `value`, which reaches `setControlValue`, and `view`, which reaches the navigation allowlist — so honouring it would mean guessing a control signal from free text.

Typed actions are the contract. The dead parameter is removed and prose is refused rather than guessed at, matching the "reject, never coerce" rule the numeric guards already follow.

## The fix

1. **`query` is removed from the advertised schema**, with a comment recording why it must not come back.
2. **A prose-only call is refused** with an error naming the typed actions, and enqueues nothing.
3. **An explicit action still wins.** `{ action: 'navigate', view: 'agents', query: '...' }` is unaffected — only the ambiguous prose-only call is rejected, so no working call changes behaviour.

After:

| | after |
|---|---|
| `ADVERTISED_PARAMS` | `query` gone (9 params) |
| prose-only → enqueued | *nothing* |
| prose-only → status | `"error"`, message names the typed actions |
| `{action:'navigate', view:'agents', query:'...'}` | `navigate` / `{"view":"agents"}` / `"success"` |

## The anti-rot guard

The action union already had a test forcing every declared action to be classified as reachable or withheld. **Parameters had no equivalent — which is exactly how this rotted.** This adds one: every advertised parameter other than `action` must appear in the forwarding allowlist.

It fails in *both* directions — re-adding `query` to the schema, or dropping a key from the allowlist — and carries anti-vacuity guards so a stale extraction regex cannot make it pass by comparing two empty sets.

## Mutation testing

Five mutations, each caught, each with precise attribution:

| mutation | tests that failed |
|---|---|
| A — re-advertise `query` in the schema | parity test + no-query test |
| B — remove the prose guard | refusal test **only** |
| C — make the guard unconditional (reject prose even with a typed action) | scope-guard test **only** |
| D — drop `source` from the forwarding allowlist | parity test |
| E — break the allowlist extraction regex | parity test, via the anti-vacuity assertion |

**C is the one that matters most**: it proves over-rejecting a valid typed action is caught, so this cannot be "fixed" harder without a test failing. **E** proves the parity test is not vacuous.

## Validation

- `typescript` — **5357 passed / 21 skipped / 329 files** (baseline 5353, exactly +4 new)
- `tsc --noEmit` — clean
- `eslint src/ --max-warnings 0` — clean
- `conformance.py` — 8 passed, 0 failed, 1 skipped
- `parity_harness.py --runtime both` — PASS

## Scope

Two source files plus the changelog. No runtime behaviour changes for any call that was working before.

---

### Also checked this round, and deliberately *not* changed

Two leads were investigated and closed as negatives rather than shipped as speculative fixes:

- **`config.get` has no `requiresAuth` while `config.set`/`config.apply` do.** Not a live hole. On WS, `handleMessage` permits only `connect` until `info.authenticated`, and `handleConnect` sets that only after `isAuthCredentialValid` passes. On HTTP, `server.ts:1716` is fail-closed for everything outside `publicHttpMethods` (`status`, `health`, `ping`). And the desktop agent acts through an *already authenticated* connection, so the flag would not have blocked the escape fixed in #400 anyway.
- **`logs.ts:277` renders `JSON.stringify(log.data)` as unmarked page text.** No credential reaches it: `log-store.ts` applies `redactSecrets`/`redactSecretsInText`, `logger.ts:292` redacts `data`, and `logGatewayRequest` only records `transport`/`outcome`/`durationMs` — no params, auth, or frames. A sweep of every UI component for click-triggered secret disclosure also came back clean; every site that renders secret-like text is already inside `data-desktop-private`.
