### PR TITLE
fix(parity): stop the parity map from declaring shipped Python code absent

### DIFF
--- a/.claude/skills/ts-python-parity-check/SKILL.md
+++ b/.claude/skills/ts-python-parity-check/SKILL.md
@@ -24,9 +24,9 @@ All paths relative to repo root `/Users/rapptertwo/Documents/GitHub/openrappter`
 | BasicAgent    | `typescript/src/agents/BasicAgent.ts`       | `python/openrappter/agents/basic_agent.py`         | `typescript/src/__tests__/parity/data-sloshing.test.ts` | `python/tests/test_basic_agent.py`         |
 | ShellAgent    | `typescript/src/agents/ShellAgent.ts`       | `python/openrappter/agents/shell_agent.py`         | `typescript/src/agents/ShellAgent.test.ts`            | `python/tests/test_shell_agent.py`          |
 | LearnNewAgent | `typescript/src/agents/LearnNewAgent.ts`    | `python/openrappter/agents/learn_new_agent.py`     | `typescript/src/__tests__/parity/learn-new-agent.test.ts` | `python/tests/test_learn_new_agent.py`  |
-| broadcast     | `typescript/src/agents/broadcast.ts`        | `python/openrappter/agents/broadcast.py`           | `typescript/src/__tests__/parity/multiagent.test.ts`  | `python/tests/test_broadcast.py`            |
-| router        | `typescript/src/agents/router.ts`           | `python/openrappter/agents/router.py`              | `typescript/src/__tests__/parity/multiagent.test.ts`  | `python/tests/test_router.py`               |
-| subagent      | `typescript/src/agents/subagent.ts`         | `python/openrappter/agents/subagent.py`            | `typescript/src/__tests__/parity/multiagent.test.ts`  | `python/tests/test_subagent.py`             |
+| broadcast     | `typescript/src/agents/broadcast.ts`        | `python/openrappter/agents/broadcast.py`           | `typescript/src/__tests__/integration/agents.test.ts` | `python/tests/test_broadcast.py`            |
+| router        | `typescript/src/agents/router.ts`           | `python/openrappter/agents/router.py`              | `typescript/src/__tests__/integration/agents.test.ts` | `python/tests/test_router.py`               |
+| subagent      | `typescript/src/agents/subagent.ts`         | `python/openrappter/agents/subagent.py`            | `typescript/src/__tests__/integration/agents.test.ts` | `python/tests/test_subagent.py`             |
 | chain         | `typescript/src/agents/chain.ts`            | `python/openrappter/agents/chain.py`               | `typescript/src/__tests__/parity/agent-chain.test.ts` | `python/tests/test_agent_chain.py`          |
 | graph         | `typescript/src/agents/graph.ts`            | `python/openrappter/agents/graph.py`               | `typescript/src/__tests__/parity/agent-graph.test.ts` | `python/tests/test_agent_graph.py`          |
 | tracer        | `typescript/src/agents/tracer.ts`           | `python/openrappter/agents/tracer.py`              | `typescript/src/__tests__/parity/agent-tracer.test.ts`| `python/tests/test_agent_tracer.py`         |
@@ -35,11 +35,27 @@ All paths relative to repo root `/Users/rapptertwo/Documents/GitHub/openrappter`
 | code_review   | `typescript/src/agents/CodeReviewAgent.ts`  | `python/openrappter/agents/code_review_agent.py`   | `typescript/src/__tests__/parity/code-review.test.ts` | `python/tests/test_code_review.py`          |
 | web_agent     | `typescript/src/agents/WebAgent.ts`         | `python/openrappter/agents/web_agent.py`           | `typescript/src/__tests__/parity/tool-agents.test.ts` | `python/tests/test_web_agent.py`            |
 | clawhub       | `typescript/src/clawhub.ts`                 | `python/openrappter/clawhub.py`                    | `typescript/src/__tests__/parity/skills.test.ts`      | `python/tests/test_module_exports.py`       |
