### PR TITLE
fix(gateway): stop the Python dashboard claiming an HTTP surface it lacks

### DIFF
--- a/.claude/skills/ts-python-parity-check/SKILL.md
+++ b/.claude/skills/ts-python-parity-check/SKILL.md
@@ -47,6 +47,7 @@ Notes:
 - If a filename isn't listed, resolve it by convention: TS `CamelCase.ts` ⇔ Python `snake_case.py`; multi-agent primitives (`broadcast`/`router`/`subagent`/`chain`/`graph`/`tracer`) keep their lowercase names in both languages.
 - If a pair genuinely has no Python counterpart yet, say so explicitly in the report — that's a real divergence to flag, not a silent pass. Resolve absence against the authoritative list in [Modules with no Python counterpart](#modules-with-no-python-counterpart) rather than from memory.
 - The `mcp` pair covers a wire protocol, so parity means the bytes an external client receives — `protocolVersion`, `inputSchema` shape, and the `isError` flag — not just method names. Nothing in either codebase constructs `McpServer`, so an internal-callers search proves nothing about reachability here.
+- The `gateway/dashboard` pair is a **partial port**, so listing it here does not mean the two files have comparable scope. `dashboard.ts` is an HTTP handler -- `handle(req, res)`, `sendJson()` and a `prefix` that routes requests -- and none of that is ported. `dashboard.py` is the trace store and agent executor only. Audit the storage/execution half for parity and report the HTTP surface as an explicit limitation; do not read a green dashboard audit as covering the transport. Pinned by `TestDashboardHttpSurfaceIsNotPorted` in `python/tests/test_showcase_living_dashboard.py`, which fails if the HTTP layer is ever ported so this note cannot go stale silently.
 
 ## Modules with no Python counterpart
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `DashboardHandler.execute_agent()` dropped the `status` key when an agent
+  returned something that was not JSON. TypeScript falls back to
+  `{ status: 'success', raw: resultStr }` (`dashboard.ts:398`); Python fell
+  back to `{'raw': ...}`, so `result['status']` raised `KeyError` for a
+  plain-text agent but returned a value for a JSON one -- the result shape
+  depended on what the agent happened to emit.
+
+- `python/openrappter/gateway/dashboard.py` described itself as an "HTTP
+  dashboard handler" that "mirrors TypeScript gateway/dashboard.ts". It
+  handles no HTTP: `handle()`, `sendJson()` and prefix routing are not
+  ported, and the `_prefix` it stored was never read by anything. The
+  docstring now states the actual scope and names the omission, the dead
+  `_prefix` is gone, and the parity map records `gateway/dashboard` as a
+  partial port so a green dashboard audit is not mistaken for transport
+  coverage.
+
 - Python's `StreamManager.push_block()` could not mark a block finished. The
   `done` field was public, mirrored TypeScript, and was named in the module
   docstring as the signal that a block is "marked done" -- but it was

--- a/python/openrappter/gateway/dashboard.py
+++ b/python/openrappter/gateway/dashboard.py
@@ -1,10 +1,17 @@
 """
-DashboardHandler - HTTP dashboard handler for agent management and trace storage.
+DashboardHandler - in-memory trace store and agent executor.
 
-Provides in-memory trace storage with circular buffer and agent execution
-with automatic trace recording.
+Holds registered agents plus a bounded (circular) trace buffer, and executes
+an agent by name while recording a trace for the call.
 
-Mirrors TypeScript gateway/dashboard.ts
+Partial port of TypeScript gateway/dashboard.ts. That module is an HTTP
+handler -- it owns `handle(req, res)`, `sendJson()` and a `prefix` used to
+route requests under `/api` -- and none of that HTTP surface is ported here.
+This class is the storage and execution half only; callers wire it up to a
+transport themselves. The limitation is recorded in the gateway/dashboard
+note in .claude/skills/ts-python-parity-check/SKILL.md and pinned by
+TestDashboardHttpSurfaceIsNotPorted in
+python/tests/test_showcase_living_dashboard.py.
 """
 
 import time
@@ -19,7 +26,6 @@ class DashboardHandler:
         self._agents = {}  # name -> agent
         self._traces = []  # list of trace entry dicts
         self._max_traces = options.get('max_traces', 500)
