### PR TITLE
fix: remove four more advertised agent parameters that nothing reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Four more agents advertised a `query` parameter that no implementation reads,
+  the same defect fixed for `DesktopControl` in #401. A sweep of both runtimes
+  found every case, and the severity was not uniform. `DemoRecorder` (both
+  runtimes) defaults `action` to `record_rar`, so prose fell through and
+  recorded a screen capture of the RAR walkthrough, wrote the video to disk,
+  and returned success for a demo nobody asked for. `HNPipeline` declares
+  `required: []`, so prose returned the default-keyword stories as a success.
+  `DocScanner` and `NotesIntake` declare `required: ['path']` and so failed
+  safe with "path is required" -- a misleading schema rather than a false
+  success. All five advertised parameters are removed, and `DemoRecorder` now
+  refuses a prose-only call rather than recording the wrong demo, while a typed
+  action carrying stray prose still runs unchanged.
+
+- Agents can no longer advertise a parameter nothing reads. `capability-reachability`
+  already stopped an agent declaring a capability it cannot reach; the same check
+  now exists one level down for parameters, across both runtimes -- 34 TypeScript
+  agents and 21 Python agents, 284 advertised parameters. The check is
+  deliberately permissive, treating any mention of the name outside the metadata
+  block as a use, so it cannot redden CI over a spelling it does not recognise.
+  It carries anti-vacuity floors because an extractor returning nothing would
+  satisfy every "no dead parameters" assertion perfectly: the first draft of the
+  sweep did exactly that for Python, silently reporting a clean runtime that had
+  a dead parameter sitting in it.
+
 - `DesktopControl` no longer advertises a `query` parameter that it silently
   threw away. The schema offered `query: 'Natural-language fallback.'` --
   copied from `ShowAndTell`, where every `query` really does land in a free-text

--- a/python/openrappter/agents/demo_recorder_agent.py
+++ b/python/openrappter/agents/demo_recorder_agent.py
@@ -103,7 +103,6 @@ class DemoRecorderAgent(BasicAgent):
                         "type": "boolean",
                         "description": "Enable TTS narration (default true)",
                     },
-                    "query": {"type": "string", "description": "Natural language description"},
                 },
                 "required": [],
             },

--- a/typescript/src/agents/DemoRecorderAgent.test.ts
+++ b/typescript/src/agents/DemoRecorderAgent.test.ts
@@ -27,3 +27,47 @@ describe('DemoRecorderAgent output names', () => {
     expect(result.status).toBe('success');
   });
 });
+
+/**
+ * This agent advertised a `query` natural-language parameter that nothing read.
+ * `action` defaults to `record_rar`, so prose did not fail -- it fell through
+ * and recorded the RAR walkthrough, wrote the video to disk, and returned
+ * success for a demo the caller never asked for.
+ */
+describe('DemoRecorderAgent natural-language calls', () => {
+  it('refuses a prose-only call instead of recording the default demo', async () => {
+    const agent = new DemoRecorderAgent();
+
+    const result = JSON.parse(
+      await agent.perform({ query: 'record a demo of the settings screen' })
+    );
+
+    expect(result.status).toBe('error');
+    expect(result.message).toMatch(/typed action/i);
+    // Anti-vacuity: the message must name the actions, not just any error.
+    expect(result.message).toContain('record_rar');
+  });
+
+  it('does not advertise the unimplemented natural-language query parameter', () => {
+    const properties = (
+      new DemoRecorderAgent().metadata.parameters as {
+        properties: Record<string, unknown>;
+      }
+    ).properties;
+
+    expect(Object.keys(properties)).toContain('action');
+    expect(Object.keys(properties)).not.toContain('query');
+  });
+
+  it('still runs a typed action that carries stray prose alongside it', async () => {
+    const agent = new DemoRecorderAgent();
+
+    // Scope guard: refusing prose must not refuse a well-formed command.
+    const result = JSON.parse(
+      await agent.perform({ action: 'list_scripts', query: 'show me the demos' })
+    );
+
+    expect(result.status).toBe('success');
+    expect(result.action).toBe('list_scripts');
+  });
+});

