### PR TITLE
fix: stop step/node timeouts from outliving the work they bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Step and node timeouts no longer outlive the work they bound. Both runtimes
+  raced a step against a timer and then leaked the loser. In Python,
+  `AgentChain` started its timeout worker with `threading.Thread(target=run)`
+  and no daemon flag, so when a step timed out the abandoned worker kept the
+  interpreter alive until the step we gave up on finally returned: a 100ms
+  timeout on a 5s step released `run()` in 0.20s but the process still took
+  5.14s to exit, so the timeout bought the caller nothing. In TypeScript,
+  `AgentChain` and `AgentGraph` raced against a `setTimeout` whose handle was
+  never captured, so it was never cleared; when the step won the race the timer
+  stayed pending and held the event loop open for the full window. A graph
+  configured with a five-minute `nodeTimeout` kept Node alive for five minutes
+  after a completely successful run. The Python worker is now a daemon and the
+  TypeScript timers are cleared in a `finally`, so both paths release the
+  process as soon as the work is done.
+
+- The step-timeout path had no test in either runtime, which is why both leaks
+  survived. It now has one, including a check that the timer is actually armed
+  before asserting it is gone -- without that, "no pending timers at the end"
+  passes just as well when the timeout was never set up at all.
+
 - Four more agents advertised a `query` parameter that no implementation reads,
   the same defect fixed for `DesktopControl` in #401. A sweep of both runtimes
   found every case, and the severity was not uniform. `DemoRecorder` (both

--- a/python/openrappter/agents/chain.py
+++ b/python/openrappter/agents/chain.py
@@ -191,7 +191,10 @@ class AgentChain:
             except Exception as e:
                 error[0] = e
 
-        thread = threading.Thread(target=run)
+        # daemon=True: on timeout we abandon this worker, and a non-daemon
+        # thread would block interpreter exit until the step we gave up on
+        # finally returns -- making the timeout buy nothing.
+        thread = threading.Thread(target=run, daemon=True)
         thread.start()
         thread.join(timeout=self._step_timeout / 1000)
 

--- a/python/tests/test_agent_chain.py
+++ b/python/tests/test_agent_chain.py
@@ -1,6 +1,7 @@
 """Tests for AgentChain - sequential agent pipeline with data_slush forwarding."""
 
 import json
+import threading
 import time
 import pytest
 
@@ -255,3 +256,65 @@ class TestEmptyChain:
         assert result.status == "success"
         assert len(result.steps) == 0
         assert result.final_result is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: step timeout
+#
+# The timeout exists to bound how long a caller waits on one step. It only
+# does that if abandoning the step actually releases the process: a non-daemon
+# worker keeps the interpreter alive until the step we gave up on finishes,
+# so a 100ms timeout on a 5s step still costs the caller 5s at exit.
+# ---------------------------------------------------------------------------
+
+class SleepyAgent(BasicAgent):
+    """Sleeps well past the step timeout so the chain abandons it."""
+
+    def __init__(self, seconds=2.0):
+        self._seconds = seconds
+        metadata = {
+            "name": "Sleepy",
+            "description": "Sleeps",
+            "parameters": {"type": "object", "properties": {}, "required": []},
+        }
+        super().__init__(name="Sleepy", metadata=metadata)
+
+    def perform(self, **kwargs):
+        time.sleep(self._seconds)
+        return json.dumps({"status": "success"})
+
+
+class TestStepTimeout:
+    def test_slow_step_times_out_and_releases_the_caller(self):
+        chain = AgentChain({"step_timeout": 100})
+        chain.add_step("slow", SleepyAgent(2.0))
+
+        started = time.time()
+        result = chain.run()
+        elapsed = time.time() - started
+
+        assert result.status == "error"
+        assert "timeout" in (result.error or "").lower()
+        # Released at the timeout, not at the sleeping step's own pace.
+        assert elapsed < 1.0, f"run() took {elapsed:.2f}s for a 100ms timeout"
+
+    def test_abandoned_worker_is_a_daemon_so_it_cannot_block_exit(self):
+        before = set(threading.enumerate())
+
+        chain = AgentChain({"step_timeout": 100})
+        chain.add_step("slow", SleepyAgent(2.0))
+        result = chain.run()
+        assert result.status == "error"
+
+        survivors = [
+            t for t in threading.enumerate()
+            if t not in before and t.is_alive()
+        ]
+        # Anti-vacuity: `all(...)` over an empty list passes and proves nothing,
+        # so first pin that the abandoned worker really is still running.
+        assert survivors, "expected the abandoned step worker to still be alive"
+        non_daemon = [t.name for t in survivors if not t.daemon]
+        assert not non_daemon, (
+            "these workers outlive the timeout as non-daemon threads and will "
+            f"block interpreter exit until the step finishes: {non_daemon}"
+        )

--- a/typescript/src/__tests__/parity/agent-chain.test.ts
+++ b/typescript/src/__tests__/parity/agent-chain.test.ts
@@ -4,7 +4,7 @@
  * Tests the sequential agent pipeline with automatic data_slush forwarding.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { AgentChain, createAgentChain } from '../../agents/chain.js';
 import { ShellAgent } from '../../agents/ShellAgent.js';
 import { BasicAgent } from '../../agents/BasicAgent.js';
@@ -213,5 +213,70 @@ describe('AgentChain', () => {
       expect(result.steps).toEqual([]);
       expect(result.finalResult).toBeNull();
     });
+  });
+});
+
+// ── Step timeout: the timer must not outlive the step ──
+//
+// executeWithTimeout races the step against a setTimeout. If the step wins,
+// an uncleared timer stays pending for the full timeout, and a pending timer
+// keeps the Node event loop alive long after the work is finished. A chain
+// configured with a generous stepTimeout would hold the process open for that
+// entire window on a completely successful run.
+
+class GatedAgent extends BasicAgent {
+  constructor(private readonly gate: Promise<string>) {
+    const metadata: AgentMetadata = {
+      name: 'Gated',
+      description: 'Resolves only when the test releases it',
+      parameters: { type: 'object', properties: {}, required: [] },
+    };
+    super('Gated', metadata);
+  }
+
+  async perform(_kwargs: Record<string, unknown>): Promise<string> {
+    return this.gate;
+  }
+}
+
+describe('AgentChain step timeout does not leak timers', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears the step timer when the step wins the race', async () => {
+    vi.useFakeTimers();
+
+    let release!: (value: string) => void;
+    const gate = new Promise<string>((resolve) => {
+      release = resolve;
+    });
+
+    const chain = new AgentChain({ stepTimeout: 300_000 });
+    chain.add('gated', new GatedAgent(gate));
+    const running = chain.run({});
+
+    // Let the race arm its timer before measuring.
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Anti-vacuity: if the timeout never armed, "0 timers at the end" would
+    // pass for the wrong reason and this test would prove nothing.
+    expect(vi.getTimerCount()).toBe(1);
+
+    release(JSON.stringify({ status: 'success' }));
+    const result = await running;
+
+    expect(result.status).toBe('success');
+    expect(vi.getTimerCount()).toBe(0);
+  });
+
+  it('arms no timer at all when stepTimeout is unset', async () => {
+    vi.useFakeTimers();
+    const chain = new AgentChain();
+    chain.add('echo', new EchoAgent());
+    const result = await chain.run({ query: 'hi' });
+    expect(result.status).toBe('success');
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/typescript/src/__tests__/parity/agent-graph.test.ts
+++ b/typescript/src/__tests__/parity/agent-graph.test.ts
@@ -5,7 +5,7 @@
  * cycle detection, and data_slush merging.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, afterEach } from 'vitest';
 import { AgentGraph, createAgentGraph } from '../../agents/graph.js';
 import { BasicAgent } from '../../agents/BasicAgent.js';
 import type { AgentMetadata } from '../../agents/types.js';
@@ -318,5 +318,56 @@ describe('AgentGraph', () => {
       const result = await graph.run();
       expect(result.nodes.get('slow')?.status).toBe('error');
     });
+  });
+});
+
+// ── Node timeout: the timer must not outlive the node ──
+//
+// Same defect as AgentChain: executeWithTimeout raced the node against a
+// setTimeout it never cleared, so a node that finished well inside its budget
+// still left a pending timer holding the event loop open for the full window.
+
+class GatedNodeAgent extends BasicAgent {
+  constructor(private readonly gate: Promise<string>) {
+    const metadata: AgentMetadata = {
+      name: 'GatedNode',
+      description: 'Resolves only when the test releases it',
+      parameters: { type: 'object', properties: {}, required: [] },
+    };
+    super('GatedNode', metadata);
+  }
+
+  async perform(_kwargs: Record<string, unknown>): Promise<string> {
+    return this.gate;
+  }
+}
+
+describe('AgentGraph node timeout does not leak timers', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('clears the node timer when the node wins the race', async () => {
+    vi.useFakeTimers();
+
+    let release!: (value: string) => void;
+    const gate = new Promise<string>((resolve) => {
+      release = resolve;
+    });
+
+    const graph = createAgentGraph({ nodeTimeout: 300_000 })
+      .addNode({ name: 'gated', agent: new GatedNodeAgent(gate) });
+    const running = graph.run();
+
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Anti-vacuity: prove the timeout actually armed before asserting it is gone.
+    expect(vi.getTimerCount()).toBe(1);
+
+    release(JSON.stringify({ status: 'success' }));
+    await running;
+
+    expect(vi.getTimerCount()).toBe(0);
   });
 });

