### PR TITLE
fix(gateway): report the channels health check Python advertises but omits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The Python gateway's `health` response omitted the `channels` check that
+  TypeScript reports. Every shared `channels.*` method guards on
+  `channel_registry`, and `channels.list` answers `[]` when it is absent --
+  which a client cannot tell apart from "no channels are configured". Python
+  now reports `channels` (and TypeScript's `storage` placeholder), so the
+  advertised channel surface can be pre-flighted on both runtimes.
+
+- `contracts/gateway-rpc-parity.json` claimed `health`'s `checks` sub-object
+  agreed between the runtimes, and scoped the only exception to the optional
+  `instance` field. It did not agree: TypeScript reported five checks and
+  Python two. The claim was prose, and prose cannot fail a build, so the
+  disagreement survived. Check names are now data under `health_checks`,
+  asserted by both runtimes. The contract's stated TypeScript method count
+  was also stale (54; the live count is 74).
+
 - `DashboardHandler.execute_agent()` dropped the `status` key when an agent
   returned something that was not JSON. TypeScript falls back to
   `{ status: 'success', raw: resultStr }` (`dashboard.ts:398`); Python fell

--- a/contracts/gateway-rpc-parity.json
+++ b/contracts/gateway-rpc-parity.json
@@ -1,7 +1,7 @@
 {
   "schema": "rapp-gateway-rpc-parity/1.0",
   "why": [
-    "The two gateways drifted without anything noticing. TypeScript registers 54 RPC",
+    "The two gateways drifted without anything noticing. TypeScript registers 74 RPC",
     "methods and Python 10, which is expected \u2014 they have different scopes \u2014 but the",
     "overlap must agree, and a method must not quietly appear in one runtime only.",
     "",
@@ -33,6 +33,27 @@
       "code-execution surface. Tracked as an issue rather than added unilaterally."
     ]
   },
+  "health_checks": {
+    "why": [
+      "`health` is in `shared`, and its `checks` sub-object is the part a monitor",
+      "actually reads. It was described in prose as agreeing; it did not. Python",
+      "reported two of TypeScript's five checks, and prose cannot fail a build,",
+      "so the disagreement survived. These lists are asserted by both runtimes."
+    ],
+    "shared": [
+      "agents",
+      "channels",
+      "gateway",
+      "storage"
+    ],
+    "typescript_only": {
+      "copilot": [
+        "`!!this.onAuthTokenUpdate` \u2014 whether a Copilot auth-token callback is",
+        "wired. The Python gateway has no auth-token-update hook at all, so this",
+        "check has nothing to report and is not expressible there."
+      ]
+    }
+  },
   "typescript_only_note": [
     "TypeScript registers many methods Python does not (cron.*, chat.*, twin.*,",
     "surgeon.*, backup.*, auth.*, and others). That is by design \u2014 the TypeScript",
@@ -53,9 +74,15 @@
     "A client written against one cannot read the other. Only `description`",
     "overlaps; TypeScript's `id` is Python's `name`.",
     "",
-    "`health` does agree \u2014 status, version, uptime, timestamp, checks \u2014 except",
-    "that Python never sends the optional `instance`, which TypeScript documents",
-    "as meaning 'unknown' when absent, so that is compatible by design.",
+    "`health`'s top-level keys agree \u2014 status, version, uptime, timestamp,",
+    "checks, metrics \u2014 except that Python never sends the optional `instance`,",
+    "which TypeScript documents as meaning 'unknown' when absent, so that is",
+    "compatible by design.",
+    "",
+    "Its `checks` sub-object did NOT agree, and this file used to say it did.",
+    "TypeScript reported five checks and Python two. That claim now lives in",
+    "`health_checks` above, where both runtimes assert it, because a sentence",
+    "here cannot fail a build and so cannot notice when it stops being true.",
     "",
     "Tracked as an issue rather than fixed here: choosing a canonical shape",
     "breaks whichever side's clients are not chosen, which is an owner decision."

--- a/python/openrappter/gateway/server.py
+++ b/python/openrappter/gateway/server.py
@@ -346,8 +346,18 @@ class GatewayServer:
             "version": self.version,
             "uptime": int(time.time() - self._started_at) if self._started_at else 0,
             "timestamp": _iso_timestamp(),
+            # Mirrors gateway/server.ts:1935 minus `copilot`, which reports
+            # whether an auth-token callback is wired and has no Python hook to
+            # report on. `storage` is TypeScript's hardcoded placeholder, kept
+            # so the key set a monitor iterates over is the same on both sides.
+            # `channels` is the load-bearing one: every shared `channels.*`
+            # method guards on this registry, and `channels.list` returns []
+            # when it is absent, which is indistinguishable from "no channels
+            # configured" unless health says which it is.
             "checks": {
                 "gateway": self.running,
+                "storage": True,
+                "channels": self.channel_registry is not None,
                 "agents": self.agent_registry is not None,
             },
             "metrics": self.metrics.snapshot(len(self._connections)),

--- a/python/tests/test_gateway_rpc_parity.py
+++ b/python/tests/test_gateway_rpc_parity.py
@@ -64,3 +64,44 @@ class TestSharedSurface:
             "these Python gateway methods are in neither `shared` nor `python_only`; "
             f"add them to contracts/gateway-rpc-parity.json: {unexplained}"
         )
+
+
+class TestHealthChecks:
+    """`health` is shared, and `checks` is the part a monitor actually reads.
+
+    The contract described `checks` in prose as agreeing between the runtimes.
+    It did not: TypeScript reported five checks and Python two. Prose cannot
+    fail a build, so the disagreement survived. These tests assert the lists in
+    `health_checks`, and TypeScript has the matching test.
+    """
+
+    def test_the_contract_declares_the_check_names(self):
+        # Guards the rest: an empty list would make every assertion vacuous.
+        assert len(CONTRACT["health_checks"]["shared"]) >= 4
+
+    def test_health_reports_exactly_the_shared_checks(self):
+        checks = set(GatewayServer().get_health()["checks"])
+        expected = set(CONTRACT["health_checks"]["shared"])
+        assert checks == expected, (
+            f"missing={sorted(expected - checks)} unexpected={sorted(checks - expected)}; "
+            "update contracts/gateway-rpc-parity.json#health_checks rather than drifting"
+        )
+
+    def test_typescript_only_checks_are_not_reported_here(self):
+        # If Python gains one of these it is no longer TypeScript-only and the
+        # contract must move it to `shared`.
+        checks = set(GatewayServer().get_health()["checks"])
+        crossed = sorted(set(CONTRACT["health_checks"]["typescript_only"]) & checks)
+        assert crossed == [], f"declared typescript-only but reported by Python: {crossed}"
+
+    def test_the_channels_check_tracks_the_channel_registry(self):
+        """The reason this check has to exist.
+
+        All five shared `channels.*` methods guard on `channel_registry is
+        None`, and `channels.list` answers `[]` in that case — which a client
+        cannot tell apart from "zero channels are configured". TypeScript
+        exposes the difference as `checks.channels`; without it, Python offers
+        no way to pre-flight the channel surface it advertises as shared.
+        """
+        assert GatewayServer().get_health()["checks"]["channels"] is False
+        assert GatewayServer(channel_registry=object()).get_health()["checks"]["channels"] is True

--- a/typescript/src/__tests__/integration/gateway-rpc-parity.test.ts
+++ b/typescript/src/__tests__/integration/gateway-rpc-parity.test.ts
@@ -24,6 +24,7 @@ const CONTRACT = JSON.parse(
 ) as {
   shared: string[];
   python_only: Record<string, string[]>;
+  health_checks: { shared: string[]; typescript_only: Record<string, string[]> };
   what_this_does_not_pin?: string[];
 };
 
@@ -70,5 +71,44 @@ describe('gateway RPC parity with the Python runtime', () => {
     const have = await registered();
     const crossed = Object.keys(CONTRACT.python_only).filter((m) => have.has(m)).sort();
     expect(crossed).toEqual([]);
+  });
+});
+
+describe('health checks parity with the Python runtime', () => {
+  /**
+   * `health` is shared, and `checks` is the part a monitor actually reads. The
+   * contract described it in prose as agreeing between the runtimes; it did
+   * not — TypeScript reported five checks and Python two. Prose cannot fail a
+   * build, so the disagreement survived. Python has the matching test.
+   */
+  async function healthChecks(): Promise<Set<string>> {
+    server = new GatewayServer({ port: 0, bind: 'loopback', auth: { mode: 'none' } });
+    await server.start();
+    const method = (server as unknown as {
+      methods: Map<string, { handler: () => Promise<{ checks: Record<string, unknown> }> }>;
+    }).methods.get('health')!;
+    return new Set(Object.keys((await method.handler()).checks));
+  }
+
+  it('the contract declares the check names', () => {
+    // Guards the rest: an empty list would make every assertion vacuous.
+    expect(CONTRACT.health_checks.shared.length).toBeGreaterThanOrEqual(4);
+  });
+
+  it('reports every shared check', async () => {
+    const have = await healthChecks();
+    const missing = CONTRACT.health_checks.shared.filter((c) => !have.has(c)).sort();
+    expect(missing).toEqual([]);
+  });
+
+  it('reports nothing beyond shared plus its own declared extras', async () => {
+    // The whole point: a new check cannot appear without being classified,
+    // which is how `checks` drifted apart unnoticed in the first place.
+    const explained = new Set([
+      ...CONTRACT.health_checks.shared,
+      ...Object.keys(CONTRACT.health_checks.typescript_only),
+    ]);
+    const unexplained = [...(await healthChecks())].filter((c) => !explained.has(c)).sort();
+    expect(unexplained).toEqual([]);
   });
 });


