### PR TITLE
fix(python): add StreamManager.delete_session for TS parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Python's `StreamManager` had no way to free a session. The class mirrors
+  TypeScript's `StreamManager` and its module docstring said so explicitly, but
+  TypeScript ships a tested `deleteSession()` that removes a session and its
+  subscribers, and Python shipped no removal method at all -- the entire public
+  API was `create_session`, `complete`, `error`, `get_session`, `push_block`,
+  `push_delta`, `on_block`, `active_sessions`. `complete()` and `error()` only
+  flip `status` and stamp `completed_at`; they never remove. Because sessions are
+  deliberately retained after completion so the transcript stays readable,
+  nothing was ever reclaimed, and each session holds its full `blocks` content.
+  Measured before the fix: 100 sessions created, pushed to, and completed left
+  `len(_sessions) == 100`, `len(_subscribers) == 100` and 977 KB of block content
+  pinned, growing monotonically, while `active_sessions` reported `0` -- the
+  manager's own health metric said nothing was active while a megabyte was held.
+  After the fix the same churn loop stays flat at 0 sessions, 0 subscribers and
+  0 KB. `delete_session()` clears both `_sessions` and `_subscribers`, is a no-op
+  on an unknown id, and returns `None` to match the TypeScript `void` signature
+  rather than a more useful bool, since the justification for the change is
+  parity. `complete()` deliberately still does not evict, so reading a finished
+  transcript keeps working. This was one of two public-API divergences found by
+  diffing the two classes method-for-method; the other, TypeScript's
+  `setGateway()` WebSocket transport hook, is not ported and is now named as a
+  known exception in the Python module docstring instead of being papered over by
+  a blanket "mirrors the TypeScript API" claim.
 - Corrected `fable5/reports/code-review.md`, whose top-ranked finding was
   fabricated. The report's #1 top priority -- HIGH severity, described as
   "verified directly in source" -- claimed Python's `AgentChain`/`AgentGraph`
@@ -27,8 +50,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   830-835). All original wording is preserved and annotated inline so the record
   of what was claimed stays auditable. Two neighbouring claims were graded
   separately and survive: the `chain.py` `daemon=True` thread leak (confirmed,
-  fixed in #403) and `streaming.py` `_sessions` never being evicted (plausible,
-  still open).
+  fixed in #403) and `streaming.py` `_sessions` never being evicted (plausible
+  when written, since confirmed and fixed by the `delete_session` entry above).
 - Python's `AgentGraph` accepted a `node_timeout` and then ignored it. The
   constructor stored `self._node_timeout` and nothing ever read it again -- that
   assignment was the only line in the whole file matching "timeout" -- so a node

--- a/fable5/reports/code-review.md
+++ b/fable5/reports/code-review.md
@@ -27,7 +27,7 @@ Two findings in the same cluster were graded separately and **survive**:
 | Report line | Claim | Verdict |
 |---|---|---|
 | 173 | `chain.py` timeout threads not marked `daemon=True` | **CONFIRMED AND FIXED** in PR #403. Substantively correct and reproducible: a slow step kept the interpreter alive after `join()` returned (process exit 5.14s to 0.33s once fixed). |
-| 179 | `streaming.py` `_sessions` never evicted | **PLAUSIBLE, OPEN.** `_sessions` is real and, unlike `_subscribers` (deleted at line 154), is never deleted anywhere in the module. Not yet proven to be an observable leak; tracked as a lead, not a confirmed defect. |
+| 179 | `streaming.py` `_sessions` never evicted | **CONFIRMED AND FIXED.** Upgraded from PLAUSIBLE after measurement: 100 created-and-completed sessions retained 977 KB with no public API to release them, while `active_sessions` reported `0`. `delete_session()` added for parity with TypeScript's tested `deleteSession()`. |
 
 ### Why this is worse than a bad citation
 
@@ -214,7 +214,7 @@ _Fable 5 review of openrappter (Python/TypeScript) identified 9 findings across 
   - Fix: Wrap token.set() calls in try/finally to ensure tokens are always reset, or initialize context_snapshot to empty dict in execute() before setting token.
 - **🟠 MEDIUM — Streaming Manager Sessions Never Evicted - Unbounded Memory Growth** (gateway/streaming.py - Stream session lifecycle)
   - Evidence: `gateway/streaming.py:52-68, 70-77, 88-90 - _sessions dict grows indefinitely. create_session() adds entries, complete()/error() mark them done but never delete. No cleanup of completed sessions anywhere in the module.`