-        self._prefix = options.get('prefix', '/api')
 
     def register_agent(self, agent):
         """Register a single agent."""
@@ -81,7 +87,9 @@ class DashboardHandler:
             try:
                 result = json.loads(result_str) if isinstance(result_str, str) else result_str
             except (json.JSONDecodeError, TypeError):
-                result = {'raw': result_str}
+                # Mirrors dashboard.ts:398 -- a non-JSON agent result is
+                # wrapped so that result['status'] is present either way.
+                result = {'status': 'success', 'raw': result_str}
 
             self.add_trace({
                 'agent_name': agent_name,

--- a/python/tests/test_showcase_living_dashboard.py
+++ b/python/tests/test_showcase_living_dashboard.py
@@ -333,3 +333,88 @@ class TestFullSelfMonitoringLoop:
         # The MCP server holds the DashboardQuery tool registration
         assert mcp.tool_count == 1
         assert mcp.has_tool('DashboardQuery')
+
+
+# ---------------------------------------------------------------------------
+# DashboardHandler.execute_agent result shape
+# ---------------------------------------------------------------------------
+
+class _PlainTextAgent:
+    name = 'plain'
+
+    def execute(self, **kwargs):
+        return 'not json at all'
+
+
+class _JsonAgent:
+    name = 'jsonish'
+
+    def execute(self, **kwargs):
+        return '{"status": "success", "answer": 42}'
+
+
+class TestExecuteAgentResultShape:
+    def test_non_json_result_keeps_the_status_key(self):
+        """Mirrors the fallback at typescript/src/gateway/dashboard.ts:398,
+        which is `{ status: 'success', raw: resultStr }`. Python used to drop
+        `status`, so a caller reading result['status'] got a KeyError for a
+        plain-text agent but a value for a JSON one -- the shape depended on
+        whether the agent happened to emit JSON.
+        """
+        dashboard = DashboardHandler()
+        dashboard.register_agent(_PlainTextAgent())
+
+        outcome = dashboard.execute_agent('plain')
+
+        assert outcome['status'] == 'success'
+        assert outcome['result'] == {'status': 'success', 'raw': 'not json at all'}
+
+    def test_json_result_is_passed_through_parsed(self):
+        dashboard = DashboardHandler()
+        dashboard.register_agent(_JsonAgent())
+
+        outcome = dashboard.execute_agent('jsonish')
+
+        assert outcome['result'] == {'status': 'success', 'answer': 42}
+
+    def test_status_key_is_present_for_both_agent_kinds(self):
+        """The invariant the fallback exists to preserve: every successful
+        execute_agent result exposes result['status'], whatever the agent
+        returned."""
+        dashboard = DashboardHandler()
+        dashboard.register_agent(_PlainTextAgent())
+        dashboard.register_agent(_JsonAgent())
+
+        for name in ('plain', 'jsonish'):
+            assert dashboard.execute_agent(name)['result']['status'] == 'success'
+
+
+class TestDashboardHttpSurfaceIsNotPorted:
+    """Tripwire for a recorded parity limitation.
+
+    typescript/src/gateway/dashboard.ts is an HTTP handler: it owns handle(),
+    sendJson() and a `prefix` used to route requests. The Python module ports
+    only the trace store and agent execution -- no HTTP surface at all.
+
+    That limitation is recorded in the parity map. This test exists so the
+    record cannot silently go stale: if someone ports the HTTP layer, this
+    fails and the parity note has to be updated in the same change.
+    """
+
+    def test_python_dashboard_exposes_no_http_entrypoints(self):
+        dashboard = DashboardHandler()
+
+        for attr in ('handle', 'send_json', 'sendJson'):
+            assert not hasattr(dashboard, attr), (
+                f'DashboardHandler grew {attr!r}. The HTTP surface is now '
+                'partly ported -- update the gateway/dashboard note in '
+                '.claude/skills/ts-python-parity-check/SKILL.md.'
+            )
+
+    def test_no_dead_route_prefix_is_stored(self):
+        """A route prefix only means something to a router. Storing one on a
+        class that never routes is dead state that reads as though HTTP
+        handling exists."""
+        dashboard = DashboardHandler({'prefix': '/api'})
+
+        assert not hasattr(dashboard, '_prefix')


### PR DESCRIPTION
Two problems in `gateway/dashboard.py`, both left behind by the same half-finished port.

## 1. The success result shape depended on what the agent emitted

`execute_agent()` parses the agent's string result as JSON and falls back when that fails. TypeScript's fallback keeps the `status` key:

```ts
// typescript/src/gateway/dashboard.ts:398
result = { status: 'success', raw: resultStr } as unknown as AgentResult;
```

Python's dropped it:

```python
result = {'raw': result_str}
```

Measured on `main` before the fix:

```
python result : {'raw': 'not json at all'}
TS  result    : { status: 'success', raw: 'not json at all' }
python has status key? False
```

So `result['status']` raised `KeyError` for a plain-text agent and returned a value for a JSON one. A caller cannot read the field without knowing what the agent happened to emit.

## 2. It advertised an HTTP surface it does not have

The module docstring read:

> DashboardHandler - **HTTP dashboard handler** for agent management and trace storage.
> ...
> **Mirrors** TypeScript gateway/dashboard.ts

It handles no HTTP. `dashboard.ts` owns `handle(req, res)`, `sendJson()` and a `prefix` that routes requests under `/api`; none of it is ported.

```
has handle()? False   has send_json()? False
```

And `_prefix` was dead state — written in the constructor, never read:

```
$ grep -rn "_prefix" python/ --include=*.py | grep -i dashboard
python/openrappter/gateway/dashboard.py:22:        self._prefix = options.get('prefix', '/api')
```

That is the module's only occurrence in the entire Python tree. A route prefix stored on a class that cannot route reads as evidence that routing exists.

## The parity-map angle

The parity map lists `gateway/dashboard` as a checked pair with tests on both sides, which implies the two files have comparable scope. They do not — `dashboard.ts` is 15KB of handler, `dashboard.py` is 3.5KB of storage.

This is the same failure mode as the false-absence claims fixed in #407, inverted: not a false *absence* claim but a false *presence* one. Both mislead an audit without producing any warning.

SKILL.md now records the pair as a partial port and tells auditors to report the HTTP surface as an explicit limitation rather than reading a green dashboard audit as transport coverage.

## The fix

- `execute_agent()` fallback is now `{'status': 'success', 'raw': result_str}`, matching `dashboard.ts:398`.
- Docstring states the actual scope and names the omission.
- Dead `_prefix` removed.
- SKILL.md gains a `gateway/dashboard` partial-port note.

## Verification

- 5 tests added; **3 fail on unfixed source**. The other two pin current reality as a tripwire.
- **Mutation-tested 6/6:**

| mutation | caught by |
|---|---|
| fallback drops `status` (revert) | `test_non_json_result_keeps_the_status_key` |
| fallback `status` set to `'error'` | `test_non_json_result_keeps_the_status_key` |
| fallback drops `raw` | `test_non_json_result_keeps_the_status_key` |
| fallback applied to JSON results too | `test_json_result_is_passed_through_parsed` |
| dead `_prefix` reintroduced | `test_no_dead_route_prefix_is_stored` |
| a `handle()` method appears | `test_python_dashboard_exposes_no_http_entrypoints` |

The last mutation is the point of the tripwire: it confirms the test actually fires when the HTTP layer is ported, rather than passing vacuously forever. If someone does port it, the parity note must be updated in the same change.

Source restored byte-identical after the run (sha256 verified).

- Full Python suite: **2166 passed / 6 skipped / 0 failed**, up from 2161.

## Deliberately not changed

- **`execute_agent` classifying any non-throwing call as `status: 'success'`**, even when the agent returned a structured `{"status":"error"}`. This looks like the `isError` bug fixed in #408, but it is **not a parity divergence** — `dashboard.ts:402-434` classifies exactly the same way, on throw only. Changing it would be a behavior change in both runtimes and a product decision, not a parity fix.
- **`get_traces(0)` returning every trace.** Both runtimes use a falsy check (`if limit:` / `if (limit)`), and `slice(-0)` returns the whole array in JS anyway, so the quirk is shared rather than divergent.
- **Trace id formats** (`trace_{ms}` base-10 in Python vs `trace_${Date.now().toString(36)}` base-36 in TS). Ids are opaque and never compared across runtimes.