--- a/typescript/src/agents/chain.ts
+++ b/typescript/src/agents/chain.ts
@@ -220,15 +220,22 @@ export class AgentChain {
     const promise = agent.execute(kwargs);
     if (!this.options.stepTimeout) return promise;
 
-    return Promise.race([
-      promise,
-      new Promise<string>((_, reject) =>
-        setTimeout(
-          () => reject(new Error(`Step timeout after ${this.options.stepTimeout}ms`)),
-          this.options.stepTimeout,
-        )
-      ),
-    ]);
+    // The timer must be cleared on the winning path too: an uncleared timer
+    // stays pending and keeps the event loop alive long after the work is done.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<string>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`Step timeout after ${this.options.stepTimeout}ms`)),
+            this.options.stepTimeout,
+          );
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 }
 

--- a/typescript/src/agents/graph.ts
+++ b/typescript/src/agents/graph.ts
@@ -402,15 +402,22 @@ export class AgentGraph {
     const promise = agent.execute(kwargs);
     if (!this.options.nodeTimeout) return promise;
 
-    return Promise.race([
-      promise,
-      new Promise<string>((_, reject) =>
-        setTimeout(
-          () => reject(new Error(`Node timeout after ${this.options.nodeTimeout}ms`)),
-          this.options.nodeTimeout,
-        )
-      ),
-    ]);
+    // The timer must be cleared on the winning path too: an uncleared timer
+    // stays pending and keeps the event loop alive long after the work is done.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    try {
+      return await Promise.race([
+        promise,
+        new Promise<string>((_, reject) => {
+          timer = setTimeout(
+            () => reject(new Error(`Node timeout after ${this.options.nodeTimeout}ms`)),
+            this.options.nodeTimeout,
+          );
+        }),
+      ]);
+    } finally {
+      if (timer !== undefined) clearTimeout(timer);
+    }
   }
 
   /**


### PR DESCRIPTION
Both runtimes race a step against a timer and then **leak whichever one loses**. The symptom is the same in each: the timeout mechanism keeps the process alive after the work it was meant to bound has finished.

The two halves are complements, not the same bug — Python leaks when the step is **slow** and the timeout fires; TypeScript leaks when the step is **fast** and the timeout doesn't.

## Python: the abandoned worker blocks interpreter exit

`AgentChain._execute_with_timeout` started its worker with no daemon flag:

```python
thread = threading.Thread(target=run)
```

On timeout the chain raises and walks away — but a non-daemon thread blocks interpreter shutdown. Measured with a 100 ms `step_timeout` against a 5 s step:

```
CHAIN_DONE status=error after=0.20s
STILL_ALIVE=['Thread-1 (run)']   DAEMON_FLAGS=[False]
real 5.14
```

`run()` returned in **0.20 s** and the process still took **5.14 s** to exit. The timeout bought the caller nothing: they waited the full duration of the step they explicitly gave up on. After the fix, the same script exits in **0.33 s**.

This also matches the house convention rather than inventing one. `_bounded_workers.py`, `imessage/rpc.py` (×3) and `channels/webhook.py` all set `daemon=True` explicitly, and `pokemon_agent.py` sets `daemon=False` deliberately where it wants a blocking writer. `chain.py:194` was the **only** thread in the package that specified nothing at all — and it is created precisely in the path where the thread is known to be stuck.

## TypeScript: the uncleared timer holds the event loop open

`AgentChain` and `AgentGraph` both did this:

```ts
return Promise.race([
  promise,
  new Promise<string>((_, reject) =>
    setTimeout(() => reject(new Error(`Step timeout after ...`)), this.options.stepTimeout)
  ),
]);
```

The handle is never captured, so it can never be cleared. When the step wins the race the timer is still pending, and a pending timer keeps Node's event loop alive for the entire window. Measured against the real chain with a 300 s `stepTimeout` and an immediately-resolving step:

```
PROBE status=success timersBefore=0 timersAfter=1
```

A graph configured with a five-minute `nodeTimeout` would hold the process open for **five minutes after a completely successful run**.

## The fixes

Small and symmetric: `daemon=True` on the Python worker, and `clearTimeout` in a `finally` on both TypeScript paths so the timer is dropped whichever side wins the race.

## Why this survived

**No test in either runtime referenced `step_timeout` or `stepTimeout`.** The feature was entirely uncovered. There are tests now — and they assert the timer is *actually armed* before asserting it is gone:

```ts
expect(vi.getTimerCount()).toBe(1);   // anti-vacuity: the timeout really armed
release(...);
expect(vi.getTimerCount()).toBe(0);   // the fix
```

Without that first line the test is vacuous: *"no pending timers at the end"* passes just as well when the timeout was never set up at all. The Python test has the same guard — `all(t.daemon for t in survivors)` is trivially true over an empty list, so it first pins that the abandoned worker really is still running.

## Mutation testing — 5 mutations, all caught

| mutation | caught by |
|---|---|
| drop `daemon=True` | the daemon test **only** |
| drop `clearTimeout` in `chain.ts` | chain timer test **only** |
| drop `clearTimeout` in `graph.ts` | graph timer test **only** |
| ignore `stepTimeout` entirely (TS) | the armed-timer assertion |
| never time out (Python) | both Python timeout tests |

The last two are the anti-vacuity probes: they disable the feature rather than the fix, and are caught by the armed-timer guards instead of passing silently.

## Validation

- `typescript` — **5368 passed** / 21 skipped (baseline 5365, exactly +3)
- `python` — **2109 passed** / 6 skipped (baseline 2108, exactly +2)
- `tsc --noEmit` clean · `eslint --max-warnings 0` clean
- `typescript/ui` — 138 passed · `npm run build` clean
- `conformance.py` — 8 passed, 0 failed, 1 skipped
- `parity_harness.py --runtime both` — PASS

### One pre-existing failure, explicitly not mine

`test_imessage_rpc.py::test_rpc_child_exit_fails_request` fails locally. I stashed these changes and ran it 12 times against clean `main`: it failed **9/12**. It is flaky on this machine independent of this work — in fact it failed *more* often without my changes. Not touched here; logged for its own round.

## Noted, deliberately not fixed here

`graph.py` reads `node_timeout` into `self._node_timeout` and **never uses it again** — the only line matching "timeout" in the file is that assignment. Python's `AgentGraph` silently ignores a node timeout that TypeScript's enforces (`agent-graph.test.ts` covers `nodeTimeout`). That is a real parity gap, but implementing it is a feature change with its own test surface, so it does not belong in a bug-fix PR. Logged as the next round's lead.