--- a/typescript/src/agents/DemoRecorderAgent.ts
+++ b/typescript/src/agents/DemoRecorderAgent.ts
@@ -258,10 +258,6 @@ export class DemoRecorderAgent extends BasicAgent {
             type: 'boolean',
             description: 'Enable TTS narration (default true)',
           },
-          query: {
-            type: 'string',
-            description: 'Natural language description of what to demo',
-          },
         },
         required: [],
       },
@@ -272,6 +268,24 @@ export class DemoRecorderAgent extends BasicAgent {
   }
 
   async perform(kwargs: Record<string, unknown>): Promise<string> {
+    // This agent used to advertise a `query` natural-language parameter that
+    // nothing read. Prose fell through to the `record_rar` default, so a caller
+    // asking for some other demo silently got a screen recording of the RAR
+    // walkthrough and a success reply. Refuse rather than record the wrong
+    // thing; an explicit action still wins, so prose alongside one is ignored
+    // exactly as before.
+    if (
+      typeof kwargs.action !== 'string' &&
+      typeof kwargs.query === 'string' &&
+      kwargs.query.trim() !== ''
+    ) {
+      return JSON.stringify({
+        status: 'error',
+        message:
+          'DemoRecorder takes a typed action, not a natural-language query. ' +
+          'Use action with one of: record_rar, record_custom, list_scripts, status.',
+      });
+    }
     const action = (kwargs.action as string) || 'record_rar';
     const withNarration = kwargs.with_narration !== false;
     const outputName = kwargs.output_name ?? `demo_${Date.now()}`;

--- a/typescript/src/agents/DocScannerAgent.ts
+++ b/typescript/src/agents/DocScannerAgent.ts
@@ -31,7 +31,7 @@ interface FileInfo { path: string; name: string; ext: string; size: number; mtim
 
 export class DocScannerAgent extends BasicAgent {
   constructor() {
-    const metadata: AgentMetadata = { name: 'DocScanner', description: 'Scans a directory for documents and notes, reporting file count, types, recent changes, and TODOs found.', parameters: { type: 'object', properties: { path: { type: 'string', description: 'Directory to scan' }, query: { type: 'string', description: 'Natural language query' } }, required: ['path'] } };
+    const metadata: AgentMetadata = { name: 'DocScanner', description: 'Scans a directory for documents and notes, reporting file count, types, recent changes, and TODOs found.', parameters: { type: 'object', properties: { path: { type: 'string', description: 'Directory to scan' } }, required: ['path'] } };
     super('DocScanner', metadata);
   }
 

--- a/typescript/src/agents/HNPipelineAgent.ts
+++ b/typescript/src/agents/HNPipelineAgent.ts
@@ -27,7 +27,7 @@ interface Highlight { title: string; url: string; score: number; relevance_keywo
 export class HNPipelineAgent extends BasicAgent {
   private hnAgent: BasicAgent;
   constructor(hnAgent?: BasicAgent) {
-    const metadata: AgentMetadata = { name: 'HNPipeline', description: 'Fetches top Hacker News stories, filters by project-relevant keywords, and returns highlights.', parameters: { type: 'object', properties: { keywords: { type: 'array', items: { type: 'string' }, description: 'Keywords to filter stories by' }, count: { type: 'integer', description: 'Number of stories to fetch (1-10)' }, query: { type: 'string', description: 'Natural language query' } }, required: [] } };
+    const metadata: AgentMetadata = { name: 'HNPipeline', description: 'Fetches top Hacker News stories, filters by project-relevant keywords, and returns highlights.', parameters: { type: 'object', properties: { keywords: { type: 'array', items: { type: 'string' }, description: 'Keywords to filter stories by' }, count: { type: 'integer', description: 'Number of stories to fetch (1-10)' } }, required: [] } };
     super('HNPipeline', metadata);
     this.hnAgent = hnAgent || new HackerNewsAgent();
   }

--- a/typescript/src/agents/NotesIntakeAgent.ts
+++ b/typescript/src/agents/NotesIntakeAgent.ts
@@ -30,7 +30,7 @@ interface ActionItem { text: string; file: string; line: number; urgency: 'high'
 
 export class NotesIntakeAgent extends BasicAgent {
   constructor() {
-    const metadata: AgentMetadata = { name: 'NotesIntake', description: 'Scans an Obsidian vault or notes directory, extracts action items, tags, and identifies smart reminders by urgency.', parameters: { type: 'object', properties: { path: { type: 'string', description: 'Notes directory or Obsidian vault path' }, query: { type: 'string', description: 'Natural language query' } }, required: ['path'] } };
+    const metadata: AgentMetadata = { name: 'NotesIntake', description: 'Scans an Obsidian vault or notes directory, extracts action items, tags, and identifies smart reminders by urgency.', parameters: { type: 'object', properties: { path: { type: 'string', description: 'Notes directory or Obsidian vault path' } }, required: ['path'] } };
     super('NotesIntake', metadata);
   }
 

--- a/typescript/src/agents/__tests__/parameter-reachability.test.ts
+++ b/typescript/src/agents/__tests__/parameter-reachability.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, existsSync } from 'node:fs';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * An agent must not advertise a parameter its implementation never reads.
+ *
+ * The sibling file `capability-reachability.test.ts` stops an agent declaring a
+ * capability it cannot reach. This is the same failure one level down: a
+ * parameter offered in `metadata.parameters.properties` that no code consumes.
+ *
+ * `DesktopControlAgent` advertised `query: 'Natural-language fallback.'` while
+ * `perform` forwarded a fixed key allowlist that never contained it, so the key
+ * was stripped, `action` fell through to its default, and the caller was handed
+ * `status: "success"` for an instruction nobody carried out (#401). That fix
+ * came with a parameter-contract test, but only for that one agent -- so this
+ * sweep was run across both runtimes, and found four more:
+ *
+ *   - `DemoRecorder` (both runtimes) -- prose fell through to the `record_rar`
+ *     default, so asking for some other demo produced a screen recording of the
+ *     RAR walkthrough, on disk, reported as success.
+ *   - `HNPipeline` -- `required: []`, so prose returned the default-keyword
+ *     stories and reported success.
+ *   - `DocScanner`, `NotesIntake` -- `required: ['path']`, so these failed
+ *     safe with "path is required". A documentation lie, not a false success.
+ *
+ * All five advertised the same never-implemented `query`, copied from
+ * `ShowAndTellAgent`, where `query` genuinely is read (`kwargs.note ??
+ * kwargs.query`). A parameter that does not mean what it says cannot be used to
+ * make a decision, and the two that defaulted an action turned that into work
+ * the caller never asked for, reported as work the caller did ask for.
+ *
+ * SCOPE, deliberately permissive. "Reached" means the parameter's name appears
+ * anywhere in the file outside the metadata block -- not that it is used
+ * correctly. A parameter read into a variable that is then dropped still counts
+ * here. The check is built to bias toward false negatives so it cannot redden
+ * CI over a spelling it does not recognise; it is a floor, not a ceiling.
+ */
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const TS_AGENTS_DIR = path.resolve(here, '..');
+const PY_AGENTS_DIR = path.resolve(here, '../../../../python/openrappter/agents');
+
+/**
+ * Strip comments so prose *about* a parameter is not mistaken for a use of it.
+ *
+ * Only whole-line comments and block comments are removed. A trailing `//` is
+ * deliberately left alone: stripping it means finding `//` inside string
+ * literals and regular expressions (`/https:\/\//`), and mangling a line of
+ * real code here would invent a missing parameter rather than find one.
+ */
+function stripComments(source: string): string {
+  return source
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((line) => {
+      const t = line.trim();
+      return !t.startsWith('//') && !t.startsWith('#') && !t.startsWith('*');
+    })
+    .join('\n');
+}
+
+/** Body and end offset of the `{...}` opening at `openIdx`. */
+function blockAt(
+  source: string,
+  openIdx: number,
+): { body: string; end: number } | null {
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    if (source[i] === '{') depth++;
+    else if (source[i] === '}') {
+      depth--;
+      if (depth === 0) return { body: source.slice(openIdx + 1, i), end: i };
+    }
+  }
+  return null;
+}
+
+/**
+ * Keys at depth 0 of an object literal or dict body.
+ *
+ * Quoted and bare keys both count, so this reads TypeScript object literals and
+ * Python dicts alike. The quoted form is checked before the string-open branch;
+ * checking it after silently returns zero keys for every Python agent, which is
+ * how the first draft of this sweep reported a clean Python runtime that had a
+ * dead parameter sitting in it.
+ */
+function topLevelKeys(body: string): string[] {
+  const keys: string[] = [];
+  const KEY = /^["']?([A-Za-z_][A-Za-z0-9_]*)["']?\s*:/;
+  let depth = 0;
+  let inString: string | null = null;
+  for (let i = 0; i < body.length; i++) {
+    const c = body[i];
+    if (inString) {
+      if (c === '\\') i++;
+      else if (c === inString) inString = null;
+      continue;
+    }
+    if (depth === 0) {
+      const prev = i === 0 ? ',' : body[i - 1];
+      if (',{\n \t'.includes(prev)) {
+        const m = KEY.exec(body.slice(i));
+        if (m) {
+          keys.push(m[1]);
+          i += m[0].length - 1;
+          continue;
+        }
+      }
+    }
+    if (c === '"' || c === "'" || c === '`') inString = c;
+    else if (c === '{' || c === '[' || c === '(') depth++;
+    else if (c === '}' || c === ']' || c === ')') depth--;
+  }
+  return keys;
+}
+
+interface AgentScan {
+  file: string;
+  advertised: string[];
+  dead: string[];
+}
+
+function scanAgent(file: string, source: string): AgentScan | null {
+  const clean = stripComments(source);
+  const paramsMatch = /["']?parameters["']?\s*:\s*\{/.exec(clean);
+  if (!paramsMatch) return null;
+  const params = blockAt(clean, paramsMatch.index + paramsMatch[0].length - 1);
+  if (!params) return null;
+  const propsMatch = /["']?properties["']?\s*:\s*\{/.exec(params.body);
+  if (!propsMatch) return null;
+  const props = blockAt(
+    params.body,
+    propsMatch.index + propsMatch[0].length - 1,
+  );
+  if (!props) return null;
+
+  const advertised = topLevelKeys(props.body);
+  // Everything except the metadata block is where a use could live.
+  const rest =
+    clean.slice(0, paramsMatch.index) + clean.slice(params.end + 1);
+  const dead = advertised.filter(
+    (name) => !new RegExp(`\\b${name}\\b`).test(rest),
+  );
+  return { file, advertised, dead };
+}
+
+function scanDir(dir: string, ext: string): AgentScan[] {
+  if (!existsSync(dir)) return [];
+  return readdirSync(dir)
+    .filter(
+      (f) =>
+        f.endsWith(ext) &&
+        !f.toLowerCase().includes('test') &&
+        !f.startsWith('__'),
+    )
+    .map((f) => scanAgent(f, readFileSync(path.join(dir, f), 'utf8')))
+    .filter((r): r is AgentScan => r !== null);
+}
+
+describe('agent parameter reachability', () => {
+  const ts = scanDir(TS_AGENTS_DIR, '.ts');
+  const py = scanDir(PY_AGENTS_DIR, '.py');
+
+  it('extracts parameters from both runtimes', () => {
+    // Anti-vacuity. Every assertion below is "no dead parameters found", which
+    // an extractor returning nothing would satisfy perfectly. These floors are
+    // set well under the real counts at the time of writing -- TypeScript 34
+    // agents / 158 parameters, Python 21 / 126 -- so ordinary churn will not
+    // trip them but a silently broken parser will.
+    expect(ts.length).toBeGreaterThanOrEqual(30);
+    expect(py.length).toBeGreaterThanOrEqual(18);
+    expect(ts.reduce((n, a) => n + a.advertised.length, 0)).toBeGreaterThanOrEqual(140);
+    expect(py.reduce((n, a) => n + a.advertised.length, 0)).toBeGreaterThanOrEqual(110);
+
+    // The Python arm read zero keys from every file in the first draft, which
+    // no count alone would have exposed, so pin one known Python agent.
+    const pyDemo = py.find((a) => a.file === 'demo_recorder_agent.py');
+    expect(pyDemo?.advertised).toContain('action');
+    expect(pyDemo?.advertised).toContain('with_narration');
+
+    const tsDesktop = ts.find((a) => a.file === 'DesktopControlAgent.ts');
+    expect(tsDesktop?.advertised).toContain('view');
+  });
+
+  it('has no TypeScript agent advertising a parameter nothing reads', () => {
+    const offenders = ts
+      .filter((a) => a.dead.length > 0)
+      .map((a) => `${a.file}: ${a.dead.join(', ')}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('has no Python agent advertising a parameter nothing reads', () => {
+    const offenders = py
+      .filter((a) => a.dead.length > 0)
+      .map((a) => `${a.file}: ${a.dead.join(', ')}`);
+    expect(offenders).toEqual([]);
+  });
+
+  it('detects a dead parameter when one is introduced', () => {
+    // The three assertions above are all "expected empty". This proves the
+    // detector can actually go red, using the exact shape that was shipped for
+    // months: advertised in metadata, referenced nowhere else.
+    const withDeadParam = `
+      const metadata = {
+        name: 'Probe',
+        parameters: {
+          type: 'object',
+          properties: {
+            path: { type: 'string', description: 'Directory to scan' },
+            query: { type: 'string', description: 'Natural language query' },
+          },
+          required: ['path'],
+        },
+      };
+      async perform(kwargs) { return kwargs.path; }
+    `;
+    const result = scanAgent('Probe.ts', withDeadParam);
+    expect(result?.advertised).toEqual(['path', 'query']);
+    expect(result?.dead).toEqual(['query']);
+  });
+
+  it('does not count a parameter mentioned only in a comment as read', () => {
+    const commentOnly = `
+      const metadata = {
+        parameters: {
+          type: 'object',
+          properties: { query: { type: 'string', description: 'q' } },
+          required: [],
+        },
+      };
+      // TODO: one day actually handle query here
+      async perform(kwargs) { return '{}'; }
+    `;
+    expect(scanAgent('CommentOnly.ts', commentOnly)?.dead).toEqual(['query']);
+  });
+});


### PR DESCRIPTION
Follow-up to #401, which removed a `query` parameter that `DesktopControlAgent` advertised but never read. This sweeps **both runtimes** for the same shape and finds every remaining case: **four more agents, five files**, all advertising the same never-implemented `query`.

## Severity is not uniform, and `required` is why

| agent | `required` | prose-only call does this | verdict |
|---|---|---|---|
| **DemoRecorder** (TS + Python) | `[]`, `action` defaults to `record_rar` | **records a screen capture of the RAR walkthrough, writes the video to disk**, returns `success` | false success **with a side effect** |
| **HNPipeline** | `[]` | returns default-keyword stories, returns `success` | false success |
| **DocScanner** | `['path']` | `{"status":"error","message":"path is required"}` | fails safe — misleading schema only |
| **NotesIntake** | `['path']` | `{"status":"error","message":"path is required"}` | fails safe — misleading schema only |

DemoRecorder is the one that matters. Read straight off the dispatch:

```ts
const action = (kwargs.action as string) || 'record_rar';
...
case 'record_rar':
  return await this.recordDemo(RAR_DEMO_SCRIPT, outputName as string, withNarration);
```

Ask it for a demo of the settings screen and you get a recording of something else entirely, on disk, reported as the thing you asked for. *(Established by reading the dispatch, not by executing it — probing that path would start a real screen recording on the machine.)*

## Why removal, not implementation

I checked whether anything downstream was actually waiting for `query` before deleting it. **No generic dispatcher injects it** — the router, `AgentRegistry`, `Assistant` and `chain` contain no reference to `query` at all, and a repo-wide search for a generic `query:` injection into agent kwargs returns only unrelated `flight-recorder` and `memory` search APIs.

The parameter was copied from `ShowAndTellAgent`, where `query` **is** genuinely read (`kwargs.note ?? kwargs.query`) because that agent has a free-text field to receive prose. These four have no such field.

DemoRecorder additionally **refuses** a prose-only call rather than recording the wrong demo, matching the guard added to DesktopControl in #401. It is conditional, so an explicit action still wins and `{ action: 'list_scripts', query: '...' }` is unaffected. The Python metadata is updated in step to preserve parity.

## The actual deliverable: a gate

`capability-reachability.test.ts` already stops an agent declaring a capability it cannot reach. `parameter-reachability.test.ts` now does the same **one level down**, across both runtimes:

- **34 TypeScript agents**, 158 advertised parameters
- **21 Python agents**, 126 advertised parameters
- **284 parameters checked**

It is **deliberately permissive**: any mention of the name outside the metadata block counts as a use. That biases it toward false negatives so it cannot redden CI over a spelling it does not recognise. It is a floor, not a ceiling.

### The anti-vacuity floors are not decorative

Every headline assertion in this file is *"expected empty"*, which an extractor returning nothing satisfies perfectly. That is not hypothetical — **the first draft of this sweep did exactly that.** It tested the quoted-key pattern *after* the string-open branch, so every Python dict key fell into string-tracking and it read **zero keys from every Python file**, then reported a clean Python runtime that had a dead parameter sitting in it. The floors plus a pinned Python agent (`demo_recorder_agent.py` must advertise `action` and `with_narration`) now make that failure loud.

## Mutation testing — 7 mutations, all caught

| mutation | caught by |
|---|---|
| re-advertise `query` in TS DemoRecorder | DemoRecorder no-query test |
| re-advertise `query` in **Python** DemoRecorder | Python reachability gate |
| re-advertise `query` in HNPipeline | TypeScript reachability gate |
| remove the prose guard | prose-refusal test **only** |
| make the guard unconditional | scope-guard test **only** |
| reintroduce the quoted-key ordering bug | anti-vacuity floor |
| disable comment stripping | comment-only unit test + TS gate |

Mutations 4 and 5 are a matched pair: one proves the guard is load-bearing, the other proves **over**-rejecting a valid typed call also fails a test, so this cannot be "fixed" harder without going red.

### One honest limitation, measured rather than assumed

Re-advertising `query` in **DemoRecorder** is caught by that agent's own test, **not by the sweep** — because its new guard mentions `kwargs.query`, and the permissive rule counts that as a use. The sweep catches the four agents that have no such guard, which is the case it exists for. Both layers are present, and the mutation table shows exactly which one fires.

## Validation

- `typescript` — **5365 passed / 21 skipped / 330 files** (baseline 5357, exactly +8)
- `python` — **2108 passed / 6 skipped**, 51 subtests
- `tsc --noEmit` — clean
- `eslint src/ --max-warnings 0` — clean
- `conformance.py` — 8 passed, 0 failed, 1 skipped
- `parity_harness.py --runtime both` — PASS

No behaviour changes for any call that was working before.
