### PR TITLE
fix(mcp): report structured agent failures as MCP tool errors in Python

### DIFF
--- a/.claude/skills/ts-python-parity-check/SKILL.md
+++ b/.claude/skills/ts-python-parity-check/SKILL.md
@@ -36,7 +36,7 @@ All paths relative to repo root `/Users/rapptertwo/Documents/GitHub/openrappter`
 | web_agent     | `typescript/src/agents/WebAgent.ts`         | `python/openrappter/agents/web_agent.py`           | `typescript/src/__tests__/parity/tool-agents.test.ts` | `python/tests/test_web_agent.py`            |
 | clawhub       | `typescript/src/clawhub.ts`                 | `python/openrappter/clawhub.py`                    | `typescript/src/__tests__/parity/skills.test.ts`      | `python/tests/test_module_exports.py`       |
 | watchmaker    | `typescript/src/agents/WatchmakerAgent.ts`  | `python/openrappter/agents/watchmaker_agent.py`    | `typescript/src/__tests__/parity/watchmaker.test.ts`  | `python/tests/test_showcase_watchmaker.py`  |
-| mcp           | `typescript/src/mcp/server.ts`              | `python/openrappter/mcp/server.py`                 | `typescript/src/__tests__/parity/mcp-server.test.ts`  | none — see note below                       |
+| mcp           | `typescript/src/mcp/server.ts`              | `python/openrappter/mcp/server.py`                 | `typescript/src/__tests__/parity/mcp-server.test.ts`  | `python/tests/test_mcp_server.py`           |
 | gateway/server | `typescript/src/gateway/server.ts`         | `python/openrappter/gateway/server.py`             | `typescript/src/__tests__/parity/gateway-rpc-methods.test.ts` | `python/tests/test_gateway_rpc_parity.py` |
 | gateway/streaming | `typescript/src/gateway/streaming.ts`   | `python/openrappter/gateway/streaming.py`          | `typescript/src/gateway/__tests__/streaming.test.ts`  | `python/tests/test_showcase_stream_weaver.py` |
 | gateway/dashboard | `typescript/src/gateway/dashboard.ts`   | `python/openrappter/gateway/dashboard.py`          | `typescript/src/__tests__/parity/showcase-living-dashboard.test.ts` | `python/tests/test_showcase_living_dashboard.py` |
@@ -46,7 +46,7 @@ Notes:
 - The Memory agent splits in Python: `context_memory_agent.py` + `manage_memory_agent.py` mirror one TS `MemoryAgent.ts`. Treat both Python files as the pair. Python parity test: `python/tests/test_memory_agents.py`.
 - If a filename isn't listed, resolve it by convention: TS `CamelCase.ts` ⇔ Python `snake_case.py`; multi-agent primitives (`broadcast`/`router`/`subagent`/`chain`/`graph`/`tracer`) keep their lowercase names in both languages.
 - If a pair genuinely has no Python counterpart yet, say so explicitly in the report — that's a real divergence to flag, not a silent pass. Resolve absence against the authoritative list in [Modules with no Python counterpart](#modules-with-no-python-counterpart) rather than from memory.