### PR DESCRIPTION
`contracts/gateway-rpc-parity.json` lists `health` as **shared** by both gateways. Its `checks` sub-object is the part a monitor actually reads, and the two runtimes disagreed about it.

Measured live, both servers started:

```
TS_CHECKS_KEYS = ["agents","channels","copilot","gateway","storage"]
PY checks keys : ['agents', 'gateway']
```

## Why `channels` is the one that costs something

All five shared `channels.*` methods guard on the same optional dependency:

```python
async def _m_channels_list(self, params, info):
    if self.channel_registry is None:
        return []
```

So on a gateway with no channel registry wired:

```
health.checks        : {'gateway': False, 'agents': False}
channel_registry set?: False
channels.list        → []
```

`[]` is **indistinguishable from a fully-wired gateway that simply has no channels configured.** TypeScript exposes the difference as `checks.channels`; Python advertised the same five channel methods as shared while offering no way to pre-flight them.

## What changed

Python's `checks` now reports:

- **`channels`** — `self.channel_registry is not None`, mirroring `!!this.channelRegistry` at `server.ts:1938`.
- **`storage`** — mirroring TypeScript's hardcoded `true` placeholder, so the key set a monitor iterates over is the same shape on both sides.

`copilot` is **not** ported. It reports whether a Copilot auth-token callback is wired (`!!this.onAuthTokenUpdate`) and the Python gateway has no such hook, so it is recorded as TypeScript-only rather than faked into agreement.

