### PR TITLE
fix(gateway): let Python stream blocks be marked done and replaced by id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Python's `StreamManager.push_block()` could not mark a block finished. The
+  `done` field was public, mirrored TypeScript, and was named in the module
+  docstring as the signal that a block is "marked done" -- but it was
+  hardcoded `False` at every construction site, so no Python code path could
+  ever set it `True` and a subscriber waiting on `block.done` waited forever.
+  It also always generated a fresh UUID, so the caller-supplied block id and
+  the replace-by-id upsert that TypeScript guarantees were both unreachable;
+  pushing an updated block appended a duplicate instead of revising the
+  original. `push_block()` now accepts keyword-only `done`, `block_id` and
+  `delta` and replaces a block whose id already exists, matching
+  `pushBlock` in `typescript/src/gateway/streaming.ts`. Existing positional
+  callers are unaffected. The module docstring claimed it mirrored the
+  TypeScript API "with one known exception" (the WebSocket transport hook),
+  so this gap was undocumented as well as unreachable.
+
 - `test_imessage_rpc.py` failed roughly half the time when run immediately
   after the full suite, and passed when run warm -- the pattern that trains
   people to re-run red builds instead of reading them. Root cause was a

--- a/python/openrappter/gateway/streaming.py
+++ b/python/openrappter/gateway/streaming.py
@@ -103,20 +103,44 @@ class StreamManager:
         block_type: BlockType,
         content: str,
         metadata: Optional[Dict] = None,
+        *,
+        done: bool = False,
+        block_id: Optional[str] = None,
+        delta: Optional[str] = None,
     ) -> StreamBlock:
-        """Create a new block, append it to the session, and notify subscribers."""
+        """Upsert a block into the session and notify subscribers.
+
+        Mirrors the TypeScript ``pushBlock``, which takes the whole block as an
+        object and so lets the caller set ``id``, ``done`` and ``delta``. The
+        signature here stays flat and positional rather than copying that
+        object shape, but the capabilities have to match: ``done`` is the
+        documented completion signal for a block, and a caller that supplies
+        ``block_id`` is updating a block it already pushed.
+
+        A block whose id already exists in the session is *replaced*, not
+        appended, so repeatedly pushing the same id revises one block instead
+        of growing the transcript. Without a caller-supplied ``block_id`` every
+        block gets a fresh UUID and therefore always appends.
+        """
         session = self._require_session(session_id)