-  - **PLAUSIBLE, OPEN (2026-08-20).** `_sessions` is real, and unlike `_subscribers` (deleted at `streaming.py:154`) it is never deleted anywhere in the module. Not yet proven to produce an observable leak; tracked as a lead rather than a confirmed defect.
+  - **CONFIRMED AND FIXED (2026-08-20).** Upgraded from PLAUSIBLE after measurement. A churn loop of 100 sessions -- each created, pushed to, and completed -- left `len(_sessions) == 100`, `len(_subscribers) == 100` and 977 KB of block content retained, growing monotonically, while `active_sessions` reported `0`. The public API contained no method capable of removing a session. Fixed by adding `delete_session()`, mirroring TypeScript's tested `deleteSession()` at `streaming.ts:198`. Note the severity framing above is broader than the evidence supports: Python's `stream_manager` singleton has no production callers today, so this was a latent public-API defect rather than an active production leak.
   - Fix: Add explicit delete(session_id) method and call it from handlers after status is transmitted to client, or implement LRU eviction with max_sessions limit.
 - **🟠 MEDIUM — JSON Serialization Error Path in Python Gateway Does Not Preserve Request ID** (gateway/server.py - RPC error handling)
   - Evidence: `gateway/server.py:756-774 - If json.dumps(result) succeeds but json.loads(encoded) fails with RecursionError/OverflowError (line 764), error frame is sent. However, this catches ALL serialization issues after result is computed. Better to validate result schema earlier.`

--- a/python/openrappter/gateway/streaming.py
+++ b/python/openrappter/gateway/streaming.py
@@ -6,7 +6,13 @@ StreamBlock is the atomic unit of streamed output. Each block has a type
 accumulate content via deltas before being marked done.
 
 StreamManager maintains sessions keyed by a caller-supplied id, notifies