## The contract was asserting this in prose

The contract said:

> `health` does agree — status, version, uptime, timestamp, checks — except that Python never sends the optional `instance` ... so that is compatible by design.

It named `checks` as agreeing and scoped the sole exception to `instance`. That was false, and nothing could notice, **because a sentence cannot fail a build.** This is the same shape as the last two rounds' findings (#410's docstring scoping its divergence to "one known exception", #411's module calling itself an HTTP handler): a document asserting a guarantee the code does not keep.

Check names are now **data**, under a new `health_checks` block, asserted from both runtimes — each must report every `shared` check and nothing it has not classified. The prose now points at the pin instead of restating it.

While verifying, the contract's stated TypeScript method count was also stale: it claimed **54**, the live count is **74**. Measured by starting the server and reading its method map, not by grepping — a regex pass reported 90 and missed the three methods registered through a loop over a `publicMethods` array, which is exactly the kind of error the runtime measurement avoids.

## Verification

- **7 tests added** (4 Python, 3 TypeScript). **2 fail on unfixed source** — the two that depend on the code change.
- **Mutation-tested 10/10**, both runtimes, both restored byte-identical (sha256 verified):

| mutation | caught by |
|---|---|
| drop `channels` check (revert the fix) | `test_health_reports_exactly_the_shared_checks` + `test_the_channels_check_tracks_the_channel_registry` |
| drop `storage` check | `test_health_reports_exactly_the_shared_checks` |
| Python claims the TS-only `copilot` check | key-set test + `test_typescript_only_checks_are_not_reported_here` |
| `channels` hardcoded `True` | `test_the_channels_check_tracks_the_channel_registry` |
| `channels` hardcoded `False` | `test_the_channels_check_tracks_the_channel_registry` |
| contract drops `channels` from `shared` | vacuity guard + key-set test |
| contract `shared` emptied | vacuity guard + key-set test |
| TS drops `storage` | `reports every shared check` |
| TS drops `channels` | `reports every shared check` |
| TS gains an unclassified check | `reports nothing beyond shared plus its own declared extras` |

The two hardcoded-`channels` mutations matter most: they are caught **only** by the registry-tracking test, which proves that assertion is load-bearing rather than redundant with the key-set assertion. A key-set test alone would pass while the flag lied.

- Python: **2170 passed / 6 skipped** (from 2166).
- TypeScript: **5371 passed / 21 skipped**, 330 files (from 5368).

TypeScript product code is untouched — the only `typescript/` change is the test file.

## Verified clean, not changed

- **`status`** is an exact 7-key match (`running, port, connections, uptime, version, startedAt, metrics`), uptime floored to integer seconds on both sides. No action.
- **`ping`** matches exactly — `{pong: <ms int>}` on both.
- **The `shared` / `python_only` method classification is accurate.** The live overlap is exactly the 9 names in `shared`, and `agents.execute` remains genuinely Python-only.
- **The method-list asymmetry itself** (74 vs 10) is by design and already documented in `typescript_only_note`. Only the count was corrected.