+| watchmaker    | `typescript/src/agents/WatchmakerAgent.ts`  | `python/openrappter/agents/watchmaker_agent.py`    | `typescript/src/__tests__/parity/watchmaker.test.ts`  | `python/tests/test_showcase_watchmaker.py`  |
+| mcp           | `typescript/src/mcp/server.ts`              | `python/openrappter/mcp/server.py`                 | `typescript/src/__tests__/parity/mcp-server.test.ts`  | none — see note below                       |
+| gateway/server | `typescript/src/gateway/server.ts`         | `python/openrappter/gateway/server.py`             | `typescript/src/__tests__/parity/gateway-rpc-methods.test.ts` | `python/tests/test_gateway_rpc_parity.py` |
+| gateway/streaming | `typescript/src/gateway/streaming.ts`   | `python/openrappter/gateway/streaming.py`          | `typescript/src/gateway/__tests__/streaming.test.ts`  | `python/tests/test_showcase_stream_weaver.py` |
+| gateway/dashboard | `typescript/src/gateway/dashboard.ts`   | `python/openrappter/gateway/dashboard.py`          | `typescript/src/__tests__/parity/showcase-living-dashboard.test.ts` | `python/tests/test_showcase_living_dashboard.py` |
+| gateway/observability | `typescript/src/gateway/observability.ts` | `python/openrappter/gateway/observability.py` | `typescript/src/__tests__/integration/gateway-observability.test.ts` | `python/tests/test_gateway_observability.py` |
 
 Notes:
 - The Memory agent splits in Python: `context_memory_agent.py` + `manage_memory_agent.py` mirror one TS `MemoryAgent.ts`. Treat both Python files as the pair. Python parity test: `python/tests/test_memory_agents.py`.
 - If a filename isn't listed, resolve it by convention: TS `CamelCase.ts` ⇔ Python `snake_case.py`; multi-agent primitives (`broadcast`/`router`/`subagent`/`chain`/`graph`/`tracer`) keep their lowercase names in both languages.
-- If a pair genuinely has no Python counterpart yet (e.g. `OuroborosAgent`, `WatchmakerAgent`, gateway/UI), say so explicitly in the report — that's a real divergence to flag, not a silent pass.
+- If a pair genuinely has no Python counterpart yet, say so explicitly in the report — that's a real divergence to flag, not a silent pass. Resolve absence against the authoritative list in [Modules with no Python counterpart](#modules-with-no-python-counterpart) rather than from memory.
+- The `mcp` pair has no dedicated Python parity test; `python/tests/test_module_exports.py` only asserts the module imports. Treat MCP behavioral parity as unverified on the Python side.
+
+## Modules with no Python counterpart
+
+Authoritative list, pinned by `python/tests/test_parity_map.py`. A module named
+here is skipped by parity audits, so a wrong entry silently removes shipped code
+from every audit — add one only after confirming no Python module exists.
+
+- `OuroborosAgent` -- TS-only self-modification agent; no Python module exists.
+- `UI` -- the web UI is TypeScript/Lit only; Python ships no UI layer.
 
 ## Procedure
 
@@ -154,4 +170,4 @@ PARITY OK ✅  |  DIVERGENCE ❌ — <one-line summary>
 - **A skipped or failing suite is never a pass.** If either suite can't run, the verdict is at best "UNKNOWN — <reason>", never "PARITY OK".
 - **Don't touch the main worktree or other worktrees.** Stay in the current working directory per repo worktree etiquette. Ignore `.claude/worktrees/` and `openclaw/` submodule drift in `git status`.
 - **No new report files.** Return the report as your message; do not create `.md` files.
