### PR TITLE
fix: enforce node_timeout in Python AgentGraph instead of ignoring it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Python's `AgentGraph` accepted a `node_timeout` and then ignored it. The
+  constructor stored `self._node_timeout` and nothing ever read it again -- that
+  assignment was the only line in the whole file matching "timeout" -- so a node
+  that hung, hung the entire graph forever. TypeScript has always enforced its
+  `nodeTimeout`, and both `CLAUDE.md` and the Obsidian vault document the option
+  as part of `GraphOptions`, so the bound was promised in three places and
+  applied in one. Measured before the fix: a graph with a 100ms `node_timeout`
+  running a 3s node returned after 3.03s and reported the node as `success` --
+  the caller was told the work finished inside a budget it had blown by 30x.
+  It now fails that node at 100ms with `Node timeout after 100ms`, matching the
+  TypeScript message exactly, and dependents skip through the normal
+  failure path. The timeout is still opt-in: unset means unbounded, as before.
+
 - Step and node timeouts no longer outlive the work they bound. Both runtimes
   raced a step against a timer and then leaked the loser. In Python,
   `AgentChain` started its timeout worker with `threading.Thread(target=run)`

--- a/python/openrappter/agents/graph.py
+++ b/python/openrappter/agents/graph.py
@@ -14,6 +14,7 @@ Mirrors TypeScript agents/graph.ts
 """
 
 import json
+import threading
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass, field
@@ -266,7 +267,7 @@ class AgentGraph:
                 kwargs['upstream_slush'] = upstream_slush
 
         try:
-            result_str = node.agent.execute(**kwargs)
+            result_str = self._execute_with_timeout(node.agent, kwargs)
             duration_ms = int((time.time() - node_start) * 1000)
 
             try:
@@ -302,6 +303,41 @@ class AgentGraph:
                 duration_ms=duration_ms,
                 status='error',
             )
+
+    def _execute_with_timeout(self, agent, kwargs):
+        """Execute an agent, enforcing the optional per-node timeout.
+
+        Mirrors AgentChain._execute_with_timeout. Raising TimeoutError here is
+        deliberate: _execute_node already turns any exception into an error
+        GraphNodeResult, so a timed-out node fails exactly like a raising one
+        and its dependents are skipped by the normal failure path.
+        """
+        if not self._node_timeout:
+            return agent.execute(**kwargs)
+
+        result = [None]
+        error = [None]
+
+        def run():
+            try:
+                result[0] = agent.execute(**kwargs)
+            except Exception as e:  # noqa: BLE001 - re-raised on the caller's thread
+                error[0] = e
+
+        # daemon=True: on timeout we abandon this worker, and a non-daemon
+        # thread would block interpreter exit until the node we gave up on
+        # finally returns -- making the timeout buy nothing.
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        thread.join(timeout=self._node_timeout / 1000)
+
+        if thread.is_alive():
+            raise TimeoutError(f"Node timeout after {self._node_timeout}ms")
+
+        if error[0] is not None:
+            raise error[0]
+
+        return result[0]
 
     def _should_skip(self, name, skipped, completed):
         """Determine whether a node should be skipped."""

--- a/python/tests/test_agent_graph.py
+++ b/python/tests/test_agent_graph.py
@@ -357,3 +357,103 @@ class TestParallelExecution:
         thread_ids = {a.thread_id for a in agents}
         # At least 2 different thread IDs (main thread won't be reused by executor)
         assert len(thread_ids) >= 2, f"Expected multiple threads, got {thread_ids}"
+
+
+# ---------------------------------------------------------------------------
+# Tests: node timeout
+#
+# node_timeout was accepted by the constructor and then never read, so Python
+# silently ignored a bound TypeScript has always enforced: a hung node hung the
+# whole graph forever. Measured before the fix -- a 100ms budget against a 3s
+# node returned after 3.03s and reported status "success".
+# ---------------------------------------------------------------------------
+
+class TestNodeTimeout:
+    def test_slow_node_times_out_and_fails(self):
+        graph = create_agent_graph({"node_timeout": 100})
+        graph.add_node(name="slow", agent=SlowAgent("Slow", delay=5.0))
+
+        started = time.time()
+        result = graph.run()
+        elapsed = time.time() - started
+
+        node = result.nodes["slow"]
+        assert node.status == "error"
+        assert "timeout" in node.result.get("message", "").lower()
+        # Released at the timeout, not at the sleeping node's own pace. Without
+        # this the test passes even when the timeout is ignored entirely.
+        assert elapsed < 1.0, f"run() took {elapsed:.2f}s for a 100ms node_timeout"
+
+    def test_timeout_message_matches_typescript(self):
+        """TS raises `Node timeout after ${nodeTimeout}ms`; Python must match."""
+        graph = create_agent_graph({"node_timeout": 100})
+        graph.add_node(name="slow", agent=SlowAgent("Slow", delay=5.0))
+
+        node = graph.run().nodes["slow"]
+        assert node.result["message"] == "Node timeout after 100ms"
+
+    def test_timed_out_node_skips_its_dependents(self):
+        """A timed-out node fails like any other, so dependents are skipped."""
+        graph = create_agent_graph({"node_timeout": 100})
+        graph.add_node(name="slow", agent=SlowAgent("Slow", delay=5.0))
+        graph.add_node(name="after", agent=EchoAgent("After"), depends_on=["slow"])
+
+        result = graph.run()
+
+        assert result.nodes["slow"].status == "error"
+        assert result.nodes["after"].status == "skipped"
+        assert result.status == "partial"
+
+    def test_fast_node_is_unaffected_by_a_generous_timeout(self):
+        """A node well inside its budget must not be failed or delayed."""
+        graph = create_agent_graph({"node_timeout": 10000})
+        graph.add_node(name="quick", agent=EchoAgent("Quick"))
+
+        started = time.time()
+        result = graph.run()
+        elapsed = time.time() - started
+
+        assert result.nodes["quick"].status == "success"
+        assert result.status == "success"
+        # The wait is bounded by the node, never by the timeout budget.
+        assert elapsed < 1.0, f"a fast node took {elapsed:.2f}s under a 10s budget"
+
+    def test_no_timeout_configured_lets_a_slow_node_finish(self):
+        """The timeout is opt-in: unset means unbounded, as before."""
+        graph = create_agent_graph()
+        graph.add_node(name="slow", agent=SlowAgent("Slow", delay=0.3))
+
+        result = graph.run()
+        assert result.nodes["slow"].status == "success"
+
+    def test_abandoned_worker_is_a_daemon_so_it_cannot_block_exit(self):
+        before = set(threading.enumerate())
+
+        graph = create_agent_graph({"node_timeout": 100})
+        graph.add_node(name="slow", agent=SlowAgent("Slow", delay=5.0))
+        assert graph.run().nodes["slow"].status == "error"
+
+        survivors = [
+            t for t in threading.enumerate()
+            if t not in before and t.is_alive()
+        ]
+        # Anti-vacuity: `all(...)` over an empty list passes and proves nothing,
+        # so first pin that the abandoned worker really is still running.
+        assert survivors, "expected the abandoned node worker to still be alive"
+        non_daemon = [t.name for t in survivors if not t.daemon]
+        assert not non_daemon, (
+            "these workers outlive the timeout as non-daemon threads and will "
+            f"block interpreter exit until the node finishes: {non_daemon}"
+        )
+
+    def test_timeout_applies_on_the_sequential_path_too(self):
+        """run() has two dispatch branches; parallel=False must be bounded too."""
+        graph = create_agent_graph({"node_timeout": 100, "parallel": False})
+        graph.add_node(name="slow", agent=SlowAgent("Slow", delay=5.0))
+
+        started = time.time()
+        result = graph.run()
+        elapsed = time.time() - started
+
+        assert result.nodes["slow"].status == "error"
+        assert elapsed < 1.0, f"sequential path took {elapsed:.2f}s for a 100ms timeout"


### PR DESCRIPTION
`AgentGraph.__init__` stored the option and nothing ever read it:

```python
self._node_timeout = options.get('node_timeout')
```

That assignment was **the only line in `graph.py` matching "timeout"**. The option was accepted, stored, and silently dropped — so a hung node hung the whole graph forever, with no bound at all.

This is a parity gap, not just a dead field. TypeScript's `AgentGraph` enforces `nodeTimeout` and has had a test for it all along, and the option is documented as part of `GraphOptions` in **both `CLAUDE.md:135` and the Obsidian vault**. The bound was promised in three places and applied in one.

## Measured

Before, with a 100 ms `node_timeout` against a 3 s node:

```
node_timeout=100ms   node sleeps 3.0s
ELAPSED       = 3.03s
GRAPH_STATUS  = success
NODE_STATUS   = success
NODE_MESSAGE  = None
```

The caller waited **30× its stated budget** and was then told the node *succeeded*. That is worse than merely slow: nothing in the result reveals the budget was blown, so no caller could detect it.

After:

```
ELAPSED       = 0.10s
GRAPH_STATUS  = partial
NODE_STATUS   = error
NODE_MESSAGE  = Node timeout after 100ms
```

## The implementation

Mirrors `AgentChain._execute_with_timeout`, including `daemon=True` on the worker — the lesson from #403. A non-daemon worker abandoned on timeout blocks interpreter exit until the node we gave up on finally returns, which would have handed straight back the latency the timeout just saved. The process exits in 0.22 s.

Raising `TimeoutError` is deliberate: `_execute_node` already converts any exception into an error `GraphNodeResult`, so a timed-out node fails exactly like a raising one and its dependents skip via the existing failure path — **no new branch**.

Parity was checked in three specifics, not assumed:

| | TypeScript | Python (now) |
|---|---|---|
| node status on timeout | `'error'` | `'error'` |
| message | `Node timeout after ${nodeTimeout}ms` | `Node timeout after 100ms` |
| aggregate status | `partial` when any error/skip | `partial` (rule already identical) |

Both dispatch branches in `run()` funnel through `_execute_node`, so the parallel `ThreadPoolExecutor` path and the sequential `parallel=False` path are both bounded. There is a test for each.

## Tests — 7

The timeout fires and fails the node; the message matches TypeScript; dependents are skipped; a fast node under a generous budget is neither failed nor delayed; an unset timeout still means unbounded (the option stays opt-in); the abandoned worker is a daemon; and the sequential path is bounded too.

The **timing assertions are the anti-vacuity guards**. Without asserting that `run()` returned in well under the node's own duration, every one of these tests passes just as well when the timeout is ignored — which is exactly the bug being fixed:

```python
assert elapsed < 1.0, f"run() took {elapsed:.2f}s for a 100ms node_timeout"
```

## Mutation testing — 5 mutations, all caught

| mutation | caught by |
|---|---|
| restore the dead option (never call the wrapper) | the timeout tests |
| drop `daemon=True` | the daemon test **only** |
| treat `node_timeout` as **seconds** not ms | 4 tests |
| wrong timeout message | the 2 message assertions **only** |
| force the timeout on, ignoring the opt-out | the opt-out test + 8 pre-existing tests |

The units mutation is the one I most wanted covered: ms/seconds confusion is the classic way a timeout silently becomes 1000× too generous and looks fine in every test that doesn't measure elapsed time.

## Validation

- `python` — **2117 passed** / 6 skipped (baseline 2110, exactly +7)
- `conformance.py` — 8 passed, 0 failed, 1 skipped
- `parity_harness.py --runtime both` — PASS
- **No TypeScript files are touched by this change.**