-- The `mcp` pair has no dedicated Python parity test; `python/tests/test_module_exports.py` only asserts the module imports. Treat MCP behavioral parity as unverified on the Python side.
+- The `mcp` pair covers a wire protocol, so parity means the bytes an external client receives — `protocolVersion`, `inputSchema` shape, and the `isError` flag — not just method names. Nothing in either codebase constructs `McpServer`, so an internal-callers search proves nothing about reachability here.
 
 ## Modules with no Python counterpart
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Python's MCP server diverged from TypeScript on five wire-visible points,
+  none of them covered by a test. The most serious: a tool whose agent
+  *resolved* with a structured `{"status": "error"}` envelope was reported to
+  the client as a **success**. TypeScript classifies that case through the
+  shared `agentResultIsError` helper and sets MCP's `isError` flag, and the
+  helper's own docstring states that every composition layer -- chain, graph,
+  broadcast, MCP, chat -- routes through it "so the two runtimes cannot drift
+  apart". Python ships the same classifier as `result_status.agent_result_is_error`
+  and already used it in chain, graph, subagent, and basic_agent; the MCP
+  server was the single layer that did not, so a declared failure reached the
+  client indistinguishable from success.
+
+  Also fixed, all confirmed by direct request/response capture: `initialize`
+  omitted the spec-required `protocolVersion` (TypeScript returns
+  `2024-11-05`, pinned by its parity test) so the response was not
+  spec-conformant; `tools/list` emitted `required: []` where TypeScript omits
+  the key entirely, which is not equivalent for strict schema validators;
+  `tools/call` returned an unknown-tool message of `Tool not found: X` against
+  TypeScript's `Unknown tool: X`; and JSON results were passed through
+  unformatted where TypeScript re-serialises with a 2-space indent, so
+  identical agent output rendered differently in the two runtimes.
+
+  Added `python/tests/test_mcp_server.py` (21 tests) mirroring
+  `typescript/src/__tests__/parity/mcp-server.test.ts`. The module previously
+  had no behavioral test at all -- `test_module_exports.py` only asserted that
+  it imports. One test pins the `isError` invariant against the shared
+  classifier itself rather than a hard-coded example, so the two cannot drift
+  again.
+
 - The TS<->Python parity map (`.claude/skills/ts-python-parity-check/SKILL.md`)
   told auditors that three shipped subsystems did not exist in Python. It
   listed `gateway`, `WatchmakerAgent`, and `mcp` as having "no Python

--- a/python/openrappter/mcp/server.py
+++ b/python/openrappter/mcp/server.py
@@ -10,6 +10,9 @@ Mirrors TypeScript mcp/server.ts
 import json
 
 from openrappter import __version__
+from openrappter.result_status import agent_result_is_error
+
+PROTOCOL_VERSION = '2024-11-05'
 
 
 class McpServer:
@@ -47,22 +50,16 @@ class McpServer:
 
         if method == 'initialize':
             return self._json_rpc_result(request_id, {
-                'serverInfo': self._server_info,
+                'protocolVersion': PROTOCOL_VERSION,
                 'capabilities': {'tools': {}},
+                'serverInfo': self._server_info,
             })
 
         if method == 'tools/list':
-            tools = []
-            for name, agent in self._agents.items():
-                meta = agent.metadata if hasattr(agent, 'metadata') else {}
-                tools.append({
-                    'name': name,
-                    'description': meta.get('description', ''),
-                    'inputSchema': meta.get(
-                        'parameters',
-                        {'type': 'object', 'properties': {}},
-                    ),
-                })
+            tools = [
+                self._agent_to_tool(name, agent)
+                for name, agent in self._agents.items()
+            ]
             return self._json_rpc_result(request_id, {'tools': tools})
 
         if method == 'tools/call':
@@ -71,19 +68,23 @@ class McpServer:
             agent = self._agents.get(tool_name)
             if not agent:
                 return self._json_rpc_error(
-                    request_id, -32602, f'Tool not found: {tool_name}'
+                    request_id, -32602, f'Unknown tool: {tool_name}'
                 )
 
             try:
                 result_str = agent.execute(**tool_args)