-subscribers on every mutation, and mirrors the TypeScript StreamManager API.
+subscribers on every mutation, and mirrors the TypeScript StreamManager API
+with one known exception: the TS class also accepts a GatewayBroadcaster
+(constructor arg + setGateway) to push blocks over WebSocket. That transport
+hook is not ported here, so callers must drive delivery via on_block.
+
+Sessions are retained after complete()/error() so the finished transcript
+stays readable; call delete_session() to reclaim them.
 """
 
 from __future__ import annotations
@@ -154,6 +160,23 @@ class StreamManager:
                     del self._subscribers[session_id]
 
         return unsubscribe
+
+    # ── Cleanup ────────────────────────────────────────────────────────────
+
+    def delete_session(self, session_id: str) -> None:
+        """Remove a session and its subscribers from memory.
+
+        Sessions are retained after ``complete()``/``error()`` so callers can
+        still read the finished transcript via ``get_session()``. That means
+        nothing is reclaimed until this is called: without it a long-lived
+        manager grows without bound, because every session holds its full
+        ``blocks`` content.
+
+        Deleting an unknown session id is a no-op, mirroring the TypeScript
+        ``deleteSession``. Returns None (not a bool) to match that signature.
+        """
+        self._sessions.pop(session_id, None)
+        self._subscribers.pop(session_id, None)
 
     # ── Computed properties ────────────────────────────────────────────────
 

--- a/python/tests/test_showcase_stream_weaver.py
+++ b/python/tests/test_showcase_stream_weaver.py
@@ -165,3 +165,90 @@ class TestActiveSessionsCount:
         manager.error("sess_2")
 
         assert manager.active_sessions == 1
+
+
+# ---------------------------------------------------------------------------
+# Session cleanup
+#
+# Mirrors typescript/src/gateway/__tests__/streaming.test.ts
+# "deleteSession removes session and subscribers".
+# ---------------------------------------------------------------------------
+
+class TestDeleteSession:
+    def test_delete_session_removes_session(self):
+        manager = StreamManager()
+        manager.create_session("del_1")
+
+        manager.delete_session("del_1")
+
+        assert manager.get_session("del_1") is None
+
+    def test_delete_session_removes_subscribers(self):
+        """A stale callback must not fire for a later session reusing the id.
+
+        This is the assertion that proves _subscribers was cleared too:
+        checking get_session() alone would still pass if only _sessions
+        were popped.
+        """
+        manager = StreamManager()
+        manager.create_session("del_1")
+        received = []
+        manager.on_block("del_1", lambda block, session: received.append(block))
+
+        manager.delete_session("del_1")
+
+        manager.create_session("del_1")
+        manager.push_block("del_1", "text", "after delete")
+
+        assert received == []
+
+    def test_delete_unknown_session_is_noop(self):
+        manager = StreamManager()
+        manager.create_session("keep")
+
+        manager.delete_session("never_existed")
+
+        assert manager.get_session("keep") is not None
+
+    def test_delete_session_leaves_other_sessions_intact(self):
+        manager = StreamManager()
+        manager.create_session("sess_1")
+        manager.create_session("sess_2")
+        manager.push_block("sess_2", "text", "kept")
+
+        manager.delete_session("sess_1")
+
+        assert manager.get_session("sess_1") is None
+        survivor = manager.get_session("sess_2")
+        assert survivor is not None
+        assert len(survivor.blocks) == 1
+
+    def test_completed_sessions_are_retained_until_deleted(self):
+        """complete() must NOT evict: callers still read the finished transcript.
+
+        Retention is intentional, which is exactly why an explicit deletion
+        method has to exist -- otherwise nothing is ever reclaimed.
+        """
+        manager = StreamManager()
+        for n in range(10):
+            sid = f"sess_{n}"
+            manager.create_session(sid)
+            manager.push_block(sid, "text", "payload")
+            manager.complete(sid)
+
+        # Every session is finished, yet all are still held.
+        assert manager.active_sessions == 0
+        assert len(manager._sessions) == 10
+        assert manager.get_session("sess_0") is not None
+
+        for n in range(10):
+            manager.delete_session(f"sess_{n}")
+
+        assert len(manager._sessions) == 0
+        assert len(manager._subscribers) == 0
+
+    def test_delete_session_matches_typescript_void_return(self):
+        manager = StreamManager()
+        manager.create_session("sess_1")
+
+        assert manager.delete_session("sess_1") is None


### PR DESCRIPTION
## Python's `StreamManager` had no way to free a session

`python/openrappter/gateway/streaming.py` mirrors `typescript/src/gateway/streaming.ts`, and its module docstring said so in as many words: *"mirrors the TypeScript StreamManager API."*

TypeScript ships a **tested** cleanup method:

```ts
// streaming.ts:198
deleteSession(sessionId: string): void {
  this.sessions.delete(sessionId);
  this.subscribers.delete(sessionId);
}
```

Python's entire public API was `create_session`, `complete`, `error`, `get_session`, `push_block`, `push_delta`, `on_block`, `active_sessions`. **No removal method existed.** `complete()` and `error()` only flip `status` and stamp `completed_at`.

Sessions are retained after completion *on purpose*, so a caller can still read the finished transcript. That is a reasonable design — but it means nothing is ever reclaimed unless an explicit deletion method exists, and each session holds its full `blocks` content.

## Measured, not assumed

A churn loop creating, pushing 10 KB to, and completing sessions:

| cycle | `len(_sessions)` | `len(_subscribers)` | retained | `active_sessions` |
|------:|-----------------:|--------------------:|---------:|------------------:|
| 1 | 20 | 20 | 195 KB | 0 |
| 2 | 40 | 40 | 391 KB | 0 |
| 3 | 60 | 60 | 586 KB | 0 |
| 4 | 80 | 80 | 781 KB | 0 |
| 5 | 100 | 100 | **977 KB** | **0** |

Every session is `complete`. The manager's own health metric reports **`active_sessions == 0`** while a megabyte is pinned — so the one number an operator would watch actively conceals the retention. Scanning the public API for anything that could release it (`delete`/`remove`/`clear`/`close`/`evict`/`prune`/`reset`) returned **`NONE`**.

After the fix, the identical loop stays flat at **0 sessions / 0 subscribers / 0 KB** across all five cycles.

## Found by a method-for-method API diff

Rather than eyeballing it, I extracted both public surfaces and mapped `camelCase` → `snake_case` (with an anti-vacuity floor so a broken extractor can't report a comforting "no divergence"):

```
TS public methods (10): activeSessions, complete, createSession, deleteSession,
                        error, getSession, onBlock, pushBlock, pushDelta, setGateway
PY public methods  (8): active_sessions, complete, create_session,
                        error, get_session, on_block, push_block, push_delta

IN TS BUT NOT PYTHON (2):
   - deleteSession -> delete_session   MISSING
   - setGateway    -> set_gateway      MISSING
```

The repo's own `ts-python-parity-check` skill classifies "a public method exists on one side but not the other" as a **blocking** API divergence, and `CLAUDE.md` makes TS↔Python parity a core invariant.

**Only `deleteSession` is ported here.** `setGateway` is a whole WebSocket transport hook (`GatewayBroadcaster`) with no Python consumer; speculatively porting it would be a much larger change, so it is instead **named as a known exception in the module docstring** rather than left covered by a blanket "mirrors the TypeScript API" claim that was not true. Divergence goes 2 → 1, and the remaining one is now documented instead of silent.

## Deliberate design decisions

- **Returns `None`, not `bool`.** A bool would be more useful, but TS returns `void`. Closing a parity gap by opening a smaller one would undercut the entire justification for the change. M3 pins this.
- **`complete()` still does not evict.** Auto-eviction would break reading a finished transcript, and TS doesn't do it either. M5 pins this.
- **Unknown id is a no-op**, mirroring `Map.delete`. M4 pins this.

## Mutation testing — 5/5, each caught by its specific test

| # | Mutation | Test that failed |
|---|----------|------------------|
| M1 | `_sessions.pop` removed | `test_delete_session_removes_session` (+2 others) |
| M2 | `_subscribers.pop` removed | `test_delete_session_removes_subscribers` — **only this one** |
| M3 | returns `bool` instead of `None` | `test_delete_session_matches_typescript_void_return` — only this one |
| M4 | raises on unknown id | `test_delete_unknown_session_is_noop` — only this one |
| M5 | `complete()` auto-evicts | `test_completed_sessions_are_retained_until_deleted` — only this one |

M2 is the load-bearing one. It mirrors the TS test's technique: delete the session, **re-create it under the same id**, push a block, and assert the stale callback never fires. Asserting `get_session() is None` alone would still pass with `_subscribers` leaking. Source restored byte-identical afterwards.

This mirrors `typescript/src/gateway/__tests__/streaming.test.ts:85` *"deleteSession removes session and subscribers"*.

## Correcting my own framing

I originally logged this as a production memory leak. **It is not one, and I've said so in the code review rather than quietly shipping the stronger claim.** Python's `stream_manager` singleton has **zero production callers** — only `__all__` exports and tests. This is a *latent public-API defect*: `StreamManager` is publicly exported, fully functional (not a stub), and any consumer of it has no way to free a session. That is worth fixing, but it is not an active leak, and the report's "unbounded memory growth" severity framing is broader than the evidence supports. The fable5 finding is upgraded PLAUSIBLE → CONFIRMED **with that qualifier attached**.

## Verification

- [x] Retention measured before (977 KB, monotonic) and after (flat 0 KB)
- [x] API diff 2 divergences → 1, remainder documented
- [x] 5/5 mutations caught by their **specific** test; source restored byte-identical
- [x] Full Python suite **2128 passed / 6 skipped** (was 2122; +6 new tests), no regressions
- [x] `parity_harness.py --runtime both` → PASS 15/15
- [x] `conformance.py` → 8 passed / 0 failed / 1 skipped
- [x] Citation gate re-run **after committing** (the round-190 lesson: a git-dependent test must be validated in the tracked state)

## Follow-up, not bundled

The `ts-python-parity-check` skill's mapping lists `gateway` as having **no Python counterpart**, but `python/openrappter/gateway/streaming.py` plainly exists. That stale mapping is likely why this divergence went unnoticed — worth a separate fix.