-        block = StreamBlock(
-            id=str(uuid.uuid4()),
+        resolved = StreamBlock(
+            id=block_id if block_id is not None else str(uuid.uuid4()),
             type=block_type,
             content=content,
-            done=False,
+            done=done,
             timestamp=time.time(),
+            delta=delta,
             metadata=metadata,
         )
-        session.blocks.append(block)
-        self._notify(session_id, block)
-        return block
+        existing = next(
+            (i for i, b in enumerate(session.blocks) if b.id == resolved.id), None
+        )
+        if existing is not None:
+            session.blocks[existing] = resolved
+        else:
+            session.blocks.append(resolved)
+        self._notify(session_id, resolved)
+        return resolved
 
     def push_delta(self, session_id: str, block_id: str, delta: str) -> StreamBlock:
         """Append a delta to an existing block's content.

--- a/python/tests/test_showcase_stream_weaver.py
+++ b/python/tests/test_showcase_stream_weaver.py
@@ -252,3 +252,111 @@ class TestDeleteSession:
         manager.create_session("sess_1")
 
         assert manager.delete_session("sess_1") is None
+
+
+# ---------------------------------------------------------------------------
+# Block identity, completion, and replacement
+#
+# These mirror three guarantees pinned by the TypeScript suite in
+# typescript/src/gateway/__tests__/streaming.test.ts:
+#   - 'adds a new block with auto-generated id'      (defaults)
+#   - 'respects a caller-supplied block id'          (id passthrough)
+#   - 'replaces an existing block with the same id'  (upsert semantics)
+#
+# The TS pushBlock takes the whole block as an object, so `done`, `id` and
+# `delta` are caller-supplied there. Python keeps its flatter positional
+# signature -- signature *shape* is not what parity means -- but must offer
+# the same capabilities.
+# ---------------------------------------------------------------------------
+
+class TestBlockIdentityAndCompletion:
+    def test_push_block_defaults_to_generated_id_and_not_done(self):
+        manager = StreamManager()
+        manager.create_session("sess_1")
+
+        block = manager.push_block("sess_1", "text", "hello")
+
+        uuid.UUID(block.id)  # raises if not a generated UUID
+        assert block.done is False
+        assert block.delta is None
+
+    def test_push_block_respects_caller_supplied_id(self):
+        manager = StreamManager()
+        manager.create_session("sess_1")
+
+        block = manager.push_block(
+            "sess_1", "thinking", "reasoning...", block_id="blk-custom"
+        )
+
+        assert block.id == "blk-custom"
+
+    def test_push_block_can_mark_a_block_done(self):
+        """`done` is a public field and the documented completion signal.
+
+        Before this was fixed no Python code path could ever set it True, so a
+        subscriber waiting on block.done waited forever.
+        """
+        manager = StreamManager()
+        manager.create_session("sess_1")
+
+        block = manager.push_block("sess_1", "text", "final", done=True)
+
+        assert block.done is True
+
+        session = manager.get_session("sess_1")
+        assert session is not None
+        assert session.blocks[0].done is True
+
+    def test_push_block_replaces_existing_block_with_same_id(self):
+        manager = StreamManager()
+        manager.create_session("sess_1")
+
+        manager.push_block("sess_1", "text", "original", block_id="blk1")
+        manager.push_block("sess_1", "text", "updated", block_id="blk1", done=True)
+
+        session = manager.get_session("sess_1")
+        assert session is not None
+        assert len(session.blocks) == 1
+        assert session.blocks[0].content == "updated"
+        assert session.blocks[0].done is True
+
+    def test_push_block_stores_caller_supplied_delta(self):
+        manager = StreamManager()
+        manager.create_session("sess_1")
+
+        block = manager.push_block("sess_1", "text", "abc", delta="c")
+
+        assert block.delta == "c"
+
+    def test_replacement_notifies_subscribers_with_the_new_block(self):
+        manager = StreamManager()
+        manager.create_session("sess_1")
+        seen = []
+        manager.on_block("sess_1", lambda b, s: seen.append((b.content, b.done)))
+
+        manager.push_block("sess_1", "text", "original", block_id="blk1")
+        manager.push_block("sess_1", "text", "updated", block_id="blk1", done=True)
+
+        assert seen == [("original", False), ("updated", True)]
+
+    def test_thinking_ts_call_pattern_is_expressible(self):
+        """typescript/src/gateway/thinking.ts:114 is the only production caller
+        of pushBlock, and it supplies id + done=True + metadata at once. A
+        Python port of that module has to be able to make the same call.
+        """
+        manager = StreamManager()
+        manager.create_session("sess_1")
+
+        block = manager.push_block(
+            "sess_1",
+            "thinking",
+            "chain of thought",
+            metadata={"redacted": False},
+            done=True,
+            block_id="think-1",
+        )
+
+        assert block.id == "think-1"
+        assert block.type == "thinking"
+        assert block.done is True
+        assert block.metadata == {"redacted": False}


### PR DESCRIPTION
## The defect

`StreamBlock.done` is a public field on the Python dataclass, mirrors the TypeScript interface, and is named in the module docstring as the signal that a block "may accumulate content via deltas before being **marked done**."

No Python code path could set it.

```
$ grep -n "done" python/openrappter/gateway/streaming.py
6:accumulate content via deltas before being marked done.
38:    done: bool
113:            done=False,     <- push_block
134:            done=False,     <- push_delta's new block
```

Both construction sites hardcode `False`, and nothing else in the repo assigns it. A subscriber waiting on `block.done` waits forever. TypeScript takes it from the caller (`streaming.ts:131`, `done: block.done`).

## Two more capabilities that were unreachable

`push_block` also always generated a fresh UUID, so the caller could not supply a block id. That made two guarantees the TypeScript suite explicitly pins impossible to express in Python:

| TS test | file |
|---|---|
| `respects a caller-supplied block id` | `streaming.test.ts:122` |
| `replaces an existing block with the same id` | `streaming.test.ts:126` |

Neither had a Python mirror — not because the mirror was forgotten, but because there was no capability to test. Without upsert, pushing a revised block appended a duplicate rather than replacing the original.

## Why it matters beyond symmetry

`typescript/src/gateway/thinking.ts:114` is the **only production caller of `pushBlock` in either runtime**, and it uses all three of the missing capabilities in a single call:

```ts
this.streamManager.pushBlock(sessionId, {
  id: block.id,
  type: 'thinking',
  content: block.content,
  done: true,
  metadata: { redacted: block.redacted },
});
```

Python supported `metadata` only. A port of `thinking.ts` was not expressible.

This was also **undocumented**. The Python module docstring claims it "mirrors the TypeScript StreamManager API with one known exception" — and names that exception as the WebSocket transport hook. So the file asserted parity on exactly the surface where it diverged.

## The fix

`push_block` takes keyword-only `done`, `block_id` and `delta`, and upserts by id using the same find-then-replace-or-append that `pushBlock` does.

The signature stays flat and positional rather than copying the TypeScript object parameter. Signature *shape* is not what parity means here; capability is. Every existing caller passes three positional arguments and is unaffected.

## Verification

- 7 tests added; **6 fail on unfixed source**, the 7th pins the pre-existing defaults so they cannot regress.
- **Mutation-tested 8/8, bidirectionally.** Each invariant was broken in both directions and each direction is caught by a *different* test, so the suite cannot be satisfied by a build that is wrong the other way:

| mutation | caught by |
|---|---|
| `done` ignored (revert) | `test_push_block_can_mark_a_block_done` |
| `done` forced `True` | `test_push_text_block_has_id_content_type` |
| `block_id` ignored | `test_push_block_respects_caller_supplied_id` |
| `block_id` used when `None` | `test_push_multiple_block_types` |
| never replace | `test_push_block_replaces_existing_block_with_same_id` |
| always replace first block | `test_push_multiple_block_types` |
| `delta` dropped | `test_push_block_stores_caller_supplied_delta` |
| no notify on replacement | `test_replacement_notifies_subscribers_with_the_new_block` |

Source restored byte-identical after the run (sha256 verified).

- Full Python suite: **2161 passed / 6 skipped / 0 failed**, up from 2154.

## Deliberately not changed

- **The WebSocket transport hook** (`GatewayBroadcaster`, `setGateway`). Documented as an intentional non-port.
- **`create_session` accepting `None`** (TS requires an id). Python is a superset; not a defect.
- **`active_sessions` as a property vs. `activeSessions()` as a method.** Idiomatic-language shape, no behavioral difference.
- **Timestamp units.** TS uses `Date.now()` (ms int), Python `time.time()` (s float). A real divergence, but Python's `StreamManager` has no transport and no serializing consumer, so nothing observes it today; changing the unit would silently break existing Python callers for no present benefit. Logged for a future round rather than fixed opportunistically here.