-- **Missing counterpart ≠ silent pass.** If a module exists in TS but has no Python mirror (e.g. `OuroborosAgent`, `WatchmakerAgent`, gateway/UI/MCP), state that as an explicit divergence/limitation in the report.
+- **Missing counterpart ≠ silent pass.** If a module exists in TS but has no Python mirror, state that as an explicit divergence/limitation in the report — but resolve absence against [Modules with no Python counterpart](#modules-with-no-python-counterpart), never from memory. `gateway`, `WatchmakerAgent`, and `mcp` were each wrongly listed as Python-less here while shipping ~2,460 lines of Python, which removed all three from every audit that trusted this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The TS<->Python parity map (`.claude/skills/ts-python-parity-check/SKILL.md`)
+  told auditors that three shipped subsystems did not exist in Python. It
+  listed `gateway`, `WatchmakerAgent`, and `mcp` as having "no Python
+  counterpart" while Python ships ~2,460 lines across them, including the
+  production `GatewayServer` wired up at `cli.py:1234`. Because the skill's
+  rule is "missing counterpart -> flag as a limitation," a wrong absence claim
+  does not warn -- it instructs the audit to skip real code, so those modules
+  were silently excluded from every parity check that trusted the map. This is
+  the likely reason the missing `StreamManager.delete_session` (previous entry)
+  went unnoticed. The map also cited a TS parity test,
+  `__tests__/parity/multiagent.test.ts`, that does not exist anywhere in the
+  repo, for `broadcast`/`router`/`subagent`.
+
+  Fixed by adding the seven missing pair rows, repointing the three phantom
+  test paths at `__tests__/integration/agents.test.ts` (which actually imports
+  `BroadcastManager`, `AgentRouter`, and `SubAgentManager`), and replacing the
+  two duplicated free-text absence claims with a single machine-checkable list
+  containing only the two genuine cases, `OuroborosAgent` and the UI. Added
+  `python/tests/test_parity_map.py`, which reads the map and fails if any path
+  it names is missing or if any module it declares absent has Python code --
+  so the map can no longer drift from the filesystem unnoticed. Also recorded
+  that `mcp` has no Python parity test, making that coverage gap explicit
+  rather than implied.
+
 - Python's `StreamManager` had no way to free a session. The class mirrors
   TypeScript's `StreamManager` and its module docstring said so explicitly, but
   TypeScript ships a tested `deleteSession()` that removes a session and its

--- a/python/tests/test_parity_map.py
+++ b/python/tests/test_parity_map.py
@@ -1,0 +1,163 @@
+"""Accuracy gate for the TS<->Python parity map.
+
+``.claude/skills/ts-python-parity-check/SKILL.md`` calls its file-pair table the
+"source of truth" for parity audits, and it is: an auditor resolves a changed
+file to its mirror through that table. That makes the map load-bearing, and it
+makes one particular error silent and expensive -- a claim that a module has
+**no Python counterpart** when Python code for it exists. Such a claim does not
+produce a warning; it instructs the auditor to skip real, shipped code, so
+divergences in that module accumulate unnoticed and every audit reports a clean
+pass. A missing table row fails the same way.
+
+This gate checks the map against the filesystem in both directions:
+
+* every path the table names must exist (no dangling rows);
+* every module declared to have no Python counterpart must genuinely have none.
+
+Deliberately NOT checked:
+
+* Whether the two sides of a pair are *at parity*. That is the skill's job, and
+  it needs semantic comparison; this gate only asserts the map is not lying
+  about what exists.
+* Completeness of the table. Requiring a row for every Python module would
+  force rows for internal helpers that have no TS mirror by design, and a gate
+  that fails for benign reasons gets disabled. Absence claims are checked
+  because those are the ones that silence an audit.
+
+The filesystem is read directly rather than through ``git grep`` on purpose: a
+check whose result depends on whether a file has been committed yet passes
+locally on new files and fails in CI, or worse, the reverse.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SKILL = REPO_ROOT / ".claude/skills/ts-python-parity-check/SKILL.md"
+PY_PACKAGE = REPO_ROOT / "python/openrappter"
+
+# A pair-table row: | module | ts | python | ts test | py test |
+ROW = re.compile(r"^\|(?P<cells>.+)\|\s*$")
+BACKTICKED = re.compile(r"`([^`]+)`")
+
+# The structured absence list this gate pins. Prose may describe it, but exactly
+# one machine-readable copy may exist, so the two cannot drift apart.
+ABSENCE_HEADING = "## Modules with no Python counterpart"
+BULLET = re.compile(r"^-\s+`(?P<name>[^`]+)`\s*(?:--|—)\s*(?P<why>.+)$")
+
+# Anti-vacuity floors. Every silent false-clean this gate could suffer comes
+# from a regex that matched nothing, so a parse that finds implausibly little
+# is treated as a failure rather than a pass.
+MIN_PAIR_ROWS = 12
+MIN_ABSENCE_ENTRIES = 1
+
+
+def _skill_text() -> str:
+    assert SKILL.is_file(), f"parity skill not found at {SKILL}"
+    return SKILL.read_text(encoding="utf-8")
+
+
+def _pair_rows() -> list[tuple[str, list[str]]]:
+    """Return (module, [referenced paths]) for each pair-table row."""
+    rows: list[tuple[str, list[str]]] = []
+    for line in _skill_text().splitlines():
+        m = ROW.match(line.strip())
+        if not m:
+            continue
+        cells = [c.strip() for c in m.group("cells").split("|")]
+        if len(cells) < 2 or set(cells[0]) <= {"-", ":"}:
+            continue  # separator row
+        paths = [p for c in cells[1:] for p in BACKTICKED.findall(c) if "/" in p]
+        if paths:
+            rows.append((cells[0], paths))
+    return rows
+
+
+def _absence_entries() -> list[str]:
+    """Module names declared to have no Python counterpart."""
+    text = _skill_text()
+    start = text.find(ABSENCE_HEADING)
+    assert start != -1, (
+        f"{SKILL.name} must declare its absence claims under a "
+        f"{ABSENCE_HEADING!r} heading so they can be verified."
+    )
+    body = text[start + len(ABSENCE_HEADING) :]
+    end = body.find("\n## ")
+    if end != -1:
+        body = body[:end]
+    return [m.group("name") for line in body.splitlines() if (m := BULLET.match(line.strip()))]
+
+
+def _snake(name: str) -> str:
+    return re.sub(r"(?<!^)(?=[A-Z])", "_", name).lower()
+
+
+def _python_evidence(name: str) -> list[Path]:
+    """Python modules that would contradict a 'no Python counterpart' claim."""
+    stem = _snake(name)
+    hits: list[Path] = []
+    for path in PY_PACKAGE.rglob("*.py"):
+        if "__pycache__" in path.parts:
+            continue
+        # A module file named for it, or any module inside a package named for it.
+        if path.stem == stem or stem in {p.lower() for p in path.parent.parts}:
+            hits.append(path)
+    return sorted(hits)
+
+
+# ── The map must not name files that do not exist ──
+
+
+def test_pair_table_paths_all_exist() -> None:
+    rows = _pair_rows()
+    assert len(rows) >= MIN_PAIR_ROWS, (
+        f"parsed only {len(rows)} pair rows (floor {MIN_PAIR_ROWS}); the table "
+        "format likely changed and this gate is no longer reading it"
+    )
+    missing = [
+        f"{module}: {path}"
+        for module, paths in rows
+        for path in paths
+        if not (REPO_ROOT / path).exists()
+    ]
+    assert not missing, "parity map references paths that do not exist:\n  " + "\n  ".join(missing)
+
+
+# ── The map must not claim real code is absent ──
+
+
+def test_absence_claims_are_true() -> None:
+    entries = _absence_entries()
+    assert len(entries) >= MIN_ABSENCE_ENTRIES, (
+        f"parsed only {len(entries)} absence entries (floor {MIN_ABSENCE_ENTRIES}); "
+        "the bullet format likely changed and this gate is no longer reading it"
+    )
+    contradicted = []
+    for name in entries:
+        evidence = _python_evidence(name)
+        if evidence:
+            shown = ", ".join(str(p.relative_to(REPO_ROOT)) for p in evidence[:3])
+            contradicted.append(f"{name} -> {shown}")
+    assert not contradicted, (
+        "parity map claims these modules have no Python counterpart, but Python "
+        "code for them exists -- an audit told to skip them would silently pass "
+        "over shipped code:\n  " + "\n  ".join(contradicted)
+    )
+
+
+@pytest.mark.parametrize("name", ["gateway", "WatchmakerAgent", "mcp"])
+def test_regression_subsystems_are_never_declared_absent(name: str) -> None:
+    """These three were each wrongly declared absent while shipping in Python.
+
+    Pinned by name because the generic check above only holds while the resolver
+    keeps working; if ``_python_evidence`` ever silently stops finding modules,
+    the generic test degrades to a pass and this one still fails.
+    """
+    assert _python_evidence(name), f"expected Python code for {name}; resolver may be broken"
+    assert name not in _absence_entries(), (
+        f"{name} ships in Python and must not be declared absent in the parity map"
+    )


### PR DESCRIPTION
## The defect

`.claude/skills/ts-python-parity-check/SKILL.md` calls its file-pair table the **source of truth** for parity audits — it is how an auditor resolves a changed file to its mirror. In two places it declared that `gateway`, `WatchmakerAgent`, and `mcp` have **no Python counterpart**.

All three ship in Python, ~2,460 lines:

| Claimed absent | Actually exists | Lines |
|---|---|---|
| `gateway` | `python/openrappter/gateway/` — `server.py`, `streaming.py`, `dashboard.py`, `observability.py` | 1,671 |
| `WatchmakerAgent` | `python/openrappter/agents/watchmaker_agent.py` | 669 |
| `mcp` | `python/openrappter/mcp/server.py` | 112 |

`GatewayServer` is not dormant — it is constructed in production at `python/openrappter/cli.py:1234`.

**Why this is worse than a stale doc.** The skill's rule is *"missing counterpart → flag as a limitation."* A wrong absence claim therefore produces no warning. It instructs the audit to skip real, shipped code and report a clean pass. All three subsystems were silently excluded from every parity check that trusted the map — which is the likely reason the missing `StreamManager.delete_session` fixed in #406 went unnoticed for so long.

The table also cited `typescript/src/__tests__/parity/multiagent.test.ts` as the TS parity test for `broadcast`, `router`, and `subagent`. **That file does not exist anywhere in the repo.** I did not know about this one — the new gate found it.

## The fix

- Added the 7 missing pair rows (watchmaker, mcp, and the four gateway modules), each path verified to exist.
- Repointed the 3 phantom test paths at `__tests__/integration/agents.test.ts`, which actually imports `BroadcastManager`, `AgentRouter`, and `SubAgentManager`.
- Replaced the **two duplicated free-text absence claims** with one machine-checkable list. Duplication is how the two copies drifted; now there is a single source.
- The corrected list contains only the two genuine cases: `OuroborosAgent` (verified: no Python module) and the UI (verified: no Python UI layer).
- Recorded that `mcp` has **no** Python parity test, making that coverage gap explicit rather than implied by a blank cell.

## The guard

`python/tests/test_parity_map.py` reads the map and fails if:
1. any path it names does not exist, or
2. any module it declares absent has Python code.

Check 2 is the one that would have caught this bug. Check 1 caught the phantom test path I wasn't looking for.

It reads the **filesystem directly rather than via `git grep`** — deliberately. A check whose result depends on whether a file has been committed yet passes locally on new files and fails in CI, or the reverse. Re-verified in the committed state: 10 passed.

## Mutation testing

7/7 caught, each by its specific test:

| # | Mutation | Failed |
|---|---|---|
| M1 | `gateway` declared absent | generic + `[gateway]` case only |
| M2 | `WatchmakerAgent` declared absent | generic + `[WatchmakerAgent]` case only |
| M3 | `mcp` declared absent | generic + `[mcp]` case only |
| M4 | phantom test path restored | `test_pair_table_paths_all_exist` only |
| M5 | absence heading removed | all 4 absence tests |
| M6 | absence list emptied | anti-vacuity floor fired |
| M7 | pair table truncated | anti-vacuity floor fired |

M1–M3 are perfectly discriminating: each fails only its *own* parametrised case. M6/M7 exist because every silent false-clean I have shipped came from a regex that matched nothing — a parse finding implausibly little is treated as failure, not success.

Source restored byte-identical after the run.

## Scope, honestly

This does **not** fix any parity divergence. It fixes the map that decides whether divergences get looked for at all. The three subsystems it un-hides have never been audited; that work is now possible, not done. I also have not verified the table is *complete* — requiring a row per Python module would force rows for internal helpers with no TS mirror by design, and a gate that fails for benign reasons gets disabled. Absence claims are checked because those are the ones that silence an audit.

## Verification

- `python/tests/test_parity_map.py` — 5 passed
- Full Python suite — **2133 passed / 6 skipped** (was 2128; +5 new). No regressions.
- Citation gate re-run post-commit — 5 passed
