### PR TITLE
test(imessage): stop terminal-condition tests racing a cold interpreter spawn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `test_imessage_rpc.py` failed roughly half the time when run immediately
+  after the full suite, and passed when run warm -- the pattern that trains
+  people to re-run red builds instead of reading them. Root cause was a
+  1-second timeout in the two tests that assert *terminal* conditions (the RPC
+  child exited, or emitted unframeable output). Those conditions resolve as
+  soon as the child acts, so the timeout is only a safety net against a hang,
+  but 1s raced a cold Python interpreter spawn: warm, the request resolves in
+  ~25ms; the first spawn after heavy disk activity measured ~920ms against the
+  1s budget. Past that the client correctly raised `ImsgRpcTimeout` instead of
+  the expected terminal error and the assertion failed. The client was never
+  at fault. Raised the safety net to 30s via a named constant, which leaves
+  the tests just as fast -- they resolve on the terminal condition, not the
+  timeout -- and measurably more consistent (0.57s per run, against 0.72-1.89s
+  before).
+
 - Python's MCP server diverged from TypeScript on five wire-visible points,
   none of them covered by a test. The most serious: a tool whose agent
   *resolved* with a structured `{"status": "error"}` envelope was reported to

--- a/python/tests/test_imessage_rpc.py
+++ b/python/tests/test_imessage_rpc.py
@@ -14,6 +14,16 @@ from openrappter.imessage.rpc import (
     ImsgRpcTimeout,
 )
 
+# Tests that assert a *terminal* condition -- the child exited, or emitted
+# unframeable output -- resolve as soon as the child acts, so this timeout is
+# only a safety net against a hang and must be generous. It was previously 1s,
+# which raced a cold Python interpreter spawn: warm, the request resolves in
+# ~25ms, but the first spawn after heavy disk activity measured ~920ms against
+# that 1s budget. Any jitter past it surfaced as ImsgRpcTimeout instead of the
+# expected terminal error, so the suite failed ~50% of the time when run
+# straight after the full suite and passed when run warm.
+TERMINAL_TIMEOUT = 30.0
+
 
 def fake_rpc(tmp_path, behavior="normal"):
     script = tmp_path / "fake-imsg"
@@ -69,11 +79,11 @@ def test_rpc_child_exit_fails_request(tmp_path):
     client = ImsgRpcClient(fake_rpc(tmp_path, "exit"))
     client.start()
     with pytest.raises(ImsgRpcClosed):
-        client.request("probe", {}, timeout=1)
+        client.request("probe", {}, timeout=TERMINAL_TIMEOUT)
 
 
 def test_rpc_malformed_stdout_is_terminal(tmp_path):
     client = ImsgRpcClient(fake_rpc(tmp_path, "malformed"))
     client.start()
     with pytest.raises(ImsgRpcProtocolError):
-        client.request("probe", {}, timeout=1)
+        client.request("probe", {}, timeout=TERMINAL_TIMEOUT)


### PR DESCRIPTION
## The symptom

`test_imessage_rpc.py` failed roughly half the time when run immediately after the full suite, and passed when run warm. Measured on clean `main` with all other work stashed — **3 of 6 consecutive runs failed**, then 8 of 8 passed once the machine was warm.

That pattern is the damaging kind: it trains people to re-run a red build rather than read it.

## Root cause

The two affected tests assert **terminal** conditions — the RPC child exited, or emitted unframeable output. Those resolve the moment the child acts, so the `timeout` argument is only a safety net against a hang. It was set to `1`.

Measured:

| | |
|---|---|
| `client.request()` warm | **24.6 ms** |
| first spawn, cold cache | **~920 ms** |
| test budget | **1000 ms** |

A margin under 8% on a subprocess spawn is not a budget, it's a coin flip. The tests were racing a cold Python interpreter start against a one-second deadline. When the spawn lost, the client did exactly the right thing and raised `ImsgRpcTimeout` — but the test expected `ImsgRpcClosed` / `ImsgRpcProtocolError`, so it failed.

**The client was never at fault.** I checked the read loop first on the assumption that ~920ms implied a coarse poll interval; it doesn't — detection is prompt, and `client.request()` is 24.6ms warm. The cost is entirely cold-start. Only the test's budget was wrong.

This also explains the observed ordering precisely: the full suite churns the filesystem cache, so the next runs pay cold-start and fail; by the fourth run everything is warm and it passes.

## Fix

Raised the safety net to 30s behind a named constant carrying the measurement, so the next person doesn't re-tighten it.

## Verification

The flake is timing-dependent, so I made it deterministic rather than re-running and hoping. Simulating a 1.2s cold spawn:

```
      exit | OLD timeout=1            -> ImsgRpcTimeout       FAIL (test would flake)
      exit | NEW TERMINAL_TIMEOUT=30  -> ImsgRpcClosed        PASS
 malformed | OLD timeout=1            -> ImsgRpcTimeout       FAIL (test would flake)
 malformed | NEW TERMINAL_TIMEOUT=30  -> ImsgRpcProtocolError PASS
```

Both directions confirmed: the old budget reproduces the exact failure, the new one holds.

**The tests do not get slower.** They resolve on the terminal condition, never on the timeout — 30s is a ceiling, not a wait. They are in fact faster and far more consistent, because runs that previously lost the race burned the full second:

```
before: 0.72s / 1.89s / 1.83s / 1.73s / 1.33s / 0.80s   (and ~50% failures when cold)
after:  0.57s / 0.56s / 0.56s / 0.57s / 0.58s
```

## Scope

Test-only. No production code changed. `test_rpc_timeout_does_not_retry` deliberately keeps its tight `default_timeout=0.05` — that test *wants* the timeout to fire, so a generous budget would defeat it.