-                text = (
-                    result_str
-                    if isinstance(result_str, str)
-                    else json.dumps(result_str)
-                )
-                return self._json_rpc_result(request_id, {
-                    'content': [{'type': 'text', 'text': text}],
-                })
+                # An agent that *resolves* with {"status": "error"} has still
+                # failed. Every composition layer routes through the shared
+                # classifier so the two runtimes cannot drift apart.
+                contract_error = agent_result_is_error(result_str)
+                result = {
+                    'content': [
+                        {'type': 'text', 'text': self._render(result_str)}
+                    ],
+                }
+                if contract_error:
+                    result['isError'] = True
+                return self._json_rpc_result(request_id, result)
             except Exception as e:
                 return self._json_rpc_result(request_id, {
                     'isError': True,
@@ -100,6 +101,42 @@ class McpServer:
     # ------------------------------------------------------------------
     # Private helpers
     # ------------------------------------------------------------------
+
+    def _agent_to_tool(self, name, agent):
+        """Convert agent metadata to an MCP tool definition."""
+        meta = getattr(agent, 'metadata', None) or {}
+        parameters = meta.get('parameters') or {}
+        schema = {
+            'type': 'object',
+            'properties': parameters.get('properties', {}),
+        }
+        # Emit `required` only when non-empty: an empty list is not equivalent
+        # to omission for strict schema validators.
+        required = parameters.get('required') or []
+        if required:
+            schema['required'] = required
+        return {
+            'name': meta.get('name', name),
+            'description': meta.get('description', ''),
+            'inputSchema': schema,
+        }
+
+    def _render(self, result):
+        """Render an agent result as MCP text content.
+
+        JSON results are re-serialised with a stable indent so identical agent
+        output produces identical text in both runtimes; anything that is not
+        JSON passes through untouched.
+        """
+        content = result
+        if isinstance(result, str):
+            try:
+                content = json.loads(result)
+            except ValueError:
+                return result
+        if isinstance(content, str):
+            return content
+        return json.dumps(content, indent=2)
 
     def _json_rpc_result(self, request_id, result):
         return {'jsonrpc': '2.0', 'id': request_id, 'result': result}

--- a/python/tests/test_mcp_server.py
+++ b/python/tests/test_mcp_server.py
@@ -1,0 +1,289 @@
+"""Parity tests for the Python MCP server.
+
+Mirrors `typescript/src/__tests__/parity/mcp-server.test.ts`. Until this file
+existed, `python/openrappter/mcp/server.py` had no behavioral test at all --
+`test_module_exports.py` only asserted that the module imports. The parity map
+compounded that by listing `mcp` as having no Python counterpart, so audits
+skipped it entirely and five wire-visible divergences accumulated unnoticed.
+
+MCP is a wire protocol: its consumers are external clients, not this codebase.
+Nothing here constructs `McpServer`, so an internal-callers search finds no
+users and proves nothing about reachability. These tests assert the bytes an
+external client actually receives.
+
+Deliberately NOT checked:
+  * The stdio transport. TypeScript ships `serve()`/`stdio.ts`; the Python
+    module docstring says transport is handled externally. That is a
+    documented scope boundary, not a defect, so it is not asserted here.
+  * `recordInvocation` journalling. TypeScript-only observability with no
+    Python counterpart; a feature gap rather than a protocol divergence.
+"""
+
+import json
+
+import pytest
+
+from openrappter.agents.basic_agent import BasicAgent
+from openrappter.mcp import McpServer
+from openrappter.result_status import agent_result_is_error
+
+PROTOCOL_VERSION = '2024-11-05'
+
+
+def _meta(name, required=None, properties=None):
+    return {
+        'name': name,
+        'description': f'{name} description',
+        'parameters': {
+            'type': 'object',
+            'properties': properties if properties is not None else {},
+            'required': required if required is not None else [],
+        },
+    }
+
+
+class EchoAgent(BasicAgent):
+    def __init__(self):
+        super().__init__(
+            name='Echo',
+            metadata=_meta('Echo', properties={'text': {'type': 'string'}}),
+        )
+
+    def perform(self, **kwargs):
+        return json.dumps({'status': 'success', 'echo': kwargs.get('text', '')})
+
+
+class RequiredArgAgent(BasicAgent):
+    def __init__(self):
+        super().__init__(
+            name='NeedsArg',
+            metadata=_meta(
+                'NeedsArg',
+                required=['target'],
+                properties={'target': {'type': 'string'}},
+            ),
+        )
+
+    def perform(self, **kwargs):
+        return 'done'
+
+
+class ThrowingAgent(BasicAgent):
+    def __init__(self):
+        super().__init__(name='Thrower', metadata=_meta('Thrower'))
+
+    def perform(self, **kwargs):
+        raise RuntimeError('Intentional failure')
+
+
+class ContractFailAgent(BasicAgent):
+    """Resolves successfully but reports failure in the envelope."""
+
+    def __init__(self):
+        super().__init__(name='ContractFail', metadata=_meta('ContractFail'))
+
+    def perform(self, **kwargs):
+        return json.dumps({'status': 'error', 'message': 'Contract failure'})
+
+
+class PlainTextAgent(BasicAgent):
+    def __init__(self):
+        super().__init__(name='Plain', metadata=_meta('Plain'))
+
+    def perform(self, **kwargs):
+        return 'not json at all'
+
+
+def _server(*agents):
+    server = McpServer()
+    for agent in agents:
+        server.register_agent(agent)
+    return server
+
+
+def _call(server, method, params=None, request_id=1):
+    request = {'jsonrpc': '2.0', 'id': request_id, 'method': method}
+    if params is not None:
+        request['params'] = params
+    return server.handle_request(request)
+
+
+# ---------------------------------------------------------------- initialize
+
+
+def test_initialize_reports_protocol_version():
+    """The MCP spec requires protocolVersion in the initialize result.
+
+    TypeScript pins '2024-11-05' at parity/mcp-server.test.ts:229. Omitting it
+    is invisible to any caller that does not validate, which is why it lasted.
+    """
+    result = _call(_server(), 'initialize', {})['result']
+    assert result['protocolVersion'] == PROTOCOL_VERSION
+
+
+def test_initialize_reports_capabilities_and_server_info():
+    result = _call(_server(), 'initialize', {})['result']
+    assert result['capabilities'] == {'tools': {}}
+    assert result['serverInfo']['name'] == 'openrappter'
+    assert result['serverInfo']['version']
+
+
+def test_server_info_honours_options():
+    server = McpServer({'name': 'custom', 'version': '9.9.9'})
+    result = _call(server, 'initialize', {})['result']
+    assert result['serverInfo'] == {'name': 'custom', 'version': '9.9.9'}
+
+
+# ----------------------------------------------------------------- registry
+
+
+def test_registration_tracks_tools():
+    server = _server(EchoAgent())
+    assert server.tool_count == 1
+    assert server.has_tool('Echo')
+    assert not server.has_tool('Missing')
+
+
+# --------------------------------------------------------------- tools/list
+
+
+def test_tools_list_exposes_registered_agents():
+    tools = _call(_server(EchoAgent()), 'tools/list')['result']['tools']
+    assert len(tools) == 1
+    assert tools[0]['name'] == 'Echo'
+    assert tools[0]['description'] == 'Echo description'
+    assert tools[0]['inputSchema']['type'] == 'object'
+    assert tools[0]['inputSchema']['properties'] == {'text': {'type': 'string'}}
+
+
+def test_tools_list_omits_empty_required():
+    """TypeScript emits `required` only when non-empty (server.ts:105).
+
+    An empty `required: []` is not equivalent for strict schema validators,
+    which is why the two runtimes must agree on omission rather than shape.
+    """
+    tools = _call(_server(EchoAgent()), 'tools/list')['result']['tools']
+    assert 'required' not in tools[0]['inputSchema']
+
+
+def test_tools_list_keeps_non_empty_required():
+    tools = _call(_server(RequiredArgAgent()), 'tools/list')['result']['tools']
+    assert tools[0]['inputSchema']['required'] == ['target']
+
+
+# --------------------------------------------------------------- tools/call
+
+
+def test_tools_call_returns_text_content():
+    response = _call(
+        _server(EchoAgent()),
+        'tools/call',
+        {'name': 'Echo', 'arguments': {'text': 'hi'}},
+    )
+    content = response['result']['content']
+    assert content[0]['type'] == 'text'
+    assert json.loads(content[0]['text'])['echo'] == 'hi'
+
+
+def test_tools_call_pretty_prints_json_results():
+    """TypeScript re-serialises parsed JSON with 2-space indent (server.ts:180).
+
+    The text field is what a client renders to a human, so identical agent
+    output must produce identical text in both runtimes.
+    """
+    response = _call(
+        _server(EchoAgent()),
+        'tools/call',
+        {'name': 'Echo', 'arguments': {'text': 'hi'}},
+    )
+    text = response['result']['content'][0]['text']
+    assert text == json.dumps(
+        {'status': 'success', 'echo': 'hi'}, indent=2
+    )
+
+
+def test_tools_call_passes_through_non_json_results():
+    response = _call(
+        _server(PlainTextAgent()), 'tools/call', {'name': 'Plain', 'arguments': {}}
+    )
+    assert response['result']['content'][0]['text'] == 'not json at all'
+
+
+def test_tools_call_unknown_tool_is_invalid_params():
+    response = _call(
+        _server(), 'tools/call', {'name': 'NonExistent', 'arguments': {}}
+    )
+    assert response['error']['code'] == -32602
+    assert 'NonExistent' in response['error']['message']
+
+
+def test_tools_call_unknown_tool_message_matches_typescript():
+    response = _call(
+        _server(), 'tools/call', {'name': 'NonExistent', 'arguments': {}}
+    )
+    assert response['error']['message'] == 'Unknown tool: NonExistent'
+
+
+def test_tools_call_reports_raised_exceptions_as_tool_errors():
+    response = _call(
+        _server(ThrowingAgent()), 'tools/call', {'name': 'Thrower', 'arguments': {}}
+    )
+    assert 'error' not in response
+    assert response['result']['isError'] is True
+    assert 'Intentional failure' in response['result']['content'][0]['text']
+
+
+def test_tools_call_marks_structured_agent_errors_as_tool_errors():
+    """An agent that *resolves* with {"status": "error"} has still failed.
+
+    `result_status.agent_result_is_error` is the shared classifier and its
+    TypeScript twin documents that every composition layer -- chain, graph,
+    broadcast, MCP, chat -- must route through it so the runtimes cannot
+    drift. The Python MCP server was the one layer that did not, so it
+    reported a declared failure to the client as a success.
+    """
+    response = _call(
+        _server(ContractFailAgent()),
+        'tools/call',
+        {'name': 'ContractFail', 'arguments': {}},
+    )
+    assert 'error' not in response
+    assert response['result']['isError'] is True
+    assert 'Contract failure' in response['result']['content'][0]['text']
+
+
+def test_successful_call_does_not_set_is_error():
+    response = _call(
+        _server(EchoAgent()), 'tools/call', {'name': 'Echo', 'arguments': {'text': 'x'}}
+    )
+    assert 'isError' not in response['result']
+
+
+def test_is_error_agrees_with_shared_classifier():
+    """Pins the invariant itself rather than one hard-coded example."""
+    for agent, name in ((EchoAgent(), 'Echo'), (ContractFailAgent(), 'ContractFail')):
+        response = _call(
+            _server(agent), 'tools/call', {'name': name, 'arguments': {}}
+        )
+        text = response['result']['content'][0]['text']
+        assert response['result'].get('isError', False) is agent_result_is_error(text)
+
+
+# ------------------------------------------------------- ping / unknown verb
+
+
+def test_ping_returns_empty_result():
+    assert _call(_server(), 'ping')['result'] == {}
+
+
+def test_unknown_method_is_method_not_found():
+    response = _call(_server(), 'nope/nope')
+    assert response['error']['code'] == -32601
+    assert 'nope/nope' in response['error']['message']
+
+
+@pytest.mark.parametrize('method', ['initialize', 'tools/list', 'ping'])
+def test_responses_echo_request_id_and_version(method):
+    response = _call(_server(), method, {}, request_id='abc-123')
+    assert response['jsonrpc'] == '2.0'
+    assert response['id'] == 'abc-123'


### PR DESCRIPTION
## The defect that matters

`typescript/src/agents/result-status.ts` states an invariant in its own docstring:

> Every composition layer (chain, graph, broadcast, **MCP**, chat) classifies through this function so the two runtimes cannot drift apart.

Python ships that classifier as `result_status.agent_result_is_error` and already routes `chain.py`, `graph.py`, `subagent.py`, and `basic_agent.py` through it. **`mcp/server.py` was the one layer that did not.**

Consequence, captured directly from the server:

```
agent returns: {"status": "error", "message": "disk on fire"}

shared classifier says agent FAILED: True
MCP response says isError:          <ABSENT>
```

An MCP client asks "did this tool fail?" and Python answers *no* for an agent that explicitly declared failure. TypeScript answers *yes*. `parity/mcp-server.test.ts` has a test named `marks structured agent errors as MCP tool errors`; Python had no counterpart.

## Four more, all measured

| Surface | TypeScript | Python (before) |
|---|---|---|
| `initialize` | `protocolVersion: '2024-11-05'` | **key absent** — not spec-conformant |
| `tools/list` | omits `required` when empty (`server.ts:105`) | emits `required: []` |
| `tools/call` unknown tool | `Unknown tool: X` | `Tool not found: X` |
| `tools/call` JSON content | re-serialised, 2-space indent | raw passthrough |

`protocolVersion` is required by the MCP spec's `InitializeResult` and TypeScript's parity test pins the literal at line 229. The `required: []` case is not cosmetic — an empty array and an absent key are not equivalent to a strict schema validator.

## Why it went unnoticed

`python/openrappter/mcp/server.py` had **no behavioral test whatsoever**. `test_module_exports.py` asserted only that the module imports. Compounding it, the parity map declared `mcp` to have no Python counterpart, so audits skipped it — the exact failure mode fixed in #407. This PR is the first audit of the subsystem that fix un-hid.

Worth stating plainly: nothing in either codebase constructs `McpServer`. For most classes that would argue the code is dormant. For an MCP server it does not — its consumers are *external* clients by definition, so an internal-callers search is the wrong instrument. These are the bytes a real client receives.

## The test

`python/tests/test_mcp_server.py`, 21 tests mirroring the TypeScript parity file. Written **before** the fix and confirmed to fail on unfixed code: 6 failed / 15 passed, the 6 matching exactly the divergences above.

`test_is_error_agrees_with_shared_classifier` pins the *invariant* rather than an example — it asserts the MCP flag equals `agent_result_is_error()` for both a succeeding and a failing agent, so the two cannot drift apart again regardless of which envelope shapes get added later.

## Mutation testing — 9/9

| # | Mutation | Caught by |
|---|---|---|
| M1 | drop `protocolVersion` | `..._reports_protocol_version` |
| M2 | wrong `protocolVersion` value | `..._reports_protocol_version` |
| M3 | **never** flag contract errors | `..._marks_structured_agent_errors` + invariant test |
| M4 | **always** flag contract errors | `..._does_not_set_is_error` + invariant test |
| M5 | revert unknown-tool message | `..._message_matches_typescript` |
| M6 | always emit `required` | `..._omits_empty_required` |
| M7 | never emit `required` | `..._keeps_non_empty_required` |
| M8 | drop pretty-printing | `..._pretty_prints_json_results` |
| M9 | pretty-print non-JSON too | `..._passes_through_non_json_results` |

M3/M4 and M6/M7 are deliberately **bidirectional**: a test that only catches "stops flagging" would pass a build that flags everything. Source restored byte-identical.

## Scope

Not addressed: TypeScript's `serve()`/`stdio.ts` transport (Python's docstring documents transport as external — a scope boundary, not a defect) and `recordInvocation` journalling (TS-only observability). Both are noted in the test docstring as deliberate exclusions rather than left silent.

## Verification

- `test_mcp_server.py` — **21 passed** (6 failed before the fix)
- Full Python suite — **2152 passed / 6 skipped**, +21 net new
- 2 unrelated failures in `test_imessage_rpc.py` are **pre-existing local flake**: with this branch stashed, clean `main` failed those same tests in **3 of 6 consecutive runs**. Green on CI.
